### PR TITLE
Make `Before` hook stop the test if it fails

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -299,7 +299,7 @@ export NVM_SH=$([ -e $NVM_DIR/nvm.sh ] && echo "$NVM_DIR/nvm.sh" || echo /usr/lo
 . "$NVM_SH"
 cd api_tests;
 nvm use;
-./ledger_query_service/harness.sh ./ledger_query_service/lqs_test.js || { [ "$CAT_LOGS" ] && cd "$LOG_DIR" && cat *.log; exit 1; }
+./ledger_query_service/harness.sh ./ledger_query_service/test.js || { [ "$CAT_LOGS" ] && cd "$LOG_DIR" && cat *.log; exit 1; }
 '''
 ]
 

--- a/api_tests/e2e/rfc003/btc_eth-erc20/test.js
+++ b/api_tests/e2e/rfc003/btc_eth-erc20/test.js
@@ -33,25 +33,17 @@ describe('RFC003: Bitcoin for ERC20', () => {
     let token_contract_address;
     before(async function () {
         this.timeout(3000);
-        await test_lib.fund_eth(20).then(async () => {
-            console.log(`Gave 20 Ether to funded address`);
-            await Promise.all(
+        return await test_lib.fund_eth(20).then(async () => {
+            return await Promise.all(
                 [
                     test_lib.give_eth_to(toby.eth_address(), 10),
                     test_lib.give_eth_to(bob_eth_address, bob_initial_eth),
                 ]
-            ).then(receipt => {
-                console.log(`Giving 10 Ether to Toby; success: ${receipt[0].status}`);
-                console.log(`Giving ${bob_initial_eth} Ether to Bob; success: ${receipt[1].status}`);
+            ).then(() => {
                 return test_lib.deploy_erc20_token_contract(toby).then(receipt => {
                     token_contract_address = receipt.contractAddress;
-                    console.log(`Deploying ERC20 token contract; success: ${receipt.status}`);
                 });
-            }).catch(error => {
-                console.log(`Error on giving Ether to Toby: ${error}`);
             });
-        }).catch(error => {
-            console.log(`Error on funding Ether: ${error}`);
         });
     });
 

--- a/api_tests/e2e/rfc003/btc_eth/test.js
+++ b/api_tests/e2e/rfc003/btc_eth/test.js
@@ -29,22 +29,15 @@ const bitcoin_rpc_client = test_lib.bitcoin_rpc_client();
 
 describe('RFC003 Bitcoin for Ether', () => {
 
-    before(() => {
-        test_lib.fund_eth(20).then(() => {
-            console.log(`Gave 20 Ether to funded address`);
-            Promise.all(
+    before(async function () {
+        this.timeout(3000);
+        return await test_lib.fund_eth(20).then(async () => {
+            return await Promise.all(
                 [
                     test_lib.give_eth_to(bob_eth_address, bob_initial_eth),
                     test_lib.give_eth_to(alice.wallet.eth_address(), alice_initial_eth)
                 ]
-            ).then(receipt => {
-                console.log(`Giving ${bob_initial_eth} Ether to Bob; success: ${receipt[0].status}`);
-                console.log(`Giving ${alice_initial_eth} Ether to Alice; success: ${receipt[1].status}`);
-            }).catch(error => {
-                console.log(`Error on giving Ether to Alice or Bob: ${error}`);
-            });
-        }).catch(error => {
-            console.log(`Error on funding Ether: ${error}`);
+            );
         });
     });
 

--- a/api_tests/ledger_query_service/test.js
+++ b/api_tests/ledger_query_service/test.js
@@ -26,12 +26,8 @@ function sleep(ms) {
 
 describe("Test Ledger Query Service API", () => {
 
-    before(() => {
-        test_lib.fund_eth(20).then(() => {
-            console.log(`Gave 20 Ether to funded address`);
-        }).catch(error => {
-            console.log(`Error on funding Ether: ${error}`);
-        });
+    before(async function () {
+        return await test_lib.fund_eth(20);
     });
 
     describe('Bitcoin', () => {


### PR DESCRIPTION
in all JS e2e tests, return the promise so that the `Before` hook stops the test if it fails.

Remove unnecessary logs, if it fails, it will show the failure stack.

Related to #436.