### PR TITLE
Decouple config from connection

### DIFF
--- a/application/comit_node/src/comit_client/bam.rs
+++ b/application/comit_node/src/comit_client/bam.rs
@@ -178,10 +178,12 @@ impl ClientFactory<BamClient> for BamClientPool {
                 let socket = TcpStream::connect(&comit_node_socket_addr).wait()?;
                 info!("Connection to {} established", comit_node_socket_addr);
                 let codec = json::JsonFrameCodec::default();
-                let (incoming_frames, response_source) =
-                    json::JsonFrameHandler::create(
-                        Config::<json::Request, json::Response>::default(),
-                    );
+
+                let response_source = Arc::new(Mutex::new(json::JsonResponseSource::default()));
+                let incoming_frames = json::JsonFrameHandler::create(
+                    Config::<json::Request, json::Response>::default(),
+                    Arc::clone(&response_source),
+                );
                 let (client, outgoing_frames) = bam::client::Client::create(response_source);
                 let connection = connection::new(codec, socket, incoming_frames, outgoing_frames);
                 let socket_addr = comit_node_socket_addr;

--- a/application/comit_node/src/comit_server.rs
+++ b/application/comit_node/src/comit_server.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     swap_protocols::rfc003::bob::BobSpawner,
 };
-use bam::{connection::Connection, json};
+use bam::{self, connection, json};
 use futures::{Future, Stream};
 use std::{io, net::SocketAddr, sync::Arc};
 use tokio::{self, net::TcpListener};
