### PR TITLE
More generic e2e tasks in Makefile

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -84,7 +84,7 @@ workspace = false
 dependencies = [
     "build",
     "pre-e2e-tests",
-    "specified-e2e-test",
+    "e2e-tests",
     "post-e2e-tests",
 ]
 
@@ -204,20 +204,6 @@ npm install;
 ]
 
 [tasks.e2e-tests]
-description = "Runs end-to-end tests."
-workspace = false
-private = true
-script_runner = "bash"
-script = [
-'''
-for DIR in $(ls ./api_tests/e2e/rfc003/); do
-    export LOG_DIR="./e2e/rfc003/${DIR}/log";
-    ./api_tests/e2e/comit-harness.sh ./api_tests/e2e/rfc003/${DIR} || { [ "$CAT_LOGS" ] && cd "$LOG_DIR" && cat *.log; exit 1; }
-done;
-'''
-]
-
-[tasks.specified-e2e-test]
 # Usage: `cargo make e2e <folder>` folder can be:
 # - empty (run all tests)
 # - btc_eth or btc_eth-erc20

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -206,64 +206,38 @@ npm install;
 [tasks.e2e-tests]
 description = "Runs end-to-end tests."
 workspace = false
-dependencies = [
-    "btc-eth",
-    "btc-erc20",
+private = true
+script_runner = "bash"
+script = [
+'''
+for DIR in $(ls ./api_tests/e2e/rfc003/); do
+    export LOG_DIR="./e2e/rfc003/${DIR}/log";
+    ./api_tests/e2e/comit-harness.sh ./api_tests/e2e/rfc003/${DIR} || { [ "$CAT_LOGS" ] && cd "$LOG_DIR" && cat *.log; exit 1; }
+done;
+'''
 ]
 
 [tasks.specified-e2e-test]
 # Usage: `cargo make e2e <folder>` folder can be:
 # - empty (run all tests)
 # - btc_eth or btc_eth-erc20
-description = "Runs RFC003 end-to-end tests specified on command line"
+description = "Runs RFC003 end-to-end tests specified on command line. Supports GLOB."
 workspace = false
-env = {  }
+private = true
 script_runner = "bash"
 script = [
 '''
-set +x;
 export PARAMS=$@;
-export NVM_SH=$([ -e $NVM_DIR/nvm.sh ] && echo "$NVM_DIR/nvm.sh" || echo /usr/local/opt/nvm/nvm.sh );
-. "$NVM_SH"
-cd api_tests;
-nvm use;
-[[ -z ${PARAMS} ]] && export PARAMS=$(ls ./e2e/rfc003/);
-for DIR in ${PARAMS}; do
-    export LOG_DIR="./e2e/rfc003/${DIR}/log";
-    ./e2e/comit-harness.sh ./e2e/rfc003/${DIR} || { [ "$CAT_LOGS" ] && cd "$LOG_DIR" && cat *.log; exit 1; }
+[[ -z ${PARAMS} ]] && export PARAMS=$(ls ./api_tests/e2e/rfc003/);
+export ROOT=$(pwd);
+for GLOB_DIR in ${PARAMS}; do
+    cd "$ROOT/api_tests/e2e/rfc003/"
+    for DIR in ${GLOB_DIR}; do
+        cd "$ROOT";
+        export LOG_DIR="./e2e/rfc003/${DIR}/log";
+        ./api_tests/e2e/comit-harness.sh ./api_tests/e2e/rfc003/${DIR} || { [ "$CAT_LOGS" ] && cd "$LOG_DIR" && cat *.log; exit 1; }
+    done;
 done;
-'''
-]
-
-[tasks.btc-eth]
-description = "Runs RFC003 BTC<->ETH end-to-end tests."
-workspace = false
-env = { "LOG_DIR" = "./e2e/rfc003/btc_eth/log" }
-script_runner = "bash"
-script = [
-'''
-set +x;
-export NVM_SH=$([ -e $NVM_DIR/nvm.sh ] && echo "$NVM_DIR/nvm.sh" || echo /usr/local/opt/nvm/nvm.sh );
-. "$NVM_SH"
-cd api_tests;
-nvm use;
-./e2e/comit-harness.sh ./e2e/rfc003/btc_eth || { [ "$CAT_LOGS" ] && cd "$LOG_DIR" && cat *.log; exit 1; }
-'''
-]
-
-[tasks.btc-erc20]
-description = "Runs RFC003 BTC<->ERC20 end-to-end tests."
-workspace = false
-env = { "LOG_DIR" = "./e2e/rfc003/btc_eth-erc20/log" }
-script_runner = "bash"
-script = [
-'''
-set +x;
-export NVM_SH=$([ -e $NVM_DIR/nvm.sh ] && echo "$NVM_DIR/nvm.sh" || echo /usr/local/opt/nvm/nvm.sh );
-. "$NVM_SH"
-cd api_tests;
-nvm use;
-./e2e/comit-harness.sh ./e2e/rfc003/btc_eth-erc20 || { [ "$CAT_LOGS" ] && cd "$LOG_DIR" && cat *.log; exit 1; }
 '''
 ]
 

--- a/api_tests/e2e/comit-harness.sh
+++ b/api_tests/e2e/comit-harness.sh
@@ -106,9 +106,8 @@ generate_btc_blocks_every 5;
 sleep 2;
 
 log "Run test";
-(
 set +x;
 export NVM_SH=$([ -e $NVM_DIR/nvm.sh ] && echo "$NVM_DIR/nvm.sh" || echo /usr/local/opt/nvm/nvm.sh );
 . "$NVM_SH"
-)
+nvm use;
 npm test "${TEST_PATH}/test.js";

--- a/api_tests/e2e/comit-harness.sh
+++ b/api_tests/e2e/comit-harness.sh
@@ -3,9 +3,9 @@
 set -e;
 export PROJECT_ROOT=$(git rev-parse --show-toplevel)
 source "$PROJECT_ROOT/api_tests/harness-lib.sh"
-cd "$PROJECT_ROOT/api_tests";
 
-TEST_PATH="$1"
+TEST_PATH="$1";
+export TEST_PATH=$(cd ${TEST_PATH} && pwd) && cd -; # Makes path absolute
 
 if [[ -z "${TEST_PATH}" ]] || [[ ! -d "${TEST_PATH}" ]]
 then
@@ -23,6 +23,8 @@ BETA=${DIR#*_}
 BETA_CHAIN=${BETA%-*}
 
 CHAINS="${ALPHA_CHAIN} ${BETA_CHAIN}" # Extract chain name before and after underscore
+
+cd "$PROJECT_ROOT/api_tests";
 
 END(){
     set +e;
@@ -104,4 +106,9 @@ generate_btc_blocks_every 5;
 sleep 2;
 
 log "Run test";
+(
+set +x;
+export NVM_SH=$([ -e $NVM_DIR/nvm.sh ] && echo "$NVM_DIR/nvm.sh" || echo /usr/local/opt/nvm/nvm.sh );
+. "$NVM_SH"
+)
 npm test "${TEST_PATH}/test.js";

--- a/api_tests/e2e/comit-harness.sh
+++ b/api_tests/e2e/comit-harness.sh
@@ -5,7 +5,7 @@ export PROJECT_ROOT=$(git rev-parse --show-toplevel)
 source "$PROJECT_ROOT/api_tests/harness-lib.sh"
 
 TEST_PATH="$1";
-export TEST_PATH=$(cd ${TEST_PATH} && pwd) && cd -; # Makes path absolute
+export TEST_PATH=$(cd ${TEST_PATH} && pwd); # Convert to absolute path
 
 if [[ -z "${TEST_PATH}" ]] || [[ ! -d "${TEST_PATH}" ]]
 then

--- a/api_tests/e2e/rfc003/btc_eth-erc20/test.js
+++ b/api_tests/e2e/rfc003/btc_eth-erc20/test.js
@@ -32,7 +32,7 @@ describe('RFC003: Bitcoin for ERC20', () => {
 
     let token_contract_address;
     before(async function () {
-        this.timeout(3000);
+        this.timeout(4000);
         return await test_lib.fund_eth(20).then(async () => {
             return await Promise.all(
                 [


### PR DESCRIPTION
- No need to update makefile when adding new folder in `rfc003/`
- `npm install` only ran once as part of pre-e2e
- GLOB support!

GLOB Support:
`cargo make e2e`: Runs all comit_node tests
`cargo make e2e btc*`: Runs all comit_node tests with alpha btc
`cargo make e2e *eth*`: Runs all tests involving eth