### PR TITLE
Rename *_htlc_id to *_htlc_location everywhere

### DIFF
--- a/application/comit_node/src/swap_protocols/rfc003/alice/actions/btc_eth.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/alice/actions/btc_eth.rs
@@ -23,18 +23,18 @@ impl StateActions<BitcoinFund, EtherRedeem, BitcoinRefund>
             })],
             SS::SourceFunded { .. } => vec![],
             SS::BothFunded(BothFunded {
-                ref source_htlc_id,
-                ref target_htlc_id,
+                ref source_htlc_location,
+                ref target_htlc_location,
                 ref swap,
                 ..
             }) => vec![
                 Action::RedeemHtlc(EtherRedeem {
-                    contract_address: target_htlc_id.clone(),
+                    contract_address: target_htlc_location.clone(),
                     execution_gas: 42, //TODO: generate gas cost directly
                     data: swap.secret,
                 }),
                 Action::RefundHtlc(BitcoinRefund {
-                    outpoint: source_htlc_id.clone(),
+                    outpoint: source_htlc_location.clone(),
                     htlc: bitcoin_htlc(swap),
                     value: swap.source_asset,
                     transient_keypair: swap.source_identity.into(),
@@ -42,30 +42,30 @@ impl StateActions<BitcoinFund, EtherRedeem, BitcoinRefund>
             ],
             SS::SourceFundedTargetRefunded(SourceFundedTargetRefunded {
                 ref swap,
-                ref source_htlc_id,
+                ref source_htlc_location,
                 ..
             })
             | SS::SourceFundedTargetRedeemed(SourceFundedTargetRedeemed {
                 ref swap,
-                ref source_htlc_id,
+                ref source_htlc_location,
                 ..
             }) => vec![Action::RefundHtlc(BitcoinRefund {
-                outpoint: source_htlc_id.clone(),
+                outpoint: source_htlc_location.clone(),
                 htlc: bitcoin_htlc(swap),
                 value: swap.source_asset,
                 transient_keypair: swap.source_identity.into(),
             })],
             SS::SourceRefundedTargetFunded(SourceRefundedTargetFunded {
-                ref target_htlc_id,
+                ref target_htlc_location,
                 ref swap,
                 ..
             })
             | SS::SourceRedeemedTargetFunded(SourceRedeemedTargetFunded {
-                ref target_htlc_id,
+                ref target_htlc_location,
                 ref swap,
                 ..
             }) => vec![Action::RedeemHtlc(EtherRedeem {
-                contract_address: target_htlc_id.clone(),
+                contract_address: target_htlc_location.clone(),
                 execution_gas: 42, //TODO: generate cas cost correctly
                 data: swap.secret,
             })],

--- a/application/comit_node/src/swap_protocols/rfc003/bob/actions/btc_eth.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/bob/actions/btc_eth.rs
@@ -30,35 +30,36 @@ impl StateActions<AcceptRequest, DeclineRequest, EtherDeploy, BitcoinRedeem, Eth
                 })]
             }
             SS::BothFunded(BothFunded {
-                ref target_htlc_id, ..
+                ref target_htlc_location,
+                ..
             }) => vec![Action::RefundHtlc(EtherRefund {
-                contract_address: target_htlc_id.clone(),
+                contract_address: target_htlc_location.clone(),
                 execution_gas: 42, //TODO: generate gas cost directly
             })],
             SS::SourceFundedTargetRefunded { .. } => vec![],
             SS::SourceFundedTargetRedeemed { .. } => vec![],
             SS::SourceRefundedTargetFunded(SourceRefundedTargetFunded {
-                ref target_htlc_id,
+                ref target_htlc_location,
                 ..
             }) => vec![Action::RefundHtlc(EtherRefund {
-                contract_address: target_htlc_id.clone(),
+                contract_address: target_htlc_location.clone(),
                 execution_gas: 42, //TODO: generate gas cost directly
             })],
             SS::SourceRedeemedTargetFunded(SourceRedeemedTargetFunded {
                 ref swap,
-                ref target_htlc_id,
-                ref source_htlc_id,
+                ref target_htlc_location,
+                ref source_htlc_location,
                 ref secret,
             }) => vec![
                 Action::RedeemHtlc(BitcoinRedeem {
-                    outpoint: source_htlc_id.clone(),
+                    outpoint: source_htlc_location.clone(),
                     htlc: bitcoin_htlc(swap),
                     value: swap.source_asset,
                     transient_keypair: swap.source_identity.into(),
                     secret: *secret,
                 }),
                 Action::RefundHtlc(EtherRefund {
-                    contract_address: target_htlc_id.clone(),
+                    contract_address: target_htlc_location.clone(),
                     execution_gas: 42, //TODO: generate gas cost directly
                 }),
             ],

