### PR TITLE
Move extract_secret to transaction

### DIFF
--- a/application/comit_node/src/swap_protocols/rfc003/actions/bob/btc_erc20.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/bob/btc_erc20.rs
@@ -120,10 +120,10 @@ impl StateActions for SwapStates<Bob<Bitcoin, Ethereum, BitcoinQuantity, Erc20Qu
             SS::AlphaFundedBetaRedeemed(AlphaFundedBetaRedeemed {
                 ref swap,
                 ref alpha_htlc_location,
-                ref secret,
+                ref beta_redeemed_tx,
                 ..
             }) => vec![Action::Redeem(
-                swap.redeem_action(*alpha_htlc_location, *secret),
+                swap.redeem_action(*alpha_htlc_location, beta_redeemed_tx.secret),
             )],
             _ => vec![],
         }

--- a/application/comit_node/src/swap_protocols/rfc003/actions/bob/btc_eth.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/bob/btc_eth.rs
@@ -98,10 +98,10 @@ impl StateActions for SwapStates<Bob<Bitcoin, Ethereum, BitcoinQuantity, EtherQu
             SS::AlphaFundedBetaRedeemed(AlphaFundedBetaRedeemed {
                 ref swap,
                 ref alpha_htlc_location,
-                ref secret,
+                ref beta_redeemed_tx,
                 ..
             }) => vec![Action::Redeem(
-                swap.redeem_action(*alpha_htlc_location, *secret),
+                swap.redeem_action(*alpha_htlc_location, beta_redeemed_tx.secret),
             )],
             _ => vec![],
         }

