### PR TITLE
Allow Bob to accept a swap

### DIFF
--- a/api_tests/e2e/rfc003/btc_eth/test.js
+++ b/api_tests/e2e/rfc003/btc_eth/test.js
@@ -41,6 +41,15 @@ describe('RFC003 Bitcoin for Ether', () => {
         });
     });
 
+    it("No action should be found for a random id", async () => {
+        return chai.request(alice.comit_node_url())
+            .post('/swaps/rfc003/7b289045-a9e5-426f-98c8-38d89fc9167c/accept')
+            .send({
+            }).then((res) => {
+                res.should.have.status(404);
+            });
+    });
+
     let alice_swap_id;
     let swap_location;
     it("Alice should be able to make a swap request via HTTP api", async () => {

--- a/application/comit_node/src/bin/comit_node.rs
+++ b/application/comit_node/src/bin/comit_node.rs
@@ -31,6 +31,7 @@ use comit_node::{
             self,
             alice_ledger_actor::AliceLedgerActor,
             ledger_htlc_service::{BitcoinService, EthereumService},
+            pending_response_store::PendingResponseStore,
             state_store::InMemoryStateStore,
         },
         InMemoryMetadataStore,
@@ -63,6 +64,7 @@ fn main() {
     let event_store = Arc::new(InMemoryEventStore::default());
     let metadata_store = Arc::new(InMemoryMetadataStore::default());
     let state_store = Arc::new(InMemoryStateStore::default());
+    let pending_response_store = Arc::new(PendingResponseStore::default());
     let ethereum_service = create_ethereum_service(&settings);
     let bitcoin_service = create_bitcoin_service(&settings, &key_store);
     let ledger_query_service_api_client = create_ledger_query_service_api_client(&settings);
@@ -74,6 +76,7 @@ fn main() {
         Arc::clone(&event_store),
         Arc::clone(&metadata_store),
         Arc::clone(&state_store),
+        pending_response_store.clone(),
         Arc::clone(&ethereum_service),
         Arc::clone(&bitcoin_service),
         Arc::clone(&ledger_query_service_api_client),
@@ -215,6 +218,7 @@ fn spawn_alice_swap_request_handler_for_rfc003(
     event_store: Arc<InMemoryEventStore<SwapId>>,
     metadata_store: Arc<InMemoryMetadataStore<SwapId>>,
     state_store: Arc<InMemoryStateStore<SwapId>>,
+    pending_response_store: Arc<PendingResponseStore<SwapId>>,
     ethereum_service: Arc<EthereumService>,
     bitcoin_service: Arc<BitcoinService>,
     ledger_query_service: Arc<DefaultLedgerQueryServiceApiClient>,
@@ -244,6 +248,7 @@ fn spawn_alice_swap_request_handler_for_rfc003(
         metadata_store,
         key_store,
         state_store,
+        pending_response_store,
         client_factory,
         event_store,
         comit_node_addr,

--- a/application/comit_node/src/comit_client/mod.rs
+++ b/application/comit_node/src/comit_client/mod.rs
@@ -29,7 +29,7 @@ pub trait ClientFactory<C: Client>: Send + Sync + RefUnwindSafe + Debug {
     fn client_for(&self, comit_node_socket_addr: SocketAddr) -> Result<Arc<C>, ClientFactoryError>;
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SwapReject {
     /// The counterparty rejected the request
     Rejected,

--- a/application/comit_node/src/comit_client/rfc003.rs
+++ b/application/comit_node/src/comit_client/rfc003.rs
@@ -1,6 +1,6 @@
 use swap_protocols::rfc003::{Ledger, SecretHash};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Request<AL: Ledger, BL: Ledger, AA, BA> {
     pub alpha_asset: AA,
     pub beta_asset: BA,

--- a/application/comit_node/src/comit_server.rs
+++ b/application/comit_node/src/comit_server.rs
@@ -14,7 +14,7 @@ impl ComitServer {
         sender: mpsc::UnboundedSender<(
             SwapId,
             rfc003::bob::SwapRequestKind,
-            oneshot::Sender<Result<rfc003::bob::SwapResponseKind, failure::Error>>,
+            oneshot::Sender<rfc003::bob::SwapResponseKind>,
         )>,
     ) -> Self {
         Self { sender }
@@ -48,6 +48,6 @@ pub struct ComitServer {
     sender: mpsc::UnboundedSender<(
         SwapId,
         rfc003::bob::SwapRequestKind,
-        oneshot::Sender<Result<rfc003::bob::SwapResponseKind, failure::Error>>,
+        oneshot::Sender<rfc003::bob::SwapResponseKind>,
     )>,
 }

--- a/application/comit_node/src/http_api/mod.rs
+++ b/application/comit_node/src/http_api/mod.rs
@@ -7,6 +7,10 @@ pub mod ledger;
 #[macro_use]
 pub mod asset;
 
+mod problem;
+
+pub use self::problem::*;
+
 pub const PATH: &str = "swaps";
 
 mod ledger_impls {

--- a/application/comit_node/src/http_api/problem.rs
+++ b/application/comit_node/src/http_api/problem.rs
@@ -1,0 +1,50 @@
+use http::StatusCode;
+use http_api_problem::{HttpApiProblem, HttpStatusCode};
+use std::{error::Error, fmt};
+use warp::{Rejection, Reply};
+
+#[derive(Debug)]
+pub struct HttpApiProblemStdError {
+    inner: HttpApiProblem,
+}
+
+impl HttpApiProblemStdError {
+    pub fn new<P: Into<HttpApiProblem>>(inner: P) -> Self {
+        Self {
+            inner: inner.into(),
+        }
+    }
+}
+
+impl From<HttpApiProblem> for HttpApiProblemStdError {
+    fn from(problem: HttpApiProblem) -> Self {
+        Self { inner: problem }
+    }
+}
+
+impl fmt::Display for HttpApiProblemStdError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.inner.title)
+    }
+}
+
+impl Error for HttpApiProblemStdError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+}
+
+pub fn unpack_problem(rejection: Rejection) -> Result<impl Reply, Rejection> {
+    if let Some(ref err) = rejection.find_cause::<HttpApiProblemStdError>() {
+        let code = err
+            .inner
+            .status
+            .unwrap_or(HttpStatusCode::InternalServerError);
+        let json = warp::reply::json(&err.inner);
+        return Ok(warp::reply::with_status(
+            json,
+            StatusCode::from_u16(code.to_u16()).unwrap(),
+        ));
+    }
+    Err(rejection)
+}

--- a/application/comit_node/src/http_api/rfc003/action.rs
+++ b/application/comit_node/src/http_api/rfc003/action.rs
@@ -1,0 +1,102 @@
+use bitcoin_support::BitcoinQuantity;
+use ethereum_support::EtherQuantity;
+use event_store::EventStore;
+use failure;
+use http_api::rfc003::swap::HttpApiProblemStdError;
+use http_api_problem::HttpApiProblem;
+use std::{str::FromStr, sync::Arc};
+use swap_protocols::{
+    ledger::{Bitcoin, Ethereum},
+    rfc003::{
+        roles::{Bob, Role},
+        state_machine::*,
+        state_store::StateStore,
+    },
+    MetadataStore,
+};
+use swaps::common::SwapId;
+use warp::{self, Rejection, Reply};
+
+#[derive(Clone, Copy, Debug)]
+pub enum Action {
+    Accept,
+    Decline,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct ActionBody {}
+
+impl FromStr for Action {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
+        match s {
+            "accept" => Ok(Action::Accept),
+            "decline" => Ok(Action::Decline),
+            _ => Err(()),
+        }
+    }
+}
+
+pub fn post<E: EventStore<SwapId>, T: MetadataStore<SwapId>, S: StateStore<SwapId>>(
+    event_store: Arc<E>,
+    metadata_store: Arc<T>,
+    state_store: Arc<S>,
+    id: SwapId,
+    action: Action,
+    body: ActionBody,
+) -> Result<impl Reply, Rejection> {
+    use swap_protocols::{Assets, Ledgers, Metadata, Roles};
+
+    let result: Result<(), failure::Error> =
+        match metadata_store.get(&id) {
+            Err(e) => {
+                error!("Issue retrieve swap metadata for id {}", id);
+                Err(failure::Error::from(e))
+            }
+            Ok(Metadata {
+                source_ledger: Ledgers::Bitcoin,
+                target_ledger: Ledgers::Ethereum,
+                source_asset: Assets::Bitcoin,
+                target_asset: Assets::Ether,
+                role,
+            }) => match role {
+                Roles::Alice => {
+                    return Err(warp::reject::custom(HttpApiProblemStdError {
+                        http_api_problem: HttpApiProblem::new("incorrect-state-for-action")
+                            .set_status(400)
+                            .set_detail("Only Bob can accept or decline a swap"),
+                    }));
+                }
+                Roles::Bob => update_state::<
+                    S,
+                    Bob<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity>,
+                >(state_store, &id, action),
+            },
+            _ => unreachable!("No other type is expected to be found in the store"),
+        };
+
+    result.map(|_| warp::reply::with_status(warp::reply(), warp::http::StatusCode::OK))
+}
+
+fn update_state<S: StateStore<SwapId>, R: Role>(
+    state_store: Arc<S>,
+    id: &SwapId,
+    action: Action,
+) -> Result<(), failure::Error> {
+    let _: Result<(), failure::Error> = match state_store.get::<R>(id) {
+        Err(e) => Err(failure::Error::from(e)),
+        Ok(state) => match action {
+            Action::Accept => unimplemented!(),
+            Action::Decline => decline::<R>(state),
+        },
+    };
+    Ok(())
+}
+
+fn decline<R: Role>(state: SwapStates<R>) -> Result<(), failure::Error> {
+    match state {
+        SwapStates::Start(start) => unimplemented!(),
+        _ => unimplemented!(),
+    }
+}

--- a/application/comit_node/src/http_api/rfc003/action.rs
+++ b/application/comit_node/src/http_api/rfc003/action.rs
@@ -52,8 +52,7 @@ pub fn post<T: MetadataStore<SwapId>>(
             beta_asset: AssetKind::Ether,
             role,
         }) => match role {
-            RoleKind::Alice => Err(HttpApiProblem::new("incorrect-state-for-action")
-                .set_status(400)
+            RoleKind::Alice => Err(HttpApiProblem::with_title_and_type_from_status(400)
                 .set_detail("Only Bob can accept or decline a swap")),
             RoleKind::Bob => {
                 update_state::<Bitcoin, Ethereum>(pending_responses.as_ref(), &id, action, body)

--- a/application/comit_node/src/http_api/rfc003/action.rs
+++ b/application/comit_node/src/http_api/rfc003/action.rs
@@ -65,7 +65,10 @@ pub fn post<T: MetadataStore<SwapId>>(
             Err(HttpApiProblem::new("swap-not-found").set_status(404))
         }
         _ => {
-            warn!("Swap with id {} was found but the meta-data is unknown", id);
+            warn!(
+                "Swap with id {} was found but the meta-data does not match supported types",
+                id
+            );
             Err(HttpApiProblem::new("swap-not-found").set_status(404))
         }
     };

--- a/application/comit_node/src/http_api/rfc003/action.rs
+++ b/application/comit_node/src/http_api/rfc003/action.rs
@@ -1,5 +1,5 @@
 use frunk;
-use http_api::rfc003::swap::HttpApiProblemStdError;
+use http_api::HttpApiProblemStdError;
 use http_api_problem::HttpApiProblem;
 use std::{str::FromStr, sync::Arc};
 use swap_protocols::{

--- a/application/comit_node/src/http_api/rfc003/action.rs
+++ b/application/comit_node/src/http_api/rfc003/action.rs
@@ -1,17 +1,10 @@
-use bitcoin_support::BitcoinQuantity;
-use ethereum_support::EtherQuantity;
-use event_store::EventStore;
-use failure;
+use frunk;
 use http_api::rfc003::swap::HttpApiProblemStdError;
 use http_api_problem::HttpApiProblem;
 use std::{str::FromStr, sync::Arc};
 use swap_protocols::{
     ledger::{Bitcoin, Ethereum},
-    rfc003::{
-        roles::{Bob, Role},
-        state_machine::*,
-        state_store::StateStore,
-    },
+    rfc003::{bob::PendingResponses, Ledger},
     MetadataStore,
 };
 use swaps::common::SwapId;
@@ -22,9 +15,6 @@ pub enum Action {
     Accept,
     Decline,
 }
-
-#[derive(Clone, Deserialize, Debug)]
-pub struct ActionBody {}
 
 impl FromStr for Action {
     type Err = ();
@@ -38,65 +28,86 @@ impl FromStr for Action {
     }
 }
 
-pub fn post<E: EventStore<SwapId>, T: MetadataStore<SwapId>, S: StateStore<SwapId>>(
-    event_store: Arc<E>,
+#[derive(Debug, Deserialize, LabelledGeneric)]
+struct AcceptSwapRequestHttpBody<AL: Ledger, BL: Ledger> {
+    alpha_ledger_success_identity: AL::Identity,
+    beta_ledger_refund_identity: BL::Identity,
+    beta_ledger_lock_duration: BL::LockDuration,
+}
+
+pub fn post<T: MetadataStore<SwapId>>(
     metadata_store: Arc<T>,
-    state_store: Arc<S>,
+    pending_responses: Arc<PendingResponses<SwapId>>,
     id: SwapId,
     action: Action,
-    body: ActionBody,
+    body: serde_json::Value,
 ) -> Result<impl Reply, Rejection> {
-    use swap_protocols::{Assets, Ledgers, Metadata, Roles};
+    use swap_protocols::{AssetKind, LedgerKind, Metadata, RoleKind};
 
-    let result: Result<(), failure::Error> =
-        match metadata_store.get(&id) {
-            Err(e) => {
-                error!("Issue retrieve swap metadata for id {}", id);
-                Err(failure::Error::from(e))
+    let result = match metadata_store.get(&id) {
+        Ok(Metadata {
+            alpha_ledger: LedgerKind::Bitcoin,
+            beta_ledger: LedgerKind::Ethereum,
+            alpha_asset: AssetKind::Bitcoin,
+            beta_asset: AssetKind::Ether,
+            role,
+        }) => match role {
+            RoleKind::Alice => Err(HttpApiProblem::new("incorrect-state-for-action")
+                .set_status(400)
+                .set_detail("Only Bob can accept or decline a swap")),
+            RoleKind::Bob => {
+                update_state::<Bitcoin, Ethereum>(pending_responses.as_ref(), &id, action, body)
+                    .map_err(From::from)
             }
-            Ok(Metadata {
-                source_ledger: Ledgers::Bitcoin,
-                target_ledger: Ledgers::Ethereum,
-                source_asset: Assets::Bitcoin,
-                target_asset: Assets::Ether,
-                role,
-            }) => match role {
-                Roles::Alice => {
-                    return Err(warp::reject::custom(HttpApiProblemStdError {
-                        http_api_problem: HttpApiProblem::new("incorrect-state-for-action")
-                            .set_status(400)
-                            .set_detail("Only Bob can accept or decline a swap"),
-                    }));
-                }
-                Roles::Bob => update_state::<
-                    S,
-                    Bob<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity>,
-                >(state_store, &id, action),
-            },
-            _ => unreachable!("No other type is expected to be found in the store"),
-        };
+        },
+        Err(e) => {
+            error!("Failed to retrieve meta data for swap {}: {:?}", id, e);
+            Err(HttpApiProblem::new("swap-not-found").set_status(404))
+        }
+        _ => {
+            warn!("Swap with id {} was found but the meta-data is unknown", id);
+            Err(HttpApiProblem::new("swap-not-found").set_status(404))
+        }
+    };
 
-    result.map(|_| warp::reply::with_status(warp::reply(), warp::http::StatusCode::OK))
+    result
+        .map(|_| warp::reply())
+        .map_err(HttpApiProblemStdError::from)
+        .map_err(warp::reject::custom)
 }
 
-fn update_state<S: StateStore<SwapId>, R: Role>(
-    state_store: Arc<S>,
+fn update_state<AL: Ledger, BL: Ledger>(
+    pending_responses: &PendingResponses<SwapId>,
     id: &SwapId,
     action: Action,
-) -> Result<(), failure::Error> {
-    let _: Result<(), failure::Error> = match state_store.get::<R>(id) {
-        Err(e) => Err(failure::Error::from(e)),
-        Ok(state) => match action {
-            Action::Accept => unimplemented!(),
-            Action::Decline => decline::<R>(state),
-        },
-    };
-    Ok(())
-}
-
-fn decline<R: Role>(state: SwapStates<R>) -> Result<(), failure::Error> {
-    match state {
-        SwapStates::Start(start) => unimplemented!(),
-        _ => unimplemented!(),
-    }
+    body: serde_json::Value,
+) -> Result<(), HttpApiProblem> {
+    pending_responses
+        .take::<AL, BL>(id)
+        .ok_or_else(|| HttpApiProblem::with_title_from_status(500))
+        .and_then(|pending_response| match action {
+            Action::Accept => serde_json::from_value::<AcceptSwapRequestHttpBody<AL, BL>>(body)
+                .map_err(|e| {
+                    error!(
+                        "Failed to deserialize body of accept response for swap {}: {:?}",
+                        id, e
+                    );
+                    HttpApiProblem::new("invalid-body")
+                        .set_status(400)
+                        .set_detail("Failed to deserialize given body.")
+                })
+                .and_then(|body| {
+                    pending_response
+                        .send(Ok(frunk::labelled_convert_from(body)))
+                        .map_err(|_| {
+                            error!(
+                                "Failed to send pending response of swap {} through channel",
+                                id
+                            );
+                            HttpApiProblem::with_title_from_status(500)
+                        })
+                }),
+            Action::Decline => Err(HttpApiProblem::with_title_from_status(500)
+                .set_detail("declining a swap is not yet implemented")),
+        })
 }

--- a/application/comit_node/src/http_api/rfc003/action.rs
+++ b/application/comit_node/src/http_api/rfc003/action.rs
@@ -53,7 +53,7 @@ pub fn post<T: MetadataStore<SwapId>>(
             role,
         }) => match role {
             RoleKind::Alice => Err(HttpApiProblem::with_title_and_type_from_status(400)
-                .set_detail("Only Bob can accept or decline a swap")),
+                .set_detail(format!("Swap {} was initiated by this comit_node, only the counter-part can accept or decline", id))),
             RoleKind::Bob => {
                 update_state::<Bitcoin, Ethereum>(pending_responses.as_ref(), &id, action, body)
                     .map_err(From::from)

--- a/application/comit_node/src/http_api/rfc003/mod.rs
+++ b/application/comit_node/src/http_api/rfc003/mod.rs
@@ -1,1 +1,2 @@
+pub mod action;
 pub mod swap;

--- a/application/comit_node/src/http_api/rfc003/swap.rs
+++ b/application/comit_node/src/http_api/rfc003/swap.rs
@@ -156,9 +156,7 @@ pub fn get_swap<E: EventStore<SwapId>, T: MetadataStore<SwapId>, S: StateStore<S
     let metadata = metadata_store.get(&id);
     info!("Fetched metadata of swap with id {}: {:?}", id, metadata);
 
-    let result = handle_get_swap(id, &event_store, &metadata_store, &state_store);
-
-    match result {
+    match handle_get_swap(id, &event_store, &metadata_store, &state_store) {
         Some(swap_status) => Ok(warp::reply::json(&swap_status)),
         None => Err(warp::reject::custom(HttpApiProblemStdError::new(
             Error::NotFound,

--- a/application/comit_node/src/http_api/route_factory.rs
+++ b/application/comit_node/src/http_api/route_factory.rs
@@ -50,6 +50,6 @@ pub fn create<
         .and_then(http_api::rfc003::action::post);
 
     path.and(rfc003_get_swap.or(rfc003.and(rfc003_post_action.or(rfc003_post_swap))))
-        .recover(http_api::rfc003::swap::customize_error)
+        .recover(http_api::unpack_problem)
         .boxed()
 }

--- a/application/comit_node/src/http_api/route_factory.rs
+++ b/application/comit_node/src/http_api/route_factory.rs
@@ -3,7 +3,7 @@ use futures::sync::mpsc::UnboundedSender;
 use http_api;
 use std::{panic::RefUnwindSafe, sync::Arc};
 use swap_protocols::{
-    rfc003::{self, state_store},
+    rfc003::{self, bob::PendingResponses, state_store},
     MetadataStore,
 };
 use swaps::common::SwapId;
@@ -17,15 +17,17 @@ pub fn create<
     event_store: Arc<E>,
     metadata_store: Arc<T>,
     state_store: Arc<S>,
+    pending_responses: Arc<PendingResponses<SwapId>>,
     sender: UnboundedSender<(SwapId, rfc003::alice::SwapRequestKind)>,
 ) -> BoxedFilter<(impl Reply,)> {
     let path = warp::path(http_api::PATH);
     let rfc003 = warp::path(http_api::rfc003::swap::PATH);
 
-    let event_store = warp::any().map(move || event_store.clone());
-    let metadata_store = warp::any().map(move || metadata_store.clone());
-    let state_store = warp::any().map(move || state_store.clone());
+    let event_store = warp::any().map(move || Arc::clone(&event_store));
+    let metadata_store = warp::any().map(move || Arc::clone(&metadata_store));
+    let state_store = warp::any().map(move || Arc::clone(&state_store));
     let sender = warp::any().map(move || sender.clone());
+    let pending_responses = warp::any().map(move || Arc::clone(&pending_responses));
 
     let rfc003_post_swap = warp::post2()
         .and(warp::body::json())
@@ -40,9 +42,8 @@ pub fn create<
         .and_then(http_api::rfc003::swap::get_swap);
 
     let rfc003_post_action = warp::post2()
-        .and(event_store)
         .and(metadata_store)
-        .and(state_store)
+        .and(pending_responses)
         .and(warp::path::param::<SwapId>())
         .and(warp::path::param::<http_api::rfc003::action::Action>())
         .and(warp::body::json())

--- a/application/comit_node/src/ledger_query_service/cache.rs
+++ b/application/comit_node/src/ledger_query_service/cache.rs
@@ -14,10 +14,10 @@ pub struct QueryIdCache<L: Ledger, Q: Query> {
 }
 
 impl<L: Ledger, Q: Query> QueryIdCache<L, Q> {
-    pub fn wrap(inner: Arc<CreateQuery<L, Q>>) -> Self {
+    pub fn wrap<C: CreateQuery<L, Q>>(inner: Arc<C>) -> Self {
         Self {
             query_ids: Mutex::new(HashMap::new()),
-            inner,
+            inner: inner as Arc<CreateQuery<L, Q>>,
         }
     }
 }

--- a/application/comit_node/src/ledger_query_service/client.rs
+++ b/application/comit_node/src/ledger_query_service/client.rs
@@ -174,6 +174,15 @@ impl FetchQueryResults<Ethereum> for DefaultLedgerQueryServiceApiClient {
     }
 }
 
+impl FetchFullQueryResults<Ethereum> for DefaultLedgerQueryServiceApiClient {
+    fn fetch_full_query_results(
+        &self,
+        query: &QueryId<Ethereum>,
+    ) -> Box<Future<Item = Vec<<Ethereum as Ledger>::Transaction>, Error = Error> + Send> {
+        self.fetch_full_results(query)
+    }
+}
+
 impl LedgerQueryServiceApiClient<Ethereum, EthereumQuery> for DefaultLedgerQueryServiceApiClient {
     fn delete(&self, query: &QueryId<Ethereum>) -> Box<Future<Item = (), Error = Error> + Send> {
         self._delete(&query)

--- a/application/comit_node/src/ledger_query_service/first_match.rs
+++ b/application/comit_node/src/ledger_query_service/first_match.rs
@@ -11,8 +11,20 @@ use tokio::timer::Interval;
 
 #[derive(Debug, Clone)]
 pub struct FirstMatch<L: Ledger> {
-    pub fetch_results: Arc<FetchFullQueryResults<L>>,
-    pub poll_interval: Duration,
+    fetch_results: Arc<FetchFullQueryResults<L>>,
+    poll_interval: Duration,
+}
+
+impl<L: Ledger> FirstMatch<L> {
+    pub fn new<F: FetchFullQueryResults<L>>(
+        fetch_full_query_results: Arc<F>,
+        poll_interval: Duration,
+    ) -> Self {
+        Self {
+            fetch_results: fetch_full_query_results as Arc<FetchFullQueryResults<L>>,
+            poll_interval,
+        }
+    }
 }
 
 impl<L: Ledger> FirstMatch<L> {

--- a/application/comit_node/src/lib.rs
+++ b/application/comit_node/src/lib.rs
@@ -39,6 +39,7 @@ extern crate event_store;
 extern crate fern;
 extern crate frunk_core;
 extern crate hex;
+extern crate http;
 extern crate http_api_problem;
 extern crate hyper;
 extern crate rand;

--- a/application/comit_node/src/lib.rs
+++ b/application/comit_node/src/lib.rs
@@ -20,6 +20,7 @@ extern crate state_machine_future;
 extern crate maplit;
 #[macro_use]
 extern crate frunk;
+#[macro_use]
 extern crate serde_json;
 
 #[cfg(test)]

--- a/application/comit_node/src/swap_protocols/asset.rs
+++ b/application/comit_node/src/swap_protocols/asset.rs
@@ -2,7 +2,7 @@ use bam_api::header::{FromBamHeader, ToBamHeader};
 use bitcoin_support::BitcoinQuantity;
 use ethereum_support::{Erc20Quantity, EtherQuantity};
 use http_api::asset::{FromHttpAsset, ToHttpAsset};
-use std::fmt::Debug;
+use std::{fmt::Debug, hash::Hash};
 
 pub trait Asset:
     Clone
@@ -11,6 +11,8 @@ pub trait Asset:
     + Sync
     + 'static
     + PartialEq
+    + Eq
+    + Hash
     + FromHttpAsset
     + ToHttpAsset
     + FromBamHeader

--- a/application/comit_node/src/swap_protocols/ledger/bitcoin.rs
+++ b/application/comit_node/src/swap_protocols/ledger/bitcoin.rs
@@ -4,7 +4,7 @@ use bitcoin_support::{
 use secp256k1_support::PublicKey;
 use swap_protocols::ledger::Ledger;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Bitcoin {
     pub network: Network,
 }

--- a/application/comit_node/src/swap_protocols/ledger/ethereum.rs
+++ b/application/comit_node/src/swap_protocols/ledger/ethereum.rs
@@ -2,7 +2,7 @@ use ethereum_support::{Address, EtherQuantity, Transaction, H256};
 use secp256k1_support::PublicKey;
 use swap_protocols::ledger::Ledger;
 
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
 pub struct Ethereum {}
 
 impl Ledger for Ethereum {

--- a/application/comit_node/src/swap_protocols/ledger/mod.rs
+++ b/application/comit_node/src/swap_protocols/ledger/mod.rs
@@ -7,6 +7,7 @@ mod ethereum;
 pub use self::{bitcoin::Bitcoin, ethereum::Ethereum};
 use bam_api::header::{FromBamHeader, ToBamHeader};
 use http_api::ledger::{FromHttpLedger, ToHttpLedger};
+use std::hash::Hash;
 
 pub trait Ledger:
     Clone
@@ -16,6 +17,8 @@ pub trait Ledger:
     + 'static
     + Default
     + PartialEq
+    + Eq
+    + Hash
     + FromHttpLedger
     + ToHttpLedger
     + FromBamHeader
@@ -30,6 +33,8 @@ pub trait Ledger:
         + Send
         + Sync
         + PartialEq
+        + Eq
+        + Hash
         + 'static
         + From<Self::Address>
         + Serialize

--- a/application/comit_node/src/swap_protocols/metadata_store.rs
+++ b/application/comit_node/src/swap_protocols/metadata_store.rs
@@ -28,9 +28,11 @@ pub struct Metadata {
     pub role: RoleKind,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Fail)]
 pub enum Error {
+    #[fail(display = "Metadata not found")]
     NotFound,
+    #[fail(display = "Metadata already exists")]
     DuplicateKey,
 }
 

--- a/application/comit_node/src/swap_protocols/rfc003/bob/handler.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/bob/handler.rs
@@ -179,7 +179,7 @@ fn spawn_state_machine<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset, S: StateSto
 
     let save_state = state_store
         .insert(id, state.clone())
-        .expect("handle errors :)");
+        .expect("handle errors :)"); //TODO: handle errors
 
     let context = Context {
         alpha_ledger_events,

--- a/application/comit_node/src/swap_protocols/rfc003/bob/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/bob/mod.rs
@@ -1,9 +1,11 @@
 mod handler;
+mod pending_responses;
 mod swap_request;
 mod swap_response;
 
 pub use self::{
     handler::SwapRequestHandler,
+    pending_responses::PendingResponses,
     swap_request::{SwapRequest, SwapRequestKind},
-    swap_response::{SwapResponse, SwapResponseKind},
+    swap_response::SwapResponseKind,
 };

--- a/application/comit_node/src/swap_protocols/rfc003/bob/pending_responses.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/bob/pending_responses.rs
@@ -9,6 +9,10 @@ use swap_protocols::{
     rfc003::{events::ResponseFuture, roles::Bob, state_machine::StateMachineResponse, Ledger},
 };
 
+#[allow(type_alias_bounds)]
+type PendingResponseSender<SL: Ledger, TL: Ledger> =
+    Sender<Result<StateMachineResponse<SL::Identity, TL::Identity, TL::LockDuration>, SwapReject>>;
+
 #[derive(Debug, Default)]
 pub struct PendingResponses<K: Hash + Eq> {
     pending_responses: Mutex<HashMap<K, Box<Any + Send + 'static>>>,
@@ -21,32 +25,30 @@ impl<K: Hash + Eq + Clone + Send + Sync + 'static> PendingResponses<K> {
     ) -> Box<ResponseFuture<Bob<SL, TL, SA, TA>>> {
         let (sender, receiver) = oneshot::channel();
 
-        let mut pending_responses = self.pending_responses.lock().unwrap();
+        let mut pending_responses = match self.pending_responses.lock() {
+            Ok(guard) => guard,
+            Err(e) => e.into_inner(),
+        };
 
         let _old = pending_responses.insert(key, Box::new(sender));
 
         Box::new(receiver.map_err(|_| unreachable!("The sender should never be dropped")))
     }
 
-    pub fn take<SL: Ledger, TL: Ledger>(
-        &self,
-        key: &K,
-    ) -> Option<
-        Sender<
-            Result<StateMachineResponse<SL::Identity, TL::Identity, TL::LockDuration>, SwapReject>,
-        >,
-    > {
-        let mut pending_responses = self.pending_responses.lock().unwrap();
-        pending_responses.remove(key).map(|sender| {
-            let sender = sender
-                .downcast::<Sender<
-                    Result<
-                        StateMachineResponse<SL::Identity, TL::Identity, TL::LockDuration>,
-                        SwapReject,
-                    >,
-                >>()
-                .unwrap();
-            *sender
+    pub fn take<SL: Ledger, TL: Ledger>(&self, key: &K) -> Option<PendingResponseSender<SL, TL>> {
+        let mut pending_responses = match self.pending_responses.lock() {
+            Ok(guard) => guard,
+            Err(e) => e.into_inner(),
+        };
+
+        pending_responses.remove(key).and_then(|sender| {
+            match sender.downcast::<PendingResponseSender<SL, TL>>() {
+                Ok(sender) => Some(*sender),
+                Err(e) => {
+                    error!("Failed to downcast sender to expected type: {:?}", e);
+                    None
+                }
+            }
         })
     }
 }

--- a/application/comit_node/src/swap_protocols/rfc003/bob/swap_response.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/bob/swap_response.rs
@@ -1,19 +1,13 @@
-use swap_protocols::{
-    ledger::{Bitcoin, Ethereum},
-    rfc003::Ledger,
-};
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum SwapResponse<AL: Ledger, BL: Ledger> {
-    Accept {
-        beta_ledger_refund_identity: BL::Identity,
-        alpha_ledger_success_identity: AL::Identity,
-        beta_ledger_lock_duration: BL::LockDuration,
-    },
-    Decline,
-}
+use comit_client::SwapReject;
+use ethereum_support;
+use swap_protocols::rfc003::{ethereum::Seconds, state_machine::StateMachineResponse};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum SwapResponseKind {
-    BitcoinEthereum(SwapResponse<Bitcoin, Ethereum>),
+    BitcoinEthereum(
+        Result<
+            StateMachineResponse<secp256k1_support::KeyPair, ethereum_support::Address, Seconds>,
+            SwapReject,
+        >,
+    ),
 }

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/mod.rs
@@ -26,7 +26,7 @@ pub trait Htlc {
     fn compile_to_hex(&self) -> ByteCode;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Seconds(pub u64);
 
 impl From<Duration> for Seconds {
@@ -55,5 +55,11 @@ impl From<HtlcParams<Ethereum, EtherQuantity>> for EtherHtlc {
             htlc_params.success_identity,
             htlc_params.secret_hash,
         )
+    }
+}
+
+impl HtlcParams<Ethereum, EtherQuantity> {
+    pub fn bytecode(&self) -> Bytes {
+        EtherHtlc::from(self.clone()).compile_to_hex().into()
     }
 }

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/queries.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/queries.rs
@@ -3,10 +3,21 @@ use ledger_query_service::EthereumQuery;
 use swap_protocols::{
     ledger::Ethereum,
     rfc003::{
-        events::{NewHtlcRedeemedQuery, NewHtlcRefundedQuery},
+        events::{NewHtlcFundedQuery, NewHtlcRedeemedQuery, NewHtlcRefundedQuery},
         state_machine::HtlcParams,
     },
 };
+
+impl NewHtlcFundedQuery<Ethereum, EtherQuantity> for EthereumQuery {
+    fn new_htlc_funded_query(htlc_params: &HtlcParams<Ethereum, EtherQuantity>) -> Self {
+        EthereumQuery::Transaction {
+            from_address: None,
+            to_address: None,
+            is_contract_creation: Some(true),
+            transaction_data: Some(htlc_params.bytecode()),
+        }
+    }
+}
 
 impl NewHtlcRefundedQuery<Ethereum, EtherQuantity> for EthereumQuery {
     fn new_htlc_refunded_query(

--- a/application/comit_node/src/swap_protocols/rfc003/events/alice.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/events/alice.rs
@@ -12,7 +12,8 @@ use swap_protocols::{
     },
 };
 
-struct AliceComitClient<C, SL: Ledger, TL: Ledger> {
+#[allow(missing_debug_implementations)]
+pub struct AliceToBob<C, SL: Ledger, TL: Ledger> {
     #[allow(clippy::type_complexity)]
     response_future:
         Option<Box<StateMachineResponseFuture<SL::Identity, TL::Identity, TL::LockDuration>>>,
@@ -20,7 +21,7 @@ struct AliceComitClient<C, SL: Ledger, TL: Ledger> {
 }
 
 impl<C: comit_client::Client, SL: Ledger, TL: Ledger, SA: Asset, TA: Asset>
-    CommunicationEvents<Alice<SL, TL, SA, TA>> for AliceComitClient<C, SL, TL>
+    CommunicationEvents<Alice<SL, TL, SA, TA>> for AliceToBob<C, SL, TL>
 {
     fn request_responded(
         &mut self,

--- a/application/comit_node/src/swap_protocols/rfc003/events/bob.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/events/bob.rs
@@ -1,0 +1,60 @@
+use comit_client::{self, SwapReject};
+use futures::{sync::oneshot, Future};
+use std::sync::Arc;
+use swap_protocols::{
+    asset::Asset,
+    rfc003::{
+        bob::PendingResponses,
+        events::{CommunicationEvents, ResponseFuture},
+        ledger::Ledger,
+        roles::Bob,
+        state_machine::StateMachineResponse,
+    },
+};
+use swaps::common::SwapId;
+
+#[derive(DebugStub)]
+pub struct BobToAlice<SL: Ledger, TL: Ledger, SA: Asset, TA: Asset> {
+    #[debug_stub = "ResponseFuture"]
+    response_future: Box<ResponseFuture<Bob<SL, TL, SA, TA>>>,
+}
+
+impl<SL: Ledger, TL: Ledger, SA: Asset, TA: Asset> BobToAlice<SL, TL, SA, TA> {
+    pub fn new(
+        pending_responses: Arc<PendingResponses<SwapId>>,
+        current_swap: SwapId,
+        response_sender: oneshot::Sender<
+            Result<
+                StateMachineResponse<SL::HtlcIdentity, TL::HtlcIdentity, TL::LockDuration>,
+                SwapReject,
+            >,
+        >,
+    ) -> Self {
+        Self {
+            response_future: {
+                let future = pending_responses
+                    .create::<SL, TL, SA, TA>(current_swap)
+                    .and_then(|response| {
+                        response_sender
+                            .send(response.clone())
+                            .expect("should never fail");
+
+                        Ok(response)
+                    });
+
+                Box::new(future)
+            },
+        }
+    }
+}
+
+impl<SL: Ledger, TL: Ledger, SA: Asset, TA: Asset> CommunicationEvents<Bob<SL, TL, SA, TA>>
+    for BobToAlice<SL, TL, SA, TA>
+{
+    fn request_responded(
+        &mut self,
+        _request: &comit_client::rfc003::Request<SL, TL, SA, TA>,
+    ) -> &mut ResponseFuture<Bob<SL, TL, SA, TA>> {
+        &mut self.response_future
+    }
+}

--- a/application/comit_node/src/swap_protocols/rfc003/events/bob.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/events/bob.rs
@@ -37,7 +37,7 @@ impl<SL: Ledger, TL: Ledger, SA: Asset, TA: Asset> BobToAlice<SL, TL, SA, TA> {
                     .and_then(|response| {
                         response_sender
                             .send(response.clone())
-                            .expect("should never fail");
+                            .expect("receiver should never go out of scope");
 
                         Ok(response)
                     });

--- a/application/comit_node/src/swap_protocols/rfc003/events/lqs.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/events/lqs.rs
@@ -23,6 +23,17 @@ pub struct LqsEvents<L: Ledger, Q: Query> {
     htlc_redeemed_or_refunded: Option<Box<RedeemedOrRefunded<L>>>,
 }
 
+impl<L: Ledger, Q: Query> LqsEvents<L, Q> {
+    pub fn new(create_ledger_query: QueryIdCache<L, Q>, ledger_first_match: FirstMatch<L>) -> Self {
+        Self {
+            create_ledger_query,
+            ledger_first_match,
+            htlc_funded_query: None,
+            htlc_redeemed_or_refunded: None,
+        }
+    }
+}
+
 impl<L, A, Q> LedgerEvents<L, A> for LqsEvents<L, Q>
 where
     L: Ledger,

--- a/application/comit_node/src/swap_protocols/rfc003/ledger.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ledger.rs
@@ -1,5 +1,5 @@
 use serde::{de::DeserializeOwned, Serialize};
-use std::fmt::Debug;
+use std::{fmt::Debug, hash::Hash};
 use swap_protocols::{
     self,
     rfc003::secret::{Secret, SecretHash},
@@ -7,6 +7,8 @@ use swap_protocols::{
 
 pub trait Ledger: swap_protocols::Ledger + ExtractSecret {
     type LockDuration: PartialEq
+        + Eq
+        + Hash
         + Debug
         + Clone
         + Send

--- a/application/comit_node/src/swap_protocols/rfc003/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/mod.rs
@@ -10,6 +10,7 @@ pub mod ethereum;
 pub mod events;
 pub mod is_contained_in_transaction;
 pub mod ledger_htlc_service;
+pub mod pending_response_store;
 pub mod roles;
 pub mod state_machine;
 pub mod state_store;

--- a/application/comit_node/src/swap_protocols/rfc003/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/mod.rs
@@ -10,7 +10,6 @@ pub mod ethereum;
 pub mod events;
 pub mod is_contained_in_transaction;
 pub mod ledger_htlc_service;
-pub mod pending_response_store;
 pub mod roles;
 pub mod state_machine;
 pub mod state_store;

--- a/application/comit_node/src/swap_protocols/rfc003/pending_response_store.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/pending_response_store.rs
@@ -1,0 +1,40 @@
+use comit_client::SwapReject;
+use futures::{
+    sync::oneshot::{self, Sender},
+    Future,
+};
+use std::{any::Any, collections::HashMap, hash::Hash, sync::Mutex};
+use swap_protocols::{
+    asset::Asset,
+    rfc003::{events::ResponseFuture, messages::AcceptResponseBody, roles::Bob, Ledger},
+};
+
+pub type SenderAction<SL, TL> = Sender<Result<AcceptResponseBody<SL, TL>, SwapReject>>;
+
+#[derive(Debug, Default)]
+pub struct PendingResponseStore<K: Hash + Eq> {
+    pending_responses: Mutex<HashMap<K, Box<Any + Send + 'static>>>,
+}
+
+impl<K: Hash + Eq + Clone + Send + Sync + 'static> PendingResponseStore<K> {
+    pub fn create<SL: Ledger, TL: Ledger, SA: Asset, TA: Asset>(
+        &self,
+        key: K,
+    ) -> Box<ResponseFuture<Bob<SL, TL, SA, TA>>> {
+        let (sender, receiver) = oneshot::channel();
+
+        let mut pending_responses = self.pending_responses.lock().unwrap();
+
+        let _old = pending_responses.insert(key, Box::new(sender));
+
+        Box::new(receiver.map_err(|_| unreachable!("The sender should never be dropped")))
+    }
+
+    pub fn take<SL: Ledger, TL: Ledger>(&self, key: &K) -> Option<SenderAction<SL, TL>> {
+        let mut pending_responses = self.pending_responses.lock().unwrap();
+        pending_responses.remove(key).map(|sender| {
+            let sender = sender.downcast::<SenderAction<SL, TL>>().unwrap();
+            *sender
+        })
+    }
+}

--- a/application/comit_node/src/swap_protocols/rfc003/state_machine_test.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/state_machine_test.rs
@@ -88,7 +88,7 @@ macro_rules! init {
             alpha_ledger_events: Box::new($alpha_events),
             beta_ledger_events: Box::new($beta_events),
             state_repo: Arc::new(state_sender),
-            response_event: Box::new($response_event),
+            communication_events: Box::new($response_event),
         };
         let state: SwapStates<$role> = $state;
         let final_state_future = Swap::start_in(state, context);

--- a/application/comit_node/src/swap_protocols/rfc003/state_store.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/state_store.rs
@@ -6,9 +6,11 @@ use std::{
 };
 use swap_protocols::rfc003::{roles::Role, state_machine::SwapStates, SaveState};
 
-#[derive(Debug)]
+#[derive(Debug, Fail)]
 pub enum Error {
+    #[fail(display = "State not found")]
     NotFound,
+    #[fail(display = "State already exists for given key")]
     DuplicateKey,
 }
 

--- a/application/ledger_query_service/src/route_factory.rs
+++ b/application/ledger_query_service/src/route_factory.rs
@@ -106,14 +106,14 @@ impl RouteFactory {
             .and(query_repository.clone())
             .and(query_result_repository.clone())
             .and(client.clone())
-            .and(warp::path::param())
+            .and(warp::path::param::<u32>())
             .and(warp::query::<QueryParams>())
             .and_then(routes::retrieve_query);
 
         let delete = warp::delete2()
             .and(query_repository)
             .and(query_result_repository)
-            .and(warp::path::param())
+            .and(warp::path::param::<u32>())
             .and_then(routes::delete_query);
 
         endpoint

--- a/vendor/bitcoin_support/src/blocks.rs
+++ b/vendor/bitcoin_support/src/blocks.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Blocks(u32);
 
 pub const BTC_BLOCKS_IN_24H: Blocks = Blocks::new(24 * 60 / 10);


### PR DESCRIPTION
This PR adds two routes to the HTTP API:

- accept
- decline

These are the two actions that Bob can perform when presented with a swap request. At the moment, only `accept` is implemented but this is the much more difficult one. If he accepts, his response is used for two things:

- it is sent back to Alice
- his own state machine is advanced into the next state and starts listening for Alice to deploy the first contract