### PR TITLE
Check secret length in ERC20 & ETH HTLCs

### DIFF
--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/contract_templates/erc20_contract.asm
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/contract_templates/erc20_contract.asm
@@ -2,6 +2,15 @@
     // Placeholder for deployment timestamp
     0x50000005
 
+    // Load expect secret size
+    0x20
+
+    // Load received secret size
+    calldatasize
+
+    // Compare secret size
+    eq
+
     // Load secret into memory
     calldatacopy(0, 0, 32)
 
@@ -18,6 +27,9 @@
     eq
 
     // Combine `eq` result with `call` result
+    and
+
+    // Combine result above with `eq` for the datasize
     and
 
     // Jump to redeem if hashes match

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/contract_templates/ether_contract.asm
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/contract_templates/ether_contract.asm
@@ -2,6 +2,15 @@
     // Placeholder for deployment timestamp
     0x50000005
 
+    // Load expect secret size
+    0x20
+
+    // Load received secret size
+    calldatasize
+
+    // Compare secret size
+    eq
+
     // Load secret into memory
     calldatacopy(0, 0, 32)
 
@@ -18,6 +27,9 @@
     eq
 
     // Combine `eq` result with `call` result
+    and
+
+    // Combine result above with `eq` for the datasize
     and
 
     // Jump to redeem if hashes match

--- a/application/comit_node/tests/htlc_harness/erc20_harness.rs
+++ b/application/comit_node/tests/htlc_harness/erc20_harness.rs
@@ -39,14 +39,11 @@ impl Default for Erc20HarnessParams {
     }
 }
 
