### PR TITLE
Use rust_bitcoin SigHashType in signature

### DIFF
--- a/vendor/bitcoin_support/src/lib.rs
+++ b/vendor/bitcoin_support/src/lib.rs
@@ -9,7 +9,7 @@ pub use address::Address;
 pub use bitcoin::{
     blockdata::{
         script::Script,
-        transaction::{OutPoint, Transaction, TxIn, TxOut},
+        transaction::{OutPoint, SigHashType, Transaction, TxIn, TxOut},
     },
     network::{constants::Network, serialize},
     util::{

--- a/vendor/bitcoin_witness/src/primed_transaction.rs
+++ b/vendor/bitcoin_witness/src/primed_transaction.rs
@@ -1,6 +1,6 @@
 use bitcoin_support::{
-    Address, BitcoinQuantity, OutPoint, Script, Sha256dHash, SighashComponents, Transaction, TxIn,
-    TxOut, Weight,
+    Address, BitcoinQuantity, OutPoint, Script, Sha256dHash, SigHashType, SighashComponents,
+    Transaction, TxIn, TxOut, Weight,
 };
 use secp256k1_support::{DerSerializableSignature, Message};
 use witness::{UnlockParameters, Witness};
@@ -79,8 +79,7 @@ impl PrimedTransaction {
                     let signature = keypair.sign_ecdsa(message_to_sign);
 
                     let mut serialized_signature = signature.serialize_signature_der();
-                    // Without this 1 at the end you get "Non-canonical DER Signature"
-                    serialized_signature.push(1u8);
+                    serialized_signature.push(SigHashType::All as u8);
                     transaction.input[i].witness[j] = serialized_signature;
                 }
             }


### PR DESCRIPTION
That 0x1 we always had to put on the end of a signature was actually
the sighash type!