@@ -23,17 +23,18 @@ pub fn listen<B: BobSpawner>(
         let peer_addr = connection.peer_addr();
         let codec = json::JsonFrameCodec::default();
 
-        let config = swap_config(Arc::clone(&bob_spawner));
+        let (incoming_frames, response_source) =
+            json::JsonFrameHandler::create(swap_config(Arc::clone(&bob_spawner)));
+        let (client, outgoing_frames) = bam::client::Client::create(response_source);
 
-        let connection = Connection::new(config, codec, connection);
-        let (close_future, client) = connection.start::<json::JsonFrameHandler>();
+        let connection = connection::new(codec, connection, incoming_frames, outgoing_frames);
 
         if let Ok(addr) = peer_addr {
             let bam_client = Arc::new(BamClient::new(addr, client));
             bam_client_pool.add_client(addr, bam_client);
         }
 
-        tokio::spawn(close_future.then(move |result| {
+        tokio::spawn(connection.then(move |result| {
             match result {
                 Ok(()) => info!("Connection with {:?} closed", peer_addr),
                 Err(e) => error!(

--- a/vendor/bam/src/api.rs
+++ b/vendor/bam/src/api.rs
@@ -31,11 +31,10 @@ impl RequestError {
     }
 }
 
-pub trait FrameHandler<Frame, Req, Res>
+pub trait FrameHandler<Frame>
 where
     Self: Sized,
 {
-    fn create(config: Config<Req, Res>) -> (Self, Arc<Mutex<dyn ResponseFrameSource<Res>>>);
     fn handle(
         &mut self,
         frame: Frame,

--- a/vendor/bam/src/api.rs
+++ b/vendor/bam/src/api.rs
@@ -1,6 +1,4 @@
-use crate::config::Config;
 use futures::Future;
-use std::sync::{Arc, Mutex};
 
 #[derive(Debug, PartialEq)]
 pub enum Error {

--- a/vendor/bam/src/connection.rs
+++ b/vendor/bam/src/connection.rs
@@ -1,8 +1,4 @@
-use crate::{
-    api::{FrameHandler, IntoFrame},
-    client::Client,
-    config::Config,
-};
+use crate::api::FrameHandler;
 use futures::{Future, Sink, Stream};
 use std::{fmt::Debug, io};
 use tokio::io::{AsyncRead, AsyncWrite};

--- a/vendor/bam/src/connection.rs
+++ b/vendor/bam/src/connection.rs
@@ -17,73 +17,53 @@ pub enum ClosedReason<C> {
     InvalidFrame(crate::api::Error),
 }
 
-#[derive(Debug)]
-pub struct Connection<Req, Res, Codec, Socket> {
-    config: Config<Req, Res>,
+pub fn new<
+    Frame: Debug + Send + 'static,
+    CodecErr: From<io::Error> + Send + Debug + 'static,
+    Codec: Encoder<Item = Frame, Error = CodecErr>
+        + Decoder<Item = Frame, Error = CodecErr>
+        + Send
+        + 'static,
+    Socket: AsyncRead + AsyncWrite + Send + 'static,
+>(
     codec: Codec,
     socket: Socket,
-}
+    mut incoming_frames: impl FrameHandler<Frame> + Send + 'static,
+    outgoing_frames: impl Stream<Item = Frame, Error = ()> + Send + 'static,
+) -> ConnectionLoop<CodecErr> {
+    let (sink, stream) = codec.framed(socket).split();
 
-impl<
-        Frame: Debug + Send + 'static,
-        Req: IntoFrame<Frame> + 'static,
-        Res: Send + 'static,
-        CodecErr: From<io::Error> + Send + Debug + 'static,
-        Codec: Encoder<Item = Frame, Error = CodecErr>
-            + Decoder<Item = Frame, Error = CodecErr>
-            + Send
-            + 'static,
-        Socket: AsyncRead + AsyncWrite + Send + 'static,
-    > Connection<Req, Res, Codec, Socket>
-{
-    pub fn new(config: Config<Req, Res>, codec: Codec, socket: Socket) -> Self {
-        Self {
-            config,
-            codec,
-            socket,
-        }
-    }
-
-    pub fn start<FH: FrameHandler<Frame, Req, Res> + Send + 'static>(
-        self,
-    ) -> (ConnectionLoop<CodecErr>, Client<Frame, Req, Res>) {
-        let (sink, stream) = self.codec.framed(self.socket).split();
-
-        let (mut frame_handler, response_source) = FH::create(self.config);
-        let (client, request_stream) = Client::create(response_source);
-
-        let connection_loop = stream
-            .map_err(ClosedReason::CodecError)
-            .inspect(|frame| trace!("<--- Incoming {:?}", frame))
-            .and_then(move |frame| {
-                // Some errors are non-fatal, keep going if we get these
-                match frame_handler.handle(frame) {
-                    Err(crate::api::Error::UnexpectedResponse) => {
-                        warn!("Received unexpected response - ignoring it.");
-                        Ok(None)
-                    }
-                    Err(crate::api::Error::OutOfOrderRequest) => {
-                        warn!("Received out of order request - ignoring it.");
-                        Ok(None)
-                    }
-                    Ok(result) => Ok(result),
-                    Err(e) => Err(ClosedReason::InvalidFrame(e)),
+    let connection_loop = stream
+        .map_err(ClosedReason::CodecError)
+        .inspect(|frame| trace!("<--- Incoming {:?}", frame))
+        .and_then(move |frame| {
+            // Some errors are non-fatal, keep going if we get these
+            match incoming_frames.handle(frame) {
+                Err(crate::api::Error::UnexpectedResponse) => {
+                    warn!("Received unexpected response - ignoring it.");
+                    Ok(None)
                 }
-            })
-            .filter(Option::is_some)
-            .map(|option| {
-                // FIXME: When we have Never (https://github.com/rust-lang/rust/issues/35121)
-                // and Future.recover we should be able to clean this up
-                option
-                    .unwrap()
-                    .map_err(|_| unreachable!("frame_handler ensures the error never happens"))
-            })
-            .buffer_unordered(std::usize::MAX)
-            .select(request_stream.map_err(|_| ClosedReason::InternalError))
-            .inspect(|frame| trace!("---> Outgoing {:?}", frame))
-            .forward(sink.sink_map_err(ClosedReason::CodecError))
-            .map(|_| ());
+                Err(crate::api::Error::OutOfOrderRequest) => {
+                    warn!("Received out of order request - ignoring it.");
+                    Ok(None)
+                }
+                Ok(result) => Ok(result),
+                Err(e) => Err(ClosedReason::InvalidFrame(e)),
+            }
+        })
+        .filter(Option::is_some)
+        .map(|option| {
+            // FIXME: When we have Never (https://github.com/rust-lang/rust/issues/35121)
+            // and Future.recover we should be able to clean this up
+            option
+                .unwrap()
+                .map_err(|_| unreachable!("frame_handler ensures the error never happens"))
+        })
+        .buffer_unordered(std::usize::MAX)
+        .select(outgoing_frames.map_err(|_| ClosedReason::InternalError))
+        .inspect(|frame| trace!("---> Outgoing {:?}", frame))
+        .forward(sink.sink_map_err(ClosedReason::CodecError))
+        .map(|_| ());
 
-        (Box::new(connection_loop), client)
-    }
+    Box::new(connection_loop)
 }

--- a/vendor/bam/src/connection.rs
+++ b/vendor/bam/src/connection.rs
@@ -1,4 +1,4 @@
-use crate::api::FrameHandler;
+use crate::api::{self, FrameHandler};
 use futures::{Future, Sink, Stream};
 use std::{fmt::Debug, io};
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -8,7 +8,7 @@ use tokio_codec::{Decoder, Encoder};
 pub enum ClosedReason<C> {
     CodecError(C),
     InternalError,
-    InvalidFrame(crate::api::Error),
+    InvalidFrame(api::Error),
 }
 
 pub fn new<

--- a/vendor/bam/src/json/frame.rs
+++ b/vendor/bam/src/json/frame.rs
@@ -81,21 +81,7 @@ impl From<HeaderErrors> for RequestError {
     }
 }
 
-impl FrameHandler<json::Frame, json::Request, json::Response> for JsonFrameHandler {
-    fn create(
-        config: Config<json::Request, json::Response>,
-    ) -> (Self, Arc<Mutex<dyn ResponseFrameSource<json::Response>>>) {
-        let response_source = Arc::new(Mutex::new(JsonResponseSource::default()));
-
-        let handler = JsonFrameHandler {
-            next_expected_id: 0,
-            response_source: Arc::clone(&response_source),
-            config,
-        };
-
-        (handler, response_source)
-    }
-
+impl FrameHandler<json::Frame> for JsonFrameHandler {
     fn handle(
         &mut self,
         frame: json::Frame,
@@ -156,6 +142,20 @@ impl FrameHandler<json::Frame, json::Request, json::Response> for JsonFrameHandl
 }
 
 impl JsonFrameHandler {
+    pub fn create(
+        config: Config<json::Request, json::Response>,
+    ) -> (Self, Arc<Mutex<dyn ResponseFrameSource<json::Response>>>) {
+        let response_source = Arc::new(Mutex::new(JsonResponseSource::default()));
+
+        let handler = JsonFrameHandler {
+            next_expected_id: 0,
+            response_source: Arc::clone(&response_source),
+            config,
+        };
+
+        (handler, response_source)
+    }
+
     fn dispatch_request(
         &mut self,
         _type: &JsonValue,

--- a/vendor/bam/src/json/frame.rs
+++ b/vendor/bam/src/json/frame.rs
@@ -144,16 +144,13 @@ impl FrameHandler<json::Frame> for JsonFrameHandler {
 impl JsonFrameHandler {
     pub fn create(
         config: Config<json::Request, json::Response>,
-    ) -> (Self, Arc<Mutex<dyn ResponseFrameSource<json::Response>>>) {
-        let response_source = Arc::new(Mutex::new(JsonResponseSource::default()));
-
-        let handler = JsonFrameHandler {
+        response_source: Arc<Mutex<JsonResponseSource>>,
+    ) -> Self {
+        Self {
             next_expected_id: 0,
-            response_source: Arc::clone(&response_source),
+            response_source,
             config,
-        };
-
-        (handler, response_source)
+        }
     }
 
     fn dispatch_request(

--- a/vendor/bam/tests/bi_directional.rs
+++ b/vendor/bam/tests/bi_directional.rs
@@ -1,7 +1,10 @@
 use bam::{config::Config, connection, json::*, shutdown_handle, *};
 use futures::future::{self, Future};
 use spectral::prelude::*;
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 struct Ping;
 
@@ -19,10 +22,13 @@ fn given_two_servers_both_can_ping_each_other() {
 
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
 
-    let (alice_incoming_frames, response_source) =
-        JsonFrameHandler::create(Config::default().on_request("PING", &[], |_: Request| {
+    let response_source = Arc::new(Mutex::new(JsonResponseSource::default()));
+    let alice_incoming_frames = JsonFrameHandler::create(
+        Config::default().on_request("PING", &[], |_: Request| {
             Box::new(future::ok(Response::new(Status::OK(0))))
-        }));
+        }),
+        Arc::clone(&response_source),
+    );
 
     let (mut bob_client, bob_outgoing_frames) =
         bam::client::Client::<Frame, Request, Response>::create(response_source);
@@ -35,10 +41,13 @@ fn given_two_servers_both_can_ping_each_other() {
     );
     let (alice_server, _alice_shutdown_handle) = shutdown_handle::new(alice_server);
 
-    let (bob_incoming_frames, response_source) =
-        JsonFrameHandler::create(Config::default().on_request("PING", &[], |_: Request| {
+    let response_source = Arc::new(Mutex::new(JsonResponseSource::default()));
+    let bob_incoming_frames = JsonFrameHandler::create(
+        Config::default().on_request("PING", &[], |_: Request| {
             Box::new(future::ok(Response::new(Status::OK(0))))
-        }));
+        }),
+        Arc::clone(&response_source),
+    );
 
     let (mut alice_client, alice_outgoing_frames) =
         bam::client::Client::<Frame, Request, Response>::create(response_source);

--- a/vendor/bam/tests/common/alice_and_bob.rs
+++ b/vendor/bam/tests/common/alice_and_bob.rs
@@ -2,7 +2,7 @@ use bam::{
     client::Client,
     config::Config,
     connection,
-    json::{self, Frame, JsonFrameCodec, JsonFrameHandler, Request, Response},
+    json::{self, Frame, JsonFrameCodec, JsonFrameHandler, JsonResponseSource, Request, Response},
     shutdown_handle::ShutdownHandle,
 };
 use futures::{Future, Stream};
@@ -88,7 +88,8 @@ pub fn create(
 ) {
     let (alice, bob) = memsocket::unbounded();
 
-    let (incoming_frames, response_source) = JsonFrameHandler::create(config);
+    let response_source = Arc::new(Mutex::new(JsonResponseSource::default()));
+    let incoming_frames = JsonFrameHandler::create(config, Arc::clone(&response_source));
     let (alice_client, outgoing_frames) = Client::create(response_source);
 
     let bob_server = connection::new(


### PR DESCRIPTION
While doing #439, I noticed some things that were in my way, so here is a separate PR for them.

Main achievements:

- `Connection` struct is gone and is now a simple constructor function that returns `impl Future`
- the "connection` is decoupled from the actual frame types (request and response)