-impl From<SecretHash> for Erc20HarnessParams {
-    fn from(secret_hash: SecretHash) -> Self {
+impl Erc20HarnessParams {
+    pub fn with_secret_hash(self, secret_hash: SecretHash) -> Self {
         Self {
-            alice_initial_ether: EtherQuantity::from_eth(1.0),
-            htlc_timeout: HTLC_TIMEOUT,
             htlc_secret_hash: secret_hash,
-            alice_initial_tokens: U256::from(1000),
-            htlc_token_value: U256::from(400),
+            ..self
         }
     }
 }

--- a/application/comit_node/tests/htlc_harness/erc20_harness.rs
+++ b/application/comit_node/tests/htlc_harness/erc20_harness.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use comit_node::swap_protocols::rfc003::{
     ethereum::{Erc20Htlc, Seconds},
-    Secret,
+    Secret, SecretHash,
 };
 use ethereum_support::{
     web3::{
@@ -22,7 +22,7 @@ use testcontainers::{images::parity_parity::ParityEthereum, Container, Docker};
 pub struct Erc20HarnessParams {
     pub alice_initial_ether: EtherQuantity,
     pub htlc_timeout: Duration,
-    pub htlc_secret: [u8; 32],
+    pub htlc_secret_hash: SecretHash,
     pub alice_initial_tokens: U256,
     pub htlc_token_value: U256,
 }
@@ -32,7 +32,19 @@ impl Default for Erc20HarnessParams {
         Self {
             alice_initial_ether: EtherQuantity::from_eth(1.0),
             htlc_timeout: HTLC_TIMEOUT,
-            htlc_secret: SECRET.clone(),
+            htlc_secret_hash: Secret::from_vec(SECRET).unwrap().hash(),
+            alice_initial_tokens: U256::from(1000),
+            htlc_token_value: U256::from(400),
+        }
+    }
+}
+
+impl From<SecretHash> for Erc20HarnessParams {
+    fn from(secret_hash: SecretHash) -> Self {
+        Self {
+            alice_initial_ether: EtherQuantity::from_eth(1.0),
+            htlc_timeout: HTLC_TIMEOUT,
+            htlc_secret_hash: secret_hash,
             alice_initial_tokens: U256::from(1000),
             htlc_token_value: U256::from(400),
         }
@@ -79,7 +91,7 @@ pub fn erc20_harness<D: Docker>(
         Seconds::from(params.htlc_timeout),
         alice,
         bob,
-        Secret::from(params.htlc_secret).hash(),
+        params.htlc_secret_hash,
         token_contract,
         params.htlc_token_value,
     );

--- a/application/comit_node/tests/htlc_harness/ether_harness.rs
+++ b/application/comit_node/tests/htlc_harness/ether_harness.rs
@@ -25,17 +25,20 @@ pub struct EtherHarnessParams {
 
 impl Default for EtherHarnessParams {
     fn default() -> Self {
-        EtherHarnessParams::from(Secret::from_vec(SECRET).unwrap().hash())
+        Self {
+            alice_initial_ether: EtherQuantity::from_eth(1.0),
+            htlc_timeout: HTLC_TIMEOUT,
+            htlc_secret_hash: Secret::from_vec(SECRET).unwrap().hash(),
+            htlc_eth_value: EtherQuantity::from_eth(0.4),
+        }
     }
 }
 
-impl From<SecretHash> for EtherHarnessParams {
-    fn from(secret_hash: SecretHash) -> Self {
+impl EtherHarnessParams {
+    pub fn with_secret_hash(self, secret_hash: SecretHash) -> Self {
         Self {
-            alice_initial_ether: EtherQuantity::from_eth(1.0),
-            htlc_eth_value: EtherQuantity::from_eth(0.4),
-            htlc_timeout: HTLC_TIMEOUT,
             htlc_secret_hash: secret_hash,
+            ..self
         }
     }
 }

--- a/application/comit_node/tests/htlc_harness/ether_harness.rs
+++ b/application/comit_node/tests/htlc_harness/ether_harness.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use comit_node::swap_protocols::rfc003::{
     ethereum::{EtherHtlc, Seconds},
-    Secret,
+    Secret, SecretHash,
 };
 use ethereum_support::{
     web3::{transports::EventLoopHandle, types::Address},
@@ -19,17 +19,23 @@ use testcontainers::{images::parity_parity::ParityEthereum, Container, Docker};
 pub struct EtherHarnessParams {
     pub alice_initial_ether: EtherQuantity,
     pub htlc_timeout: Duration,
-    pub htlc_secret: [u8; 32],
+    pub htlc_secret_hash: SecretHash,
     pub htlc_eth_value: EtherQuantity,
 }
 
 impl Default for EtherHarnessParams {
     fn default() -> Self {
+        EtherHarnessParams::from(Secret::from_vec(SECRET).unwrap().hash())
+    }
+}
+
+impl From<SecretHash> for EtherHarnessParams {
+    fn from(secret_hash: SecretHash) -> Self {
         Self {
             alice_initial_ether: EtherQuantity::from_eth(1.0),
             htlc_eth_value: EtherQuantity::from_eth(0.4),
             htlc_timeout: HTLC_TIMEOUT,
-            htlc_secret: SECRET.clone(),
+            htlc_secret_hash: secret_hash,
         }
     }
 }
@@ -69,7 +75,7 @@ pub fn ether_harness<D: Docker>(
             Seconds::from(params.htlc_timeout),
             alice,
             bob,
-            Secret::from(params.htlc_secret).hash(),
+            params.htlc_secret_hash,
         ),
         params.htlc_eth_value.wei(),
     );

--- a/application/comit_node/tests/htlc_harness/mod.rs
+++ b/application/comit_node/tests/htlc_harness/mod.rs
@@ -1,6 +1,9 @@
-use ethereum_support::{web3::types::Address, ToEthereumAddress};
+use comit_node::swap_protocols::rfc003::SecretHash;
+use crypto::{digest::Digest, sha2::Sha256};
+use ethereum_support::{web3::types::Address as EthereumAddress, ToEthereumAddress};
+use hex::FromHexError;
 use secp256k1_support::KeyPair;
-use std::time::Duration;
+use std::{str::FromStr, time::Duration};
 
 mod erc20_harness;
 mod ether_harness;
@@ -10,7 +13,7 @@ pub use self::{
     ether_harness::{ether_harness, EtherHarnessParams},
 };
 
-pub fn new_account(secret_key: &str) -> (KeyPair, Address) {
+pub fn new_account(secret_key: &str) -> (KeyPair, EthereumAddress) {
     let keypair = KeyPair::from_secret_key_hex(secret_key).unwrap();
     let address = keypair.public_key().to_ethereum_address();
 
@@ -19,3 +22,26 @@ pub fn new_account(secret_key: &str) -> (KeyPair, Address) {
 
 pub const SECRET: &[u8; 32] = b"hello world, you are beautiful!!";
 pub const HTLC_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug)]
+pub struct CustomSizeSecret(pub Vec<u8>);
+
+impl CustomSizeSecret {
+    pub fn hash(&self) -> SecretHash {
+        let mut sha = Sha256::new();
+        sha.input(&self.0[..]);
+
+        let mut result: [u8; SecretHash::LENGTH] = [0; SecretHash::LENGTH];
+        sha.result(&mut result);
+        SecretHash::from(result)
+    }
+}
+
+impl FromStr for CustomSizeSecret {
+    type Err = FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
+        let secret = s.as_bytes().to_vec();
+        Ok(CustomSizeSecret(secret))
+    }
+}

--- a/application/comit_node/tests/rfc003_erc20_htlc.rs
+++ b/application/comit_node/tests/rfc003_erc20_htlc.rs
@@ -33,7 +33,7 @@ fn given_erc20_token_should_deploy_erc20_htlc_and_fund_htlc() {
     assert_eq!(client.token_balance_of(token, alice), U256::from(1000));
     assert_eq!(client.token_balance_of(token, bob), U256::from(0));
 
-    // fund erc20 htlc
+    // Fund erc20 htlc
     client.sign_and_send(|nonce, gas_price| UnsignedTransaction {
         nonce,
         gas_price,
@@ -43,7 +43,7 @@ fn given_erc20_token_should_deploy_erc20_htlc_and_fund_htlc() {
         data: Some(htlc.funding_tx_payload(htlc_address)),
     });
 
-    // check htlc funding
+    // Check htlc funding
     assert_eq!(
         client.token_balance_of(token, htlc_address),
         U256::from(400)
@@ -96,7 +96,7 @@ fn given_deployed_erc20_htlc_when_refunded_after_timeout_then_tokens_are_refunde
     let (alice, bob, htlc_address, htlc, token, client, _handle, _container) =
         erc20_harness(&docker, Erc20HarnessParams::default());
 
-    // fund erc20 htlc
+    // Fund erc20 htlc
     client.sign_and_send(|nonce, gas_price| UnsignedTransaction {
         nonce,
         gas_price,
@@ -197,7 +197,7 @@ fn given_htlc_and_redeem_should_emit_redeem_log_msg() {
     let (_alice, _bob, htlc_address, htlc, token, client, _handle, _container) =
         erc20_harness(&docker, Erc20HarnessParams::default());
 
-    // fund erc20 htlc
+    // Fund erc20 htlc
     client.sign_and_send(|nonce, gas_price| UnsignedTransaction {
         nonce,
         gas_price,
@@ -214,7 +214,7 @@ fn given_htlc_and_redeem_should_emit_redeem_log_msg() {
     // Send correct secret to contract
     let transaction_receipt = client.send_data(htlc_address, Some(Bytes(SECRET.to_vec())));
 
-    // should contain 2 logs: 1 for token transfer 1 for redeeming the htlc
+    // Should contain 2 logs: 1 for token transfer 1 for redeeming the htlc
     assert_that(&transaction_receipt.logs.len()).is_equal_to(2);
 
     let redeem_topic: H256 = REDEEMED_LOG_MSG.into();
@@ -236,7 +236,7 @@ fn given_htlc_and_refund_should_emit_refund_log_msg() {
     let (_alice, _bob, htlc_address, htlc, token, client, _handle, _container) =
         erc20_harness(&docker, Erc20HarnessParams::default());
 
-    // fund erc20 htlc
+    // Fund erc20 htlc
     client.sign_and_send(|nonce, gas_price| UnsignedTransaction {
         nonce,
         gas_price,
@@ -252,7 +252,7 @@ fn given_htlc_and_refund_should_emit_refund_log_msg() {
     // Send correct secret to contract
     let transaction_receipt = client.send_data(htlc_address, None);
 
-    // should contain 2 logs: 1 for token transfer 1 for redeeming the htlc
+    // Should contain 2 logs: 1 for token transfer 1 for redeeming the htlc
     assert_that(&transaction_receipt.logs.len()).is_equal_to(2);
 
     let redeem_topic: H256 = REDEEMED_LOG_MSG.into();
@@ -269,7 +269,7 @@ fn given_htlc_and_refund_should_emit_refund_log_msg() {
 }
 
 #[test]
-fn given_funded_erc20_htlc_when_redeemed_with_short_secret_then_tokens_are_transferred() {
+fn given_funded_erc20_htlc_when_redeemed_with_short_secret_then_tokens_should_not_be_transferred() {
     let docker = Cli::default();
     let secret = CustomSizeSecret(vec![
         1u8, 2u8, 3u8, 4u8, 6u8, 6u8, 7u8, 9u8, 10u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
@@ -279,7 +279,7 @@ fn given_funded_erc20_htlc_when_redeemed_with_short_secret_then_tokens_are_trans
     let (alice, bob, htlc_address, htlc, token, client, _handle, _container) =
         erc20_harness(&docker, Erc20HarnessParams::from(secret.hash()));
 
-    // fund erc20 htlc
+    // Fund erc20 htlc
     client.sign_and_send(|nonce, gas_price| UnsignedTransaction {
         nonce,
         gas_price,
@@ -296,13 +296,16 @@ fn given_funded_erc20_htlc_when_redeemed_with_short_secret_then_tokens_are_trans
     assert_eq!(client.token_balance_of(token, alice), U256::from(600));
     assert_eq!(client.token_balance_of(token, bob), U256::from(0));
 
-    // Send correct secret to contract
+    // Send short secret to contract
     client.send_data(
         htlc_address,
         Some(Bytes(vec![1u8, 2u8, 3u8, 4u8, 6u8, 6u8, 7u8, 9u8, 10u8])),
     );
 
-    assert_eq!(client.token_balance_of(token, htlc_address), U256::from(0));
+    assert_eq!(
+        client.token_balance_of(token, htlc_address),
+        U256::from(400)
+    );
     assert_eq!(client.token_balance_of(token, alice), U256::from(600));
-    assert_eq!(client.token_balance_of(token, bob), U256::from(400));
+    assert_eq!(client.token_balance_of(token, bob), U256::from(0));
 }

--- a/application/comit_node/tests/rfc003_erc20_htlc.rs
+++ b/application/comit_node/tests/rfc003_erc20_htlc.rs
@@ -276,8 +276,10 @@ fn given_funded_erc20_htlc_when_redeemed_with_short_secret_then_tokens_should_no
         0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
     ]);
 
-    let (alice, bob, htlc_address, htlc, token, client, _handle, _container) =
-        erc20_harness(&docker, Erc20HarnessParams::from(secret.hash()));
+    let (alice, bob, htlc_address, htlc, token, client, _handle, _container) = erc20_harness(
+        &docker,
+        Erc20HarnessParams::default().with_secret_hash(secret.hash()),
+    );
 
     // Fund erc20 htlc
     client.sign_and_send(|nonce, gas_price| UnsignedTransaction {

--- a/application/comit_node/tests/rfc003_ether_htlc.rs
+++ b/application/comit_node/tests/rfc003_ether_htlc.rs
@@ -10,12 +10,15 @@ pub mod ethereum_wallet;
 pub mod htlc_harness;
 pub mod parity_client;
 
-use crate::htlc_harness::{ether_harness, EtherHarnessParams, HTLC_TIMEOUT, SECRET};
+use crate::htlc_harness::{
+    ether_harness, CustomSizeSecret, EtherHarnessParams, HTLC_TIMEOUT, SECRET,
+};
 use ethereum_support::{Bytes, EtherQuantity, H256, U256};
 use spectral::prelude::*;
 use testcontainers::clients::Cli;
 
 const HTLC_GAS_COST: u64 = 10885000;
+const HTLC_GAS_COST_SHORT_SECRET: u64 = 10878600;
 // keccak256(Redeemed())
 const REDEEMED_LOG_MSG: &str = "0xB8CAC300E37F03AD332E581DEA21B2F0B84EAAADC184A295FEF71E81F44A7413";
 // keccak256(Refunded())
@@ -166,4 +169,140 @@ fn given_htlc_and_refund_should_emit_refund_log_msg() {
     let topic: H256 = REFUNDED_LOG_MSG.into();
     assert_that(&transaction_receipt.logs[0].topics).has_length(1);
     assert_that(&transaction_receipt.logs[0].topics).contains(topic);
+}
+
+#[test]
+fn given_short_secret_left_padded_should_not_redeem() -> Result<(), failure::Error> {
+    let docker = Cli::default();
+
+    let secret = CustomSizeSecret(vec![
+        0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+        0u8, 0u8, 0u8, 0u8, 0u8, 1u8, 2u8, 3u8, 4u8, 6u8, 6u8, 7u8, 9u8, 10u8,
+    ]);
+
+    let (alice, bob, htlc, client, _handle, _container) =
+        ether_harness(&docker, EtherHarnessParams::from(secret.hash()));
+
+    assert_eq!(
+        client.eth_balance_of(bob),
+        EtherQuantity::from_eth(0.0).wei()
+    );
+    assert_eq!(
+        client.eth_balance_of(alice),
+        EtherQuantity::from_eth(0.6).wei() - U256::from(HTLC_GAS_COST_SHORT_SECRET)
+    );
+
+    assert_eq!(
+        client.eth_balance_of(htlc),
+        EtherQuantity::from_eth(0.4).wei()
+    );
+
+    client.send_data(
+        htlc,
+        Some(Bytes(vec![1u8, 2u8, 3u8, 4u8, 6u8, 6u8, 7u8, 9u8, 10u8])),
+    ); // will result in right padding and redemption should fail
+
+    assert_eq!(
+        client.eth_balance_of(bob),
+        EtherQuantity::from_eth(0.0).wei()
+    );
+    //    assert_eq!(
+    //        client.eth_balance_of(alice),
+    //        EtherQuantity::from_eth(0.6).wei() - U256::from(HTLC_GAS_COST)
+    //    );
+    assert_eq!(
+        client.eth_balance_of(htlc),
+        EtherQuantity::from_eth(0.4).wei()
+    );
+    Ok(())
+}
+
+#[test]
+fn given_short_secret_right_padded_should_redeem() -> Result<(), failure::Error> {
+    let docker = Cli::default();
+    let secret = CustomSizeSecret(vec![
+        1u8, 2u8, 3u8, 4u8, 6u8, 6u8, 7u8, 9u8, 10u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+        0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+    ]);
+
+    let (alice, bob, htlc, client, _handle, _container) =
+        ether_harness(&docker, EtherHarnessParams::from(secret.hash()));
+
+    assert_eq!(
+        client.eth_balance_of(bob),
+        EtherQuantity::from_eth(0.0).wei()
+    );
+
+    assert_eq!(
+        client.eth_balance_of(alice),
+        EtherQuantity::from_eth(0.6).wei() - U256::from(HTLC_GAS_COST_SHORT_SECRET)
+    );
+
+    assert_eq!(
+        client.eth_balance_of(htlc),
+        EtherQuantity::from_eth(0.4).wei()
+    );
+
+    client.send_data(
+        htlc,
+        Some(Bytes(vec![1u8, 2u8, 3u8, 4u8, 6u8, 6u8, 7u8, 9u8, 10u8])),
+    );
+
+    assert_eq!(
+        client.eth_balance_of(bob),
+        EtherQuantity::from_eth(0.4).wei()
+    );
+    //    assert_eq!(
+    //        client.eth_balance_of(alice),
+    //        EtherQuantity::from_eth(0.6).wei() - U256::from(HTLC_GAS_COST)
+    //    );
+    assert_eq!(
+        client.eth_balance_of(htlc),
+        EtherQuantity::from_eth(0.0).wei()
+    );
+    Ok(())
+}
+
+#[test]
+fn given_short_secret_not_padded_should_not_redeem() -> Result<(), failure::Error> {
+    let docker = Cli::default();
+    let secret = CustomSizeSecret(vec![1u8, 2u8, 3u8, 4u8, 6u8, 6u8, 7u8, 9u8, 10u8]);
+
+    let (alice, bob, htlc, client, _handle, _container) =
+        ether_harness(&docker, EtherHarnessParams::from(secret.hash()));
+
+    assert_eq!(
+        client.eth_balance_of(bob),
+        EtherQuantity::from_eth(0.0).wei()
+    );
+
+    assert_eq!(
+        client.eth_balance_of(alice),
+        EtherQuantity::from_eth(0.6).wei() - U256::from(HTLC_GAS_COST_SHORT_SECRET)
+    );
+
+    assert_eq!(
+        client.eth_balance_of(htlc),
+        EtherQuantity::from_eth(0.4).wei()
+    );
+
+    client.send_data(
+        htlc,
+        Some(Bytes(vec![1u8, 2u8, 3u8, 4u8, 6u8, 6u8, 7u8, 9u8, 10u8])),
+    ); // will result in right padded secret, hashing this is not equal than our
+       // generated secret above
+
+    assert_eq!(
+        client.eth_balance_of(bob),
+        EtherQuantity::from_eth(0.0).wei()
+    );
+    //    assert_eq!(
+    //        client.eth_balance_of(alice),
+    //        EtherQuantity::from_eth(0.6).wei() - U256::from(HTLC_GAS_COST)
+    //    );
+    assert_eq!(
+        client.eth_balance_of(htlc),
+        EtherQuantity::from_eth(0.4).wei()
+    );
+    Ok(())
 }

--- a/application/comit_node/tests/rfc003_ether_htlc.rs
+++ b/application/comit_node/tests/rfc003_ether_htlc.rs
@@ -13,12 +13,10 @@ pub mod parity_client;
 use crate::htlc_harness::{
     ether_harness, CustomSizeSecret, EtherHarnessParams, HTLC_TIMEOUT, SECRET,
 };
-use ethereum_support::{Bytes, EtherQuantity, H256, U256};
+use ethereum_support::{Bytes, EtherQuantity, H256};
 use spectral::prelude::*;
 use testcontainers::clients::Cli;
 
-const HTLC_GAS_COST: u64 = 11039400;
-const HTLC_GAS_COST_SHORT_SECRET: u64 = 11033000;
 // keccak256(Redeemed())
 const REDEEMED_LOG_MSG: &str = "0xB8CAC300E37F03AD332E581DEA21B2F0B84EAAADC184A295FEF71E81F44A7413";
 // keccak256(Refunded())
@@ -27,16 +25,12 @@ const REFUNDED_LOG_MSG: &str = "0x5D26862916391BF49478B2F5103B0720A842B45EF145A2
 #[test]
 fn given_deployed_htlc_when_redeemed_with_secret_then_money_is_transferred() {
     let docker = Cli::default();
-    let (alice, bob, htlc, client, _handle, _container) =
+    let (_alice, bob, htlc, client, _handle, _container) =
         ether_harness(&docker, EtherHarnessParams::default());
 
     assert_eq!(
         client.eth_balance_of(bob),
         EtherQuantity::from_eth(0.0).wei()
-    );
-    assert_eq!(
-        client.eth_balance_of(alice),
-        EtherQuantity::from_eth(0.6).wei() - U256::from(HTLC_GAS_COST)
     );
 
     assert_eq!(
@@ -52,10 +46,6 @@ fn given_deployed_htlc_when_redeemed_with_secret_then_money_is_transferred() {
         EtherQuantity::from_eth(0.4).wei()
     );
     assert_eq!(
-        client.eth_balance_of(alice),
-        EtherQuantity::from_eth(0.6).wei() - U256::from(HTLC_GAS_COST)
-    );
-    assert_eq!(
         client.eth_balance_of(htlc),
         EtherQuantity::from_eth(0.0).wei()
     );
@@ -64,16 +54,12 @@ fn given_deployed_htlc_when_redeemed_with_secret_then_money_is_transferred() {
 #[test]
 fn given_deployed_htlc_when_refunded_after_timeout_then_money_is_refunded() {
     let docker = Cli::default();
-    let (alice, bob, htlc, client, _handle, _container) =
+    let (_alice, bob, htlc, client, _handle, _container) =
         ether_harness(&docker, EtherHarnessParams::default());
 
     assert_eq!(
         client.eth_balance_of(bob),
         EtherQuantity::from_eth(0.0).wei()
-    );
-    assert_eq!(
-        client.eth_balance_of(alice),
-        EtherQuantity::from_eth(0.6).wei() - U256::from(HTLC_GAS_COST)
     );
     assert_eq!(
         client.eth_balance_of(htlc),
@@ -88,10 +74,6 @@ fn given_deployed_htlc_when_refunded_after_timeout_then_money_is_refunded() {
     assert_eq!(
         client.eth_balance_of(bob),
         EtherQuantity::from_eth(0.0).wei()
-    );
-    assert_eq!(
-        client.eth_balance_of(alice),
-        EtherQuantity::from_eth(1.0).wei() - U256::from(HTLC_GAS_COST)
     );
     assert_eq!(
         client.eth_balance_of(htlc),
@@ -102,16 +84,12 @@ fn given_deployed_htlc_when_refunded_after_timeout_then_money_is_refunded() {
 #[test]
 fn given_deployed_htlc_when_timeout_not_yet_reached_and_wrong_secret_then_nothing_happens() {
     let docker = Cli::default();
-    let (alice, bob, htlc, client, _handle, _container) =
+    let (_alice, bob, htlc, client, _handle, _container) =
         ether_harness(&docker, EtherHarnessParams::default());
 
     assert_eq!(
         client.eth_balance_of(bob),
         EtherQuantity::from_eth(0.0).wei()
-    );
-    assert_eq!(
-        client.eth_balance_of(alice),
-        EtherQuantity::from_eth(0.6).wei() - U256::from(HTLC_GAS_COST)
     );
     assert_eq!(
         client.eth_balance_of(htlc),
@@ -124,10 +102,6 @@ fn given_deployed_htlc_when_timeout_not_yet_reached_and_wrong_secret_then_nothin
     assert_eq!(
         client.eth_balance_of(bob),
         EtherQuantity::from_eth(0.0).wei()
-    );
-    assert_eq!(
-        client.eth_balance_of(alice),
-        EtherQuantity::from_eth(0.6).wei() - U256::from(HTLC_GAS_COST)
     );
     assert_eq!(
         client.eth_balance_of(htlc),
@@ -180,17 +154,12 @@ fn given_deployed_htlc_when_redeem_with_short_secret_then_ether_should_not_be_tr
         0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
     ]);
 
-    let (alice, bob, htlc, client, _handle, _container) =
+    let (_alice, bob, htlc, client, _handle, _container) =
         ether_harness(&docker, EtherHarnessParams::from(secret.hash()));
 
     assert_eq!(
         client.eth_balance_of(bob),
         EtherQuantity::from_eth(0.0).wei()
-    );
-
-    assert_eq!(
-        client.eth_balance_of(alice),
-        EtherQuantity::from_eth(0.6).wei() - U256::from(HTLC_GAS_COST_SHORT_SECRET)
     );
 
     assert_eq!(

--- a/application/comit_node/tests/rfc003_ether_htlc.rs
+++ b/application/comit_node/tests/rfc003_ether_htlc.rs
@@ -154,8 +154,10 @@ fn given_deployed_htlc_when_redeem_with_short_secret_then_ether_should_not_be_tr
         0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
     ]);
 
-    let (_alice, bob, htlc, client, _handle, _container) =
-        ether_harness(&docker, EtherHarnessParams::from(secret.hash()));
+    let (_alice, bob, htlc, client, _handle, _container) = ether_harness(
+        &docker,
+        EtherHarnessParams::default().with_secret_hash(secret.hash()),
+    );
 
     assert_eq!(
         client.eth_balance_of(bob),

--- a/application/comit_node/tests/rfc003_ether_htlc.rs
+++ b/application/comit_node/tests/rfc003_ether_htlc.rs
@@ -17,8 +17,8 @@ use ethereum_support::{Bytes, EtherQuantity, H256, U256};
 use spectral::prelude::*;
 use testcontainers::clients::Cli;
 
-const HTLC_GAS_COST: u64 = 10885000;
-const HTLC_GAS_COST_SHORT_SECRET: u64 = 10878600;
+const HTLC_GAS_COST: u64 = 11039400;
+const HTLC_GAS_COST_SHORT_SECRET: u64 = 11033000;
 // keccak256(Redeemed())
 const REDEEMED_LOG_MSG: &str = "0xB8CAC300E37F03AD332E581DEA21B2F0B84EAAADC184A295FEF71E81F44A7413";
 // keccak256(Refunded())
@@ -172,53 +172,8 @@ fn given_htlc_and_refund_should_emit_refund_log_msg() {
 }
 
 #[test]
-fn given_short_secret_left_padded_should_not_redeem() -> Result<(), failure::Error> {
-    let docker = Cli::default();
-
-    let secret = CustomSizeSecret(vec![
-        0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
-        0u8, 0u8, 0u8, 0u8, 0u8, 1u8, 2u8, 3u8, 4u8, 6u8, 6u8, 7u8, 9u8, 10u8,
-    ]);
-
-    let (alice, bob, htlc, client, _handle, _container) =
-        ether_harness(&docker, EtherHarnessParams::from(secret.hash()));
-
-    assert_eq!(
-        client.eth_balance_of(bob),
-        EtherQuantity::from_eth(0.0).wei()
-    );
-    assert_eq!(
-        client.eth_balance_of(alice),
-        EtherQuantity::from_eth(0.6).wei() - U256::from(HTLC_GAS_COST_SHORT_SECRET)
-    );
-
-    assert_eq!(
-        client.eth_balance_of(htlc),
-        EtherQuantity::from_eth(0.4).wei()
-    );
-
-    client.send_data(
-        htlc,
-        Some(Bytes(vec![1u8, 2u8, 3u8, 4u8, 6u8, 6u8, 7u8, 9u8, 10u8])),
-    ); // will result in right padding and redemption should fail
-
-    assert_eq!(
-        client.eth_balance_of(bob),
-        EtherQuantity::from_eth(0.0).wei()
-    );
-    //    assert_eq!(
-    //        client.eth_balance_of(alice),
-    //        EtherQuantity::from_eth(0.6).wei() - U256::from(HTLC_GAS_COST)
-    //    );
-    assert_eq!(
-        client.eth_balance_of(htlc),
-        EtherQuantity::from_eth(0.4).wei()
-    );
-    Ok(())
-}
-
-#[test]
-fn given_short_secret_right_padded_should_redeem() -> Result<(), failure::Error> {
+fn given_deployed_htlc_when_redeem_with_short_secret_then_ether_should_not_be_transferred(
+) -> Result<(), failure::Error> {
     let docker = Cli::default();
     let secret = CustomSizeSecret(vec![
         1u8, 2u8, 3u8, 4u8, 6u8, 6u8, 7u8, 9u8, 10u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
@@ -250,56 +205,9 @@ fn given_short_secret_right_padded_should_redeem() -> Result<(), failure::Error>
 
     assert_eq!(
         client.eth_balance_of(bob),
-        EtherQuantity::from_eth(0.4).wei()
-    );
-    //    assert_eq!(
-    //        client.eth_balance_of(alice),
-    //        EtherQuantity::from_eth(0.6).wei() - U256::from(HTLC_GAS_COST)
-    //    );
-    assert_eq!(
-        client.eth_balance_of(htlc),
-        EtherQuantity::from_eth(0.0).wei()
-    );
-    Ok(())
-}
-
-#[test]
-fn given_short_secret_not_padded_should_not_redeem() -> Result<(), failure::Error> {
-    let docker = Cli::default();
-    let secret = CustomSizeSecret(vec![1u8, 2u8, 3u8, 4u8, 6u8, 6u8, 7u8, 9u8, 10u8]);
-
-    let (alice, bob, htlc, client, _handle, _container) =
-        ether_harness(&docker, EtherHarnessParams::from(secret.hash()));
-
-    assert_eq!(
-        client.eth_balance_of(bob),
         EtherQuantity::from_eth(0.0).wei()
     );
 
-    assert_eq!(
-        client.eth_balance_of(alice),
-        EtherQuantity::from_eth(0.6).wei() - U256::from(HTLC_GAS_COST_SHORT_SECRET)
-    );
-
-    assert_eq!(
-        client.eth_balance_of(htlc),
-        EtherQuantity::from_eth(0.4).wei()
-    );
-
-    client.send_data(
-        htlc,
-        Some(Bytes(vec![1u8, 2u8, 3u8, 4u8, 6u8, 6u8, 7u8, 9u8, 10u8])),
-    ); // will result in right padded secret, hashing this is not equal than our
-       // generated secret above
-
-    assert_eq!(
-        client.eth_balance_of(bob),
-        EtherQuantity::from_eth(0.0).wei()
-    );
-    //    assert_eq!(
-    //        client.eth_balance_of(alice),
-    //        EtherQuantity::from_eth(0.6).wei() - U256::from(HTLC_GAS_COST)
-    //    );
     assert_eq!(
         client.eth_balance_of(htlc),
         EtherQuantity::from_eth(0.4).wei()


### PR DESCRIPTION
Ensure that the secret length sent to HTLC is as expected.

This mitigates a security issue where a shorter secret could be used to redeem.

See the commit the history where the security vulnerability is proven.

Resolves #433 

---
- [x] RTM (Ready To Merge)
