### PR TITLE
Don't send notifications on build success to slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ notifications:
   email: false
   slack:
     rooms:
-    - tenx-company:buMm6Pg6Sbhljx2HRLwNC44z#coblox-swap-bots
-    on_success: always
+    - tenx-company:buMm6Pg6Sbhljx2HRLwNC44z#coblox-bots
+    on_success: never
     on_failure: always
     on_pull_requests: true


### PR DESCRIPTION
This should give us less spam in the slack channel which should make it more useful again.

@bonomat before merging this, please rename the slack channel!