### PR TITLE
Remove final address from swap request

### DIFF
--- a/api_tests/e2e/rfc003/btc_eth/test.js
+++ b/api_tests/e2e/rfc003/btc_eth/test.js
@@ -59,8 +59,7 @@ describe("RFC003 Bitcoin for Ether", () => {
                     name: "Ether",
                     quantity: beta_asset.toString()
                 },
-                alpha_ledger_refund_identity:
-                    "ac2db2f2615c81b83Fe9366450799b4992931575",
+                alpha_ledger_refund_identity: null,
                 beta_ledger_success_identity: alice_final_address,
                 alpha_ledger_lock_duration: 144
             })

--- a/api_tests/e2e/rfc003/btc_eth/test.js
+++ b/api_tests/e2e/rfc003/btc_eth/test.js
@@ -94,9 +94,7 @@ describe("RFC003 Bitcoin for Ether", () => {
         let accept_href = res.body._links.accept.href;
         let bob_response = {
             beta_ledger_refund_identity: bob.wallet.eth_address(),
-            alpha_ledger_success_identity: bob.wallet
-                .btc_address()
-                .hash.toString("hex"),
+            alpha_ledger_success_identity: null,
             beta_ledger_lock_duration: 43200
         };
 

--- a/application/comit_node/src/http_api/rfc003/action.rs
+++ b/application/comit_node/src/http_api/rfc003/action.rs
@@ -41,8 +41,8 @@ impl FromStr for PostAction {
 
 #[derive(Debug, Deserialize, LabelledGeneric)]
 struct AcceptSwapRequestHttpBody<AL: Ledger, BL: Ledger> {
-    alpha_ledger_success_identity: AL::Identity,
-    beta_ledger_refund_identity: BL::Identity,
+    alpha_ledger_success_identity: AL::HttpIdentity,
+    beta_ledger_refund_identity: BL::HttpIdentity,
     beta_ledger_lock_duration: BL::LockDuration,
 }
 
@@ -100,7 +100,6 @@ pub fn handle_post<T: MetadataStore<SwapId>>(
                                 .set_detail("Failed to deserialize given body.")
                         })
                         .and_then(|accept_body| {
-                            //TODO: Store the user's alpha_ledger_success_identity
                             let keypair = key_store.get_transient_keypair(&id.into(), b"SUCCESS");
                             forward_response::<Bitcoin, Ethereum>(pending_responses.as_ref(), &id, Ok(StateMachineResponse{
                                 alpha_ledger_success_identity: keypair,

--- a/application/comit_node/src/http_api/rfc003/swap.rs
+++ b/application/comit_node/src/http_api/rfc003/swap.rs
@@ -52,8 +52,8 @@ pub struct SwapRequestBody<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
     alpha_ledger: AL,
     #[serde(with = "http_api::ledger::serde")]
     beta_ledger: BL,
-    alpha_ledger_refund_identity: AL::Identity,
-    beta_ledger_success_identity: BL::Identity,
+    alpha_ledger_refund_identity: AL::HttpIdentity,
+    beta_ledger_success_identity: BL::HttpIdentity,
     alpha_ledger_lock_duration: AL::LockDuration,
 }
 
@@ -291,7 +291,7 @@ mod tests {
                     "name": "Ether",
                     "quantity": "10000000000000000000"
                 },
-                "alpha_ledger_refund_identity": "ac2db2f2615c81b83fe9366450799b4992931575",
+                "alpha_ledger_refund_identity": null,
                 "beta_ledger_success_identity": "0x00a329c0648769a73afac7f9381e08fb43dbea72",
                 "alpha_ledger_lock_duration": 144
             }"#;
@@ -303,10 +303,7 @@ mod tests {
             beta_asset: EtherQuantity::from_eth(10.0),
             alpha_ledger: Bitcoin::regtest(),
             beta_ledger: Ethereum::default(),
-            alpha_ledger_refund_identity: bitcoin_support::PubkeyHash::from_hex(
-                "ac2db2f2615c81b83fe9366450799b4992931575",
-            )
-            .unwrap(),
+            alpha_ledger_refund_identity: (),
             beta_ledger_success_identity: ethereum_support::Address::from(
                 "0x00a329c0648769a73afac7f9381e08fb43dbea72",
             ),

--- a/application/comit_node/src/swap_protocols/ledger/bitcoin.rs
+++ b/application/comit_node/src/swap_protocols/ledger/bitcoin.rs
@@ -37,6 +37,7 @@ impl Ledger for Bitcoin {
     type Address = Address;
     type Identity = PubkeyHash;
     type Transaction = Transaction;
+    type HttpIdentity = ();
 
     fn address_for_identity(&self, pubkeyhash: PubkeyHash) -> Address {
         pubkeyhash.into_p2wpkh_address(self.network)

--- a/application/comit_node/src/swap_protocols/ledger/ethereum.rs
+++ b/application/comit_node/src/swap_protocols/ledger/ethereum.rs
@@ -12,6 +12,7 @@ impl Ledger for Ethereum {
     type Address = Address;
     type Identity = Address;
     type Transaction = Transaction;
+    type HttpIdentity = Address;
 
     fn address_for_identity(&self, address: Address) -> Address {
         address

--- a/application/comit_node/src/swap_protocols/ledger/mod.rs
+++ b/application/comit_node/src/swap_protocols/ledger/mod.rs
@@ -47,6 +47,7 @@ pub trait Ledger:
         + Sync
         + PartialEq
         + 'static;
+    type HttpIdentity: DeserializeOwned;
 
     fn address_for_identity(&self, identity: Self::Identity) -> Self::Address;
 }

--- a/application/comit_node/src/swap_protocols/rfc003/alice/handler.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/alice/handler.rs
@@ -63,8 +63,8 @@ impl<
             .for_each(move |(id, requests)| {
                 match requests {
                     SwapRequestKind::BitcoinEthereumBitcoinQuantityEthereumQuantity(request) => {
-                        // TODO: Store this somewhere
-                        let _alpha_ledger_refund_identity = request.alpha_ledger_refund_identity;
+                        // Generated with KeyPair for Bitcoin
+                        let _ = request.alpha_ledger_refund_identity;
 
                         let alpha_ledger_refund_identity =
                             key_store.get_transient_keypair(&id.into(), b"REFUND");

--- a/application/comit_node/src/swap_protocols/rfc003/alice/swap_request.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/alice/swap_request.rs
@@ -12,8 +12,8 @@ pub struct SwapRequest<AL: Ledger, BL: Ledger, AA, BA> {
     pub beta_asset: BA,
     pub alpha_ledger: AL,
     pub beta_ledger: BL,
-    pub alpha_ledger_refund_identity: AL::Identity,
-    pub beta_ledger_success_identity: BL::Identity,
+    pub alpha_ledger_refund_identity: AL::HttpIdentity,
+    pub beta_ledger_success_identity: BL::HttpIdentity,
     pub alpha_ledger_lock_duration: AL::LockDuration,
 }
 


### PR DESCRIPTION
For Alice, final refund address is removed from the HTTP request
to create a swap.

For Bob, final redeem address is removed from the HTTP request to accept a swap.

Resolves #484.