### PR TITLE
Add buffering of pending responses to comit_server

### DIFF
--- a/api_tests/dry/harness.sh
+++ b/api_tests/dry/harness.sh
@@ -1,7 +1,6 @@
 set -e;
 export PROJECT_ROOT=$(git rev-parse --show-toplevel)
 source "$PROJECT_ROOT/api_tests/harness-lib.sh"
-export RUST_LOG=debug;
 
 GIVEN_TEST_PATH="$1";
 

--- a/application/comit_node/src/comit_server.rs
+++ b/application/comit_node/src/comit_server.rs
@@ -33,11 +33,16 @@ impl ComitServer {
 
             let connection = Connection::new(config, codec, connection);
             let (close_future, _client) = connection.start::<json::JsonFrameHandler>();
-            tokio::spawn(close_future.map_err(move |e| {
-                error!(
-                    "Unexpected error in connection with {:?}: {:?}",
-                    peer_addr, e
-                );
+
+            tokio::spawn(close_future.then(move |result| {
+                match result {
+                    Ok(()) => info!("Connection with {:?} closed", peer_addr),
+                    Err(e) => error!(
+                        "Unexpected error in connection with {:?}: {:?}",
+                        peer_addr, e
+                    ),
+                }
+                Ok(())
             }));
             Ok(())
         })

--- a/application/comit_node/src/logging.rs
+++ b/application/comit_node/src/logging.rs
@@ -21,12 +21,8 @@ pub fn set_up_logging() {
         // TODO: get level from config file once implemented with #136
         .level(LevelFilter::Debug)
         .level_for("comit_node", LevelFilter::Trace)
+        .level_for("bam", LevelFilter::Trace)
         .level_for("comit_node::ledger_query_service", LevelFilter::Info)
-        .level_for("bitcoin_htlc", LevelFilter::Trace)
-        .level_for("comit_wallet", LevelFilter::Trace)
-        .level_for("ethereum_htlc", LevelFilter::Trace)
-        .level_for("ethereum_wallet", LevelFilter::Trace)
-        .level_for("transport_protocol", LevelFilter::Trace)
         .level_for("tokio_core::reactor", LevelFilter::Info)
         .level_for("tokio_reactor", LevelFilter::Info)
         .level_for("hyper", LevelFilter::Info)

--- a/vendor/bam/src/connection.rs
+++ b/vendor/bam/src/connection.rs
@@ -71,13 +71,14 @@ impl<
                 }
             })
             .filter(Option::is_some)
-            .and_then(|option| {
+            .map(|option| {
                 // FIXME: When we have Never (https://github.com/rust-lang/rust/issues/35121)
                 // and Future.recover we should be able to clean this up
                 option
                     .unwrap()
                     .map_err(|_| unreachable!("frame_handler ensures the error never happens"))
             })
+            .buffer_unordered(std::usize::MAX)
             .select(request_stream.map_err(|_| ClosedReason::InternalError))
             .inspect(|frame| trace!("---> Outgoing {:?}", frame))
             .forward(sink.sink_map_err(ClosedReason::CodecError))


### PR DESCRIPTION
Previously the server loop would not read in any new requests until
the previous request had been responded to. Added
`buffer_unordered` to the connection loop to allow multiple pending
messages.

Fixes #474 