### PR TITLE
Change to rust-nightly formatting

### DIFF
--- a/application/bitcoin_htlc/src/bitcoin_htlc.rs
+++ b/application/bitcoin_htlc/src/bitcoin_htlc.rs
@@ -1,6 +1,7 @@
-use bitcoin::blockdata::opcodes::All::OP_NOP3 as OP_CHECKSEQUENCEVERIFY;
-use bitcoin::blockdata::opcodes::All::*;
-use bitcoin::blockdata::script::Builder;
+use bitcoin::blockdata::{
+    opcodes::All::{OP_NOP3 as OP_CHECKSEQUENCEVERIFY, *},
+    script::Builder,
+};
 use bitcoin_support::{Address, Network, PubkeyHash, Script};
 use bitcoin_witness::{UnlockParameters, Witness, SEQUENCE_ALLOW_NTIMELOCK_NO_RBF};
 use secp256k1_support::KeyPair;

--- a/application/bitcoin_htlc/tests/redeem_htlc_on_regtest.rs
+++ b/application/bitcoin_htlc/tests/redeem_htlc_on_regtest.rs
@@ -13,8 +13,9 @@ use bitcoin_htlc::Htlc;
 use bitcoin_node::BitcoinNode;
 use bitcoin_rpc::BitcoinRpcApi;
 use bitcoin_rpc_helpers::RegtestHelperClient;
-use bitcoin_support::serialize::serialize_hex;
-use bitcoin_support::{Address, BitcoinQuantity, Network, PrivateKey, PubkeyHash};
+use bitcoin_support::{
+    serialize::serialize_hex, Address, BitcoinQuantity, Network, PrivateKey, PubkeyHash,
+};
 use bitcoin_witness::{PrimedInput, PrimedTransaction};
 use common_types::secret::Secret;
 use secp256k1_support::KeyPair;
