### PR TITLE
Implement feedback from PR #483

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,12 @@ sudo: required
 rust: nightly-2018-11-14
 addons:
   apt:
+    sources:
+    - sourceline: 'deb http://dl.yarnpkg.com/debian/ stable main'
+      key_url: 'http://dl.yarnpkg.com/debian/pubkey.gpg'
     packages:
     - libzmq3-dev
-before_install:
-  # Repo for Yarn
-  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
-  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq yarn
+    - yarn
 install: true
 services: docker
 before_script: which cargo-make || cargo install --debug cargo-make

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "aho-corasick"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -110,6 +118,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "binary_macros"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "binary_macros_impl 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "binary_macros_impl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "data-encoding 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dotenv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -312,6 +339,7 @@ name = "comit_node"
 version = "0.1.0"
 dependencies = [
  "bam 0.1.0",
+ "binary_macros 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin_rpc_client 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin_rpc_test_helpers 0.1.0",
  "bitcoin_support 0.1.0",
@@ -514,6 +542,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "debug_stub_derive"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +574,14 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dotenv"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1245,6 +1286,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1645,6 +1694,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack-impl 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro-hack-impl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,6 +1841,18 @@ dependencies = [
 
 [[package]]
 name = "regex"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1788,6 +1862,11 @@ dependencies = [
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex-syntax"
@@ -2374,6 +2453,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-id"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2879,6 +2975,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "utf8-ranges"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -3111,6 +3212,7 @@ dependencies = [
 
 [metadata]
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
+"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
@@ -3122,6 +3224,8 @@ dependencies = [
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bech32 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad20b907fd16610c3960c7fe9dae13dd243343409bab80299774c9a8b5d7bed8"
 "checksum bigdecimal 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "a33704f529287dc275e16ef871c2407ff36c01f15b374e1c28f49a5fc340369f"
+"checksum binary_macros 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d3c164dc375163e00f23ba3e2f9644f7c62145621f67c55500baac71a37cdd7f"
+"checksum binary_macros_impl 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5732223e917a7b7495e1df95d2c80e69278f944d4dc40a59d7931259a0fc5a41"
 "checksum bitcoin 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "804b37d4fcadce0ebf4cf87e0a60e71db95d5fac70d0c2cda8aae88a4d830d31"
 "checksum bitcoin-bech32 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f0a5cfe5abcb5040b36d4ea8acba95288fefebd7959b59475f2c4ec705974b4c"
 "checksum bitcoin_quantity 0.1.0 (git+https://github.com/coblox/bitcoin-quantity)" = "<none>"
@@ -3156,9 +3260,11 @@ dependencies = [
 "checksum darling 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f000e7b03a0083a30e1f10b1428a530849c21e72b338fa76869b5dbc4b045bf"
 "checksum darling_core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "86bc5ce438f4b703755d12f59bbf0a16c642766d4534e922db47569dbdd0b998"
 "checksum darling_macro 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9973050ba46be2a2935a7b316147f41a808ac604b8f0fef6eba77fd47a89daeb"
+"checksum data-encoding 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d867ddbf09de0b73e09ec798972fb7f870495a0893f6f736c1855448c5a56789"
 "checksum debug_stub_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "496b7f8a2f853313c3ca370641d7ff3e42c32974fdccda8f0684599ed0a3ff6b"
 "checksum derive_state_machine_future 0.1.8 (git+https://github.com/coblox/state_machine_future.git)" = "<none>"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
+"checksum dotenv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eea1395d2df3b5344dc577809296d9578303296e8d105c408aa80ed67d598ef1"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum elastic-array 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "88d4851b005ef16de812ea9acdb7bece2f0a40dd86c07b85631d7dafa54537bb"
@@ -3228,6 +3334,7 @@ dependencies = [
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b3629fe9fdbff6daa6c33b90f7c08355c1aca05a3d01fa8063b822fcf185f3b"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum memsocket 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f1324bd2974924512d93697a927825e50fdea665bac84df954c777bb7b6c4cc"
@@ -3271,6 +3378,8 @@ dependencies = [
 "checksum phf_shared 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "b539898d22d4273ded07f64a05737649dc69095d92cb87c7097ec68e3f150b93"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum pretty_env_logger 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8ae1b463255bf6613ad435f8997cb57f5d045ef35eb255f5a3d6085be936bd79"
+"checksum proc-macro-hack 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b773f824ff2a495833f85fcdddcf85e096949971decada2e93249fa2c6c3d32f"
+"checksum proc-macro-hack-impl 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0f674ccc446da486175527473ec8aa064f980b0966bbf767ee743a5dff6244a7"
 "checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
 "checksum prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9f36c478cd43382388dfc3a3679af175c03d19ed8039e79a3e4447e944cd3f3"
 "checksum prost-build 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6325275b85605f58f576456a47af44417edf5956a6f670bb59fbe12aff69597"
@@ -3286,7 +3395,9 @@ dependencies = [
 "checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
+"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
 "checksum relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1576e382688d7e9deecea24417e350d3062d97e32e45d70b1cde65994ff1489a"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
@@ -3353,6 +3464,8 @@ dependencies = [
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum testcontainers 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "daeed950990a60f8eacffefa091a782be1e3c402b060935f4c2dce65236f992d"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
+"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
+"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e9175261fbdb60781fcd388a4d6cc7e14764a2b629a7ad94abb439aed223a44f"
@@ -3405,6 +3518,7 @@ dependencies = [
 "checksum url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2a321979c09843d272956e73700d12c4e7d3d92b2ee112b31548aef0d4efc5a6"
 "checksum urlencoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3df3561629a8bb4c57e5a2e4c43348d9e29c7c29d9b1c4c1f47166deca8f37ed"
 "checksum utf-8 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bab35f71693630bb1953dce0f2bcd780e7cde025027124a202ac08a45ba25141"
+"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
 "checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
 "checksum uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dab5c5526c5caa3d106653401a267fed923e7046f35895ffcb5ca42db64942e6"

--- a/application/comit_node/Cargo.toml
+++ b/application/comit_node/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 regex = "1"
 
 [dependencies]
+binary_macros = "0.6"
 bitcoin_rpc_client = "0.4"
 chrono = "0.4"
 config = "0.9"

--- a/application/comit_node/src/lib.rs
+++ b/application/comit_node/src/lib.rs
@@ -24,7 +24,8 @@ extern crate state_machine_future;
 extern crate maplit;
 #[macro_use]
 extern crate frunk;
-extern crate serde_json;
+#[macro_use]
+extern crate binary_macros;
 
 #[cfg(test)]
 extern crate pretty_env_logger;
@@ -50,6 +51,7 @@ extern crate rustc_hex;
 extern crate rustic_hal;
 extern crate secp256k1_support;
 extern crate serde;
+extern crate serde_json;
 extern crate tokio;
 extern crate url;
 extern crate uuid;

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/erc20_htlc.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/erc20_htlc.rs
@@ -54,7 +54,8 @@ impl Erc20Htlc {
         htlc
     }
 
-    pub fn transfer_call(&self, htlc_contract_address: Address) -> Bytes {
+    /// Constructs the payload for funding an `Erc20` HTLC located at the given address.
+    pub fn funding_tx_payload(&self, htlc_contract_address: Address) -> Bytes {
         let target_address = format!("{:0>64}", format!("{:x}", htlc_contract_address));
         let token_amount = format!("{:0>64}", format!("{:x}", self.amount));
 

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/erc20_htlc.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/erc20_htlc.rs
@@ -4,11 +4,7 @@ use swap_protocols::rfc003::{
     SecretHash,
 };
 
-lazy_static! {
-    pub static ref TRANSFER_FN: Vec<u8> = hex::decode("a9059cbb").unwrap();
-}
-
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Erc20Htlc {
     refund_timeout: Seconds,
     refund_address: Address,
@@ -59,14 +55,13 @@ impl Erc20Htlc {
     }
 
     pub fn transfer_call(&self, htlc_contract_address: Address) -> Bytes {
-        let to_address: [u8; 20] = htlc_contract_address.into();
-        let amount: [u8; 32] = self.amount.clone().into();
+        let target_address = format!("{:0>64}", format!("{:x}", htlc_contract_address));
+        let token_amount = format!("{:0>64}", format!("{:x}", self.amount));
 
-        let mut data: Vec<u8> = vec![];
-        data.extend_from_slice(&TRANSFER_FN);
-        data.extend_from_slice(&to_address);
-        data.extend_from_slice(&amount);
-        Bytes::from(data)
+        let data = format!("{}{}{}", "a9059cbb", target_address, token_amount);
+        let hex_data = hex::decode(data).unwrap();
+
+        Bytes::from(hex_data)
     }
 }
 

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/erc20_htlc.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/erc20_htlc.rs
@@ -54,15 +54,19 @@ impl Erc20Htlc {
         htlc
     }
 
+    const TRANSFER_FN_ABI: &'static [u8; 4] = b"\xA9\x05\x9C\xBB";
+
     /// Constructs the payload for funding an `Erc20` HTLC located at the given address.
     pub fn funding_tx_payload(&self, htlc_contract_address: Address) -> Bytes {
-        let target_address = format!("{:0>64}", format!("{:x}", htlc_contract_address));
-        let token_amount = format!("{:0>64}", format!("{:x}", self.amount));
+        let htlc_contract_address: [u8; 20] = htlc_contract_address.into();
+        let amount: [u8; 32] = self.amount.clone().into();
 
-        let data = format!("{}{}{}", "a9059cbb", target_address, token_amount);
-        let hex_data = hex::decode(data).unwrap();
+        let mut data = [0u8; 4 + 32 + 32];
+        data[..4].copy_from_slice(Self::TRANSFER_FN_ABI);
+        data[16..36].copy_from_slice(&htlc_contract_address);
+        data[36..68].copy_from_slice(&amount);
 
-        Bytes::from(hex_data)
+        Bytes::from(data.to_vec())
     }
 }
 
@@ -143,4 +147,27 @@ mod tests {
         );
     }
 
+    #[test]
+    fn computes_funding_tx_payload_correctly() {
+        let htlc = Erc20Htlc::new(
+            Seconds(100),
+            Address::new(),
+            Address::new(),
+            SecretHash::from_str(
+                "1000000000000000000000000000000000000000000000000000000000000001",
+            )
+            .unwrap(),
+            Address::new(),
+            U256::from(100),
+        );
+
+        let htlc_hex = htlc.funding_tx_payload(Address::new());
+        let expected_bytes: [u8; 4 + 32 + 32] = [
+            169, 5, 156, 187, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100,
+        ];
+
+        assert_eq!(htlc_hex, Bytes(expected_bytes.to_vec()));
+    }
 }

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/erc20_htlc.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/erc20_htlc.rs
@@ -54,15 +54,14 @@ impl Erc20Htlc {
         htlc
     }
 
-    const TRANSFER_FN_ABI: &'static [u8; 4] = b"\xA9\x05\x9C\xBB";
-
     /// Constructs the payload for funding an `Erc20` HTLC located at the given address.
     pub fn funding_tx_payload(&self, htlc_contract_address: Address) -> Bytes {
-        let htlc_contract_address: [u8; 20] = htlc_contract_address.into();
-        let amount: [u8; 32] = self.amount.clone().into();
+        let transfer_fn_abi = base16!("A9059CBB");
+        let htlc_contract_address = <[u8; 20]>::from(htlc_contract_address);
+        let amount = <[u8; 32]>::from(self.amount.clone());
 
         let mut data = [0u8; 4 + 32 + 32];
-        data[..4].copy_from_slice(Self::TRANSFER_FN_ABI);
+        data[..4].copy_from_slice(transfer_fn_abi);
         data[16..36].copy_from_slice(&htlc_contract_address);
         data[36..68].copy_from_slice(&amount);
 
@@ -161,12 +160,10 @@ mod tests {
             U256::from(100),
         );
 
-        let htlc_hex = htlc.funding_tx_payload(Address::new());
-        let expected_bytes: [u8; 4 + 32 + 32] = [
-            169, 5, 156, 187, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100,
-        ];
+        let htlc_hex = htlc.funding_tx_payload(Address::from(*base16!(
+            "B97048628DB6B661D4C2AA833E95DBE1A905B280"
+        )));
+        let expected_bytes = base16!("A9059CBB000000000000000000000000B97048628DB6B661D4C2AA833E95DBE1A905B2800000000000000000000000000000000000000000000000000000000000000064");
 
         assert_eq!(htlc_hex, Bytes(expected_bytes.to_vec()));
     }

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/mod.rs
@@ -81,9 +81,9 @@ impl HtlcParams<Ethereum, Erc20Quantity> {
     pub fn bytecode(&self) -> Bytes {
         Erc20Htlc::from(self.clone()).compile_to_hex().into()
     }
-    pub fn transfer_call(&self, htlc_location: Address) -> Bytes {
+    pub fn funding_tx_payload(&self, htlc_location: Address) -> Bytes {
         Erc20Htlc::from(self.clone())
-            .transfer_call(htlc_location)
+            .funding_tx_payload(htlc_location)
             .into()
     }
 }

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/queries.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/queries.rs
@@ -75,7 +75,7 @@ pub mod erc20 {
             from_address: None,
             to_address: Some(htlc_location.clone()),
             is_contract_creation: None,
-            transaction_data: Some(htlc_params.transfer_call(htlc_location.clone())),
+            transaction_data: Some(htlc_params.funding_tx_payload(htlc_location.clone())),
             transaction_data_length: None,
         }
     }

--- a/application/comit_node/tests/ethereum_wallet/transaction.rs
+++ b/application/comit_node/tests/ethereum_wallet/transaction.rs
@@ -1,5 +1,4 @@
 use ethereum_support::{Address, Bytes, H256, U256};
-use hex;
 use rlp::{Encodable, RlpStream};
 use std::fmt;
 use tiny_keccak::keccak256;
@@ -11,12 +10,12 @@ const GAS_BUFFER: usize = 10_000;
 
 #[derive(Debug)]
 pub struct UnsignedTransaction {
-    nonce: U256,
-    gas_price: U256,
-    gas_limit: U256,
-    to: Option<Address>,
-    value: U256,
-    data: Option<Bytes>,
+    pub nonce: U256,
+    pub gas_price: U256,
+    pub gas_limit: U256,
+    pub to: Option<Address>,
+    pub value: U256,
+    pub data: Option<Bytes>,
 }
 
 struct Signature([u8; 64]);
@@ -94,102 +93,6 @@ impl Encodable for UnsignedTransaction {
 }
 
 impl UnsignedTransaction {
-    pub fn new_contract_deployment<B: Into<Bytes>, GP: Into<U256>, V: Into<U256>, N: Into<U256>>(
-        contract: B,
-        gas_price: GP,
-        value: V,
-        nonce: N,
-        extra_gas_limit: Option<u32>,
-    ) -> Self {
-        let contract_data = contract.into();
-        let data_bytes = contract_data.0.len();
-        let gas_limit = CONTRACT_CREATION_FEE + BASE_TX_FEE + data_bytes * GAS_COST_PER_BYTE;
-        let buffered_gas_limit =
-            U256::from(gas_limit) + U256::from(GAS_BUFFER) + extra_gas_limit.unwrap_or(0);
-
-        UnsignedTransaction {
-            nonce: nonce.into(),
-            gas_price: gas_price.into(),
-            gas_limit: buffered_gas_limit,
-            to: None,
-            value: value.into(),
-            data: Some(contract_data),
-        }
-    }
-
-    pub fn new_payment<A: Into<Address>, GP: Into<U256>, V: Into<U256>, N: Into<U256>>(
-        to: A,
-        gas_price: GP,
-        value: V,
-        nonce: N,
-        extra_gas_limit: Option<u32>,
-    ) -> Self {
-        UnsignedTransaction {
-            nonce: nonce.into(),
-            gas_price: gas_price.into(),
-            gas_limit: U256::from(BASE_TX_FEE) + extra_gas_limit.unwrap_or(0),
-            to: Some(to.into()),
-            value: value.into(),
-            data: None,
-        }
-    }
-
-    pub fn new_contract_invocation<
-        B: Into<Bytes>,
-        A: Into<Address>,
-        GL: Into<U256>,
-        GP: Into<U256>,
-        V: Into<U256>,
-        N: Into<U256>,
-    >(
-        data: B,
-        to: A,
-        gas_limit: GL,
-        gas_price: GP,
-        value: V,
-        nonce: N,
-    ) -> Self {
-        UnsignedTransaction {
-            nonce: nonce.into(),
-            gas_price: gas_price.into(),
-            gas_limit: gas_limit.into(),
-            to: Some(to.into()),
-            value: value.into(),
-            data: Some(data.into()),
-        }
-    }
-
-    pub fn new_erc20_approval<
-        TokenContract: Into<Address>,
-        To: Into<Address>,
-        Amount: Into<U256>,
-        GP: Into<U256>,
-        N: Into<U256>,
-    >(
-        token_contract: TokenContract,
-        to: To,
-        amount: Amount,
-        gas_price: GP,
-        nonce: N,
-    ) -> Self {
-        let function_identifier = "095ea7b3";
-        let address = format!("000000000000000000000000{}", hex::encode(to.into()));
-        let amount = format!("{:0>64}", format!("{:x}", amount.into()));
-
-        let payload = format!("{}{}{}", function_identifier, address, amount);
-
-        let data = Bytes::from(hex::decode(payload).unwrap());
-
-        UnsignedTransaction {
-            nonce: nonce.into(),
-            gas_price: gas_price.into(),
-            gas_limit: 200_000.into(),
-            to: Some(token_contract.into()),
-            value: U256::from(0),
-            data: Some(data),
-        }
-    }
-
     pub(crate) fn hash(&self, chain_id: u8) -> H256 {
         let mut stream = RlpStream::new();
         let bytes = stream
@@ -202,49 +105,5 @@ impl UnsignedTransaction {
         let tx_hash = keccak256(bytes);
 
         H256(tx_hash)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-
-    use super::*;
-
-    #[test]
-    fn erc20_contract_allowance_should_have_correct_representation() {
-        let transaction = UnsignedTransaction::new_erc20_approval(
-            "03744e31a6b9e6c6f604ff5d8ce1caef1c7bb58c",
-            "96984c3e77f38ed01d1c3d98f4bd7c8b11d51d7e",
-            1000,
-            0,
-            0,
-        );
-
-        assert_eq!(transaction.data, Some(Bytes(hex::decode("095ea7b300000000000000000000000096984c3e77f38ed01d1c3d98f4bd7c8b11d51d7e00000000000000000000000000000000000000000000000000000000000003e8").unwrap())));
-        assert_eq!(
-            transaction.to,
-            Some("03744e31a6b9e6c6f604ff5d8ce1caef1c7bb58c".into())
-        );
-    }
-
-    #[test]
-    fn gas_limit_is_computed_based_on_contract_size() {
-        let extra_gas_limit = 10;
-
-        let transaction = UnsignedTransaction::new_contract_deployment(
-            // contract occupying 5 bytes
-            Bytes(vec![0_u8; 5]),
-            0,
-            0,
-            0,
-            Some(extra_gas_limit),
-        );
-
-        assert_eq!(
-            transaction.gas_limit,
-            U256::from(CONTRACT_CREATION_FEE + BASE_TX_FEE + (5 * GAS_COST_PER_BYTE))
-                + GAS_BUFFER
-                + extra_gas_limit
-        );
     }
 }

--- a/application/comit_node/tests/ethereum_wallet/wallet.rs
+++ b/application/comit_node/tests/ethereum_wallet/wallet.rs
@@ -18,10 +18,6 @@ impl InMemoryWallet {
         InMemoryWallet { keypair, chain_id }
     }
 
-    pub fn address(&self) -> Address {
-        self.keypair.public_key().to_ethereum_address()
-    }
-
     // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#specification
     fn chain_replay_protection_offset(&self) -> u8 {
         35 + self.chain_id * 2

--- a/application/comit_node/tests/htlc_harness/erc20_harness.rs
+++ b/application/comit_node/tests/htlc_harness/erc20_harness.rs
@@ -1,0 +1,97 @@
+use comit_node::swap_protocols::rfc003::{
+    ethereum::{Erc20Htlc, Seconds},
+    Secret,
+};
+use ethereum_support::{
+    web3::{
+        transports::EventLoopHandle,
+        types::{Address, U256},
+    },
+    EtherQuantity,
+};
+use ethereum_wallet::InMemoryWallet;
+use htlc_harness::{new_account, HTLC_TIMEOUT, SECRET};
+use parity_client::ParityClient;
+use pretty_env_logger;
+use std::{sync::Arc, time::Duration};
+use tc_web3_client;
+use testcontainers::{images::parity_parity::ParityEthereum, Container, Docker};
+
+pub struct Erc20HarnessParams {
+    pub alice_initial_ether: EtherQuantity,
+    pub htlc_timeout: Duration,
+    pub htlc_secret: [u8; 32],
+    pub alice_initial_tokens: U256,
+    pub htlc_token_value: U256,
+}
+
+impl Default for Erc20HarnessParams {
+    fn default() -> Self {
+        Self {
+            alice_initial_ether: EtherQuantity::from_eth(1.0),
+            htlc_timeout: HTLC_TIMEOUT,
+            htlc_secret: SECRET.clone(),
+            alice_initial_tokens: U256::from(1000),
+            htlc_token_value: U256::from(400),
+        }
+    }
+}
+
+pub fn erc20_harness<D: Docker>(
+    docker: &D,
+    params: Erc20HarnessParams,
+) -> (
+    Address,
+    Address,
+    Address,
+    Erc20Htlc,
+    Address,
+    ParityClient,
+    EventLoopHandle,
+    Container<D, ParityEthereum>,
+) {
+    let _ = pretty_env_logger::try_init();
+
+    let (alice_keypair, alice) =
+        new_account("63be4b0d638d44b5fee5b050ab0beeeae7b68cde3d829a3321f8009cdd76b992");
+    let (_, bob) = new_account("f8218ebf6e2626bd1415c18321496e0c5725f0e1d774c7c2eab69f7650ad6e82");
+
+    let container = docker.run(ParityEthereum::default());
+
+    let (event_loop, web3) = tc_web3_client::new(&container);
+    let web3 = Arc::new(web3);
+
+    let alice_client = ParityClient::new(
+        Arc::new(InMemoryWallet::new(alice_keypair.clone(), 1)),
+        web3,
+        0,
+    );
+
+    alice_client.give_eth_to(alice, params.alice_initial_ether);
+
+    let token_contract = alice_client.deploy_erc20_token_contract();
+
+    alice_client.mint_tokens(token_contract, params.alice_initial_tokens, alice);
+
+    let erc20_htlc = Erc20Htlc::new(
+        Seconds::from(params.htlc_timeout),
+        alice,
+        bob,
+        Secret::from(params.htlc_secret).hash(),
+        token_contract,
+        params.htlc_token_value,
+    );
+
+    let tx_id = alice_client.deploy_htlc(erc20_htlc.clone(), U256::from(0));
+
+    (
+        alice,
+        bob,
+        alice_client.get_contract_address(tx_id),
+        erc20_htlc,
+        token_contract,
+        alice_client,
+        event_loop,
+        container,
+    )
+}

--- a/application/comit_node/tests/htlc_harness/ether_harness.rs
+++ b/application/comit_node/tests/htlc_harness/ether_harness.rs
@@ -1,0 +1,83 @@
+use comit_node::swap_protocols::rfc003::{
+    ethereum::{EtherHtlc, Seconds},
+    Secret,
+};
+use ethereum_support::{
+    web3::{transports::EventLoopHandle, types::Address},
+    EtherQuantity,
+};
+use ethereum_wallet::InMemoryWallet;
+use htlc_harness::{new_account, HTLC_TIMEOUT, SECRET};
+use parity_client::ParityClient;
+use pretty_env_logger;
+use std::{sync::Arc, time::Duration};
+use tc_web3_client;
+use testcontainers::{images::parity_parity::ParityEthereum, Container, Docker};
+
+pub struct EtherHarnessParams {
+    pub alice_initial_ether: EtherQuantity,
+    pub htlc_timeout: Duration,
+    pub htlc_secret: [u8; 32],
+    pub htlc_eth_value: EtherQuantity,
+}
+
+impl Default for EtherHarnessParams {
+    fn default() -> Self {
+        Self {
+            alice_initial_ether: EtherQuantity::from_eth(1.0),
+            htlc_eth_value: EtherQuantity::from_eth(0.4),
+            htlc_timeout: HTLC_TIMEOUT,
+            htlc_secret: SECRET.clone(),
+        }
+    }
+}
+
+pub fn ether_harness<D: Docker>(
+    docker: &D,
+    params: EtherHarnessParams,
+) -> (
+    Address,
+    Address,
+    Address,
+    ParityClient,
+    EventLoopHandle,
+    Container<D, ParityEthereum>,
+) {
+    let _ = pretty_env_logger::try_init();
+
+    let (alice_keypair, alice) =
+        new_account("63be4b0d638d44b5fee5b050ab0beeeae7b68cde3d829a3321f8009cdd76b992");
+    let (_, bob) = new_account("f8218ebf6e2626bd1415c18321496e0c5725f0e1d774c7c2eab69f7650ad6e82");
+
+    let container = docker.run(ParityEthereum::default());
+
+    let (event_loop, web3) = tc_web3_client::new(&container);
+    let web3 = Arc::new(web3);
+
+    let alice_client = ParityClient::new(
+        Arc::new(InMemoryWallet::new(alice_keypair.clone(), 1)),
+        web3,
+        0,
+    );
+
+    alice_client.give_eth_to(alice, params.alice_initial_ether);
+
+    let tx_id = alice_client.deploy_htlc(
+        EtherHtlc::new(
+            Seconds::from(params.htlc_timeout),
+            alice,
+            bob,
+            Secret::from(params.htlc_secret).hash(),
+        ),
+        params.htlc_eth_value.wei(),
+    );
+
+    (
+        alice,
+        bob,
+        alice_client.get_contract_address(tx_id),
+        alice_client,
+        event_loop,
+        container,
+    )
+}

--- a/application/comit_node/tests/htlc_harness/mod.rs
+++ b/application/comit_node/tests/htlc_harness/mod.rs
@@ -1,120 +1,21 @@
-use comit_node::swap_protocols::rfc003::{ethereum::Seconds, Secret};
-use ethereum_support::{
-    web3::{
-        transports::EventLoopHandle,
-        types::{Address, U256},
-    },
-    EtherQuantity, ToEthereumAddress,
-};
-use ethereum_wallet::InMemoryWallet;
-use parity_client::{Erc20HtlcDeployParams, EtherHtlcFundingParams, ParityClient};
-use pretty_env_logger;
+use ethereum_support::{web3::types::Address, ToEthereumAddress};
 use secp256k1_support::KeyPair;
-use std::{sync::Arc, time::Duration};
-use tc_web3_client;
-use testcontainers::{images::parity_parity::ParityEthereum, Container, Docker};
+use std::time::Duration;
 
-pub enum HtlcType {
-    Erc20 {
-        alice_initial_tokens: U256,
-        htlc_token_value: U256,
-    },
-    Eth {
-        htlc_eth_value: EtherQuantity,
-    },
-}
+mod erc20_harness;
+mod ether_harness;
 
-pub struct TestHarnessParams {
-    pub alice_initial_ether: EtherQuantity,
-    pub htlc_timeout: Duration,
-    pub htlc_secret: [u8; 32],
-    pub htlc_type: HtlcType,
-}
+pub use self::{
+    erc20_harness::{erc20_harness, Erc20HarnessParams},
+    ether_harness::{ether_harness, EtherHarnessParams},
+};
 
-pub fn harness<D: Docker>(
-    docker: &D,
-    params: TestHarnessParams,
-) -> (
-    Address,
-    Address,
-    Address,
-    Option<Address>,
-    ParityClient,
-    EventLoopHandle,
-    Container<D, ParityEthereum>,
-) {
-    let _ = pretty_env_logger::try_init();
-
-    let (alice_keypair, alice) =
-        new_account("63be4b0d638d44b5fee5b050ab0beeeae7b68cde3d829a3321f8009cdd76b992");
-    let (_, bob) = new_account("f8218ebf6e2626bd1415c18321496e0c5725f0e1d774c7c2eab69f7650ad6e82");
-
-    let container = docker.run(ParityEthereum::default());
-
-    let (event_loop, web3) = tc_web3_client::new(&container);
-    let web3 = Arc::new(web3);
-
-    let alice_client = ParityClient::new(
-        Arc::new(InMemoryWallet::new(alice_keypair.clone(), 1)),
-        web3,
-        0,
-    );
-
-    alice_client.give_eth_to(alice, params.alice_initial_ether);
-
-    let (token_contract, htlc) = match params.htlc_type {
-        HtlcType::Erc20 {
-            alice_initial_tokens,
-            htlc_token_value,
-        } => {
-            let token_contract = alice_client.deploy_erc20_token_contract();
-
-            alice_client.mint_tokens(token_contract, alice_initial_tokens, alice);
-
-            let htlc_params = Erc20HtlcDeployParams {
-                refund_address: alice,
-                success_address: bob,
-                time_lock: Seconds::from(params.htlc_timeout),
-                amount: htlc_token_value,
-                secret_hash: Secret::from(params.htlc_secret).hash(),
-                token_contract_address: token_contract,
-            };
-            let tx_id = alice_client.deploy_erc20_htlc(htlc_params);
-
-            (
-                Some(token_contract),
-                alice_client.get_contract_address(tx_id),
-            )
-        }
-        HtlcType::Eth { htlc_eth_value } => {
-            let htlc_params = EtherHtlcFundingParams {
-                refund_address: alice,
-                success_address: bob,
-                time_lock: Seconds::from(params.htlc_timeout),
-                amount: htlc_eth_value,
-                secret_hash: Secret::from(params.htlc_secret).hash(),
-            };
-            let tx_id = alice_client.deploy_ether_htlc(htlc_params);
-
-            //no funding needed, deployment of the HTLC can also fund it directly
-            (None, alice_client.get_contract_address(tx_id))
-        }
-    };
-
-    (
-        alice,
-        bob,
-        htlc,
-        token_contract,
-        alice_client,
-        event_loop,
-        container,
-    )
-}
-
-fn new_account(secret_key: &str) -> (KeyPair, Address) {
+pub fn new_account(secret_key: &str) -> (KeyPair, Address) {
     let keypair = KeyPair::from_secret_key_hex(secret_key).unwrap();
     let address = keypair.public_key().to_ethereum_address();
 
     (keypair, address)
 }
+
+pub const SECRET: &[u8; 32] = b"hello world, you are beautiful!!";
+pub const HTLC_TIMEOUT: Duration = Duration::from_secs(5);

--- a/application/comit_node/tests/parity_client/mod.rs
+++ b/application/comit_node/tests/parity_client/mod.rs
@@ -1,2 +1,2 @@
 mod parity_client;
-pub use self::parity_client::{Erc20HtlcDeployParams, EtherHtlcFundingParams, ParityClient};
+pub use self::parity_client::ParityClient;

--- a/application/comit_node/tests/rfc003_erc20_htlc.rs
+++ b/application/comit_node/tests/rfc003_erc20_htlc.rs
@@ -18,48 +18,43 @@ mod ethereum_wallet;
 mod htlc_harness;
 mod parity_client;
 
-use ethereum_support::{Bytes, Erc20Quantity, EtherQuantity, U256};
-use htlc_harness::*;
-use std::time::Duration;
+use ethereum_support::{Bytes, U256};
+use ethereum_wallet::transaction::UnsignedTransaction;
+use htlc_harness::{erc20_harness, Erc20HarnessParams, HTLC_TIMEOUT, SECRET};
 use testcontainers::clients::Cli;
-
-const SECRET: &[u8; 32] = b"hello world, you are beautiful!!";
-const HTLC_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[test]
 fn given_erc20_token_should_deploy_erc20_htlc_and_fund_htlc() {
     let docker = Cli::default();
-    let (alice, bob, htlc, token_contract, client, _handle, _container) = harness(
-        &docker,
-        TestHarnessParams {
-            alice_initial_ether: EtherQuantity::from_eth(1.0),
-            htlc_type: HtlcType::Erc20 {
-                alice_initial_tokens: U256::from(1000),
-                htlc_token_value: U256::from(400),
-            },
-            htlc_timeout: HTLC_TIMEOUT,
-            htlc_secret: SECRET.clone(),
-        },
-    );
-    let token = token_contract.unwrap();
+    let (alice, bob, htlc_address, htlc, token, client, _handle, _container) =
+        erc20_harness(&docker, Erc20HarnessParams::default());
 
-    assert_eq!(client.token_balance_of(token, htlc), U256::from(0));
+    assert_eq!(client.token_balance_of(token, htlc_address), U256::from(0));
     assert_eq!(client.token_balance_of(token, alice), U256::from(1000));
     assert_eq!(client.token_balance_of(token, bob), U256::from(0));
 
     // fund erc20 htlc
-    let erc20 = Erc20Quantity::new(token, U256::from(400));
-    client.fund_erc20_htlc(htlc, erc20);
+    client.sign_and_send(|nonce, gas_price| UnsignedTransaction {
+        nonce,
+        gas_price,
+        gas_limit: U256::from(100_000),
+        to: Some(token),
+        value: U256::from(0),
+        data: Some(htlc.transfer_call(htlc_address)),
+    });
 
     // check htlc funding
-    assert_eq!(client.token_balance_of(token, htlc), U256::from(400));
+    assert_eq!(
+        client.token_balance_of(token, htlc_address),
+        U256::from(400)
+    );
     assert_eq!(client.token_balance_of(token, alice), U256::from(600));
     assert_eq!(client.token_balance_of(token, bob), U256::from(0));
 
     // Send correct secret to contract
-    client.send_data(htlc, Some(Bytes(SECRET.to_vec())));
+    client.send_data(htlc_address, Some(Bytes(SECRET.to_vec())));
 
-    assert_eq!(client.token_balance_of(token, htlc), U256::from(0));
+    assert_eq!(client.token_balance_of(token, htlc_address), U256::from(0));
     assert_eq!(client.token_balance_of(token, alice), U256::from(600));
     assert_eq!(client.token_balance_of(token, bob), U256::from(400));
 }
@@ -67,32 +62,30 @@ fn given_erc20_token_should_deploy_erc20_htlc_and_fund_htlc() {
 #[test]
 fn given_funded_erc20_htlc_when_redeemed_with_secret_then_tokens_are_transferred() {
     let docker = Cli::default();
-    let (alice, bob, htlc, token_contract, client, _handle, _container) = harness(
-        &docker,
-        TestHarnessParams {
-            alice_initial_ether: EtherQuantity::from_eth(1.0),
-            htlc_type: HtlcType::Erc20 {
-                alice_initial_tokens: U256::from(1000),
-                htlc_token_value: U256::from(400),
-            },
-            htlc_timeout: HTLC_TIMEOUT,
-            htlc_secret: SECRET.clone(),
-        },
-    );
-    let token = token_contract.unwrap();
+    let (alice, bob, htlc_address, htlc, token, client, _handle, _container) =
+        erc20_harness(&docker, Erc20HarnessParams::default());
 
     // fund erc20 htlc
-    let erc20 = Erc20Quantity::new(token, U256::from(400));
-    client.fund_erc20_htlc(htlc, erc20);
+    client.sign_and_send(|nonce, gas_price| UnsignedTransaction {
+        nonce,
+        gas_price,
+        gas_limit: U256::from(100_000),
+        to: Some(token),
+        value: U256::from(0),
+        data: Some(htlc.transfer_call(htlc_address)),
+    });
 
-    assert_eq!(client.token_balance_of(token, htlc), U256::from(400));
+    assert_eq!(
+        client.token_balance_of(token, htlc_address),
+        U256::from(400)
+    );
     assert_eq!(client.token_balance_of(token, alice), U256::from(600));
     assert_eq!(client.token_balance_of(token, bob), U256::from(0));
 
     // Send correct secret to contract
-    client.send_data(htlc, Some(Bytes(SECRET.to_vec())));
+    client.send_data(htlc_address, Some(Bytes(SECRET.to_vec())));
 
-    assert_eq!(client.token_balance_of(token, htlc), U256::from(0));
+    assert_eq!(client.token_balance_of(token, htlc_address), U256::from(0));
     assert_eq!(client.token_balance_of(token, alice), U256::from(600));
     assert_eq!(client.token_balance_of(token, bob), U256::from(400));
 }
@@ -100,34 +93,32 @@ fn given_funded_erc20_htlc_when_redeemed_with_secret_then_tokens_are_transferred
 #[test]
 fn given_deployed_erc20_htlc_when_refunded_after_timeout_then_tokens_are_refunded() {
     let docker = Cli::default();
-    let (alice, bob, htlc, token_contract, client, _handle, _container) = harness(
-        &docker,
-        TestHarnessParams {
-            alice_initial_ether: EtherQuantity::from_eth(1.0),
-            htlc_type: HtlcType::Erc20 {
-                alice_initial_tokens: U256::from(1000),
-                htlc_token_value: U256::from(400),
-            },
-            htlc_timeout: HTLC_TIMEOUT,
-            htlc_secret: SECRET.clone(),
-        },
-    );
-    let token = token_contract.unwrap();
+    let (alice, bob, htlc_address, htlc, token, client, _handle, _container) =
+        erc20_harness(&docker, Erc20HarnessParams::default());
 
     // fund erc20 htlc
-    let erc20 = Erc20Quantity::new(token, U256::from(400));
-    client.fund_erc20_htlc(htlc, erc20);
+    client.sign_and_send(|nonce, gas_price| UnsignedTransaction {
+        nonce,
+        gas_price,
+        gas_limit: U256::from(100_000),
+        to: Some(token),
+        value: U256::from(0),
+        data: Some(htlc.transfer_call(htlc_address)),
+    });
 
-    assert_eq!(client.token_balance_of(token, htlc), U256::from(400));
+    assert_eq!(
+        client.token_balance_of(token, htlc_address),
+        U256::from(400)
+    );
     assert_eq!(client.token_balance_of(token, bob), U256::from(0));
     assert_eq!(client.token_balance_of(token, alice), U256::from(600));
 
     // Wait for the contract to expire
     ::std::thread::sleep(HTLC_TIMEOUT);
     ::std::thread::sleep(HTLC_TIMEOUT);
-    client.send_data(htlc, None);
+    client.send_data(htlc_address, None);
 
-    assert_eq!(client.token_balance_of(token, htlc), U256::from(0));
+    assert_eq!(client.token_balance_of(token, htlc_address), U256::from(0));
     assert_eq!(client.token_balance_of(token, alice), U256::from(1000));
     assert_eq!(client.token_balance_of(token, bob), U256::from(0));
 }
@@ -135,32 +126,33 @@ fn given_deployed_erc20_htlc_when_refunded_after_timeout_then_tokens_are_refunde
 #[test]
 fn given_deployed_erc20_htlc_when_timeout_not_yet_reached_and_wrong_secret_then_nothing_happens() {
     let docker = Cli::default();
-    let (alice, bob, htlc, token_contract, client, _handle, _container) = harness(
-        &docker,
-        TestHarnessParams {
-            alice_initial_ether: EtherQuantity::from_eth(1.0),
-            htlc_type: HtlcType::Erc20 {
-                alice_initial_tokens: U256::from(1000),
-                htlc_token_value: U256::from(400),
-            },
-            htlc_timeout: HTLC_TIMEOUT,
-            htlc_secret: SECRET.clone(),
-        },
-    );
-    let token = token_contract.unwrap();
+    let (alice, bob, htlc_address, htlc, token, client, _handle, _container) =
+        erc20_harness(&docker, Erc20HarnessParams::default());
 
     // fund erc20 htlc
-    let erc20 = Erc20Quantity::new(token, U256::from(400));
-    client.fund_erc20_htlc(htlc, erc20);
+    client.sign_and_send(|nonce, gas_price| UnsignedTransaction {
+        nonce,
+        gas_price,
+        gas_limit: U256::from(100_000),
+        to: Some(token),
+        value: U256::from(0),
+        data: Some(htlc.transfer_call(htlc_address)),
+    });
 
-    assert_eq!(client.token_balance_of(token, htlc), U256::from(400));
+    assert_eq!(
+        client.token_balance_of(token, htlc_address),
+        U256::from(400)
+    );
     assert_eq!(client.token_balance_of(token, alice), U256::from(600));
     assert_eq!(client.token_balance_of(token, bob), U256::from(0));
 
     // Don't wait for the timeout and don't send a secret
-    client.send_data(htlc, None);
+    client.send_data(htlc_address, None);
 
-    assert_eq!(client.token_balance_of(token, htlc), U256::from(400));
+    assert_eq!(
+        client.token_balance_of(token, htlc_address),
+        U256::from(400)
+    );
     assert_eq!(client.token_balance_of(token, bob), U256::from(0));
     assert_eq!(client.token_balance_of(token, alice), U256::from(600));
 }
@@ -168,33 +160,33 @@ fn given_deployed_erc20_htlc_when_timeout_not_yet_reached_and_wrong_secret_then_
 #[test]
 fn given_not_enough_tokens_when_redeemed_token_balances_dont_change() {
     let docker = Cli::default();
-    let (alice, bob, htlc, token_contract, client, _handle, _container) = harness(
+    let (alice, bob, htlc_address, htlc, token, client, _handle, _container) = erc20_harness(
         &docker,
-        TestHarnessParams {
-            alice_initial_ether: EtherQuantity::from_eth(1.0),
-            htlc_type: HtlcType::Erc20 {
-                alice_initial_tokens: U256::from(200),
-                htlc_token_value: U256::from(400),
-            },
-            htlc_timeout: HTLC_TIMEOUT,
-            htlc_secret: SECRET.clone(),
+        Erc20HarnessParams {
+            alice_initial_tokens: U256::from(200),
+            ..Default::default()
         },
     );
-    let token = token_contract.unwrap();
 
     // fund erc20 htlc
-    let erc20 = Erc20Quantity::new(token, U256::from(100));
-    client.fund_erc20_htlc(htlc, erc20);
+    client.sign_and_send(|nonce, gas_price| UnsignedTransaction {
+        nonce,
+        gas_price,
+        gas_limit: U256::from(100_000),
+        to: Some(token),
+        value: U256::from(0),
+        data: Some(htlc.transfer_call(htlc_address)),
+    });
 
-    assert_eq!(client.token_balance_of(token, htlc), U256::from(100));
-    assert_eq!(client.token_balance_of(token, alice), U256::from(100));
+    assert_eq!(client.token_balance_of(token, htlc_address), U256::from(0));
+    assert_eq!(client.token_balance_of(token, alice), U256::from(200));
     assert_eq!(client.token_balance_of(token, bob), U256::from(0));
 
     // Send correct secret to contract
-    client.send_data(htlc, Some(Bytes(SECRET.to_vec())));
+    client.send_data(htlc_address, Some(Bytes(SECRET.to_vec())));
 
-    assert_eq!(client.token_balance_of(token, htlc), U256::from(100));
-    assert_eq!(client.token_balance_of(token, alice), U256::from(100));
+    assert_eq!(client.token_balance_of(token, htlc_address), U256::from(0));
+    assert_eq!(client.token_balance_of(token, alice), U256::from(200));
     assert_eq!(client.token_balance_of(token, bob), U256::from(0));
-    assert_eq!(client.get_contract_code(htlc), Bytes::default());
+    assert_eq!(client.get_contract_code(htlc_address), Bytes::default());
 }

--- a/application/comit_node/tests/rfc003_erc20_htlc.rs
+++ b/application/comit_node/tests/rfc003_erc20_htlc.rs
@@ -40,7 +40,7 @@ fn given_erc20_token_should_deploy_erc20_htlc_and_fund_htlc() {
         gas_limit: U256::from(100_000),
         to: Some(token),
         value: U256::from(0),
-        data: Some(htlc.transfer_call(htlc_address)),
+        data: Some(htlc.funding_tx_payload(htlc_address)),
     });
 
     // check htlc funding
@@ -72,7 +72,7 @@ fn given_funded_erc20_htlc_when_redeemed_with_secret_then_tokens_are_transferred
         gas_limit: U256::from(100_000),
         to: Some(token),
         value: U256::from(0),
-        data: Some(htlc.transfer_call(htlc_address)),
+        data: Some(htlc.funding_tx_payload(htlc_address)),
     });
 
     assert_eq!(
@@ -103,7 +103,7 @@ fn given_deployed_erc20_htlc_when_refunded_after_timeout_then_tokens_are_refunde
         gas_limit: U256::from(100_000),
         to: Some(token),
         value: U256::from(0),
-        data: Some(htlc.transfer_call(htlc_address)),
+        data: Some(htlc.funding_tx_payload(htlc_address)),
     });
 
     assert_eq!(
@@ -136,7 +136,7 @@ fn given_deployed_erc20_htlc_when_timeout_not_yet_reached_and_wrong_secret_then_
         gas_limit: U256::from(100_000),
         to: Some(token),
         value: U256::from(0),
-        data: Some(htlc.transfer_call(htlc_address)),
+        data: Some(htlc.funding_tx_payload(htlc_address)),
     });
 
     assert_eq!(
@@ -175,7 +175,7 @@ fn given_not_enough_tokens_when_redeemed_token_balances_dont_change() {
         gas_limit: U256::from(100_000),
         to: Some(token),
         value: U256::from(0),
-        data: Some(htlc.transfer_call(htlc_address)),
+        data: Some(htlc.funding_tx_payload(htlc_address)),
     });
 
     assert_eq!(client.token_balance_of(token, htlc_address), U256::from(0));

--- a/application/comit_node/tests/rfc003_ether_htlc.rs
+++ b/application/comit_node/tests/rfc003_ether_htlc.rs
@@ -19,28 +19,16 @@ mod htlc_harness;
 mod parity_client;
 
 use ethereum_support::{Bytes, EtherQuantity, U256};
-use htlc_harness::*;
-use std::time::Duration;
+use htlc_harness::{ether_harness, EtherHarnessParams, HTLC_TIMEOUT, SECRET};
 use testcontainers::clients::Cli;
 
-const SECRET: &[u8; 32] = b"hello world, you are beautiful!!";
-const HTLC_TIMEOUT: Duration = Duration::from_secs(5);
 const HTLC_GAS_COST: u64 = 8879000;
 
 #[test]
 fn given_deployed_htlc_when_redeemed_with_secret_then_money_is_transferred() {
     let docker = Cli::default();
-    let (alice, bob, htlc, _, client, _handle, _container) = harness(
-        &docker,
-        TestHarnessParams {
-            alice_initial_ether: EtherQuantity::from_eth(1.0),
-            htlc_type: HtlcType::Eth {
-                htlc_eth_value: EtherQuantity::from_eth(0.4),
-            },
-            htlc_timeout: HTLC_TIMEOUT,
-            htlc_secret: SECRET.clone(),
-        },
-    );
+    let (alice, bob, htlc, client, _handle, _container) =
+        ether_harness(&docker, EtherHarnessParams::default());
 
     assert_eq!(
         client.eth_balance_of(bob),
@@ -76,17 +64,8 @@ fn given_deployed_htlc_when_redeemed_with_secret_then_money_is_transferred() {
 #[test]
 fn given_deployed_htlc_when_refunded_after_timeout_then_money_is_refunded() {
     let docker = Cli::default();
-    let (alice, bob, htlc, _, client, _handle, _container) = harness(
-        &docker,
-        TestHarnessParams {
-            alice_initial_ether: EtherQuantity::from_eth(1.0),
-            htlc_type: HtlcType::Eth {
-                htlc_eth_value: EtherQuantity::from_eth(0.4),
-            },
-            htlc_timeout: HTLC_TIMEOUT,
-            htlc_secret: SECRET.clone(),
-        },
-    );
+    let (alice, bob, htlc, client, _handle, _container) =
+        ether_harness(&docker, EtherHarnessParams::default());
 
     assert_eq!(
         client.eth_balance_of(bob),
@@ -123,17 +102,8 @@ fn given_deployed_htlc_when_refunded_after_timeout_then_money_is_refunded() {
 #[test]
 fn given_deployed_htlc_when_timeout_not_yet_reached_and_wrong_secret_then_nothing_happens() {
     let docker = Cli::default();
-    let (alice, bob, htlc, _, client, _handle, _container) = harness(
-        &docker,
-        TestHarnessParams {
-            alice_initial_ether: EtherQuantity::from_eth(1.0),
-            htlc_type: HtlcType::Eth {
-                htlc_eth_value: EtherQuantity::from_eth(0.4),
-            },
-            htlc_timeout: HTLC_TIMEOUT,
-            htlc_secret: SECRET.clone(),
-        },
-    );
+    let (alice, bob, htlc, client, _handle, _container) =
+        ether_harness(&docker, EtherHarnessParams::default());
 
     assert_eq!(
         client.eth_balance_of(bob),


### PR DESCRIPTION
This implements some feedback from PR #483.
This is includes fixing the construction of the transaction for invoking `transfer` on an ERC20 token contract.

To verify that it works, I am now using this function in the tests to transfer the tokens. This imposed a small refactoring of the harness which now passes back the HTLC so that we can call functions on it.