### PR TITLE
Do not proceed if invalid e2e folder

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -248,7 +248,7 @@ for GLOB_DIR in ${PARAMS}; do
     cd "$ROOT/api_tests/e2e/rfc003/"
     for DIR in ${GLOB_DIR}; do
         cd "$ROOT";
-        ./api_tests/npm_wrapper.sh "./e2e/rfc003/${DIR}"
+        [[ -d "./api_tests/e2e/rfc003/${DIR}" ]] && ./api_tests/npm_wrapper.sh "./e2e/rfc003/${DIR}"
     done;
 done;
 '''


### PR DESCRIPTION
Stop e2e script creating folders when passing invalid argument to `cargo make e2e`.

Resolves #596 