### PR TITLE
Add "expiry" field to Offer and SwapProposal

### DIFF
--- a/trading_service/src/exchange_api_client/fake_client.rs
+++ b/trading_service/src/exchange_api_client/fake_client.rs
@@ -1,8 +1,7 @@
 use super::client::ApiClient;
 use bitcoin_rpc::Address;
 use reqwest;
-use types::Offer;
-use types::OfferRequest;
+use types::{Epoch, Offer, OfferRequest};
 use uuid::Uuid;
 
 #[allow(dead_code)]
@@ -15,6 +14,7 @@ impl ApiClient for FakeApiClient {
             symbol: offer_request.symbol.clone(),
             rate: 0.42,
             address: Address::from("mtgyGsXBNG7Yta5rcMgWH4x9oGE5rm3ty9"),
+            expiry: Epoch(1527135132),
         };
         Ok(offer)
     }

--- a/trading_service/src/types.rs
+++ b/trading_service/src/types.rs
@@ -13,6 +13,9 @@ pub struct OfferRequestBody {
     pub amount: u32,
 }
 
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+pub struct Epoch(pub u32); // Unix timestamp
+
 impl fmt::Display for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
@@ -38,6 +41,7 @@ pub struct Offer {
     pub symbol: Symbol,
     pub rate: f32,
     pub address: Address,
+    pub expiry: Epoch,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -46,6 +50,7 @@ pub struct SwapProposal {
     pub symbol: Symbol,
     pub rate: f32,
     pub address: Address,
+    pub expiry: Epoch,
     pub secret_hash: SecretHash,
 }
 
@@ -60,6 +65,7 @@ impl SwapProposal {
         symbol: Symbol,
         rate: f32,
         address: Address,
+        expiry: Epoch,
         secret_hash: SecretHash,
     ) -> SwapProposal {
         SwapProposal {
@@ -68,6 +74,7 @@ impl SwapProposal {
             rate,
             address,
             secret_hash,
+            expiry,
         }
     }
 
@@ -77,6 +84,7 @@ impl SwapProposal {
             exchange_offer.symbol,
             exchange_offer.rate,
             exchange_offer.address,
+            exchange_offer.expiry,
             secret_hash,
         )
     }


### PR DESCRIPTION
This expiry is the expiry of the Offer made by the exchange service in
terms of the latest epoch timestamp of a block the txn can be in.