### PR TITLE
Implement fund action endpoint

### DIFF
--- a/application/comit_node/src/http_api/problem.rs
+++ b/application/comit_node/src/http_api/problem.rs
@@ -35,8 +35,12 @@ impl Error for HttpApiProblemStdError {
     }
 }
 
-pub fn not_found() -> HttpApiProblem {
+pub fn swap_not_found() -> HttpApiProblem {
     HttpApiProblem::new("swap-not-found").set_status(404)
+}
+
+pub fn action_not_found() -> HttpApiProblem {
+    HttpApiProblem::new("action-not-found").set_status(404)
 }
 
 pub fn unsupported() -> HttpApiProblem {

--- a/application/comit_node/src/http_api/problem.rs
+++ b/application/comit_node/src/http_api/problem.rs
@@ -39,10 +39,6 @@ pub fn swap_not_found() -> HttpApiProblem {
     HttpApiProblem::new("swap-not-found").set_status(404)
 }
 
-pub fn action_not_found() -> HttpApiProblem {
-    HttpApiProblem::new("action-not-found").set_status(404)
-}
-
 pub fn unsupported() -> HttpApiProblem {
     HttpApiProblem::new("swap-not-supported").set_status(400)
 }

--- a/application/comit_node/src/http_api/rfc003/action.rs
+++ b/application/comit_node/src/http_api/rfc003/action.rs
@@ -185,9 +185,10 @@ fn handle_get<T: MetadataStore<SwapId>, S: StateStore<SwapId>>(
                                 _ => None,
                             });
 
-                    action
-                        .map(|action| warp::reply::json(&action))
-                        .ok_or_else(problem::action_not_found)
+                    action.map(|action| warp::reply::json(&action)).ok_or(
+                        HttpApiProblem::with_title_and_type_from_status(400)
+                            .set_detail("Requested action is not supported for this swap"),
+                    )
                 }
                 GetAction::Redeem => unimplemented!(),
                 GetAction::Refund => unimplemented!(),

--- a/application/comit_node/src/http_api/rfc003/action.rs
+++ b/application/comit_node/src/http_api/rfc003/action.rs
@@ -1,28 +1,37 @@
+use bitcoin_support::BitcoinQuantity;
+use ethereum_support::EtherQuantity;
 use frunk;
 use http_api::{problem, HttpApiProblemStdError};
 use http_api_problem::HttpApiProblem;
 use std::{str::FromStr, sync::Arc};
 use swap_protocols::{
     ledger::{Bitcoin, Ethereum},
-    rfc003::{bob::PendingResponses, Ledger},
-    MetadataStore,
+    metadata_store::Metadata,
+    rfc003::{
+        actions::{Action, StateActions},
+        bob::PendingResponses,
+        roles::{Alice, Bob},
+        state_store::StateStore,
+        Ledger,
+    },
+    AssetKind, LedgerKind, MetadataStore, RoleKind,
 };
 use swaps::common::SwapId;
 use warp::{self, Rejection, Reply};
 
 #[derive(Clone, Copy, Debug)]
