### PR TITLE
Add failure-fallback variants for SwapRequestBodyKind

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -187,6 +187,7 @@ dependencies = [
 
 [tasks.dry-tests]
 description = "Runs tests that don't require any external services"
+env = { "LOG_DIR" = "./dry/log" }
 workspace = false
 private = true
 script_runner = "bash"

--- a/api_tests/dry/rfc003.js
+++ b/api_tests/dry/rfc003.js
@@ -78,6 +78,45 @@ describe("RFC003 HTTP API", () => {
             });
     });
 
+    it("[Alice] Returns 400 swap-not-supported for an unsupported combination of parameters", async () => {
+        await chai.request(alice.comit_node_url())
+            .post('/swaps/rfc003')
+            .send({
+                "alpha_ledger": {
+                    "name": "Thomas' wallet",
+                },
+                "beta_ledger": {
+                    "name": "Higher-Dimension" // This is the coffee place downstairs
+                },
+                "alpha_asset": {
+                    "name": "AUD",
+                    "quantity": "3.5"
+                },
+                "beta_asset": {
+                    "name": "Espresso",
+                    "double-shot": true
+                },
+                "alpha_ledger_refund_identity": "",
+                "beta_ledger_success_identity": "",
+                "alpha_ledger_lock_duration": 0
+            }).then((res) => {
+                res.should.have.status(400);
+                res.body.title.should.equal("swap-not-supported");
+            });
+    });
+
+    it("[Alice] Returns 400 bad request for malformed requests", async () => {
+        await chai.request(alice.comit_node_url())
+            .post('/swaps/rfc003')
+            .send({
+                "garbage": true
+            }).then((res) => {
+                res.should.have.status(400);
+                console.error(res.body);
+                res.body.title.should.equal("Bad request");
+            });
+    });
+
     it("[Alice] Is able to GET the swap after POSTing it", async () => {
         await chai
             .request(alice.comit_node_url())

--- a/application/comit_node/src/http_api/asset.rs
+++ b/application/comit_node/src/http_api/asset.rs
@@ -2,7 +2,7 @@ use serde::{de::DeserializeOwned, Deserializer, Serialize, Serializer};
 use serde_json;
 use std::{collections::BTreeMap, fmt};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HttpAsset {
     name: String,
     #[serde(default, flatten)]

--- a/application/comit_node/src/http_api/ledger.rs
+++ b/application/comit_node/src/http_api/ledger.rs
@@ -2,7 +2,7 @@ use serde::{de::DeserializeOwned, Deserializer, Serialize, Serializer};
 use serde_json;
 use std::{collections::HashMap, fmt};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HttpLedger {
     name: String,
     #[serde(default, flatten)]

--- a/application/comit_node/src/logging.rs
+++ b/application/comit_node/src/logging.rs
@@ -29,6 +29,7 @@ pub fn set_up_logging() {
         .level_for("tokio_core::reactor", LevelFilter::Info)
         .level_for("tokio_reactor", LevelFilter::Info)
         .level_for("hyper", LevelFilter::Info)
+        .level_for("warp", LevelFilter::Info)
         // output to stdout
         .chain(stdout())
         .apply()
@@ -37,19 +38,10 @@ pub fn set_up_logging() {
 
 fn formatter(out: FormatCallback, message: &Arguments, record: &Record) {
     // configure colors for the whole line
-    let colors_line = ColoredLevelConfig::new()
-        .error(Color::Red)
-        .warn(Color::Yellow)
-        // we actually don't need to specify the color for debug and info, they are white by default
-        .info(Color::White)
-        .debug(Color::White)
-        // depending on the terminals color scheme, this is the same as the background color
-        .trace(Color::BrightBlack);
-
-    // configure colors for the name of the level.
-    // since almost all of them are the some as the color for the whole line, we
-    // just clone `colors_line` and overwrite our changes
-    let colors_level = colors_line.info(Color::Green);
+    let colors_line = ColoredLevelConfig::default()
+        .info(Color::Green)
+        .debug(Color::Blue)
+        .trace(Color::Cyan);
 
     LOG_CONTEXT.with(|context| {
         let context = {
@@ -60,14 +52,10 @@ fn formatter(out: FormatCallback, message: &Arguments, record: &Record) {
         };
 
         out.finish(format_args!(
-            "{color_line}[{date}][{target}][{level}{color_line}]{context}{message}\x1B[0m",
-            color_line = format_args!(
-                "\x1B[{}m",
-                colors_line.get_color(&record.level()).to_fg_str()
-            ),
+            "[{date}][{target}][{level}] {context}{message}",
             date = chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
             target = record.target(),
-            level = colors_level.color(record.level()),
+            level = colors_line.color(record.level()),
             context = context,
             message = message,
         ))


### PR DESCRIPTION
This allows us to deserialize the request body in the case of a
malformed or unsupported request and write a nice log message.

Resolves #488.