### PR TITLE
Fix race-condition in `Client::send_request` that allowed for wrong dropping of response frames as "unexpected frames"

### DIFF
--- a/vendor/transport_protocol/Cargo.toml
+++ b/vendor/transport_protocol/Cargo.toml
@@ -23,4 +23,3 @@ debug_stub_derive = "0.3.0"
 [dev-dependencies]
 pretty_env_logger = "0.2"
 spectral = "0.6.0"
-


### PR DESCRIPTION
See the 2nd commit msg for details.