-pub enum Action {
+pub enum PostAction {
     Accept,
     Decline,
 }
 
-impl FromStr for Action {
+impl FromStr for PostAction {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
         match s {
-            "accept" => Ok(Action::Accept),
-            "decline" => Ok(Action::Decline),
+            "accept" => Ok(PostAction::Accept),
+            "decline" => Ok(PostAction::Decline),
             _ => Err(()),
         }
     }
@@ -39,7 +48,7 @@ pub fn post<T: MetadataStore<SwapId>>(
     metadata_store: Arc<T>,
     pending_responses: Arc<PendingResponses<SwapId>>,
     id: SwapId,
-    action: Action,
+    action: PostAction,
     body: serde_json::Value,
 ) -> Result<impl Reply, Rejection> {
     handle_post(metadata_store, pending_responses, id, action, body)
@@ -52,7 +61,7 @@ pub fn handle_post<T: MetadataStore<SwapId>>(
     metadata_store: Arc<T>,
     pending_responses: Arc<PendingResponses<SwapId>>,
     id: SwapId,
-    action: Action,
+    action: PostAction,
     body: serde_json::Value,
 ) -> Result<(), HttpApiProblem> {
     use swap_protocols::{AssetKind, LedgerKind, Metadata, RoleKind};
@@ -81,14 +90,14 @@ pub fn handle_post<T: MetadataStore<SwapId>>(
 fn forward_response<AL: Ledger, BL: Ledger>(
     pending_responses: &PendingResponses<SwapId>,
     id: &SwapId,
-    action: Action,
+    action: PostAction,
     body: serde_json::Value,
 ) -> Result<(), HttpApiProblem> {
     pending_responses
         .take::<AL, BL>(id)
         .ok_or_else(|| HttpApiProblem::with_title_from_status(500))
         .and_then(|pending_response| match action {
-            Action::Accept => serde_json::from_value::<AcceptSwapRequestHttpBody<AL, BL>>(body)
+            PostAction::Accept => serde_json::from_value::<AcceptSwapRequestHttpBody<AL, BL>>(body)
                 .map_err(|e| {
                     error!(
                         "Failed to deserialize body of accept response for swap {}: {:?}",
@@ -109,7 +118,80 @@ fn forward_response<AL: Ledger, BL: Ledger>(
                             HttpApiProblem::with_title_from_status(500)
                         })
                 }),
-            Action::Decline => Err(HttpApiProblem::with_title_from_status(500)
+            PostAction::Decline => Err(HttpApiProblem::with_title_from_status(500)
                 .set_detail("declining a swap is not yet implemented")),
         })
+}
+
+#[derive(Debug)]
+pub enum GetAction {
+    Fund,
+    Redeem,
+    Refund,
+}
+
+impl FromStr for GetAction {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
+        match s {
+            "fund" => Ok(GetAction::Fund),
+            "redeem" => Ok(GetAction::Redeem),
+            "refund" => Ok(GetAction::Refund),
+            _ => Err(()),
+        }
+    }
+}
+
+pub fn get<T: MetadataStore<SwapId>, S: StateStore<SwapId>>(
+    metadata_store: Arc<T>,
+    state_store: Arc<S>,
+    id: SwapId,
+    action: GetAction,
+) -> Result<impl Reply, Rejection> {
+    handle_get(metadata_store, state_store, &id, &action)
+        .map_err(HttpApiProblemStdError::from)
+        .map_err(warp::reject::custom)
+}
+
+fn handle_get<T: MetadataStore<SwapId>, S: StateStore<SwapId>>(
+    metadata_store: Arc<T>,
+    state_store: Arc<S>,
+    id: &SwapId,
+    action: &GetAction,
+) -> Result<impl Reply, HttpApiProblem> {
+    let metadata = metadata_store
+        .get(id)?
+        .ok_or_else(problem::swap_not_found)?;
+    get_swap!(
+        &metadata,
+        state_store,
+        id,
+        state,
+        (|| {
+            let state = state.ok_or(HttpApiProblem::with_title_and_type_from_status(500))?;
+            trace!("Retrieved state for {}: {:?}", id, state);
+
+            match action {
+                GetAction::Fund => {
+                    let action =
+                        state
+                            .actions()
+                            .iter()
+                            .find_map(|state_action| match state_action {
+                                Action::Fund(fund_action) => {
+                                    Some(serde_json::to_value(&fund_action).unwrap())
+                                }
+                                _ => None,
+                            });
+
+                    action
+                        .map(|action| warp::reply::json(&action))
+                        .ok_or_else(problem::action_not_found)
+                }
+                GetAction::Redeem => unimplemented!(),
+                GetAction::Refund => unimplemented!(),
+            }
+        })
+    )
 }

--- a/application/comit_node/src/http_api/route_factory.rs
+++ b/application/comit_node/src/http_api/route_factory.rs
@@ -48,7 +48,7 @@ pub fn create<T: MetadataStore<SwapId>, S: state_store::StateStore<SwapId>>(
         .and(metadata_store)
         .and(pending_responses)
         .and(warp::path::param::<SwapId>())
-        .and(warp::path::param::<http_api::rfc003::action::Action>())
+        .and(warp::path::param::<http_api::rfc003::action::PostAction>())
         .and(warp::post2())
         .and(warp::path::end())
         .and(warp::body::json())

--- a/application/comit_node/src/swap_protocols/rfc003/actions/bitcoin.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/bitcoin.rs
@@ -3,7 +3,7 @@ use bitcoin_witness::{PrimedInput, PrimedTransaction};
 use secp256k1_support::KeyPair;
 use swap_protocols::rfc003::{bitcoin::Htlc, Secret};
 
-#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize)]
 pub struct BitcoinFund {
     pub address: Address,
     pub value: BitcoinQuantity,

--- a/application/comit_node/src/swap_protocols/rfc003/actions/ethereum.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/ethereum.rs
@@ -1,7 +1,7 @@
 use ethereum_support::{web3::types::U256, Address, Bytes, EtherQuantity};
 use swap_protocols::rfc003::Secret;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub struct EtherDeploy {
     pub data: Bytes,
     pub value: EtherQuantity,


### PR DESCRIPTION
- Split `http_api::rfc003::action::Action` into `GetAction` and
  `PostAction`. The get actions return fund/redeem/refund data related
  to HTLCs; the post actions accept/decline a swap.
- Split HTTP API problem `not-found` into `swap-not-found` and
  `action-not-found`.