--- a/application/comit_node/src/swap_protocols/rfc003/bitcoin/extract_secret.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/bitcoin/extract_secret.rs
@@ -1,0 +1,90 @@
+use bitcoin_support::Transaction;
+use swap_protocols::{
+    ledger::Bitcoin,
+    rfc003::{
+        secret::{Secret, SecretHash},
+        ExtractSecret, Ledger,
+    },
+};
+
+impl ExtractSecret for Transaction {
+    fn extract_secret(&self, secret_hash: &SecretHash) -> Option<Secret> {
+        self.input.iter().find_map(|txin| {
+            txin.witness
+                .iter()
+                .find_map(|script_item| match Secret::from_vec(&script_item) {
+                    Ok(secret) => match secret.hash() == *secret_hash {
+                        true => Some(secret),
+                        false => None,
+                    },
+                    Err(_) => None,
+                })
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bitcoin_support::{serialize::deserialize, OutPoint, Script, Transaction, TxIn};
+    use hex;
+    use spectral::prelude::*;
+    use std::str::FromStr;
+
+    fn setup(secret: &Secret) -> Transaction {
+        Transaction {
+            version: 1,
+            lock_time: 0,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: Script::new(),
+                sequence: 0,
+                witness: vec![
+                    vec![],                       // Signature
+                    vec![],                       // Public key
+                    secret.raw_secret().to_vec(), // Secret
+                    vec![1u8],                    // Bool to enter redeem branch
+                    vec![],                       // Previous Script
+                ],
+            }],
+            output: vec![],
+        }
+    }
+
+    #[test]
+    fn extract_correct_secret() {
+        let secret = Secret::from(*b"This is our favourite passphrase");
+        let transaction = setup(&secret);
+
+        assert_that!(transaction.extract_secret(&secret.hash()))
+            .is_some()
+            .is_equal_to(&secret);
+    }
+
+    #[test]
+    fn extract_incorrect_secret() {
+        let secret = Secret::from(*b"This is our favourite passphrase");
+        let transaction = setup(&secret);
+
+        let secret_hash = SecretHash::from_str(
+            "bfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbf\
+             bfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbf",
+        )
+        .unwrap();
+        assert_that!(transaction.extract_secret(&secret_hash)).is_none();
+    }
+
+    #[test]
+    fn extract_correct_secret_from_mainnet_transaction() {
+        let hex_tx = hex::decode("0200000000010124e06fe5594b941d06c7385dc7307ec694a41f7d307423121855ee17e47e06ad0100000000ffffffff0137aa0b000000000017a914050377baa6e8c5a07aed125d0ef262c6d5b67a038705483045022100d780139514f39ed943179e4638a519101bae875ec1220b226002bcbcb147830b0220273d1efb1514a77ee3dd4adee0e896b7e76be56c6d8e73470ae9bd91c91d700c01210344f8f459494f74ebb87464de9b74cdba3709692df4661159857988966f94262f20ec9e9fb3c669b2354ea026ab3da82968a2e7ab9398d5cbed4e78e47246f2423e01015b63a82091d6a24697ed31932537ae598d3de3131e1fcd0641b9ac4be7afcb376386d71e8876a9149f4a0cf348b478336cb1d87ea4c8313a7ca3de1967029000b27576a91465252e57f727a27f32c77098e14d88d8dbec01816888ac00000000").unwrap();
+        let transaction: Transaction = deserialize(&hex_tx).unwrap();
+        let hex_secret =
+            hex::decode("ec9e9fb3c669b2354ea026ab3da82968a2e7ab9398d5cbed4e78e47246f2423e")
+                .unwrap();
+        let secret = Secret::from_vec(&hex_secret).unwrap();
+
+        assert_that!(transaction.extract_secret(&secret.hash()))
+            .is_some()
+            .is_equal_to(&secret);
+    }
+}

--- a/application/comit_node/src/swap_protocols/rfc003/bitcoin/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/bitcoin/mod.rs
@@ -2,14 +2,11 @@ use bitcoin_support::{Address, BitcoinQuantity, Blocks, OutPoint};
 use secp256k1_support::KeyPair;
 use swap_protocols::{
     ledger::Bitcoin,
-    rfc003::{
-        secret::{Secret, SecretHash},
-        state_machine::HtlcParams,
-        Ledger, RedeemTransaction,
-    },
+    rfc003::{state_machine::HtlcParams, Ledger},
 };
 
 mod actions;
+mod extract_secret;
 mod htlc;
 mod queries;
 mod validation;
@@ -24,23 +21,6 @@ impl Ledger for Bitcoin {
     type LockDuration = Blocks;
     type HtlcLocation = OutPoint;
     type HtlcIdentity = KeyPair;
-
-    fn extract_secret(
-        transaction: &RedeemTransaction<Self>,
-        secret_hash: &SecretHash,
-    ) -> Option<Secret> {
-        transaction.as_ref().input.iter().find_map(|txin| {
-            txin.witness
-                .iter()
-                .find_map(|script_item| match Secret::from_vec(&script_item) {
-                    Ok(secret) => match secret.hash() == *secret_hash {
-                        true => Some(secret),
-                        false => None,
-                    },
-                    Err(_) => None,
-                })
-        })
-    }
 }
 
 impl From<HtlcParams<Bitcoin, BitcoinQuantity>> for Htlc {
@@ -57,81 +37,5 @@ impl From<HtlcParams<Bitcoin, BitcoinQuantity>> for Htlc {
 impl HtlcParams<Bitcoin, BitcoinQuantity> {
     pub fn compute_address(&self) -> Address {
         Htlc::from(self.clone()).compute_address(self.ledger.network)
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use bitcoin_support::{serialize::deserialize, OutPoint, Script, Transaction, TxIn};
-    use hex;
-    use spectral::prelude::*;
-    use std::str::FromStr;
-
-    fn setup(secret: &Secret) -> Transaction {
-        Transaction {
-            version: 1,
-            lock_time: 0,
-            input: vec![TxIn {
-                previous_output: OutPoint::null(),
-                script_sig: Script::new(),
-                sequence: 0,
-                witness: vec![
-                    vec![],                       // Signature
-                    vec![],                       // Public key
-                    secret.raw_secret().to_vec(), // Secret
-                    vec![1u8],                    // Bool to enter redeem branch
-                    vec![],                       // Previous Script
-                ],
-            }],
-            output: vec![],
-        }
-    }
-
-    #[test]
-    fn extract_correct_secret() {
-        let secret = Secret::from(*b"This is our favourite passphrase");
-        let transaction = setup(&secret);
-
-        assert_that!(Bitcoin::extract_secret(
-            &RedeemTransaction(transaction),
-            &secret.hash()
-        ))
-        .is_some()
-        .is_equal_to(&secret);
-    }
-
-    #[test]
-    fn extract_incorrect_secret() {
-        let secret = Secret::from(*b"This is our favourite passphrase");
-        let transaction = setup(&secret);
-
-        let secret_hash = SecretHash::from_str(
-            "bfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbf\
-             bfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbf",
-        )
-        .unwrap();
-        assert_that!(Bitcoin::extract_secret(
-            &RedeemTransaction(transaction),
-            &secret_hash
-        ))
-        .is_none();
-    }
-
-    #[test]
-    fn extract_correct_secret_from_mainnet_transaction() {
-        let hex_tx = hex::decode("0200000000010124e06fe5594b941d06c7385dc7307ec694a41f7d307423121855ee17e47e06ad0100000000ffffffff0137aa0b000000000017a914050377baa6e8c5a07aed125d0ef262c6d5b67a038705483045022100d780139514f39ed943179e4638a519101bae875ec1220b226002bcbcb147830b0220273d1efb1514a77ee3dd4adee0e896b7e76be56c6d8e73470ae9bd91c91d700c01210344f8f459494f74ebb87464de9b74cdba3709692df4661159857988966f94262f20ec9e9fb3c669b2354ea026ab3da82968a2e7ab9398d5cbed4e78e47246f2423e01015b63a82091d6a24697ed31932537ae598d3de3131e1fcd0641b9ac4be7afcb376386d71e8876a9149f4a0cf348b478336cb1d87ea4c8313a7ca3de1967029000b27576a91465252e57f727a27f32c77098e14d88d8dbec01816888ac00000000").unwrap();
-        let transaction: Transaction = deserialize(&hex_tx).unwrap();
-        let hex_secret =
-            hex::decode("ec9e9fb3c669b2354ea026ab3da82968a2e7ab9398d5cbed4e78e47246f2423e")
-                .unwrap();
-        let secret = Secret::from_vec(&hex_secret).unwrap();
-
-        assert_that!(Bitcoin::extract_secret(
-            &RedeemTransaction(transaction),
-            &secret.hash()
-        ))
-        .is_some()
-        .is_equal_to(&secret);
     }
 }

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/extract_secret.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/extract_secret.rs
@@ -1,0 +1,83 @@
+use ethereum_support::Transaction;
+use swap_protocols::{
+    ledger::Ethereum,
+    rfc003::{
+        secret::{Secret, SecretHash},
+        ExtractSecret, Ledger,
+    },
+};
+
+impl ExtractSecret for Transaction {
+    fn extract_secret(&self, secret_hash: &SecretHash) -> Option<Secret> {
+        let data = &self.input.0;
+        info!(
+            "Attempting to extract secret for {:?} from transaction {:?}",
+            secret_hash, self.hash
+        );
+        match Secret::from_vec(&data) {
+            Ok(secret) => match secret.hash() == *secret_hash {
+                true => Some(secret),
+                false => {
+                    error!(
+                        "Input ({:?}) in transaction {:?} is NOT the pre-image to {:?}",
+                        data, self.hash, secret_hash
+                    );
+                    None
+                }
+            },
+            Err(e) => {
+                error!("Failed to create secret from {:?}: {:?}", data, e);
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ethereum_support::{Bytes, Transaction, H256, U256};
+    use pretty_env_logger;
+    use spectral::prelude::*;
+    use std::str::FromStr;
+
+    fn setup(secret: &Secret) -> Transaction {
+        let _ = pretty_env_logger::try_init();
+        Transaction {
+            hash: H256::from(123),
+            nonce: U256::from(1),
+            block_hash: None,
+            block_number: None,
+            transaction_index: None,
+            from: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse().unwrap(),
+            to: Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".parse().unwrap()),
+            value: U256::from(0),
+            gas_price: U256::from(0),
+            gas: U256::from(0),
+            input: Bytes::from(secret.raw_secret().to_vec()),
+        }
+    }
+
+    #[test]
+    fn extract_correct_secret() {
+        let secret = Secret::from(*b"This is our favourite passphrase");
+        let transaction = setup(&secret);
+
+        assert_that!(transaction.extract_secret(&secret.hash()))
+            .is_some()
+            .is_equal_to(&secret);
+    }
+
+    #[test]
+    fn extract_incorrect_secret() {
+        let secret = Secret::from(*b"This is our favourite passphrase");
+        let transaction = setup(&secret);
+
+        let secret_hash = SecretHash::from_str(
+            "bfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbf\
+             bfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbf",
+        )
+        .unwrap();
+        assert_that!(transaction.extract_secret(&secret_hash)).is_none();
+    }
+}

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/mod.rs
@@ -3,16 +3,13 @@ use hex;
 pub use std_ext::time::Seconds;
 use swap_protocols::{
     ledger::Ethereum,
-    rfc003::{
-        secret::{Secret, SecretHash},
-        state_machine::HtlcParams,
-        Ledger, RedeemTransaction,
-    },
+    rfc003::{state_machine::HtlcParams, Ledger},
 };
 
 mod actions;
 mod erc20_htlc;
 mod ether_htlc;
+mod extract_secret;
 mod queries;
 mod validation;
 
@@ -35,35 +32,6 @@ impl Ledger for Ethereum {
     type LockDuration = Seconds;
     type HtlcLocation = Address;
     type HtlcIdentity = Address;
-
-    fn extract_secret(
-        transaction: &RedeemTransaction<Self>,
-        secret_hash: &SecretHash,
-    ) -> Option<Secret> {
-        let transaction = transaction.as_ref();
-
-        let data = &transaction.input.0;
-        info!(
-            "Attempting to extract secret for {:?} from transaction {:?}",
-            secret_hash, transaction.hash
-        );
-        match Secret::from_vec(&data) {
-            Ok(secret) => match secret.hash() == *secret_hash {
-                true => Some(secret),
-                false => {
-                    error!(
-                        "Input ({:?}) in transaction {:?} is NOT the pre-image to {:?}",
-                        data, transaction.hash, secret_hash
-                    );
-                    None
-                }
-            },
-            Err(e) => {
-                error!("Failed to create secret from {:?}: {:?}", data, e);
-                None
-            }
-        }
-    }
 }
 
 impl From<HtlcParams<Ethereum, EtherQuantity>> for EtherHtlc {
@@ -104,61 +72,5 @@ impl HtlcParams<Ethereum, Erc20Quantity> {
         Erc20Htlc::from(self.clone())
             .funding_tx_payload(htlc_location)
             .into()
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use ethereum_support::{Bytes, Transaction, H256, U256};
-    use pretty_env_logger;
-    use spectral::prelude::*;
-    use std::str::FromStr;
-
-    fn setup(secret: &Secret) -> Transaction {
-        let _ = pretty_env_logger::try_init();
-        Transaction {
-            hash: H256::from(123),
-            nonce: U256::from(1),
-            block_hash: None,
-            block_number: None,
-            transaction_index: None,
-            from: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse().unwrap(),
-            to: Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".parse().unwrap()),
-            value: U256::from(0),
-            gas_price: U256::from(0),
-            gas: U256::from(0),
-            input: Bytes::from(secret.raw_secret().to_vec()),
-        }
-    }
-
-    #[test]
-    fn extract_correct_secret() {
-        let secret = Secret::from(*b"This is our favourite passphrase");
-        let transaction = setup(&secret);
-
-        assert_that!(Ethereum::extract_secret(
-            &RedeemTransaction(transaction),
-            &secret.hash()
-        ))
-        .is_some()
-        .is_equal_to(&secret);
-    }
-
-    #[test]
-    fn extract_incorrect_secret() {
-        let secret = Secret::from(*b"This is our favourite passphrase");
-        let transaction = setup(&secret);
-
-        let secret_hash = SecretHash::from_str(
-            "bfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbf\
-             bfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbf",
-        )
-        .unwrap();
-        assert_that!(Ethereum::extract_secret(
-            &RedeemTransaction(transaction),
-            &secret_hash
-        ))
-        .is_none();
     }
 }

--- a/application/comit_node/src/swap_protocols/rfc003/ledger.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ledger.rs
@@ -23,29 +23,25 @@ pub trait Ledger: swap_protocols::Ledger {
         + PartialEq
         + Debug
         + Into<<Self as swap_protocols::ledger::Ledger>::Identity>;
+}
 
-    fn extract_secret(
-        transaction: &RedeemTransaction<Self>,
-        secret_hash: &SecretHash,
-    ) -> Option<Secret>;
+pub trait ExtractSecret {
+    fn extract_secret(&self, secret_hash: &SecretHash) -> Option<Secret>;
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FundTransaction<L: Ledger>(pub L::Transaction);
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct RedeemTransaction<L: Ledger>(pub L::Transaction);
+pub struct RedeemTransaction<L: Ledger> {
+    pub transaction: L::Transaction,
+    pub secret: Secret,
+}
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RefundTransaction<L: Ledger>(pub L::Transaction);
 
 impl<L: Ledger> AsRef<L::Transaction> for FundTransaction<L> {
-    fn as_ref(&self) -> &L::Transaction {
-        &self.0
-    }
-}
-
-impl<L: Ledger> AsRef<L::Transaction> for RedeemTransaction<L> {
     fn as_ref(&self) -> &L::Transaction {
         &self.0
     }

--- a/application/comit_node/src/swap_protocols/rfc003/lightning/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/lightning/mod.rs
@@ -1,22 +1,9 @@
 use secp256k1_support::PublicKey;
 use std_ext::time::Seconds;
-use swap_protocols::{
-    ledger::Lightning,
-    rfc003::{
-        secret::{Secret, SecretHash},
-        Ledger, RedeemTransaction,
-    },
-};
+use swap_protocols::{ledger::Lightning, rfc003::Ledger};
 
 impl Ledger for Lightning {
     type LockDuration = Seconds;
     type HtlcLocation = ();
     type HtlcIdentity = PublicKey;
-
-    fn extract_secret(
-        _payment: &RedeemTransaction<Self>,
-        _secret_hash: &SecretHash,
-    ) -> Option<Secret> {
-        unimplemented!()
-    }
 }

--- a/application/comit_node/src/swap_protocols/rfc003/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/mod.rs
@@ -24,7 +24,7 @@ mod state_machine_test;
 
 pub use self::{
     error::Error,
-    ledger::{FundTransaction, Ledger, RedeemTransaction, RefundTransaction},
+    ledger::{ExtractSecret, FundTransaction, Ledger, RedeemTransaction, RefundTransaction},
     save_state::SaveState,
     secret::{RandomnessSource, Secret, SecretFromErr, SecretHash},
 };

--- a/application/comit_node/src/swap_protocols/rfc003/state_machine_test.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/state_machine_test.rs
@@ -192,14 +192,15 @@ fn alpha_refunded() {
                 vout: 0,
             }))),
             htlc_funded: Some(Box::new(future::ok(None))),
-            htlc_redeemed_or_refunded: Some(Box::new(future::ok(Either::A(RedeemTransaction(
-                bitcoin_support::Transaction {
+            htlc_redeemed_or_refunded: Some(Box::new(future::ok(Either::A(RedeemTransaction {
+                transaction: bitcoin_support::Transaction {
                     version: 1,
                     lock_time: 42,
                     input: vec![],
                     output: vec![],
-                }
-            ))))),
+                },
+                secret: start.secret,
+            })))),
             ..Default::default()
         },
         FakeLedgerEvents::<Ethereum> {
@@ -276,14 +277,15 @@ fn bob_transition_alpha_refunded() {
                 vout: 0,
             }))),
             htlc_funded: Some(Box::new(future::ok(None))),
-            htlc_redeemed_or_refunded: Some(Box::new(future::ok(Either::A(RedeemTransaction(
-                bitcoin_support::Transaction {
+            htlc_redeemed_or_refunded: Some(Box::new(future::ok(Either::A(RedeemTransaction {
+                transaction: bitcoin_support::Transaction {
                     version: 1,
                     lock_time: 42,
                     input: vec![],
                     output: vec![],
-                }
-            ))))),
+                },
+                secret: Secret::from(*b"hello world, you are beautiful!!"),
+            })))),
             ..Default::default()
         },
         FakeLedgerEvents::<Ethereum> {


### PR DESCRIPTION
This moves the extract_secret functionality back to the transaction. Now that we've cleaned things up a lot this makes a lot of sense. The motivation for doing this is so we don't have to implement extract_secret for Lightning (it's only used for LQS ledgers).