### PR TITLE
Remove application build artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ script:
 - cargo test --all
 after_script:
 - expr $TRAVIS_TEST_RESULT > /dev/null && .travis/upload-container-logs-to-gcs.sh
+before_cache:
+- .travis/clean-workspace-artifacts.sh
 notifications:
   email: false
   slack:

--- a/.travis/clean-workspace-artifacts.sh
+++ b/.travis/clean-workspace-artifacts.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+which toml || cargo install tomlcli
+
+find vendor application -name Cargo.toml `# find all Cargo.toml files` | \
+xargs -I '{}' -n 1 toml --nocolor '{}' package.name | `# extract package name` \
+xargs -n 1 -t cargo clean -p `# pass package name to cargo clean`


### PR DESCRIPTION
I was too annoyed by the cache upload, so I put together a small script that cleans the target folder from application build-artifacts.

This prevents Travis from re-uploading the whole cache file because
now, only the built dependencies should remain in the target folder.