### PR TITLE
Calculate gas to be paid

### DIFF
--- a/application/comit_node/src/http_api/swap.rs
+++ b/application/comit_node/src/http_api/swap.rs
@@ -343,14 +343,11 @@ fn handle_get_swap<E: EventStore<TradeId>>(
                     >>(id);
 
                     match contract_deployed {
-                        Ok(contract_deployed) => {
-                            Some(SwapStatus::Redeemable {
-                                contract_address: contract_deployed.address,
-                                data: requested.secret,
-                                // TODO: check how much gas we should tell the customer to pay
-                                gas: 3500,
-                            })
-                        }
+                        Ok(contract_deployed) => Some(SwapStatus::Redeemable {
+                            contract_address: contract_deployed.address,
+                            data: requested.secret,
+                            gas: 110,
+                        }),
                         Err(_) => {
                             let htlc = bitcoin_htlc::Htlc::new(
                                 accepted.source_ledger_success_identity,


### PR DESCRIPTION
The gas cost associated with running an ethereum contract when the
hashes match is calculated to be the sum of the following operations:

- Deploy timestamp (1 word): 3 gas
- Load secret (1 word) into memory: 3 gas
- Hash secret with SHA-256: 72 gas
- Deploy correct secret hash (1 word): 3 gas
- Load hashed secret from memory: 3 gas
- Compare hashed secret with existing one: 3 gas
- Logical combination: 3 gas
- Conditional jump: 10 gas
- Destroy contract and send funds to success address: 0 gas

This adds up to 100 gas, to which a 10% buffer is added.

Resource used: https://docs.google.com/spreadsheets/d/1n6mRqkBz3iWcOlRem_mO09GtSKEKrAsfO7Frgx18pNU/edit#gid=0