### PR TITLE
Allow RequestHandler to be mutable

### DIFF
--- a/vendor/transport_protocol/src/config.rs
+++ b/vendor/transport_protocol/src/config.rs
@@ -1,13 +1,15 @@
 use std::collections::{HashMap, HashSet};
 
 pub struct Config<Req, Res> {
-    request_types: HashMap<String, (HashSet<String>, Box<Fn(Req) -> Res + Send + 'static>)>,
+    known_headers: HashMap<String, HashSet<String>>,
+    request_handlers: HashMap<String, Box<FnMut(Req) -> Res + Send + 'static>>,
 }
 
 impl<Req, Res> Config<Req, Res> {
     pub fn new() -> Self {
         Self {
-            request_types: HashMap::new(),
+            known_headers: HashMap::new(),
+            request_handlers: HashMap::new(),
         }
     }
 
@@ -18,21 +20,26 @@ impl<Req, Res> Config<Req, Res> {
         request_handler: RH,
     ) -> Self
     where
-        RH: Fn(Req) -> Res + Send,
+        RH: FnMut(Req) -> Res + Send,
     {
         let header_keys = header_keys.into_iter().map(|key| (*key).into()).collect();
         let request_handler = Box::new(request_handler);
 
-        self.request_types
-            .insert(request_type.into(), (header_keys, request_handler));
+        self.known_headers.insert(request_type.into(), header_keys);
+        self.request_handlers
+            .insert(request_type.into(), request_handler);
+
         self
     }
 
     pub fn known_headers_for(&self, request_type: &str) -> Option<&HashSet<String>> {
-        self.request_types.get(request_type).as_ref().map(|t| &t.0)
+        self.known_headers.get(request_type)
     }
 
-    pub fn request_handler_for(&self, request_type: &str) -> Option<&Box<Fn(Req) -> Res + Send>> {
-        self.request_types.get(request_type).as_ref().map(|t| &t.1)
+    pub fn request_handler_for(
+        &mut self,
+        request_type: &str,
+    ) -> Option<&mut Box<FnMut(Req) -> Res + Send>> {
+        self.request_handlers.get_mut(request_type)
     }
 }

--- a/vendor/transport_protocol/src/json/frame.rs
+++ b/vendor/transport_protocol/src/json/frame.rs
@@ -151,7 +151,7 @@ impl From<serde_json::Error> for Error {
 
 impl JsonFrameHandler {
     fn dispatch_request(
-        &self,
+        &mut self,
         _type: JsonValue,
         headers: JsonValue,
         body: JsonValue,

--- a/vendor/transport_protocol/tests/common/counter.rs
+++ b/vendor/transport_protocol/tests/common/counter.rs
@@ -1,0 +1,16 @@
+use transport_protocol::{config::Config, json::*, *};
+
+#[derive(Default)]
+pub struct CounterState {
+    invocations: u32,
+}
+
+pub fn config() -> Config<Request, Response> {
+    let mut state = CounterState::default();
+
+    Config::new().on_request("COUNT", &[], move |_request: Request| {
+        state.invocations += 1;
+
+        Response::new(Status::OK(0)).with_body(state.invocations)
+    })
+}

--- a/vendor/transport_protocol/tests/common/mod.rs
+++ b/vendor/transport_protocol/tests/common/mod.rs
@@ -1,6 +1,7 @@
 mod alice_and_bob;
 
 pub mod buy;
+pub mod counter;
 pub mod ping;
 pub mod place_order;
 pub mod say_hello;

--- a/vendor/transport_protocol/tests/requests.rs
+++ b/vendor/transport_protocol/tests/requests.rs
@@ -15,7 +15,7 @@ extern crate log;
 
 #[macro_use]
 pub mod common;
-use common::{setup::setup, *};
+use common::{buy, counter, ping, place_order, say_hello, setup::setup};
 use futures::future::Future;
 use spectral::prelude::*;
 
@@ -283,4 +283,29 @@ fn handle_request_with_payload() {
         .is_ok()
         .is_some()
         .is_equal_to(include_json_line!("place_apple_phone_order_response.json"));
+}
+
+#[test]
+fn handle_request_with_mutable_state() {
+    let (mut _runtime, alice, _bob) = setup(counter::config());
+
+    let count_1 = alice
+        .send_with_newline(r#"{"type":"REQUEST","id":0,"payload":{"type":"COUNT"}}"#)
+        .and_then(|_| alice.receive())
+        .wait();
+
+    let count_2 = alice
+        .send_with_newline(r#"{"type":"REQUEST","id":1,"payload":{"type":"COUNT"}}"#)
+        .and_then(|_| alice.receive())
+        .wait();
+
+    assert_that(&count_1)
+        .is_ok()
+        .is_some()
+        .is_equal_to(&r#"{"type":"RESPONSE","id":0,"payload":{"body":1,"status":"OK00"}}"#.into());
+
+    assert_that(&count_2)
+        .is_ok()
+        .is_some()
+        .is_equal_to(&r#"{"type":"RESPONSE","id":1,"payload":{"body":2,"status":"OK00"}}"#.into());
 }


### PR DESCRIPTION
This change allows for mutable request handlers without any additional locking to occur.

This is possible by moving the whichever state is necessary into the closure of the request handler as demonstrated by the `counter` example.