--- a/application/comit_node/src/swap_protocols/rfc003/events/default.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/events/default.rs
@@ -157,12 +157,13 @@ where
     fn source_htlc_refunded_target_htlc_funded(
         &mut self,
         swap: &OngoingSwap<SL, TL, SA, TA, S>,
-        source_htlc_id: &SL::HtlcLocation,
+        source_htlc_location: &SL::HtlcLocation,
     ) -> &mut Box<SourceRefundedOrTargetFunded<SL, TL>> {
         let swap = swap.clone();
 
         let source_ledger_fetch_query_results = self.source_ledger_fetch_query_results.clone();
-        let source_refunded_query = SLQuery::new_source_htlc_refunded_query(&swap, source_htlc_id);
+        let source_refunded_query =
+            SLQuery::new_source_htlc_refunded_query(&swap, source_htlc_location);
         let source_refunded_query_id = self
             .create_source_ledger_query
             .create_query(source_refunded_query);

--- a/application/comit_node/src/swap_protocols/rfc003/events/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/events/mod.rs
@@ -57,21 +57,21 @@ pub trait SourceHtlcRefundedTargetHtlcFunded<
     fn source_htlc_refunded_target_htlc_funded(
         &mut self,
         swap: &OngoingSwap<SL, TL, SA, TA, S>,
-        source_htlc_id: &SL::HtlcLocation,
+        source_htlc_location: &SL::HtlcLocation,
     ) -> &mut Box<SourceRefundedOrTargetFunded<SL, TL>>;
 }
 
 pub trait TargetHtlcRedeemedOrRefunded<TL: Ledger>: Send {
     fn target_htlc_redeemed_or_refunded(
         &mut self,
-        target_htlc_id: &TL::HtlcLocation,
+        target_htlc_location: &TL::HtlcLocation,
     ) -> &mut Box<RedeemedOrRefunded<TL>>;
 }
 
 pub trait SourceHtlcRedeemedOrRefunded<SL: Ledger>: Send {
     fn source_htlc_redeemed_or_refunded(
         &mut self,
-        source_htlc_id: &SL::HtlcLocation,
+        source_htlc_location: &SL::HtlcLocation,
     ) -> &mut Box<RedeemedOrRefunded<SL>>;
 }
 

--- a/application/comit_node/tests/rfc003_states.rs
+++ b/application/comit_node/tests/rfc003_states.rs
@@ -64,7 +64,7 @@ impl SourceHtlcRefundedTargetHtlcFunded<Bitcoin, Ethereum, BitcoinQuantity, Ethe
     fn source_htlc_refunded_target_htlc_funded(
         &mut self,
         _swap: &OngoingSwap<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity, Secret>,
-        _source_htlc_id: &bitcoin_support::OutPoint,
+        _source_htlc_location: &bitcoin_support::OutPoint,
     ) -> &mut Box<events::SourceRefundedOrTargetFunded<Bitcoin, Ethereum>> {
         self.source_htlc_refunded_target_htlc_funded
             .as_mut()
@@ -75,7 +75,7 @@ impl SourceHtlcRefundedTargetHtlcFunded<Bitcoin, Ethereum, BitcoinQuantity, Ethe
 impl TargetHtlcRedeemedOrRefunded<Ethereum> for FakeEvents {
     fn target_htlc_redeemed_or_refunded(
         &mut self,
-        _target_htlc_id: &ethereum_support::Address,
+        _target_htlc_location: &ethereum_support::Address,
     ) -> &mut Box<events::RedeemedOrRefunded<Ethereum>> {
         unimplemented!()
     }
@@ -84,7 +84,7 @@ impl TargetHtlcRedeemedOrRefunded<Ethereum> for FakeEvents {
 impl SourceHtlcRedeemedOrRefunded<Bitcoin> for FakeEvents {
     fn source_htlc_redeemed_or_refunded(
         &mut self,
-        _target_htlc_id: &bitcoin_support::OutPoint,
+        _target_htlc_location: &bitcoin_support::OutPoint,
     ) -> &mut Box<events::RedeemedOrRefunded<Bitcoin>> {
         unimplemented!()
     }
@@ -210,7 +210,7 @@ fn source_refunded() {
         },
         SourceFunded {
             swap: OngoingSwap::new(start.clone(), bob_response.clone()),
-            source_htlc_id: OutPoint {
+            source_htlc_location: OutPoint {
                 txid: Sha256dHash::from_data(b"funding"),
                 vout: 0
             }


### PR DESCRIPTION
It was previously named htlc_id because of the associated type.
That one was renamed a while ago but the variable/parameter names
stayed. This commit fixes that.