### PR TITLE
Refactor mocking of ApiClient in trading client

### DIFF
--- a/application/comit_node_client/src/api_client/fake_client.rs
+++ b/application/comit_node_client/src/api_client/fake_client.rs
@@ -11,7 +11,7 @@ use offer::Symbol;
 use std::str::FromStr;
 use uuid::Uuid;
 
-#[allow(dead_code)]
+#[derive(Default)]
 pub struct FakeApiClient;
 
 impl ApiClient for FakeApiClient {

--- a/application/comit_node_client/src/api_client/mod.rs
+++ b/application/comit_node_client/src/api_client/mod.rs
@@ -4,20 +4,4 @@ use reqwest;
 mod client;
 mod fake_client;
 
-pub use self::client::{
-    ApiClient, BuyOfferRequestBody, BuyOrderRequestBody, ComitNodeApiUrl, OfferResponseBody,
-    RequestToFund, TradeId, TradingServiceError,
-};
-
-#[cfg(test)]
-pub fn create_client(_url: &ComitNodeApiUrl) -> impl ApiClient {
-    fake_client::FakeApiClient {}
-}
-
-#[cfg(not(test))]
-pub fn create_client(url: &ComitNodeApiUrl) -> impl ApiClient {
-    client::DefaultApiClient {
-        client: reqwest::Client::new(),
-        url: url.clone(),
-    }
-}
+pub use self::{client::*, fake_client::*};

--- a/application/comit_node_client/src/bin/comit_node_client.rs
+++ b/application/comit_node_client/src/bin/comit_node_client.rs
@@ -8,7 +8,7 @@ extern crate comit_node_client;
 extern crate uuid;
 
 use comit_node_client::{
-    api_client::ComitNodeApiUrl,
+    api_client::{ComitNodeApiUrl, DefaultApiClient},
     offer::{self, OrderType, Symbol},
     order,
     redeem::{self, RedeemOutput},
@@ -93,13 +93,18 @@ fn main() {
     let trading_api_url =
         ComitNodeApiUrl(var("COMIT_NODE_URL").expect("env variable COMIT_NODE_URL must be set"));
 
+    let client = DefaultApiClient {
+        url: trading_api_url,
+        client: reqwest::Client::new(),
+    };
+
     let output = match Opt::from_args() {
         Opt::Offer {
             symbol,
             order_type,
             amount,
         } => offer::run(
-            trading_api_url,
+            &client,
             Symbol::from_str(&symbol).unwrap_or_exit("Invalid Symbol"),
             order_type,
             amount,
@@ -110,7 +115,7 @@ fn main() {
             success_address,
             refund_address,
         } => order::run(
-            trading_api_url,
+            &client,
             Symbol::from_str(&symbol).unwrap_or_exit("Invalid Symbol"),
             uid,
             success_address,
@@ -121,7 +126,7 @@ fn main() {
             uid,
             console,
         } => redeem::run(
-            trading_api_url,
+            &client,
             Symbol::from_str(&symbol).unwrap_or_exit("Invalid Symbol"),
             uid,
             RedeemOutput::new(console),

--- a/application/comit_node_client/src/order.rs
+++ b/application/comit_node_client/src/order.rs
@@ -1,11 +1,9 @@
-use api_client::{
-    create_client, ApiClient, BuyOrderRequestBody, ComitNodeApiUrl, TradingServiceError,
-};
+use api_client::{ApiClient, BuyOrderRequestBody, TradingServiceError};
 use offer::Symbol;
 use uuid::Uuid;
 
-pub fn run(
-    trading_api_url: ComitNodeApiUrl,
+pub fn run<C: ApiClient>(
+    client: &C,
     symbol: Symbol,
     uid: Uuid,
     success_address: String,
@@ -13,7 +11,6 @@ pub fn run(
 ) -> Result<String, TradingServiceError> {
     let order_request_body = BuyOrderRequestBody::new(success_address, refund_address);
 
-    let client = create_client(&trading_api_url);
     let request_to_fund = client.request_order(&symbol, uid, &order_request_body)?;
 
     Ok(format!(
@@ -38,16 +35,15 @@ pub fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str::FromStr;
+    use api_client::FakeApiClient;
 
     #[test]
     fn accept_order_happy_path() {
-        let trading_api_url = ComitNodeApiUrl("stub".to_string());
-        let symbol = Symbol::from_str("ETH-BTC").unwrap();
-        let uid = Uuid::from_str("27b36adf-eda3-4684-a21c-a08a84f36fb1").unwrap();
+        let symbol = "ETH-BTC".parse().unwrap();
+        let uid = "27b36adf-eda3-4684-a21c-a08a84f36fb1".parse().unwrap();
 
         let response = run(
-            trading_api_url,
+            &FakeApiClient::default(),
             symbol,
             uid,
             "0x00a329c0648769a73afac7f9381e08fb43dbea72".to_string(),

--- a/application/comit_node_client/src/redeem.rs
+++ b/application/comit_node_client/src/redeem.rs
@@ -1,4 +1,4 @@
-use api_client::{create_client, ApiClient, ComitNodeApiUrl, TradingServiceError};
+use api_client::{ApiClient, TradingServiceError};
 use common_types;
 use ethereum_support;
 use offer::Symbol;
@@ -49,14 +49,12 @@ impl EthereumPaymentURL {
     }
 }
 
-pub fn run(
-    trading_api_url: ComitNodeApiUrl,
+pub fn run<C: ApiClient>(
+    client: &C,
     symbol: Symbol,
     uid: Uuid,
     output_type: RedeemOutput,
 ) -> Result<String, TradingServiceError> {
-    let client = create_client(&trading_api_url);
-
     let redeem_details = client.request_redeem_details(symbol, uid)?;
 
     match output_type {
@@ -79,16 +77,15 @@ pub fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str::FromStr;
+    use api_client::FakeApiClient;
 
     #[test]
     fn redeem_with_valid_uid() {
-        let trading_api_url = ComitNodeApiUrl("stub".to_string());
+        let symbol = "ETH-BTC".parse().unwrap();
+        let uid = "27b36adf-eda3-4684-a21c-a08a84f36fb1".parse().unwrap();
 
-        let uid = Uuid::from_str("27b36adf-eda3-4684-a21c-a08a84f36fb1").unwrap();
-        let symbol = Symbol::from_str("ETH-BTC").unwrap();
-
-        let redeem_details = run(trading_api_url, symbol, uid, RedeemOutput::URL).unwrap();
+        let redeem_details =
+            run(&FakeApiClient::default(), symbol, uid, RedeemOutput::URL).unwrap();
 
         assert_eq!(
             redeem_details,


### PR DESCRIPTION
I stumbled upon this when reviewing #256 and thought I'll just quickly fix that. 

Mocking with type parameters is more idiomatic Rust compared to using
the conditional compilation flag. It also gives more power over the
actual output in the tests.

Resolves #258.