### PR TITLE
Make `StateActions` only have one associated type

### DIFF
--- a/application/comit_node/src/http_api/rfc003/action.rs
+++ b/application/comit_node/src/http_api/rfc003/action.rs
@@ -9,7 +9,7 @@ use swap_protocols::{
     ledger::{Bitcoin, Ethereum},
     metadata_store::Metadata,
     rfc003::{
-        actions::{bob::Accept, Action, Actions},
+        actions::{bob::Accept, ActionKind, Actions},
         bitcoin, ethereum,
         roles::{Alice, Bob},
         state_machine::StateMachineResponse,
@@ -295,7 +295,7 @@ impl IntoResponseBody for () {
 }
 
 impl<Accept, Decline, Deploy, Fund, Redeem, Refund> IntoResponseBody
-    for Action<Accept, Decline, Deploy, Fund, Redeem, Refund>
+    for ActionKind<Accept, Decline, Deploy, Fund, Redeem, Refund>
 where
     Deploy: IntoResponseBody,
     Fund: IntoResponseBody,
@@ -307,10 +307,10 @@ where
         query_params: GetActionQueryParams,
     ) -> Result<ActionResponseBody, HttpApiProblem> {
         match self {
-            Action::Deploy(payload) => payload.into_response_body(query_params),
-            Action::Fund(payload) => payload.into_response_body(query_params),
-            Action::Redeem(payload) => payload.into_response_body(query_params),
-            Action::Refund(payload) => payload.into_response_body(query_params),
+            ActionKind::Deploy(payload) => payload.into_response_body(query_params),
+            ActionKind::Fund(payload) => payload.into_response_body(query_params),
+            ActionKind::Redeem(payload) => payload.into_response_body(query_params),
+            ActionKind::Refund(payload) => payload.into_response_body(query_params),
             _ => {
                 error!("IntoResponseBody is not implemented for Accept/Decline");
                 Err(HttpApiProblem::with_title_and_type_from_status(500))
@@ -399,7 +399,7 @@ pub fn handle_post<T: MetadataStore<SwapId>, S: StateStore<SwapId>>(
                             .actions()
                             .into_iter()
                             .find_map(move |action| match action {
-                                Action::Accept(accept) => Some(Ok(accept)),
+                                ActionKind::Accept(accept) => Some(Ok(accept)),
                                 _ => None,
                             })
                             .unwrap_or_else(|| {
@@ -425,13 +425,13 @@ pub enum GetAction {
 impl GetAction {
     fn matches<Accept, Decline, Deploy, Fund, Redeem, Refund>(
         self,
-        other: &Action<Accept, Decline, Deploy, Fund, Redeem, Refund>,
+        other: &ActionKind<Accept, Decline, Deploy, Fund, Redeem, Refund>,
     ) -> bool {
         match other {
-            Action::Deploy(_) => self == GetAction::Deploy,
-            Action::Fund(_) => self == GetAction::Fund,
-            Action::Redeem(_) => self == GetAction::Redeem,
-            Action::Refund(_) => self == GetAction::Refund,
+            ActionKind::Deploy(_) => self == GetAction::Deploy,
+            ActionKind::Fund(_) => self == GetAction::Fund,
+            ActionKind::Redeem(_) => self == GetAction::Redeem,
+            ActionKind::Refund(_) => self == GetAction::Refund,
             _ => false,
         }
     }

--- a/application/comit_node/src/http_api/rfc003/action.rs
+++ b/application/comit_node/src/http_api/rfc003/action.rs
@@ -9,7 +9,7 @@ use swap_protocols::{
     ledger::{Bitcoin, Ethereum},
     metadata_store::Metadata,
     rfc003::{
-        actions::{bob::Accept, Action, StateActions},
+        actions::{bob::Accept, Action, Actions},
         bitcoin, ethereum,
         roles::{Alice, Bob},
         state_machine::StateMachineResponse,

--- a/application/comit_node/src/http_api/rfc003/swap.rs
+++ b/application/comit_node/src/http_api/rfc003/swap.rs
@@ -19,7 +19,7 @@ use swap_protocols::{
     ledger::{Bitcoin, Ethereum},
     rfc003::{
         self,
-        actions::{Action, StateActions},
+        actions::{Action, Actions},
         alice::SwapRequestIdentities,
         roles::{Alice, Bob},
         state_store::StateStore,

--- a/application/comit_node/src/http_api/rfc003/swap.rs
+++ b/application/comit_node/src/http_api/rfc003/swap.rs
@@ -19,7 +19,7 @@ use swap_protocols::{
     ledger::{Bitcoin, Ethereum},
     rfc003::{
         self,
-        actions::{Action, Actions},
+        actions::{ActionKind, Actions},
         alice::SwapRequestIdentities,
         roles::{Alice, Bob},
         state_store::StateStore,
@@ -299,7 +299,7 @@ fn handle_get_swap<T: MetadataStore<SwapId>, S: StateStore<SwapId>>(
             let start_state = state
                 .start_state()
                 .ok_or_else(|| HttpApiProblem::with_title_and_type_from_status(500))?;
-            let actions: Vec<ActionName> = state.actions().iter().map(Action::name).collect();
+            let actions: Vec<ActionName> = state.actions().iter().map(ActionKind::name).collect();
             (Ok((
                 GetSwapResource {
                     state: state.name(),

--- a/application/comit_node/src/swap_protocols/rfc003/actions/alice/btc_erc20.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/alice/btc_erc20.rs
@@ -4,7 +4,7 @@ use ethereum_support::{Bytes, Erc20Quantity, EtherQuantity};
 use swap_protocols::{
     ledger::{Bitcoin, Ethereum},
     rfc003::{
-        actions::{Action, Actions},
+        actions::{ActionKind, Actions},
         bitcoin,
         ethereum::{self, Erc20Htlc},
         roles::Alice,
@@ -50,7 +50,7 @@ impl OngoingSwap<Alice<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quantity>> {
 }
 
 type AliceActionKind =
-    Action<(), (), (), bitcoin::SendToAddress, ethereum::SendTransaction, bitcoin::SpendOutput>;
+    ActionKind<(), (), (), bitcoin::SendToAddress, ethereum::SendTransaction, bitcoin::SpendOutput>;
 
 impl Actions for SwapStates<Alice<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quantity>> {
     type ActionKind = AliceActionKind;
@@ -58,15 +58,15 @@ impl Actions for SwapStates<Alice<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quant
     fn actions(&self) -> Vec<AliceActionKind> {
         use self::SwapStates as SS;
         match *self {
-            SS::Accepted(Accepted { ref swap, .. }) => vec![Action::Fund(swap.fund_action())],
+            SS::Accepted(Accepted { ref swap, .. }) => vec![ActionKind::Fund(swap.fund_action())],
             SS::BothFunded(BothFunded {
                 ref alpha_htlc_location,
                 ref beta_htlc_location,
                 ref swap,
                 ..
             }) => vec![
-                Action::Redeem(swap.redeem_action(*beta_htlc_location)),
-                Action::Refund(swap.refund_action(*alpha_htlc_location)),
+                ActionKind::Redeem(swap.redeem_action(*beta_htlc_location)),
+                ActionKind::Refund(swap.refund_action(*alpha_htlc_location)),
             ],
             SS::AlphaFundedBetaRefunded(AlphaFundedBetaRefunded {
                 ref swap,
@@ -77,7 +77,7 @@ impl Actions for SwapStates<Alice<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quant
                 ref swap,
                 ref alpha_htlc_location,
                 ..
-            }) => vec![Action::Refund(swap.refund_action(*alpha_htlc_location))],
+            }) => vec![ActionKind::Refund(swap.refund_action(*alpha_htlc_location))],
             SS::AlphaRefundedBetaFunded(AlphaRefundedBetaFunded {
                 ref beta_htlc_location,
                 ref swap,
@@ -87,7 +87,7 @@ impl Actions for SwapStates<Alice<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quant
                 ref beta_htlc_location,
                 ref swap,
                 ..
-            }) => vec![Action::Redeem(swap.redeem_action(*beta_htlc_location))],
+            }) => vec![ActionKind::Redeem(swap.redeem_action(*beta_htlc_location))],
             _ => vec![],
         }
     }

--- a/application/comit_node/src/swap_protocols/rfc003/actions/alice/btc_erc20.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/alice/btc_erc20.rs
@@ -4,7 +4,7 @@ use ethereum_support::{Bytes, Erc20Quantity, EtherQuantity};
 use swap_protocols::{
     ledger::{Bitcoin, Ethereum},
     rfc003::{
-        actions::{Action, StateActions},
+        actions::{Action, Actions},
         bitcoin,
         ethereum::{self, Erc20Htlc},
         roles::Alice,
@@ -49,7 +49,7 @@ impl OngoingSwap<Alice<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quantity>> {
     }
 }
 
-impl StateActions for SwapStates<Alice<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quantity>> {
+impl Actions for SwapStates<Alice<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quantity>> {
     type Accept = ();
     type Decline = ();
     type Deploy = ();

--- a/application/comit_node/src/swap_protocols/rfc003/actions/alice/btc_erc20.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/alice/btc_erc20.rs
@@ -49,19 +49,13 @@ impl OngoingSwap<Alice<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quantity>> {
     }
 }
 
-impl Actions for SwapStates<Alice<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quantity>> {
-    type Accept = ();
-    type Decline = ();
-    type Deploy = ();
-    type Fund = bitcoin::SendToAddress;
-    type Redeem = ethereum::SendTransaction;
-    type Refund = bitcoin::SpendOutput;
+type AliceActionKind =
+    Action<(), (), (), bitcoin::SendToAddress, ethereum::SendTransaction, bitcoin::SpendOutput>;
 
-    fn actions(
-        &self,
-    ) -> Vec<
-        Action<(), (), (), bitcoin::SendToAddress, ethereum::SendTransaction, bitcoin::SpendOutput>,
-    > {
+impl Actions for SwapStates<Alice<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quantity>> {
+    type ActionKind = AliceActionKind;
+
+    fn actions(&self) -> Vec<AliceActionKind> {
         use self::SwapStates as SS;
         match *self {
             SS::Accepted(Accepted { ref swap, .. }) => vec![Action::Fund(swap.fund_action())],

--- a/application/comit_node/src/swap_protocols/rfc003/actions/alice/btc_eth.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/alice/btc_eth.rs
@@ -4,7 +4,7 @@ use ethereum_support::{Bytes, EtherQuantity, U256};
 use swap_protocols::{
     ledger::{Bitcoin, Ethereum},
     rfc003::{
-        actions::{Action, StateActions},
+        actions::{Action, Actions},
         bitcoin,
         ethereum::{self, EtherHtlc},
         roles::Alice,
@@ -47,7 +47,7 @@ impl OngoingSwap<Alice<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity>> {
     }
 }
 
-impl StateActions for SwapStates<Alice<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity>> {
+impl Actions for SwapStates<Alice<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity>> {
     type Accept = ();
     type Decline = ();
     type Deploy = ();

--- a/application/comit_node/src/swap_protocols/rfc003/actions/alice/btc_eth.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/alice/btc_eth.rs
@@ -4,7 +4,7 @@ use ethereum_support::{Bytes, EtherQuantity, U256};
 use swap_protocols::{
     ledger::{Bitcoin, Ethereum},
     rfc003::{
-        actions::{Action, Actions},
+        actions::{ActionKind, Actions},
         bitcoin,
         ethereum::{self, EtherHtlc},
         roles::Alice,
@@ -48,7 +48,7 @@ impl OngoingSwap<Alice<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity>> {
 }
 
 type AliceActionKind =
-    Action<(), (), (), bitcoin::SendToAddress, ethereum::SendTransaction, bitcoin::SpendOutput>;
+    ActionKind<(), (), (), bitcoin::SendToAddress, ethereum::SendTransaction, bitcoin::SpendOutput>;
 
 impl Actions for SwapStates<Alice<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity>> {
     type ActionKind = AliceActionKind;
@@ -56,15 +56,15 @@ impl Actions for SwapStates<Alice<Bitcoin, Ethereum, BitcoinQuantity, EtherQuant
     fn actions(&self) -> Vec<AliceActionKind> {
         use self::SwapStates as SS;
         match *self {
-            SS::Accepted(Accepted { ref swap, .. }) => vec![Action::Fund(swap.fund_action())],
+            SS::Accepted(Accepted { ref swap, .. }) => vec![ActionKind::Fund(swap.fund_action())],
             SS::BothFunded(BothFunded {
                 ref alpha_htlc_location,
                 ref beta_htlc_location,
                 ref swap,
                 ..
             }) => vec![
-                Action::Redeem(swap.redeem_action(*beta_htlc_location)),
-                Action::Refund(swap.refund_action(*alpha_htlc_location)),
+                ActionKind::Redeem(swap.redeem_action(*beta_htlc_location)),
+                ActionKind::Refund(swap.refund_action(*alpha_htlc_location)),
             ],
             SS::AlphaFundedBetaRefunded(AlphaFundedBetaRefunded {
                 ref swap,
@@ -75,7 +75,7 @@ impl Actions for SwapStates<Alice<Bitcoin, Ethereum, BitcoinQuantity, EtherQuant
                 ref swap,
                 ref alpha_htlc_location,
                 ..
-            }) => vec![Action::Refund(swap.refund_action(*alpha_htlc_location))],
+            }) => vec![ActionKind::Refund(swap.refund_action(*alpha_htlc_location))],
             SS::AlphaRefundedBetaFunded(AlphaRefundedBetaFunded {
                 ref beta_htlc_location,
                 ref swap,
@@ -85,7 +85,7 @@ impl Actions for SwapStates<Alice<Bitcoin, Ethereum, BitcoinQuantity, EtherQuant
                 ref beta_htlc_location,
                 ref swap,
                 ..
-            }) => vec![Action::Redeem(swap.redeem_action(*beta_htlc_location))],
+            }) => vec![ActionKind::Redeem(swap.redeem_action(*beta_htlc_location))],
             _ => vec![],
         }
     }

--- a/application/comit_node/src/swap_protocols/rfc003/actions/alice/btc_eth.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/alice/btc_eth.rs
@@ -47,19 +47,13 @@ impl OngoingSwap<Alice<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity>> {
     }
 }
 
-impl Actions for SwapStates<Alice<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity>> {
-    type Accept = ();
-    type Decline = ();
-    type Deploy = ();
-    type Fund = bitcoin::SendToAddress;
-    type Redeem = ethereum::SendTransaction;
-    type Refund = bitcoin::SpendOutput;
+type AliceActionKind =
+    Action<(), (), (), bitcoin::SendToAddress, ethereum::SendTransaction, bitcoin::SpendOutput>;
 
-    fn actions(
-        &self,
-    ) -> Vec<
-        Action<(), (), (), bitcoin::SendToAddress, ethereum::SendTransaction, bitcoin::SpendOutput>,
-    > {
+impl Actions for SwapStates<Alice<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity>> {
+    type ActionKind = AliceActionKind;
+
+    fn actions(&self) -> Vec<AliceActionKind> {
         use self::SwapStates as SS;
         match *self {
             SS::Accepted(Accepted { ref swap, .. }) => vec![Action::Fund(swap.fund_action())],

--- a/application/comit_node/src/swap_protocols/rfc003/actions/bob/btc_erc20.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/bob/btc_erc20.rs
@@ -75,20 +75,19 @@ impl OngoingSwap<Bob<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quantity>> {
     }
 }
 
-impl Actions for SwapStates<Bob<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quantity>> {
-    type Accept = Accept<Bitcoin, Ethereum>;
-    type Decline = Decline<Bitcoin, Ethereum>;
-    type Deploy = ethereum::ContractDeploy;
-    type Fund = ethereum::SendTransaction;
-    type Redeem = bitcoin::SpendOutput;
-    type Refund = ethereum::SendTransaction;
+type BobActionKind = Action<
+    Accept<Bitcoin, Ethereum>,
+    Decline<Bitcoin, Ethereum>,
+    ethereum::ContractDeploy,
+    ethereum::SendTransaction,
+    bitcoin::SpendOutput,
+    ethereum::SendTransaction,
+>;
 
-    #[allow(clippy::type_complexity)]
-    fn actions(
-        &self,
-    ) -> Vec<
-        Action<Self::Accept, Self::Decline, Self::Deploy, Self::Fund, Self::Redeem, Self::Refund>,
-    > {
+impl Actions for SwapStates<Bob<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quantity>> {
+    type ActionKind = BobActionKind;
+
+    fn actions(&self) -> Vec<BobActionKind> {
         use self::SwapStates as SS;
         match *self {
             SS::Start(Start { ref role, .. }) => vec![

--- a/application/comit_node/src/swap_protocols/rfc003/actions/bob/btc_erc20.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/bob/btc_erc20.rs
@@ -6,7 +6,7 @@ use swap_protocols::{
     rfc003::{
         actions::{
             bob::{Accept, Decline},
-            Action, StateActions,
+            Action, Actions,
         },
         bitcoin,
         ethereum::{self, Erc20Htlc, Htlc},
@@ -75,7 +75,7 @@ impl OngoingSwap<Bob<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quantity>> {
     }
 }
 
-impl StateActions for SwapStates<Bob<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quantity>> {
+impl Actions for SwapStates<Bob<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quantity>> {
     type Accept = Accept<Bitcoin, Ethereum>;
     type Decline = Decline<Bitcoin, Ethereum>;
     type Deploy = ethereum::ContractDeploy;

--- a/application/comit_node/src/swap_protocols/rfc003/actions/bob/btc_erc20.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/bob/btc_erc20.rs
@@ -6,7 +6,7 @@ use swap_protocols::{
     rfc003::{
         actions::{
             bob::{Accept, Decline},
-            Action, Actions,
+            ActionKind, Actions,
         },
         bitcoin,
         ethereum::{self, Erc20Htlc, Htlc},
@@ -75,7 +75,7 @@ impl OngoingSwap<Bob<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quantity>> {
     }
 }
 
-type BobActionKind = Action<
+type BobActionKind = ActionKind<
     Accept<Bitcoin, Ethereum>,
     Decline<Bitcoin, Ethereum>,
     ethereum::ContractDeploy,
@@ -91,17 +91,17 @@ impl Actions for SwapStates<Bob<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quantit
         use self::SwapStates as SS;
         match *self {
             SS::Start(Start { ref role, .. }) => vec![
-                Action::Accept(role.accept_action()),
-                Action::Decline(role.decline_action()),
+                ActionKind::Accept(role.accept_action()),
+                ActionKind::Decline(role.decline_action()),
             ],
             SS::AlphaFunded(AlphaFunded { ref swap, .. }) => {
-                vec![Action::Deploy(swap.deploy_action())]
+                vec![ActionKind::Deploy(swap.deploy_action())]
             }
             SS::AlphaFundedBetaDeployed(AlphaFundedBetaDeployed {
                 ref swap,
                 ref beta_htlc_location,
                 ..
-            }) => vec![Action::Fund(swap.fund_action(*beta_htlc_location))],
+            }) => vec![ActionKind::Fund(swap.fund_action(*beta_htlc_location))],
             SS::BothFunded(BothFunded {
                 ref beta_htlc_location,
                 ref swap,
@@ -116,13 +116,13 @@ impl Actions for SwapStates<Bob<Bitcoin, Ethereum, BitcoinQuantity, Erc20Quantit
                 ref beta_htlc_location,
                 ref swap,
                 ..
-            }) => vec![Action::Refund(swap.refund_action(*beta_htlc_location))],
+            }) => vec![ActionKind::Refund(swap.refund_action(*beta_htlc_location))],
             SS::AlphaFundedBetaRedeemed(AlphaFundedBetaRedeemed {
                 ref swap,
                 ref alpha_htlc_location,
                 ref beta_redeemed_tx,
                 ..
-            }) => vec![Action::Redeem(
+            }) => vec![ActionKind::Redeem(
                 swap.redeem_action(*alpha_htlc_location, beta_redeemed_tx.secret),
             )],
             _ => vec![],

--- a/application/comit_node/src/swap_protocols/rfc003/actions/bob/btc_eth.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/bob/btc_eth.rs
@@ -61,18 +61,19 @@ impl OngoingSwap<Bob<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity>> {
     }
 }
 
-impl Actions for SwapStates<Bob<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity>> {
-    type Accept = Accept<Bitcoin, Ethereum>;
-    type Decline = Decline<Bitcoin, Ethereum>;
-    type Deploy = ();
-    type Fund = ethereum::ContractDeploy;
-    type Redeem = bitcoin::SpendOutput;
-    type Refund = ethereum::SendTransaction;
+type BobActionKind = Action<
+    Accept<Bitcoin, Ethereum>,
+    Decline<Bitcoin, Ethereum>,
+    (),
+    ethereum::ContractDeploy,
+    bitcoin::SpendOutput,
+    ethereum::SendTransaction,
+>;
 
-    #[allow(clippy::type_complexity)]
-    fn actions(
-        &self,
-    ) -> Vec<Action<Self::Accept, Self::Decline, (), Self::Fund, Self::Redeem, Self::Refund>> {
+impl Actions for SwapStates<Bob<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity>> {
+    type ActionKind = BobActionKind;
+
+    fn actions(&self) -> Vec<BobActionKind> {
         use self::SwapStates as SS;
         match *self {
             SS::Start(Start { ref role, .. }) => vec![

--- a/application/comit_node/src/swap_protocols/rfc003/actions/bob/btc_eth.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/bob/btc_eth.rs
@@ -6,7 +6,7 @@ use swap_protocols::{
     rfc003::{
         actions::{
             bob::{Accept, Decline},
-            Action, StateActions,
+            Action, Actions,
         },
         bitcoin,
         ethereum::{self, EtherHtlc, Htlc},
@@ -61,7 +61,7 @@ impl OngoingSwap<Bob<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity>> {
     }
 }
 
-impl StateActions for SwapStates<Bob<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity>> {
+impl Actions for SwapStates<Bob<Bitcoin, Ethereum, BitcoinQuantity, EtherQuantity>> {
     type Accept = Accept<Bitcoin, Ethereum>;
     type Decline = Decline<Bitcoin, Ethereum>;
     type Deploy = ();

--- a/application/comit_node/src/swap_protocols/rfc003/actions/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/mod.rs
@@ -28,17 +28,7 @@ impl<Accept, Decline, Deploy, Fund, Redeem, Refund>
 }
 
 pub trait Actions {
-    type Accept;
-    type Decline;
-    type Deploy;
-    type Fund;
-    type Redeem;
-    type Refund;
+    type ActionKind;
 
-    #[allow(clippy::type_complexity)]
-    fn actions(
-        &self,
-    ) -> Vec<
-        Action<Self::Accept, Self::Decline, Self::Deploy, Self::Fund, Self::Redeem, Self::Refund>,
-    >;
+    fn actions(&self) -> Vec<Self::ActionKind>;
 }

--- a/application/comit_node/src/swap_protocols/rfc003/actions/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/mod.rs
@@ -2,7 +2,7 @@ pub mod alice;
 pub mod bob;
 
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
-pub enum Action<Accept, Decline, Deploy, Fund, Redeem, Refund> {
+pub enum ActionKind<Accept, Decline, Deploy, Fund, Redeem, Refund> {
     Accept(Accept),
     Decline(Decline),
     Deploy(Deploy),
@@ -12,10 +12,10 @@ pub enum Action<Accept, Decline, Deploy, Fund, Redeem, Refund> {
 }
 
 impl<Accept, Decline, Deploy, Fund, Redeem, Refund>
-    Action<Accept, Decline, Deploy, Fund, Redeem, Refund>
+    ActionKind<Accept, Decline, Deploy, Fund, Redeem, Refund>
 {
     pub fn name(&self) -> String {
-        use self::Action::*;
+        use self::ActionKind::*;
         match *self {
             Accept(_) => String::from("accept"),
             Decline(_) => String::from("decline"),

--- a/application/comit_node/src/swap_protocols/rfc003/actions/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/mod.rs
@@ -27,7 +27,7 @@ impl<Accept, Decline, Deploy, Fund, Redeem, Refund>
     }
 }
 
-pub trait StateActions {
+pub trait Actions {
     type Accept;
     type Decline;
     type Deploy;


### PR DESCRIPTION
Resolves #541.

In a nutshell, this allows us to have different actions for different roles and states.