### PR TITLE
Add PATH if cargo exec cannot be found

### DIFF
--- a/check-fmt.sh
+++ b/check-fmt.sh
@@ -3,4 +3,4 @@ set -eu
 
 CARGO_BIN=$(expr "$(which cargo)" '|' "$HOME/.cargo/bin/cargo");
 
-${CARGO_BIN} +stable-2018-05-10 fmt -- --write-mode diff
+"${CARGO_BIN}" +stable-2018-05-10 fmt -- --write-mode diff


### PR DESCRIPTION
I cannot commit with CLion due to this.

Taking a safe approach of updating the PATH if `cargo` exec cannot be found.