@@ -99,14 +100,12 @@ fn redeem_htlc_with_secret() {
     let fee = BitcoinQuantity::from_satoshi(1000);
 
     let redeem_tx = PrimedTransaction {
-        inputs: vec![
-            PrimedInput::new(
-                txid.into(),
-                vout.n,
-                input_amount,
-                htlc.unlock_with_secret(keypair, secret),
-            ),
-        ],
+        inputs: vec![PrimedInput::new(
+            txid.into(),
+            vout.n,
+            input_amount,
+            htlc.unlock_with_secret(keypair, secret),
+        )],
         output_address: alice_addr.clone(),
         locktime: 0,
     }.sign_with_fee(fee);
@@ -148,14 +147,12 @@ fn redeem_refund_htlc() {
     let fee = BitcoinQuantity::from_satoshi(1000);
 
     let redeem_tx = PrimedTransaction {
-        inputs: vec![
-            PrimedInput::new(
-                txid.clone().into(),
-                vout.n,
-                input_amount,
-                htlc.unlock_after_timeout(keypair),
-            ),
-        ],
+        inputs: vec![PrimedInput::new(
+            txid.clone().into(),
+            vout.n,
+            input_amount,
+            htlc.unlock_after_timeout(keypair),
+        )],
         output_address: alice_addr.clone(),
         locktime: 0,
     }.sign_with_fee(fee);

--- a/application/common_types/src/secret.rs
+++ b/application/common_types/src/secret.rs
@@ -1,11 +1,8 @@
-use crypto::digest::Digest;
-use crypto::sha2::Sha256;
+use crypto::{digest::Digest, sha2::Sha256};
 use hex;
 use rand::{OsRng, Rng};
-use serde::de;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt;
-use std::str::FromStr;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use std::{fmt, str::FromStr};
 
 const SHA256_DIGEST_LENGTH: usize = 32;
 

--- a/application/common_types/src/trading_symbol.rs
+++ b/application/common_types/src/trading_symbol.rs
@@ -1,9 +1,7 @@
-use serde::Deserialize;
-use serde::Deserializer;
-use serde::Serialize;
-use serde::Serializer;
-use serde::de;
-use serde::de::Visitor;
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 use std::fmt;
 
 #[derive(PartialEq, Debug)]

--- a/application/ethereum_htlc/build.rs
+++ b/application/ethereum_htlc/build.rs
@@ -1,11 +1,12 @@
 extern crate regex;
 
 use regex::Regex;
-use std::env::var;
-use std::fs::File;
-use std::io::Write;
-use std::process::Command;
-use std::process::Stdio;
+use std::{
+    env::var,
+    fs::File,
+    io::Write,
+    process::{Command, Stdio},
+};
 
 const CONTRACT: &str = include_str!("./contract.asm");
 

--- a/application/ethereum_htlc/src/htlc.rs
+++ b/application/ethereum_htlc/src/htlc.rs
@@ -2,9 +2,7 @@ use chrono;
 use common_types::secret::SecretHash;
 use ethereum_support::{Address, Bytes, U256};
 use hex;
-use std::time::Duration;
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[derive(Debug)]
 pub struct Htlc {
@@ -82,7 +80,8 @@ impl Htlc {
     }
 
     pub fn compile_to_hex(&self) -> ByteCode {
-        let expiry_timestamp = self.expiry_timestamp
+        let expiry_timestamp = self
+            .expiry_timestamp
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs();

--- a/application/ethereum_htlc/tests/common/ganache_client.rs
+++ b/application/ethereum_htlc/tests/common/ganache_client.rs
@@ -41,7 +41,8 @@ impl GanacheClient {
     pub fn deploy(&self, from: Address, htlc: ethereum_htlc::Htlc, htlc_value: i32) -> Address {
         let compiled_contract = htlc.compile_to_hex();
 
-        let contract_tx_id = self.ganache_node
+        let contract_tx_id = self
+            .ganache_node
             .get_client()
             .eth()
             .send_transaction(TransactionRequest {
@@ -57,7 +58,8 @@ impl GanacheClient {
             .wait()
             .unwrap();
 
-        let receipt = self.ganache_node
+        let receipt = self
+            .ganache_node
             .get_client()
             .eth()
             .transaction_receipt(contract_tx_id)
@@ -71,7 +73,8 @@ impl GanacheClient {
     }
 
     pub fn send_data(&self, from: Address, to: Address, data: Option<Bytes>) -> U256 {
-        let result_tx = self.ganache_node
+        let result_tx = self
+            .ganache_node
             .get_client()
             .eth()
             .send_transaction(TransactionRequest {
@@ -87,7 +90,8 @@ impl GanacheClient {
             .wait()
             .unwrap();
 
-        let receipt = self.ganache_node
+        let receipt = self
+            .ganache_node
             .get_client()
             .eth()
             .transaction_receipt(result_tx)
@@ -99,7 +103,8 @@ impl GanacheClient {
     }
 
     pub fn activate_flux_compensator(&self, hours: u64) {
-        let _ = self.ganache_node
+        let _ = self
+            .ganache_node
             .get_client()
             .api::<ganache_rust_web3::Ganache<web3::transports::Http>>()
             .evm_increase_time(60 * 60 * hours)

--- a/application/ethereum_wallet/src/fake.rs
+++ b/application/ethereum_wallet/src/fake.rs
@@ -1,9 +1,10 @@
-use InMemoryWallet;
-use Wallet;
 use hex::FromHex;
 
 use secp256k1_support::KeyPair;
-use {SignedTransaction, UnsignedTransaction};
+use InMemoryWallet;
+use SignedTransaction;
+use UnsignedTransaction;
+use Wallet;
 
 /// A wallet with static private-keys that can be used for testing purposes.
 pub struct StaticFakeWallet(InMemoryWallet);

--- a/application/ethereum_wallet/src/transaction.rs
+++ b/application/ethereum_wallet/src/transaction.rs
@@ -1,6 +1,5 @@
 use ethereum_support::{Address, Bytes, H256, U256};
-use rlp::Encodable;
-use rlp::RlpStream;
+use rlp::{Encodable, RlpStream};
 use tiny_keccak::keccak256;
 
 pub struct UnsignedTransaction {
@@ -140,10 +139,10 @@ impl UnsignedTransaction {
 mod tests {
 
     use super::*;
-    use InMemoryWallet;
     use hex::FromHex;
     use secp256k1_support::KeyPair;
     use wallet::Wallet;
+    use InMemoryWallet;
 
     #[test]
     fn contract_deployment_transaction_should_have_correct_binary_representation() {

--- a/application/ethereum_wallet/src/wallet.rs
+++ b/application/ethereum_wallet/src/wallet.rs
@@ -1,5 +1,6 @@
 use secp256k1_support::{KeyPair, RecoverableSignature};
-use {SignedTransaction, UnsignedTransaction};
+use SignedTransaction;
+use UnsignedTransaction;
 
 pub trait Wallet: Send + Sync {
     fn sign<'a>(&self, tx: &'a UnsignedTransaction) -> SignedTransaction<'a>;

--- a/application/ethereum_wallet/tests/ganache_integration_tests.rs
+++ b/application/ethereum_wallet/tests/ganache_integration_tests.rs
@@ -22,7 +22,8 @@ fn given_manually_signed_transaction_when_sent_then_it_spends_from_correct_addre
     let get_balance = || web3.eth().balance(account, None).wait().unwrap();
     let send_transaction = |transaction| {
         let txid = web3.eth().send_raw_transaction(transaction).wait().unwrap();
-        let receipt = web3.eth()
+        let receipt = web3
+            .eth()
             .transaction_receipt(txid)
             .wait()
             .unwrap()

--- a/application/exchange_service/src/bin/exchange_service.rs
+++ b/application/exchange_service/src/bin/exchange_service.rs
@@ -24,17 +24,17 @@ use bitcoin_rpc::BitcoinRpcApi;
 use bitcoin_support::{Network, PrivateKey};
 use ethereum_support::*;
 use ethereum_wallet::InMemoryWallet;
-use exchange_service::bitcoin_fee_service::StaticBitcoinFeeService;
-use exchange_service::ethereum_service::EthereumService;
-use exchange_service::event_store::EventStore;
-use exchange_service::gas_price_service::StaticGasPriceService;
-use exchange_service::rocket_factory::create_rocket_instance;
-use exchange_service::treasury_api_client::{DefaultApiClient, TreasuryApiUrl};
+use exchange_service::{
+    bitcoin_fee_service::StaticBitcoinFeeService,
+    ethereum_service::EthereumService,
+    event_store::EventStore,
+    gas_price_service::StaticGasPriceService,
+    rocket_factory::create_rocket_instance,
+    treasury_api_client::{DefaultApiClient, TreasuryApiUrl},
+};
 use hex::FromHex;
 use secp256k1_support::KeyPair;
-use std::env::var;
-use std::str::FromStr;
-use std::sync::Arc;
+use std::{env::var, str::FromStr, sync::Arc};
 
 // TODO: Make a nice command line interface here (using StructOpt f.e.)
 fn main() {

--- a/application/exchange_service/src/ethereum_service.rs
+++ b/application/exchange_service/src/ethereum_service.rs
@@ -1,13 +1,11 @@
 use ethereum_htlc::Htlc;
 use ethereum_support::*;
 use ethereum_wallet;
-use gas_price_service;
-use gas_price_service::GasPriceService;
-use std::ops::DerefMut;
-use std::sync::Arc;
-use std::sync::Mutex;
-use std::sync::MutexGuard;
-use std::sync::PoisonError;
+use gas_price_service::{self, GasPriceService};
+use std::{
+    ops::DerefMut,
+    sync::{Arc, Mutex, MutexGuard, PoisonError},
+};
 
 #[derive(Debug)]
 pub enum Error {
@@ -116,9 +114,7 @@ mod tests {
     use super::*;
     use common_types::secret::SecretHash;
     use ethereum_support;
-    use std::ops::Deref;
-    use std::str::FromStr;
-    use std::time::SystemTime;
+    use std::{ops::Deref, str::FromStr, time::SystemTime};
 
     struct EthereumApiMock {
         result: Result<H256, web3::Error>,

--- a/application/exchange_service/src/event_store.rs
+++ b/application/exchange_service/src/event_store.rs
@@ -1,18 +1,16 @@
 pub use self::OfferCreated as OfferState;
 use bitcoin_rpc;
-use bitcoin_support;
-use bitcoin_support::BitcoinQuantity;
+use bitcoin_support::{self, BitcoinQuantity};
 use common_types::secret::SecretHash;
-use ethereum_support;
-use ethereum_support::*;
+use ethereum_support::{self, *};
 use secp256k1_support::KeyPair;
-use std::collections::HashMap;
-use std::fmt;
-use std::sync::RwLock;
-use std::time::Duration;
-use std::time::SystemTime;
-use treasury_api_client::RateResponseBody;
-use treasury_api_client::Symbol;
+use std::{
+    collections::HashMap,
+    fmt,
+    sync::RwLock,
+    time::{Duration, SystemTime},
+};
+use treasury_api_client::{RateResponseBody, Symbol};
 use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/application/exchange_service/src/gas_price_service/static_gas_price_service.rs
+++ b/application/exchange_service/src/gas_price_service/static_gas_price_service.rs
@@ -1,6 +1,5 @@
 use ethereum_support::U256;
-use gas_price_service::Error;
-use gas_price_service::GasPriceService;
+use gas_price_service::{Error, GasPriceService};
 
 pub struct StaticGasPriceService(U256);
 

--- a/application/exchange_service/src/rocket_factory.rs
+++ b/application/exchange_service/src/rocket_factory.rs
@@ -1,7 +1,6 @@
 use bitcoin_fee_service::BitcoinFeeService;
 use bitcoin_rpc;
-use bitcoin_support;
-use bitcoin_support::Network;
+use bitcoin_support::{self, Network};
 use ethereum_service::EthereumService;
 use ethereum_support;
 use event_store::EventStore;

--- a/application/exchange_service/src/routes/chain_updates.rs
+++ b/application/exchange_service/src/routes/chain_updates.rs
@@ -1,19 +1,13 @@
-use bitcoin_fee_service;
-use bitcoin_fee_service::BitcoinFeeService;
-use bitcoin_htlc;
-use bitcoin_htlc::UnlockingError;
+use bitcoin_fee_service::{self, BitcoinFeeService};
+use bitcoin_htlc::{self, UnlockingError};
 use bitcoin_rpc;
-use bitcoin_support;
-use bitcoin_support::PubkeyHash;
+use bitcoin_support::{self, PubkeyHash};
 use bitcoin_witness::{PrimedInput, PrimedTransaction};
 use common_types::secret::Secret;
-use event_store::EventStore;
-use event_store::TradeId;
-use rocket::State;
-use rocket::response::status::BadRequest;
+use event_store::{EventStore, TradeId};
+use rocket::{response::status::BadRequest, State};
 use rocket_contrib::Json;
-use std::fmt::Debug;
-use std::sync::Arc;
+use std::{fmt::Debug, sync::Arc};
 
 //TODO: move back to eth_btc.rs
 
@@ -40,8 +34,11 @@ impl From<bitcoin_fee_service::Error> for BadRequest<String> {
     }
 }
 
-#[post("/trades/ETH-BTC/<trade_id>/buy-order-secret-revealed", format = "application/json",
-       data = "<redeem_btc_notification_body>")]
+#[post(
+    "/trades/ETH-BTC/<trade_id>/buy-order-secret-revealed",
+    format = "application/json",
+    data = "<redeem_btc_notification_body>"
+)]
 pub fn post_revealed_secret(
     redeem_btc_notification_body: Json<RedeemBTCNotificationBody>,
     event_store: State<EventStore>,
@@ -86,14 +83,12 @@ pub fn post_revealed_secret(
     let unlocking_parameters = htlc.unlock_with_secret(exchange_success_keypair.clone(), secret);
 
     let primed_txn = PrimedTransaction {
-        inputs: vec![
-            PrimedInput::new(
-                htlc_txid.clone().into(),
-                vout,
-                offer_created_event.btc_amount(),
-                unlocking_parameters,
-            ),
-        ],
+        inputs: vec![PrimedInput::new(
+            htlc_txid.clone().into(),
+            vout,
+            offer_created_event.btc_amount(),
+            unlocking_parameters,
+        )],
         output_address: btc_exchange_redeem_address.clone(),
         locktime: 0,
     };

--- a/application/exchange_service/src/routes/eth_btc.rs
+++ b/application/exchange_service/src/routes/eth_btc.rs
@@ -4,26 +4,16 @@ use common_types::secret::SecretHash;
 use ethereum_htlc;
 use ethereum_service;
 use ethereum_support;
-use event_store;
-use event_store::ContractDeployed;
-use event_store::EventStore;
-use event_store::OfferCreated;
 pub use event_store::OfferCreated as OfferRequestResponse;
-use event_store::OfferState;
-use event_store::OrderTaken;
-use event_store::TradeFunded;
-use event_store::TradeId;
-use rocket::State;
-use rocket::http::RawStr;
-use rocket::request::FromParam;
-use rocket::response::status::BadRequest;
+use event_store::{
+    self, ContractDeployed, EventStore, OfferCreated, OfferState, OrderTaken, TradeFunded, TradeId,
+};
+use rocket::{http::RawStr, request::FromParam, response::status::BadRequest, State};
 use rocket_contrib::Json;
 use secp256k1_support::KeyPair;
-use std::sync::Arc;
-use std::time::UNIX_EPOCH;
+use std::{sync::Arc, time::UNIX_EPOCH};
 use treasury_api_client::{ApiClient, Symbol};
-use uuid;
-use uuid::Uuid;
+use uuid::{self, Uuid};
 
 impl<'a> FromParam<'a> for TradeId {
     type Error = uuid::ParseError;
@@ -109,8 +99,11 @@ impl From<OrderTaken> for OrderTakenResponseBody {
     }
 }
 
-#[post("/trades/ETH-BTC/<trade_id>/buy-orders", format = "application/json",
-       data = "<order_request_body>")]
+#[post(
+    "/trades/ETH-BTC/<trade_id>/buy-orders",
+    format = "application/json",
+    data = "<order_request_body>"
+)]
 pub fn post_buy_orders(
     trade_id: TradeId,
     order_request_body: Json<OrderRequestBody>,
@@ -176,8 +169,11 @@ pub struct BuyOrderHtlcFundedNotification {
     vout: u32,
 }
 
-#[post("/trades/ETH-BTC/<trade_id>/buy-order-htlc-funded", format = "application/json",
-       data = "<buy_order_htlc_funded_notification>")]
+#[post(
+    "/trades/ETH-BTC/<trade_id>/buy-order-htlc-funded",
+    format = "application/json",
+    data = "<buy_order_htlc_funded_notification>"
+)]
 pub fn post_buy_orders_fundings(
     trade_id: TradeId,
     buy_order_htlc_funded_notification: Json<BuyOrderHtlcFundedNotification>,
@@ -229,14 +225,15 @@ mod tests {
     use ethereum_support::*;
     use ethereum_wallet::fake::StaticFakeWallet;
     use gas_price_service::StaticGasPriceService;
-    use rocket;
-    use rocket::http::{ContentType, Status};
-    use rocket::local::{Client, LocalResponse};
+    use rocket::{
+        self,
+        http::{ContentType, Status},
+        local::{Client, LocalResponse},
+    };
     use rocket_factory::create_rocket_instance;
     use serde::Deserialize;
     use serde_json;
-    use std::str::FromStr;
-    use std::sync::Arc;
+    use std::{str::FromStr, sync::Arc};
     use treasury_api_client::FakeApiClient;
 
     fn request_offer(client: &mut Client) -> LocalResponse {
@@ -394,9 +391,9 @@ mod tests {
             let mut response = request_offer(&mut client);
             assert_eq!(response.status(), Status::Ok);
 
-            let response =
-                serde_json::from_str::<serde_json::Value>(&response.body_string().unwrap())
-                    .unwrap();
+            let response = serde_json::from_str::<serde_json::Value>(
+                &response.body_string().unwrap(),
+            ).unwrap();
 
             response["uid"].as_str().unwrap().to_string()
         };

--- a/application/exchange_service/src/treasury_api_client/fake_client.rs
+++ b/application/exchange_service/src/treasury_api_client/fake_client.rs
@@ -1,5 +1,4 @@
-use super::Symbol;
-use super::client::ApiClient;
+use super::{client::ApiClient, Symbol};
 use bitcoin_support::BitcoinQuantity;
 use ethereum_support::EthereumQuantity;
 use reqwest;

--- a/application/fake_treasury_service/src/main.rs
+++ b/application/fake_treasury_service/src/main.rs
@@ -13,12 +13,9 @@ extern crate ethereum_support;
 
 use bitcoin_support::BitcoinQuantity;
 use ethereum_support::EthereumQuantity;
-use rocket::State;
-use rocket::http::RawStr;
-use rocket::response::status::BadRequest;
+use rocket::{http::RawStr, response::status::BadRequest, State};
 use rocket_contrib::Json;
-use std::env::var;
-use std::str::FromStr;
+use std::{env::var, str::FromStr};
 
 #[derive(Deserialize, Debug, FromForm)]
 pub struct RateRequestParams {

--- a/application/trading_client/src/bin/trading_client.rs
+++ b/application/trading_client/src/bin/trading_client.rs
@@ -7,16 +7,14 @@ extern crate structopt;
 extern crate trading_client;
 extern crate uuid;
 
-use std::env::var;
-use std::str::FromStr;
-use std::string::String;
+use std::{env::var, str::FromStr, string::String};
 use structopt::StructOpt;
-use trading_client::offer;
-use trading_client::offer::{OrderType, Symbol};
-use trading_client::order;
-use trading_client::redeem;
-use trading_client::redeem::RedeemOutput;
-use trading_client::trading_service_api_client::TradingApiUrl;
+use trading_client::{
+    offer::{self, OrderType, Symbol},
+    order,
+    redeem::{self, RedeemOutput},
+    trading_service_api_client::TradingApiUrl,
+};
 use uuid::Uuid;
 
 #[derive(Debug, StructOpt)]
@@ -32,8 +30,11 @@ enum Opt {
         #[structopt(subcommand)]
         order_type: OrderType,
         /// The amount you want to exchange (buy for a buy order, sell for a sell order). Integer.
-        #[structopt(short = "a", long = "amount",
-                    name = "amount to exchange (buy for a buy order, sell for a sell order). Integer.")]
+        #[structopt(
+            short = "a",
+            long = "amount",
+            name = "amount to exchange (buy for a buy order, sell for a sell order). Integer."
+        )]
         amount: f64,
     },
     /// Accept an order
@@ -46,12 +47,16 @@ enum Opt {
         #[structopt(short = "u", long = "uid", name = "trade id")]
         uid: Uuid,
         /// The address to receive the traded currency
-        #[structopt(short = "d", long = "success-address",
-                    name = "address to receive the traded currency")]
+        #[structopt(
+            short = "d", long = "success-address", name = "address to receive the traded currency"
+        )]
         success_address: String,
         /// The address to receive a refund in the original currency in case the trade is cancelled
-        #[structopt(short = "r", long = "refund-address",
-                    name = "address to receive your refund in case of cancellation")]
+        #[structopt(
+            short = "r",
+            long = "refund-address",
+            name = "address to receive your refund in case of cancellation"
+        )]
         refund_address: String,
     },
     /// Get details to proceed with redeem transaction

--- a/application/trading_client/src/offer.rs
+++ b/application/trading_client/src/offer.rs
@@ -1,14 +1,11 @@
-use serde::Deserialize;
-use serde::Deserializer;
-use serde::de;
-use serde::de::Visitor;
-use std::fmt;
-use std::str::FromStr;
-use trading_service_api_client::ApiClient;
-use trading_service_api_client::BuyOfferRequestBody;
-use trading_service_api_client::TradingApiUrl;
-use trading_service_api_client::TradingServiceError;
-use trading_service_api_client::create_client;
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer,
+};
+use std::{fmt, str::FromStr};
+use trading_service_api_client::{
+    create_client, ApiClient, BuyOfferRequestBody, TradingApiUrl, TradingServiceError,
+};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Currency(String);

--- a/application/trading_client/src/order.rs
+++ b/application/trading_client/src/order.rs
@@ -1,9 +1,7 @@
 use offer::Symbol;
-use trading_service_api_client::ApiClient;
-use trading_service_api_client::BuyOrderRequestBody;
-use trading_service_api_client::TradingApiUrl;
-use trading_service_api_client::TradingServiceError;
-use trading_service_api_client::create_client;
+use trading_service_api_client::{
+    create_client, ApiClient, BuyOrderRequestBody, TradingApiUrl, TradingServiceError,
+};
 use uuid::Uuid;
 
 pub fn run(

--- a/application/trading_client/src/redeem.rs
+++ b/application/trading_client/src/redeem.rs
@@ -1,12 +1,8 @@
 use common_types;
 use ethereum_support;
 use offer::Symbol;
-use std::fmt;
-use std::ops::Add;
-use trading_service_api_client::ApiClient;
-use trading_service_api_client::TradingApiUrl;
-use trading_service_api_client::TradingServiceError;
-use trading_service_api_client::create_client;
+use std::{fmt, ops::Add};
+use trading_service_api_client::{create_client, ApiClient, TradingApiUrl, TradingServiceError};
 use uuid::Uuid;
 
 pub enum RedeemOutput {

--- a/application/trading_client/src/trading_service_api_client/client.rs
+++ b/application/trading_client/src/trading_service_api_client/client.rs
@@ -1,15 +1,12 @@
 use bitcoin_rpc;
 use bitcoin_support::BitcoinQuantity;
 use common_types;
-use ethereum_support;
-use ethereum_support::EthereumQuantity;
+use ethereum_support::{self, EthereumQuantity};
 use offer::Symbol;
 use regex::Regex;
 use reqwest;
-use std::fmt;
-use std::str::FromStr;
-use uuid::ParseError;
-use uuid::Uuid;
+use std::{fmt, str::FromStr};
+use uuid::{ParseError, Uuid};
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct TradeId(Uuid);

--- a/application/trading_client/src/trading_service_api_client/fake_client.rs
+++ b/application/trading_client/src/trading_service_api_client/fake_client.rs
@@ -2,17 +2,13 @@ use super::client::ApiClient;
 use bitcoin_rpc;
 use bitcoin_support::BitcoinQuantity;
 use common_types;
-use ethereum_support;
-use ethereum_support::EthereumQuantity;
+use ethereum_support::{self, EthereumQuantity};
 use offer::Symbol;
 use std::str::FromStr;
-use trading_service_api_client::BuyOfferRequestBody;
-use trading_service_api_client::BuyOrderRequestBody;
-use trading_service_api_client::OfferResponseBody;
-use trading_service_api_client::RequestToFund;
-use trading_service_api_client::TradeId;
-use trading_service_api_client::client::RedeemDetails;
-use trading_service_api_client::client::TradingServiceError;
+use trading_service_api_client::{
+    client::{RedeemDetails, TradingServiceError},
+    BuyOfferRequestBody, BuyOrderRequestBody, OfferResponseBody, RequestToFund, TradeId,
+};
 use uuid::Uuid;
 
 #[allow(dead_code)]

--- a/application/trading_client/src/trading_service_api_client/mod.rs
+++ b/application/trading_client/src/trading_service_api_client/mod.rs
@@ -4,14 +4,10 @@ use reqwest;
 mod client;
 mod fake_client;
 
-pub use self::client::ApiClient;
-pub use self::client::BuyOfferRequestBody;
-pub use self::client::BuyOrderRequestBody;
-pub use self::client::OfferResponseBody;
-pub use self::client::RequestToFund;
-pub use self::client::TradeId;
-pub use self::client::TradingApiUrl;
-pub use self::client::TradingServiceError;
+pub use self::client::{
+    ApiClient, BuyOfferRequestBody, BuyOrderRequestBody, OfferResponseBody, RequestToFund, TradeId,
+    TradingApiUrl, TradingServiceError,
+};
 
 #[cfg(test)]
 pub fn create_client(_url: &TradingApiUrl) -> impl ApiClient {

--- a/application/trading_service/src/bin/trading_service.rs
+++ b/application/trading_service/src/bin/trading_service.rs
@@ -11,8 +11,9 @@ extern crate trading_service;
 
 use bitcoin_support::Network;
 use std::env::var;
-use trading_service::exchange_api_client::ExchangeApiUrl;
-use trading_service::rocket_factory::create_rocket_instance;
+use trading_service::{
+    exchange_api_client::ExchangeApiUrl, rocket_factory::create_rocket_instance,
+};
 
 fn main() {
     let _ = env_logger::init();

--- a/application/trading_service/src/event_store.rs
+++ b/application/trading_service/src/event_store.rs
@@ -1,14 +1,10 @@
 use bitcoin_htlc::Htlc;
-use bitcoin_rpc;
-use bitcoin_rpc::BlockHeight;
+use bitcoin_rpc::{self, BlockHeight};
 use bitcoin_support::BitcoinQuantity;
-use ethereum_support;
-use ethereum_support::EthereumQuantity;
+use ethereum_support::{self, EthereumQuantity};
 use exchange_api_client::OfferResponseBody;
 use secret::Secret;
-use std::collections::HashMap;
-use std::fmt;
-use std::sync::RwLock;
+use std::{collections::HashMap, fmt, sync::RwLock};
 use symbol::Symbol;
 use uuid::Uuid;
 

--- a/application/trading_service/src/exchange_api_client/client.rs
+++ b/application/trading_service/src/exchange_api_client/client.rs
@@ -1,7 +1,6 @@
 use bitcoin_rpc;
 use bitcoin_support::BitcoinQuantity;
-use ethereum_support;
-use ethereum_support::EthereumQuantity;
+use ethereum_support::{self, EthereumQuantity};
 use event_store::TradeId;
 use reqwest;
 use secret::SecretHash;

--- a/application/trading_service/src/routes/eth_btc.rs
+++ b/application/trading_service/src/routes/eth_btc.rs
@@ -1,35 +1,20 @@
-use bitcoin_htlc;
-use bitcoin_htlc::Htlc as BtcHtlc;
-use bitcoin_rpc;
-use bitcoin_rpc::BlockHeight;
-use bitcoin_support;
-use bitcoin_support::{BitcoinQuantity, Network, PubkeyHash};
-use ethereum_support;
-use ethereum_support::EthereumQuantity;
-use event_store;
-use event_store::ContractDeployed;
-use event_store::EventStore;
-use event_store::OfferCreated;
-use event_store::OrderCreated;
-use event_store::OrderTaken;
-use event_store::TradeId;
-use exchange_api_client::ApiClient;
-use exchange_api_client::ExchangeApiUrl;
-use exchange_api_client::OfferResponseBody;
-use exchange_api_client::OrderRequestBody;
-use exchange_api_client::create_client;
+use bitcoin_htlc::{self, Htlc as BtcHtlc};
+use bitcoin_rpc::{self, BlockHeight};
+use bitcoin_support::{self, BitcoinQuantity, Network, PubkeyHash};
+use ethereum_support::{self, EthereumQuantity};
+use event_store::{
+    self, ContractDeployed, EventStore, OfferCreated, OrderCreated, OrderTaken, TradeId,
+};
+use exchange_api_client::{
+    create_client, ApiClient, ExchangeApiUrl, OfferResponseBody, OrderRequestBody,
+};
 use rand::OsRng;
-use rocket::State;
-use rocket::http::RawStr;
-use rocket::request::FromParam;
-use rocket::response::status::BadRequest;
+use rocket::{http::RawStr, request::FromParam, response::status::BadRequest, State};
 use rocket_contrib::Json;
 use secret::Secret;
-use std::str::FromStr;
-use std::sync::Mutex;
+use std::{str::FromStr, sync::Mutex};
 use symbol::Symbol;
-use uuid;
-use uuid::Uuid;
+use uuid::{self, Uuid};
 
 impl<'a> FromParam<'a> for TradeId {
     type Error = uuid::ParseError;
@@ -97,8 +82,11 @@ impl From<event_store::Error> for BadRequest<String> {
     }
 }
 
-#[post("/trades/ETH-BTC/<trade_id>/buy-orders", format = "application/json",
-       data = "<buy_order_request_body>")]
+#[post(
+    "/trades/ETH-BTC/<trade_id>/buy-orders",
+    format = "application/json",
+    data = "<buy_order_request_body>"
+)]
 pub fn post_buy_orders(
     trade_id: TradeId,
     buy_order_request_body: Json<BuyOrderRequestBody>,
@@ -197,8 +185,11 @@ pub struct ContractDeployedRequestBody {
     pub contract_address: ethereum_support::Address,
 }
 
-#[post("/trades/ETH-BTC/<trade_id>/buy-order-contract-deployed", format = "application/json",
-       data = "<contract_deployed_request_body>")]
+#[post(
+    "/trades/ETH-BTC/<trade_id>/buy-order-contract-deployed",
+    format = "application/json",
+    data = "<contract_deployed_request_body>"
+)]
 pub fn post_contract_deployed(
     trade_id: TradeId,
     contract_deployed_request_body: Json<ContractDeployedRequestBody>,
@@ -241,8 +232,7 @@ pub fn get_redeem_orders(
 mod tests {
     use super::*;
     use exchange_api_client::ExchangeApiUrl;
-    use rocket;
-    use rocket::http::*;
+    use rocket::{self, http::*};
     use rocket_factory::create_rocket_instance;
     use serde_json;
 

--- a/check-fmt.sh
+++ b/check-fmt.sh
@@ -3,4 +3,4 @@ set -eu
 
 CARGO_BIN=$(expr "$(which cargo)" '|' "$HOME/.cargo/bin/cargo");
 
-"${CARGO_BIN}" +stable-2018-05-10 fmt -- --write-mode diff
+"${CARGO_BIN}" fmt -- --check

--- a/fmt.sh
+++ b/fmt.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-cargo +stable-2018-05-10 fmt

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+merge_imports = true

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 
 PROJECT_RUST_VERSION=nightly-2018-06-24
-RUSTFMT_RUST_VERSION=stable-2018-05-10
 
 rustup toolchain install ${PROJECT_RUST_VERSION}
-rustup toolchain install ${RUSTFMT_RUST_VERSION}
 
-rustup component add rustfmt-preview --toolchain=${RUSTFMT_RUST_VERSION}
+rustup component add rustfmt-preview --toolchain=${PROJECT_RUST_VERSION}
 
 echo ${PROJECT_RUST_VERSION} > rust-toolchain
 

--- a/vendor/bitcoin_node/src/lib.rs
+++ b/vendor/bitcoin_node/src/lib.rs
@@ -3,9 +3,11 @@ extern crate testcontainers;
 
 use bitcoin_rpc::*;
 use std::env::var;
-use testcontainers::clients::DockerCli;
-use testcontainers::images::{Bitcoind, BitcoindImageArgs};
-use testcontainers::*;
+use testcontainers::{
+    clients::DockerCli,
+    images::{Bitcoind, BitcoindImageArgs},
+    *,
+};
 
 pub struct BitcoinNode {
     container_id: String,

--- a/vendor/bitcoin_rpc/src/bitcoin_rpc_api.rs
+++ b/vendor/bitcoin_rpc/src/bitcoin_rpc_api.rs
@@ -1,6 +1,5 @@
 use bitcoincore::TxOutConfirmations;
-use jsonrpc::HTTPError;
-use jsonrpc::RpcResponse;
+use jsonrpc::{HTTPError, RpcResponse};
 use types::*;
 
 pub trait BitcoinRpcApi: Send + Sync {

--- a/vendor/bitcoin_rpc/src/bitcoincore.rs
+++ b/vendor/bitcoin_rpc/src/bitcoincore.rs
@@ -1,13 +1,11 @@
-use BitcoinRpcApi;
-use jsonrpc::HTTPClient;
-use jsonrpc::HTTPError;
-use jsonrpc::header::{Authorization, Basic, Headers};
-use jsonrpc::{JsonRpcVersion, RpcClient, RpcRequest, RpcResponse};
-use serde::de::DeserializeOwned;
-use serde::ser::Serialize;
+use jsonrpc::{
+    header::{Authorization, Basic, Headers},
+    HTTPClient, HTTPError, JsonRpcVersion, RpcClient, RpcRequest, RpcResponse,
+};
+use serde::{de::DeserializeOwned, ser::Serialize};
 use std::fmt::Debug;
-use types::Address;
-use types::*;
+use types::{Address, *};
+use BitcoinRpcApi;
 
 struct RetryConfig {
     max_retries: u32,

--- a/vendor/bitcoin_rpc/src/stub_rpc_client.rs
+++ b/vendor/bitcoin_rpc/src/stub_rpc_client.rs
@@ -1,9 +1,8 @@
+use bitcoincore::TxOutConfirmations;
+use jsonrpc::{HTTPError, RpcResponse};
+use types::*;
 use BitcoinRpcApi;
 use NewTransactionOutput;
-use bitcoincore::TxOutConfirmations;
-use jsonrpc::HTTPError;
-use jsonrpc::RpcResponse;
-use types::*;
 
 pub struct BitcoinStubClient {}
 

--- a/vendor/bitcoin_rpc/src/types/address.rs
+++ b/vendor/bitcoin_rpc/src/types/address.rs
@@ -1,15 +1,11 @@
-use bitcoin;
-use bitcoin::util::address::Address as BitcoinAddress;
-use serde::Deserialize;
-use serde::Deserializer;
-use serde::Serialize;
-use serde::Serializer;
-use serde::de;
-use std::convert::Into;
-use std::fmt;
-use std::hash::Hash;
-use std::hash::Hasher;
-use std::str::FromStr;
+use bitcoin::{self, util::address::Address as BitcoinAddress};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use std::{
+    convert::Into,
+    fmt,
+    hash::{Hash, Hasher},
+    str::FromStr,
+};
 use types::ScriptType;
 
 #[derive(Debug, PartialEq, Clone)]

--- a/vendor/bitcoin_rpc/src/types/keys.rs
+++ b/vendor/bitcoin_rpc/src/types/keys.rs
@@ -1,11 +1,6 @@
 use bitcoin::util::privkey::Privkey;
-use serde::Deserialize;
-use serde::Serialize;
-use serde::de;
-use serde::export::fmt;
-use serde::{Deserializer, Serializer};
-use std::fmt as std_fmt;
-use std::str::FromStr;
+use serde::{de, export::fmt, Deserialize, Deserializer, Serialize, Serializer};
+use std::{fmt as std_fmt, str::FromStr};
 
 #[derive(PartialEq)]
 pub struct PrivateKey(Privkey);

--- a/vendor/bitcoin_rpc/src/types/mod.rs
+++ b/vendor/bitcoin_rpc/src/types/mod.rs
@@ -36,9 +36,4 @@ pub enum SigHashType {
     Single_AnyoneCanPay,
 }
 
-pub use self::address::*;
-pub use self::block::*;
-pub use self::blockchain::*;
-pub use self::keys::*;
-pub use self::script::*;
-pub use self::transaction::*;
+pub use self::{address::*, block::*, blockchain::*, keys::*, script::*, transaction::*};

--- a/vendor/bitcoin_rpc/src/types/serde/network.rs
+++ b/vendor/bitcoin_rpc/src/types/serde/network.rs
@@ -1,6 +1,5 @@
 use bitcoin::network::constants::Network;
-use serde::Deserializer;
-use serde::de;
+use serde::{de, Deserializer};
 use std::fmt;
 
 pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Network, D::Error>

--- a/vendor/bitcoin_rpc/src/types/serde/script.rs
+++ b/vendor/bitcoin_rpc/src/types/serde/script.rs
@@ -1,8 +1,5 @@
 use bitcoin::blockdata::script::Script;
-use serde::Deserializer;
-use serde::Serializer;
-use serde::de;
-use serde::export::fmt;
+use serde::{de, export::fmt, Deserializer, Serializer};
 use std_hex;
 
 pub fn deserialize<'de, D>(deserializer: D) -> Result<Script, D::Error>

--- a/vendor/bitcoin_rpc/src/types/transaction.rs
+++ b/vendor/bitcoin_rpc/src/types/transaction.rs
@@ -1,13 +1,11 @@
-use bitcoin;
-use bitcoin::blockdata::script::Script;
-use bitcoin::blockdata::transaction::Transaction as BitcoinTransaction;
-use bitcoin::network::serialize as bitcoin_serialize;
-use bitcoin::util::hash::{HexError, Sha256dHash};
-use serde::de;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::collections::HashMap;
-use std::fmt;
-use std::str::FromStr;
+use bitcoin::{
+    self,
+    blockdata::{script::Script, transaction::Transaction as BitcoinTransaction},
+    network::serialize as bitcoin_serialize,
+    util::hash::{HexError, Sha256dHash},
+};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use std::{collections::HashMap, fmt, str::FromStr};
 use types::*;
 
 #[derive(Debug, PartialEq, Clone)]

--- a/vendor/bitcoin_rpc/tests/common/test_client.rs
+++ b/vendor/bitcoin_rpc/tests/common/test_client.rs
@@ -12,7 +12,8 @@ impl<'a> BitcoinCoreTestClient<'a> {
     pub fn a_utxo(&self) -> UnspentTransactionOutput {
         let _ = self.a_block(); // Need to generate a block first
 
-        let mut utxos = self.client
+        let mut utxos = self
+            .client
             .list_unspent(TxOutConfirmations::AtLeast(6), None, None)
             .unwrap()
             .into_result()

--- a/vendor/bitcoin_rpc/tests/integration_tests.rs
+++ b/vendor/bitcoin_rpc/tests/integration_tests.rs
@@ -7,9 +7,9 @@ extern crate log;
 mod common;
 
 use bitcoin_rpc::*;
-use common::assert::assert_successful_result;
-use common::test_client::BitcoinCoreTestClient;
-use common::test_lifecycle::setup;
+use common::{
+    assert::assert_successful_result, test_client::BitcoinCoreTestClient, test_lifecycle::setup,
+};
 use std::collections::HashMap;
 
 #[test]

--- a/vendor/bitcoin_rpc_helpers/src/lib.rs
+++ b/vendor/bitcoin_rpc_helpers/src/lib.rs
@@ -1,8 +1,9 @@
 // Place for putting common queries needed in tests
 extern crate bitcoin_rpc;
 extern crate bitcoin_support;
-use bitcoin_rpc::BitcoinRpcApi;
-use bitcoin_rpc::{TransactionId, TransactionOutput, TxOutConfirmations, UnspentTransactionOutput};
+use bitcoin_rpc::{
+    BitcoinRpcApi, TransactionId, TransactionOutput, TxOutConfirmations, UnspentTransactionOutput,
+};
 use bitcoin_support::{Address, BitcoinQuantity, Network, Sha256dHash, ToP2wpkhAddress};
 
 pub trait RegtestHelperClient {
@@ -31,24 +32,27 @@ impl<Rpc: BitcoinRpcApi> RegtestHelperClient for Rpc {
         txid: &TransactionId,
         address: &Address,
     ) -> Option<UnspentTransactionOutput> {
-        let unspent = self.list_unspent(
-            TxOutConfirmations::AtLeast(1),
-            None,
-            Some(vec![address.clone().into()]),
-        ).unwrap()
-            .into_result()
-            .unwrap();
+        let unspent =
+            self.list_unspent(
+                TxOutConfirmations::AtLeast(1),
+                None,
+                Some(vec![address.clone().into()]),
+            ).unwrap()
+                .into_result()
+                .unwrap();
 
         unspent.into_iter().find(|utxo| utxo.txid == *txid)
     }
 
     fn find_vout_for_address(&self, txid: &TransactionId, address: &Address) -> TransactionOutput {
-        let raw_txn = self.get_raw_transaction_serialized(&txid)
+        let raw_txn = self
+            .get_raw_transaction_serialized(&txid)
             .unwrap()
             .into_result()
             .unwrap();
 
-        let decoded_txn = self.decode_rawtransaction(raw_txn.clone())
+        let decoded_txn = self
+            .decode_rawtransaction(raw_txn.clone())
             .unwrap()
             .into_result()
             .unwrap();
@@ -68,7 +72,8 @@ impl<Rpc: BitcoinRpcApi> RegtestHelperClient for Rpc {
     ) -> (Sha256dHash, TransactionOutput) {
         let address = dest.to_p2wpkh_address(Network::BitcoinCoreRegtest);
 
-        let txid = self.send_to_address(&address.clone().into(), value.bitcoin())
+        let txid = self
+            .send_to_address(&address.clone().into(), value.bitcoin())
             .unwrap()
             .into_result()
             .unwrap();

--- a/vendor/bitcoin_support/src/bitcoin_quantity.rs
+++ b/vendor/bitcoin_support/src/bitcoin_quantity.rs
@@ -1,5 +1,7 @@
-use std::fmt;
-use std::ops::{Add, Sub};
+use std::{
+    fmt,
+    ops::{Add, Sub},
+};
 
 #[derive(Serialize, PartialEq, Deserialize, Clone, Debug, Copy)]
 pub struct BitcoinQuantity(u64);

--- a/vendor/bitcoin_support/src/lib.rs
+++ b/vendor/bitcoin_support/src/lib.rs
@@ -12,11 +12,16 @@ pub use bitcoin_quantity::*;
 pub use pubkey::*;
 pub use weight::*;
 
-pub use bitcoin::blockdata::script::Script;
-pub use bitcoin::blockdata::transaction::{Transaction, TxIn, TxOut};
-pub use bitcoin::network::constants::Network;
-pub use bitcoin::network::serialize;
-pub use bitcoin::util::address::Address;
-pub use bitcoin::util::bip143::SighashComponents;
-pub use bitcoin::util::hash::{Hash160, Sha256dHash};
-pub use bitcoin::util::privkey::Privkey as PrivateKey;
+pub use bitcoin::{
+    blockdata::{
+        script::Script,
+        transaction::{Transaction, TxIn, TxOut},
+    },
+    network::{constants::Network, serialize},
+    util::{
+        address::Address,
+        bip143::SighashComponents,
+        hash::{Hash160, Sha256dHash},
+        privkey::Privkey as PrivateKey,
+    },
+};

--- a/vendor/bitcoin_support/src/pubkey.rs
+++ b/vendor/bitcoin_support/src/pubkey.rs
@@ -1,7 +1,10 @@
-use bitcoin::network::constants::Network;
-use bitcoin::util::address::Address;
-use bitcoin::util::address::Payload;
-use bitcoin::util::hash::Hash160;
+use bitcoin::{
+    network::constants::Network,
+    util::{
+        address::{Address, Payload},
+        hash::Hash160,
+    },
+};
 use secp256k1_support::PublicKey;
 use std::fmt;
 

--- a/vendor/bitcoin_witness/src/primed_transaction.rs
+++ b/vendor/bitcoin_witness/src/primed_transaction.rs
@@ -1,5 +1,7 @@
-use bitcoin_support::{Address, BitcoinQuantity, Script, Sha256dHash, SighashComponents,
-                      Transaction, TxIn, TxOut, Weight};
+use bitcoin_support::{
+    Address, BitcoinQuantity, Script, Sha256dHash, SighashComponents, Transaction, TxIn, TxOut,
+    Weight,
+};
 use secp256k1_support::{DerSerializableSignature, Message};
 use witness::{UnlockParameters, Witness};
 
@@ -47,7 +49,8 @@ impl PrimedInput {
             prev_index: self.vout,
             script_sig: Script::new(),
             sequence: self.input_parameters.sequence,
-            witness: self.input_parameters
+            witness: self
+                .input_parameters
                 .witness
                 .iter()
                 .map(|witness| self.encode_witness_for_txin(witness))
@@ -125,7 +128,8 @@ impl PrimedTransaction {
         Transaction {
             version: 2,
             lock_time: self.locktime,
-            input: self.inputs
+            input: self
+                .inputs
                 .iter()
                 .map(PrimedInput::to_txin_without_signature)
                 .collect(),
@@ -157,14 +161,12 @@ mod test {
         let txid = Sha256dHash::default();
 
         let primed_txn = PrimedTransaction {
-            inputs: vec![
-                PrimedInput::new(
-                    txid,
-                    1, // First number I found that gave me a 71 byte signature
-                    BitcoinQuantity::from_bitcoin(1.0),
-                    keypair.p2wpkh_unlock_parameters(),
-                ),
-            ],
+            inputs: vec![PrimedInput::new(
+                txid,
+                1, // First number I found that gave me a 71 byte signature
+                BitcoinQuantity::from_bitcoin(1.0),
+                keypair.p2wpkh_unlock_parameters(),
+            )],
             output_address: dst_addr,
             locktime: 0,
         };

--- a/vendor/bitcoin_witness/tests/p2wpkh.rs
+++ b/vendor/bitcoin_witness/tests/p2wpkh.rs
@@ -9,8 +9,7 @@ extern crate secp256k1_support;
 use bitcoin_node::BitcoinNode;
 use bitcoin_rpc::BitcoinRpcApi;
 use bitcoin_rpc_helpers::RegtestHelperClient;
-use bitcoin_support::serialize::serialize_hex;
-use bitcoin_support::{Address, BitcoinQuantity, PrivateKey};
+use bitcoin_support::{serialize::serialize_hex, Address, BitcoinQuantity, PrivateKey};
 use bitcoin_witness::{PrimedInput, PrimedTransaction, UnlockP2wpkh};
 use secp256k1_support::KeyPair;
 use std::str::FromStr;
@@ -37,14 +36,12 @@ fn redeem_single_p2wpkh() {
     let fee = BitcoinQuantity::from_satoshi(1000);
 
     let redeem_tx = PrimedTransaction {
-        inputs: vec![
-            PrimedInput::new(
-                txid.into(),
-                vout.n,
-                input_amount,
-                keypair.p2wpkh_unlock_parameters(),
-            ),
-        ],
+        inputs: vec![PrimedInput::new(
+            txid.into(),
+            vout.n,
+            input_amount,
+            keypair.p2wpkh_unlock_parameters(),
+        )],
         output_address: alice_addr.clone(),
         locktime: 0,
     }.sign_with_fee(fee);

--- a/vendor/bitcoin_witness/tests/sign_with_rate.rs
+++ b/vendor/bitcoin_witness/tests/sign_with_rate.rs
@@ -9,8 +9,7 @@ extern crate secp256k1_support;
 use bitcoin_node::BitcoinNode;
 use bitcoin_rpc::BitcoinRpcApi;
 use bitcoin_rpc_helpers::RegtestHelperClient;
-use bitcoin_support::serialize::serialize_hex;
-use bitcoin_support::{Address, BitcoinQuantity, PrivateKey};
+use bitcoin_support::{serialize::serialize_hex, Address, BitcoinQuantity, PrivateKey};
 use bitcoin_witness::{PrimedInput, PrimedTransaction, UnlockP2wpkh};
 use secp256k1_support::KeyPair;
 
@@ -38,14 +37,12 @@ fn sign_with_rate() {
     let rate = 42.0;
 
     let primed_tx = PrimedTransaction {
-        inputs: vec![
-            PrimedInput::new(
-                txid.into(),
-                vout.n,
-                input_amount,
-                keypair.p2wpkh_unlock_parameters(),
-            ),
-        ],
+        inputs: vec![PrimedInput::new(
+            txid.into(),
+            vout.n,
+            input_amount,
+            keypair.p2wpkh_unlock_parameters(),
+        )],
         output_address: alice_addr.clone(),
         locktime: 0,
     };

--- a/vendor/ethereum_support/src/ethereum_quantity.rs
+++ b/vendor/ethereum_support/src/ethereum_quantity.rs
@@ -1,14 +1,12 @@
-use U256;
 use bigdecimal::{BigDecimal, ParseBigDecimalError};
 use byteorder::{LittleEndian, WriteBytesExt};
-use num::FromPrimitive;
-use num::ToPrimitive;
-use num::bigint::{BigInt, Sign};
+use num::{
+    bigint::{BigInt, Sign},
+    FromPrimitive, ToPrimitive,
+};
 use regex::Regex;
-use std::f64;
-use std::fmt;
-use std::mem;
-use std::str::FromStr;
+use std::{f64, fmt, mem, str::FromStr};
+use U256;
 
 #[derive(Serialize, Deserialize, Clone, Debug, Copy)]
 pub struct EthereumQuantity(U256);

--- a/vendor/ethereum_support/src/key.rs
+++ b/vendor/ethereum_support/src/key.rs
@@ -1,6 +1,6 @@
-use Address;
 use secp256k1_support::PublicKey;
 use tiny_keccak;
+use Address;
 
 pub trait ToEthereumAddress {
     fn to_ethereum_address(&self) -> Address;

--- a/vendor/ethereum_support/src/lib.rs
+++ b/vendor/ethereum_support/src/lib.rs
@@ -25,8 +25,7 @@ pub use web3_client::*;
 pub use web3_crate::futures::Future;
 
 pub mod web3 {
-    pub use web3_crate::error::Error;
-    pub use web3_crate::error::ErrorKind;
+    pub use web3_crate::error::{Error, ErrorKind};
 
     pub mod transports {
         pub use web3_crate::transports::Http;

--- a/vendor/ethereum_support/src/web3_client.rs
+++ b/vendor/ethereum_support/src/web3_client.rs
@@ -1,6 +1,8 @@
 use std::ops::Deref;
-use web3_crate::api::Web3;
-use web3_crate::transports::{EventLoopHandle, Http};
+use web3_crate::{
+    api::Web3,
+    transports::{EventLoopHandle, Http},
+};
 
 pub struct Web3Client {
     _event_loop: EventLoopHandle,

--- a/vendor/ganache_node/src/lib.rs
+++ b/vendor/ganache_node/src/lib.rs
@@ -1,13 +1,17 @@
 extern crate testcontainers;
 extern crate web3;
 
-use testcontainers::clients::DockerCli;
-use testcontainers::images::{GanacheCli, GanacheCliArgs};
-use testcontainers::{Container, Docker, Image, RunArgs};
+use testcontainers::{
+    clients::DockerCli,
+    images::{GanacheCli, GanacheCliArgs},
+    Container, Docker, Image, RunArgs,
+};
 
 use std::env::var;
-use web3::Web3;
-use web3::transports::{EventLoopHandle, Http};
+use web3::{
+    transports::{EventLoopHandle, Http},
+    Web3,
+};
 
 pub struct GanacheCliNode {
     container_id: String,

--- a/vendor/ganache_rust_web3/src/lib.rs
+++ b/vendor/ganache_rust_web3/src/lib.rs
@@ -3,10 +3,7 @@ extern crate web3;
 extern crate serde_derive;
 extern crate serde_json;
 
-use web3::Transport;
-use web3::api::Namespace;
-use web3::helpers::CallResult;
-use web3::types::U256;
+use web3::{api::Namespace, helpers::CallResult, types::U256, Transport};
 
 #[derive(Debug, Clone)]
 pub struct Ganache<T: Transport> {

--- a/vendor/ganache_rust_web3/tests/integration_tests.rs
+++ b/vendor/ganache_rust_web3/tests/integration_tests.rs
@@ -4,8 +4,7 @@ extern crate ganache_rust_web3;
 extern crate web3;
 
 use ganache_rust_web3::Ganache;
-use web3::futures::Future;
-use web3::transports;
+use web3::{futures::Future, transports};
 
 #[test]
 fn test_evm_snapshot() {
@@ -14,7 +13,8 @@ fn test_evm_snapshot() {
     let node = ganache_node::GanacheCliNode::new();
     let web3 = node.get_client();
 
-    let _ = web3.api::<Ganache<transports::Http>>()
+    let _ = web3
+        .api::<Ganache<transports::Http>>()
         .evm_snapshot()
         .wait()
         .unwrap();
@@ -27,12 +27,14 @@ fn test_evm_revert() {
     let node = ganache_node::GanacheCliNode::new();
     let web3 = node.get_client();
 
-    let snapshot_id = web3.api::<Ganache<transports::Http>>()
+    let snapshot_id = web3
+        .api::<Ganache<transports::Http>>()
         .evm_snapshot()
         .wait()
         .unwrap();
 
-    let _ = web3.api::<Ganache<transports::Http>>()
+    let _ = web3
+        .api::<Ganache<transports::Http>>()
         .evm_revert(&snapshot_id)
         .wait()
         .unwrap();
@@ -47,12 +49,14 @@ fn test_evm_increase_time() {
 
     //        let increase = U256::from(1);
     //
-    let _ = web3.api::<Ganache<transports::Http>>()
+    let _ = web3
+        .api::<Ganache<transports::Http>>()
         .evm_increase_time(0)
         .wait()
         .unwrap();
 
-    let _ = web3.api::<Ganache<transports::Http>>()
+    let _ = web3
+        .api::<Ganache<transports::Http>>()
         .evm_mine()
         .wait()
         .unwrap();
@@ -65,7 +69,8 @@ fn test_evm_mine() {
     let node = ganache_node::GanacheCliNode::new();
     let web3 = node.get_client();
 
-    let _ = web3.api::<Ganache<transports::Http>>()
+    let _ = web3
+        .api::<Ganache<transports::Http>>()
         .evm_mine()
         .wait()
         .unwrap();

--- a/vendor/jsonrpc/src/client.rs
+++ b/vendor/jsonrpc/src/client.rs
@@ -1,8 +1,7 @@
 use request::RpcRequest;
 use reqwest::{Client as HTTPClient, Error};
 use response::RpcResponse;
-use serde::Serialize;
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
 
 pub struct RpcClient {
@@ -24,7 +23,8 @@ impl RpcClient {
         R: DeserializeOwned,
     {
         debug!("Request: {:?}", request);
-        let res = self.client
+        let res = self
+            .client
             .post(self.url.as_str())
             .json(request)
             .send()

--- a/vendor/jsonrpc/src/lib.rs
+++ b/vendor/jsonrpc/src/lib.rs
@@ -14,9 +14,7 @@ mod version;
 
 pub use client::RpcClient;
 pub use request::RpcRequest;
-pub use reqwest::Client as HTTPClient;
-pub use reqwest::ClientBuilder as HTTPClientBuilder;
-pub use reqwest::Error as HTTPError;
+pub use reqwest::{Client as HTTPClient, ClientBuilder as HTTPClientBuilder, Error as HTTPError};
 pub use response::{RpcError, RpcResponse};
 pub use version::JsonRpcVersion;
 

--- a/vendor/secp256k1_support/src/keypair.rs
+++ b/vendor/secp256k1_support/src/keypair.rs
@@ -67,10 +67,10 @@ mod test {
     #[test]
     fn correct_keypair_from_secret_key_slice() {
         // taken from: https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses
-        let keypair = KeyPair::from_secret_key_slice(&hex::decode(
-            "18e14a7b6a307f426a94f8114701e7c8e774e7f9a47e2c2035db29a206321725",
-        ).unwrap())
-            .unwrap();
+        let keypair = KeyPair::from_secret_key_slice(
+            &hex::decode("18e14a7b6a307f426a94f8114701e7c8e774e7f9a47e2c2035db29a206321725")
+                .unwrap(),
+        ).unwrap();
 
         assert_eq!(
             *keypair.public_key(),

--- a/vendor/secp256k1_support/src/signature.rs
+++ b/vendor/secp256k1_support/src/signature.rs
@@ -1,8 +1,5 @@
 use secp256k1;
-pub use secp256k1::Message;
-pub use secp256k1::RecoveryId;
-pub use secp256k1::SecretKey;
-pub use secp256k1::Signature;
+pub use secp256k1::{Message, RecoveryId, SecretKey, Signature};
 
 pub trait DerSerializableSignature {
     fn serialize_signature_der(&self) -> Vec<u8>;

--- a/vendor/testcontainers_rs/src/api.rs
+++ b/vendor/testcontainers_rs/src/api.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-use std::io::Read;
-use std::str::FromStr;
+use std::{collections::HashMap, io::Read, str::FromStr};
 
 pub trait Docker {
     fn run_detached<I: Image>(&self, image: &I, run_args: RunArgs) -> String;

--- a/vendor/testcontainers_rs/src/docker_cli.rs
+++ b/vendor/testcontainers_rs/src/docker_cli.rs
@@ -1,7 +1,9 @@
 use api::*;
 use serde_json;
-use std::io::{BufRead, BufReader, Read};
-use std::process::{Command, Stdio};
+use std::{
+    io::{BufRead, BufReader, Read},
+    process::{Command, Stdio},
+};
 
 pub struct DockerCli;
 

--- a/vendor/testcontainers_rs/src/images/bitcoind.rs
+++ b/vendor/testcontainers_rs/src/images/bitcoind.rs
@@ -1,10 +1,6 @@
+use api::{Docker, ExposedPorts, Image};
+use std::{env::var, thread::sleep, time::Duration};
 use WaitForMessage;
-use api::Docker;
-use api::ExposedPorts;
-use api::Image;
-use std::env::var;
-use std::thread::sleep;
-use std::time::Duration;
 
 pub struct Bitcoind {
     tag: String,

--- a/vendor/testcontainers_rs/src/images/ganache_cli.rs
+++ b/vendor/testcontainers_rs/src/images/ganache_cli.rs
@@ -1,5 +1,5 @@
-use WaitForMessage;
 use api::*;
+use WaitForMessage;
 
 pub struct GanacheCli {
     tag: String,

--- a/vendor/testcontainers_rs/src/images/mod.rs
+++ b/vendor/testcontainers_rs/src/images/mod.rs
@@ -1,7 +1,7 @@
 mod bitcoind;
 mod ganache_cli;
 
-pub use self::bitcoind::Bitcoind;
-pub use self::bitcoind::BitcoindImageArgs;
-pub use self::ganache_cli::GanacheCli;
-pub use self::ganache_cli::GanacheCliArgs;
+pub use self::{
+    bitcoind::{Bitcoind, BitcoindImageArgs},
+    ganache_cli::{GanacheCli, GanacheCliArgs},
+};

--- a/vendor/testcontainers_rs/src/wait_for_message.rs
+++ b/vendor/testcontainers_rs/src/wait_for_message.rs
@@ -1,6 +1,4 @@
-use std::io::BufRead;
-use std::io::BufReader;
-use std::io::Read;
+use std::io::{BufRead, BufReader, Read};
 
 #[derive(PartialEq, Debug)]
 pub enum WaitResult {


### PR DESCRIPTION
**MERGE THIS ONLY IF NO OTHER PRS ARE OPEN**

This allows us to use a nightly-features of the rustfmt: `merge_imports` which is IMO very desirable.

In addition, this frees us from installing 2 versions of rust in travis which should make the builder faster and the cache smaller.