### PR TITLE
Add SourceHtlcRedeemedOrRefunded for DefaultEvents

### DIFF
--- a/application/comit_node/src/swap_protocols/rfc003/events/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/events/mod.rs
@@ -76,9 +76,17 @@ pub trait TargetHtlcRedeemedOrRefunded<
     ) -> &mut Box<RedeemedOrRefunded<TL>>;
 }
 
-pub trait SourceHtlcRedeemedOrRefunded<SL: Ledger>: Send {
+pub trait SourceHtlcRedeemedOrRefunded<
+    SL: Ledger,
+    TL: Ledger,
+    SA: Asset,
+    TA: Asset,
+    S: Into<SecretHash> + Clone,
+>: Send
+{
     fn source_htlc_redeemed_or_refunded(
         &mut self,
+        swap: &OngoingSwap<SL, TL, SA, TA, S>,
         source_htlc_location: &SL::HtlcLocation,
     ) -> &mut Box<RedeemedOrRefunded<SL>>;
 }
@@ -88,7 +96,7 @@ pub trait Events<SL: Ledger, TL: Ledger, SA: Asset, TA: Asset, S: Into<SecretHas
     + SourceHtlcFunded<SL, TL, SA, TA, S>
     + SourceHtlcRefundedTargetHtlcFunded<SL, TL, SA, TA, S>
     + TargetHtlcRedeemedOrRefunded<SL, TL, SA, TA, S>
-    + SourceHtlcRedeemedOrRefunded<SL>
+    + SourceHtlcRedeemedOrRefunded<SL, TL, SA, TA, S>
 {
 }
 
@@ -113,7 +121,10 @@ where
     S: Clone,
     Self: Query,
 {
-    fn new_source_htlc_redeemed_query(swap: &OngoingSwap<SL, TL, SA, TA, S>) -> Self;
+    fn new_source_htlc_redeemed_query(
+        swap: &OngoingSwap<SL, TL, SA, TA, S>,
+        source_htlc_location: &SL::HtlcLocation,
+    ) -> Self;
 }
 pub trait NewSourceHtlcRefundedQuery<SL, TL, SA, TA, S>: Send + Sync
 where

--- a/application/comit_node/src/swap_protocols/rfc003/state_machine.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/state_machine.rs
@@ -207,7 +207,7 @@ impl<SL: Ledger, TL: Ledger, SA: Asset, TA: Asset, S: Into<SecretHash> + Clone>
     ) -> Result<Async<AfterBothFunded<SL, TL, SA, TA, S>>, rfc003::Error> {
         if let Async::Ready(redeemed_or_refunded) = context
             .events
-            .source_htlc_redeemed_or_refunded(&state.source_htlc_location)
+            .source_htlc_redeemed_or_refunded(&state.swap, &state.source_htlc_location)
             .poll()?
         {
             let state = state.take();
@@ -272,7 +272,7 @@ impl<SL: Ledger, TL: Ledger, SA: Asset, TA: Asset, S: Into<SecretHash> + Clone>
         match try_ready!(
             context
                 .events
-                .source_htlc_redeemed_or_refunded(&state.source_htlc_location)
+                .source_htlc_redeemed_or_refunded(&state.swap, &state.source_htlc_location)
                 .poll()
         ) {
             Either::A(_source_redeemed_txid) => transition_save!(
@@ -332,7 +332,7 @@ impl<SL: Ledger, TL: Ledger, SA: Asset, TA: Asset, S: Into<SecretHash> + Clone>
         match try_ready!(
             context
                 .events
-                .source_htlc_redeemed_or_refunded(&state.source_htlc_location)
+                .source_htlc_redeemed_or_refunded(&state.swap, &state.source_htlc_location)
                 .poll()
         ) {
             Either::A(_target_redeemed_txid) => {

--- a/application/comit_node/tests/rfc003_states.rs
+++ b/application/comit_node/tests/rfc003_states.rs
@@ -84,9 +84,12 @@ impl TargetHtlcRedeemedOrRefunded<Bitcoin, Ethereum, BitcoinQuantity, EtherQuant
     }
 }
 
-impl SourceHtlcRedeemedOrRefunded<Bitcoin> for FakeEvents {
+impl SourceHtlcRedeemedOrRefunded<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity, Secret>
+    for FakeEvents
+{
     fn source_htlc_redeemed_or_refunded(
         &mut self,
+        _swap: &OngoingSwap<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity, Secret>,
         _target_htlc_location: &bitcoin_support::OutPoint,
     ) -> &mut Box<events::RedeemedOrRefunded<Bitcoin>> {
         unimplemented!()


### PR DESCRIPTION
With this PR, the implementation of `Events` for `DefaultEvents` is complete!

I updated the tracking issue accordingly to reflect on what is now missing after these PRs: https://github.com/tenx-tech/swap/issues/346

The implementation of these events introduced a few abstractions that now need to be implemented for concrete types.