### PR TITLE
Bitcoin LQS cleanup

### DIFF
--- a/api_tests/ledger_query_service/test.js
+++ b/api_tests/ledger_query_service/test.js
@@ -72,7 +72,6 @@ describe("Test Ledger Query Service API", () => {
                     .then(res => {
                         res.should.have.status(200);
                         res.body.query.to_address.should.equal(to_address);
-                        res.body.query.confirmations_needed.should.equal(1);
                         res.body.matches.should.be.empty;
                     });
             });

--- a/application/ledger_query_service/src/bitcoin/block_processor.rs
+++ b/application/ledger_query_service/src/bitcoin/block_processor.rs
@@ -4,36 +4,12 @@ use crate::{
 };
 use bitcoin_support::{serialize::BitcoinHash, MinedBlock as Block, Transaction};
 use futures::{future::join_all, Future};
-use std::sync::Arc;
 use tokio;
-
-type BlockQueryResults = Vec<QueryMatch>;
-type TransactionQueryResults = Vec<QueryMatch>;
-
-pub fn process(
-    block_queries: ArcQueryRepository<BlockQuery>,
-    transaction_queries: ArcQueryRepository<TransactionQuery>,
-    block: Block,
-) -> Box<dyn Future<Item = (BlockQueryResults, TransactionQueryResults), Error = ()> + Send> {
-    let block_query_results = check_block_queries(block_queries, block.clone());
-
-    let mut transaction_query_results = vec![];
-    for transaction in block.as_ref().txdata.as_slice() {
-        transaction_query_results.push(check_transaction_queries(
-            Arc::clone(&transaction_queries),
-            transaction.clone(),
-        ))
-    }
-    let transaction_query_results = join_all(transaction_query_results)
-        .map(|transaction_results_vec| transaction_results_vec.into_iter().flatten().collect());
-
-    Box::new(block_query_results.join(transaction_query_results))
-}
 
 pub fn check_block_queries(
     block_queries: ArcQueryRepository<BlockQuery>,
     block: Block,
-) -> impl Future<Item = BlockQueryResults, Error = ()> + Send {
+) -> impl Future<Item = Vec<QueryMatch>, Error = ()> {
     trace!("Processing {:?}", block);
     let mut result_futures = vec![];
 
@@ -46,7 +22,7 @@ pub fn check_block_queries(
             if block_matches {
                 let block_id = block.as_ref().bitcoin_hash().to_string();
                 trace!("Query {:?} matches block {}", query_id, block_id);
-                Some((query_id, block_id))
+                Some(QueryMatch(query_id.into(), block_id))
             } else {
                 None
             }
@@ -58,10 +34,10 @@ pub fn check_block_queries(
     join_all(result_futures).map(|results| results.into_iter().filter_map(|x| x).collect())
 }
 
-fn check_transaction_queries(
+pub fn check_transaction_queries(
     transaction_queries: ArcQueryRepository<TransactionQuery>,
     transaction: Transaction,
-) -> impl Future<Item = TransactionQueryResults, Error = ()> + Send {
+) -> impl Future<Item = Vec<QueryMatch>, Error = ()> + Send {
     trace!("Processing {:?}", transaction);
     let mut result_futures = vec![];
 
@@ -80,7 +56,7 @@ fn check_transaction_queries(
                     query_id,
                     transaction_id
                 );
-                Some((query_id, transaction_id))
+                Some(QueryMatch(query_id.into(), transaction_id))
             } else {
                 None
             }

--- a/application/ledger_query_service/src/bitcoin/block_processor.rs
+++ b/application/ledger_query_service/src/bitcoin/block_processor.rs
@@ -1,430 +1,93 @@
 use crate::{
-    query_repository::QueryRepository, query_result_repository::QueryResultRepository,
-    ArcQueryRepository, ArcQueryResultRepository, BlockProcessor, Query, QueryMatchResult,
+    bitcoin::queries::{BlockQuery, TransactionQuery},
+    ArcQueryRepository, QueryMatch,
 };
+use bitcoin_support::{serialize::BitcoinHash, MinedBlock as Block, Transaction};
 use futures::{future::join_all, Future};
-use std::{
-    fmt::Debug,
-    marker::PhantomData,
-    sync::{Arc, Mutex},
-};
+use std::sync::Arc;
 use tokio;
 
-type QueryMatch = (u32, String);
+type BlockQueryResults = Vec<QueryMatch>;
+type TransactionQueryResults = Vec<QueryMatch>;
 
-pub trait Transaction: Debug + 'static + Clone {
-    fn transaction_id(&self) -> String;
-}
+pub fn process(
+    block_queries: ArcQueryRepository<BlockQuery>,
+    transaction_queries: ArcQueryRepository<TransactionQuery>,
+    block: Block,
+) -> Box<dyn Future<Item = (BlockQueryResults, TransactionQueryResults), Error = ()> + Send> {
+    let block_query_results = check_block_queries(block_queries, block.clone());
 
-pub trait Block: Debug + 'static + Clone {
-    type Transaction: Transaction;
-
-    fn blockhash(&self) -> String;
-    fn prev_blockhash(&self) -> String;
-    fn transactions(&self) -> &[Self::Transaction];
-}
-
-#[derive(Debug)]
-pub struct PendingTransaction {
-    matching_query_id: u32,
-    tx_id: String,
-    pending_confirmations: u32,
-}
-
-#[derive(DebugStub)]
-pub struct DefaultBlockProcessor<T, B, TQ, BQ> {
-    #[debug_stub = "Queries"]
-    transaction_queries: ArcQueryRepository<TQ>,
-    #[debug_stub = "Queries"]
-    block_queries: ArcQueryRepository<BQ>,
-    #[debug_stub = "Results"]
-    transaction_results: ArcQueryResultRepository<TQ>,
-    pending_transactions: Arc<Mutex<Vec<PendingTransaction>>>,
-    blockhashes: Vec<String>,
-    tx_type: PhantomData<T>,
-    block_type: PhantomData<B>,
-}
-
-impl<T: Transaction, B: Block<Transaction = T>, TQ: Query<T> + 'static, BQ: Query<B> + 'static>
-    BlockProcessor<B> for DefaultBlockProcessor<T, B, TQ, BQ>
-{
-    fn process(
-        &mut self,
-        block: B,
-    ) -> Box<dyn Future<Item = (Vec<QueryMatch>, Vec<QueryMatch>), Error = ()> + Send> {
-        trace!("New block received: {:?}", block);
-        // for now work on the assumption that there is one blockchain, but warn
-        // every time that assumption doesn't hold, by comparing the previous
-        // blockhash to the most recent member of a list of ordered blockhashes
-        if let Some(last_blockhash) = self.blockhashes.last() {
-            if *last_blockhash != block.prev_blockhash() {
-                warn!(
-                    "Block {} lists {} as previous block but last processed block was {}",
-                    block.blockhash(),
-                    block.prev_blockhash(),
-                    last_blockhash
-                );
-            }
-        }
-
-        self.blockhashes.push(block.blockhash());
-        self.update_pending_transactions();
-
-        let block_results = Self::process_new_block(Arc::clone(&self.block_queries), &block);
-        let mut tx_result_vecs = vec![];
-
-        for tx in block.transactions() {
-            tx_result_vecs.push(Self::process_new_transaction(
-                Arc::clone(&self.transaction_queries),
-                Arc::clone(&self.pending_transactions),
-                tx,
-            ))
-        }
-
-        let tx_results = join_all(tx_result_vecs)
-            .map(|tx_result_vec| tx_result_vec.into_iter().flatten().collect());
-
-        Box::new(block_results.join(tx_results))
+    let mut transaction_query_results = vec![];
+    for transaction in block.as_ref().txdata.as_slice() {
+        transaction_query_results.push(check_transaction_queries(
+            Arc::clone(&transaction_queries),
+            transaction.clone(),
+        ))
     }
+    let transaction_query_results = join_all(transaction_query_results)
+        .map(|transaction_results_vec| transaction_results_vec.into_iter().flatten().collect());
+
+    Box::new(block_query_results.join(transaction_query_results))
 }
 
-impl<T: Transaction, B: Block<Transaction = T>, TQ: Query<T> + 'static, BQ: Query<B>>
-    DefaultBlockProcessor<T, B, TQ, BQ>
-{
-    fn process_new_block(
-        block_queries: ArcQueryRepository<BQ>,
-        block: &B,
-    ) -> impl Future<Item = Vec<QueryMatch>, Error = ()> + Send {
-        trace!("Processing {:?}", block);
-        let block_id = block.blockhash();
-        let mut query_match_futures = vec![];
+pub fn check_block_queries(
+    block_queries: ArcQueryRepository<BlockQuery>,
+    block: Block,
+) -> impl Future<Item = BlockQueryResults, Error = ()> + Send {
+    trace!("Processing {:?}", block);
+    let mut result_futures = vec![];
 
-        // We must collect the futures in a vector first to stop
-        // borrow checker freaking out
-        for (query_id, query) in block_queries.all() {
-            trace!("Matching query {:#?} against block {:#?}", query, block);
-            let block_id = block_id.clone();
-            let result_future = query.matches(block).map(move |result| match result {
-                QueryMatchResult::Yes { .. } => {
-                    trace!("Block {} matches Query-ID: {:?}", block_id, query_id);
-                    Some((query_id, block_id))
-                }
-                QueryMatchResult::No => None,
-            });
-            query_match_futures.push(result_future);
-        }
-
-        join_all(query_match_futures).map(|results| results.into_iter().filter_map(|x| x).collect())
-    }
-
-    fn update_pending_transactions(&mut self) {
-        trace!("Updating pending matching transactions");
-        let mut pending_transactions = self.pending_transactions.lock().unwrap();
-        pending_transactions
-            .iter_mut()
-            .for_each(|utx| utx.pending_confirmations -= 1);
-
-        pending_transactions.iter().for_each(|utx| {
-            if utx.pending_confirmations == 0 {
-                let confirmed_tx_id = &utx.tx_id;
-                trace!(
-                    "Transaction {} now has enough confirmations. Sent to query result repository",
-                    confirmed_tx_id
-                );
-                self.transaction_results
-                    .add_result(utx.matching_query_id, confirmed_tx_id.clone())
+    // We must collect the futures in a vector first to stop
+    // borrow checker freaking out
+    for (query_id, query) in block_queries.all() {
+        trace!("Matching query {:#?} against block {:#?}", query, block);
+        let block = block.clone();
+        let result_future = query.matches(&block).map(move |block_matches| {
+            if block_matches {
+                let block_id = block.as_ref().bitcoin_hash().to_string();
+                trace!("Query {:?} matches block {}", query_id, block_id);
+                Some((query_id, block_id))
+            } else {
+                None
             }
         });
 
-        pending_transactions.retain(|ref utx| utx.pending_confirmations > 0);
+        result_futures.push(result_future);
     }
 
-    fn process_new_transaction(
-        transaction_queries: ArcQueryRepository<TQ>,
-        pending_transactions: Arc<Mutex<Vec<PendingTransaction>>>,
-        transaction: &T,
-    ) -> impl Future<Item = Vec<QueryMatch>, Error = ()> + Send {
-        trace!("Processing {:?}", transaction);
-        let mut result_futures = vec![];
+    join_all(result_futures).map(|results| results.into_iter().filter_map(|x| x).collect())
+}
 
-        for (query_id, query) in transaction_queries.all() {
-            trace!(
-                "Matching query {:#?} against transaction {:#?}",
-                query,
-                transaction
-            );
+fn check_transaction_queries(
+    transaction_queries: ArcQueryRepository<TransactionQuery>,
+    transaction: Transaction,
+) -> impl Future<Item = TransactionQueryResults, Error = ()> + Send {
+    trace!("Processing {:?}", transaction);
+    let mut result_futures = vec![];
 
-            let tx_id = transaction.transaction_id();
-            let pending_transactions = Arc::clone(&pending_transactions);
-
-            let result_future =
-                query.matches(transaction).map(
-                    move |query_match_result| match query_match_result {
-                        QueryMatchResult::Yes {
-                            confirmations_needed: 0,
-                        }
-                        | QueryMatchResult::Yes {
-                            confirmations_needed: 1,
-                        } => {
-                            trace!(
-                                "Confirmed transaction {} matches Query-ID: {:?}",
-                                tx_id,
-                                query_id
-                            );
-                            Some((query_id, tx_id))
-                        }
-                        QueryMatchResult::Yes {
-                            confirmations_needed,
-                        } => {
-                            trace!(
-                                "Unconfirmed transaction {} matches Query-ID: {:?}",
-                                tx_id,
-                                query_id
-                            );
-                            let pending_tx = PendingTransaction {
-                                matching_query_id: query_id,
-                                tx_id,
-                                pending_confirmations: confirmations_needed - 1,
-                            };
-                            let mut pending_transactions = pending_transactions.lock().unwrap();
-                            pending_transactions.push(pending_tx);
-                            None
-                        }
-                        QueryMatchResult::No => None,
-                    },
+    for (query_id, query) in transaction_queries.all() {
+        trace!(
+            "Matching query {:#?} against transaction {:#?}",
+            query,
+            transaction
+        );
+        let transaction = transaction.clone();
+        let result_future = query.matches(&transaction).map(move |transaction_matches| {
+            if transaction_matches {
+                let transaction_id = transaction.txid().to_string();
+                trace!(
+                    "Query {:?} matches transaction: {}",
+                    query_id,
+                    transaction_id
                 );
-            result_futures.push(result_future);
-        }
-
-        join_all(result_futures).map(|results| results.into_iter().filter_map(|x| x).collect())
-    }
-}
-
-impl<T, B, TQ, BQ> DefaultBlockProcessor<T, B, TQ, BQ> {
-    pub fn new(
-        transaction_query_repository: Arc<dyn QueryRepository<TQ>>,
-        block_query_repository: Arc<dyn QueryRepository<BQ>>,
-        transaction_query_result_repository: Arc<dyn QueryResultRepository<TQ>>,
-    ) -> Self {
-        Self {
-            transaction_queries: transaction_query_repository,
-            block_queries: block_query_repository,
-            transaction_results: transaction_query_result_repository,
-            pending_transactions: Arc::new(Mutex::new(Vec::new())),
-            blockhashes: Vec::new(),
-            tx_type: PhantomData,
-            block_type: PhantomData,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{
-        in_memory_query_repository::InMemoryQueryRepository,
-        in_memory_query_result_repository::InMemoryQueryResultRepository,
-    };
-    use spectral::prelude::*;
-
-    #[derive(Serialize, Deserialize, Clone, Default, Debug, Copy)]
-    struct GenericTransactionQuery {
-        transaction_id: u8,
-        confirmations_needed: u32,
-    }
-
-    impl Query<GenericTransaction> for GenericTransactionQuery {
-        fn matches(
-            &self,
-            transaction: &GenericTransaction,
-        ) -> Box<dyn Future<Item = QueryMatchResult, Error = ()> + Send> {
-            if self.transaction_id == transaction.id {
-                Box::new(futures::future::ok(
-                    QueryMatchResult::yes_with_confirmations(self.confirmations_needed),
-                ))
+                Some((query_id, transaction_id))
             } else {
-                Box::new(futures::future::ok(QueryMatchResult::no()))
+                None
             }
-        }
+        });
+
+        result_futures.push(result_future);
     }
 
-    #[derive(Serialize, Deserialize, Clone, Default, Debug, Copy)]
-    struct GenericBlockQuery {
-        min_timestamp_secs: u8,
-    }
-
-    impl Query<GenericBlock> for GenericBlockQuery {
-        fn matches(
-            &self,
-            block: &GenericBlock,
-        ) -> Box<dyn Future<Item = QueryMatchResult, Error = ()> + Send> {
-            if self.min_timestamp_secs <= block.timestamp {
-                Box::new(futures::future::ok(QueryMatchResult::yes()))
-            } else {
-                Box::new(futures::future::ok(QueryMatchResult::no()))
-            }
-        }
-    }
-
-    #[derive(Debug, Copy, Clone)]
-    struct GenericTransaction {
-        id: u8,
-    }
-
-    impl Transaction for GenericTransaction {
-        fn transaction_id(&self) -> String {
-            self.id.to_string()
-        }
-    }
-
-    #[derive(Debug, Default, Clone)]
-    struct GenericBlock {
-        id: u8,
-        parent_id: u8,
-        timestamp: u8,
-        transaction_list: Vec<GenericTransaction>,
-    }
-
-    impl Block for GenericBlock {
-        type Transaction = GenericTransaction;
-
-        fn blockhash(&self) -> String {
-            self.id.to_string()
-        }
-        fn prev_blockhash(&self) -> String {
-            self.parent_id.to_string()
-        }
-        fn transactions(&self) -> &[GenericTransaction] {
-            self.transaction_list.as_slice()
-        }
-    }
-
-    struct Setup {
-        block_processor: DefaultBlockProcessor<
-            GenericTransaction,
-            GenericBlock,
-            GenericTransactionQuery,
-            GenericBlockQuery,
-        >,
-        first_block: GenericBlock,
-    }
-
-    impl Setup {
-        fn new(
-            query_transaction_id: u8,
-            transaction_id: u8,
-            confirmations_needed: u32,
-            query_timestamp: u8,
-            block_timestamp: u8,
-        ) -> Self {
-            let transaction_query_repository = Arc::new(InMemoryQueryRepository::default());
-            let transaction_query_result_repository =
-                Arc::new(InMemoryQueryResultRepository::default());
-            let block_query_repository = Arc::new(InMemoryQueryRepository::default());
-
-            let block_processor = DefaultBlockProcessor::new(
-                transaction_query_repository.clone(),
-                block_query_repository.clone(),
-                transaction_query_result_repository.clone(),
-            );
-
-            let first_transaction_query = GenericTransactionQuery {
-                transaction_id: query_transaction_id,
-                confirmations_needed,
-            };
-
-            transaction_query_repository
-                .save(first_transaction_query)
-                .unwrap();
-
-            let first_transaction = GenericTransaction { id: transaction_id };
-
-            let first_block_query = GenericBlockQuery {
-                min_timestamp_secs: query_timestamp,
-            };
-
-            block_query_repository.save(first_block_query).unwrap();
-            let first_block = GenericBlock {
-                id: 0,
-                parent_id: 0,
-                timestamp: block_timestamp,
-                transaction_list: vec![first_transaction],
-            };
-
-            Self {
-                block_processor,
-                first_block,
-            }
-        }
-    }
-
-    #[test]
-    fn given_single_confirmation_query_when_matching_transaction_processes_returns_1_block_0_tx() {
-        let harness = Setup::new(1, 1, 1, 0, 0);
-        let mut block_processor = harness.block_processor;
-
-        let (blocks, transactions) = process_results(block_processor.process(harness.first_block));
-
-        assert_that(&blocks).named(&"found blocks").has_length(1);
-        assert_that(&transactions).named(&"found txs").has_length(1);
-    }
-
-    #[test]
-    #[ignore] // TODO fixme, pending transactions does not work correctly: https://github.com/comit-network/comit-rs/issues/591
-    fn given_double_confirmation_query_when_matching_transaction_is_processed_and_confirmed_adds_result(
-    ) {
-        let harness = Setup::new(1, 1, 2, 0, 0);
-        let mut block_processor = harness.block_processor;
-
-        let (blocks, transactions) = process_results(block_processor.process(harness.first_block));
-        assert_that(&blocks).named(&"found blocks").has_length(1);
-        // Transaction not yet confirmed
-        assert_that(&transactions).named(&"found txs").has_length(0);
-
-        let empty_block = GenericBlock::default();
-        let (blocks, transactions) = process_results(block_processor.process(empty_block));
-        assert_that(&blocks).named(&"found blocks").has_length(1);
-        assert_that(&transactions).named(&"found txs").has_length(1);
-    }
-
-    #[test]
-    fn given_single_confirmation_query_when_non_matching_transaction_process_returns_1_block_0_tx()
-    {
-        let harness = Setup::new(1, 2, 1, 0, 0);
-        let mut block_processor = harness.block_processor;
-
-        let (blocks, transactions) = process_results(block_processor.process(harness.first_block));
-        assert_that(&blocks).named(&"found blocks").has_length(1);
-        assert_that(&transactions).named(&"found txs").has_length(0);
-    }
-
-    #[test]
-    fn given_block_timestamp_query_when_younger_block_process_returns_1_block_0_tx() {
-        let harness = Setup::new(1, 2, 1, 5, 6);
-        let mut block_processor = harness.block_processor;
-
-        let (blocks, transactions) = process_results(block_processor.process(harness.first_block));
-        assert_that(&blocks).named(&"found blocks").has_length(1);
-        assert_that(&transactions).named(&"found txs").has_length(0);
-    }
-
-    #[test]
-    fn given_block_timestamp_query_when_older_block_process_returns_0_block_0_tx() {
-        let harness = Setup::new(1, 2, 1, 6, 5);
-        let mut block_processor = harness.block_processor;
-
-        let (blocks, transactions) = process_results(block_processor.process(harness.first_block));
-
-        assert_that(&blocks).named(&"found blocks").has_length(0);
-        assert_that(&transactions).named(&"found txs").has_length(0);
-    }
-
-    fn process_results(
-        processing_future: Box<
-            dyn Future<Item = (Vec<QueryMatch>, Vec<QueryMatch>), Error = ()> + Send,
-        >,
-    ) -> (Vec<(u32, String)>, Vec<(u32, String)>) {
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
-        runtime.block_on(processing_future).unwrap()
-    }
+    join_all(result_futures).map(|results| results.into_iter().filter_map(|x| x).collect())
 }

--- a/application/ledger_query_service/src/bitcoin/mod.rs
+++ b/application/ledger_query_service/src/bitcoin/mod.rs
@@ -1,3 +1,8 @@
 pub mod bitcoind_zmq_listener;
 pub mod block_processor;
 pub mod queries;
+
+pub use self::{
+    block_processor::process,
+    queries::{BlockQuery, TransactionQuery},
+};

--- a/application/ledger_query_service/src/bitcoin/mod.rs
+++ b/application/ledger_query_service/src/bitcoin/mod.rs
@@ -3,6 +3,6 @@ pub mod block_processor;
 pub mod queries;
 
 pub use self::{
-    block_processor::process,
+    block_processor::{check_block_queries, check_transaction_queries},
     queries::{BlockQuery, TransactionQuery},
 };

--- a/application/ledger_query_service/src/bitcoin/queries.rs
+++ b/application/ledger_query_service/src/bitcoin/queries.rs
@@ -119,13 +119,7 @@ impl ExpandResult for BlockQuery {
 impl BlockQuery {
     pub fn matches(&self, block: &Block) -> Box<dyn Future<Item = bool, Error = ()> + Send> {
         Box::new(futures::future::ok(match self.min_height {
-            Some(height) => {
-                if height <= block.height {
-                    true
-                } else {
-                    false
-                }
-            }
+            Some(height) => height <= block.height,
             None => {
                 warn!("min_height not set, nothing to compare");
                 false

--- a/application/ledger_query_service/src/bitcoin/queries.rs
+++ b/application/ledger_query_service/src/bitcoin/queries.rs
@@ -110,13 +110,8 @@ impl ExpandResult for BlockQuery {
 
 impl BlockQuery {
     pub fn matches(&self, block: &Block) -> bool {
-        self.min_height.map_or_else(
-            || {
-                warn!("min_height not set, nothing to compare");
-                false
-            },
-            |height| height <= block.height,
-        )
+        self.min_height
+            .map_or(true, |height| height <= block.height)
     }
 }
 

--- a/application/ledger_query_service/src/bitcoin/queries.rs
+++ b/application/ledger_query_service/src/bitcoin/queries.rs
@@ -1,47 +1,43 @@
-use super::block_processor::{Block, Transaction};
 use crate::{
     query_result_repository::QueryResult,
     route_factory::{Error, ExpandResult, QueryParams, QueryType, ShouldExpand},
-    Query, QueryMatchResult,
 };
 use bitcoin_rpc_client::{BitcoinCoreClient, BitcoinRpcApi};
 use bitcoin_support::{
-    serialize::BitcoinHash, Address, MinedBlock as BitcoinBlock, OutPoint, SpendsFrom,
-    SpendsFromWith, SpendsTo, SpendsWith, Transaction as BitcoinTransaction, TransactionId,
+    Address, MinedBlock as Block, OutPoint, SpendsFrom, SpendsFromWith, SpendsTo, SpendsWith,
+    Transaction, TransactionId,
 };
 use futures::Future;
 use std::sync::Arc;
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug)]
-pub struct BitcoinTransactionQuery {
+pub struct TransactionQuery {
     pub to_address: Option<Address>,
     pub from_outpoint: Option<OutPoint>,
     pub unlock_script: Option<Vec<Vec<u8>>>,
-    #[serde(default = "default_confirmations")]
-    confirmations_needed: u32,
 }
 
-impl QueryType for BitcoinTransactionQuery {
+impl QueryType for TransactionQuery {
     fn route() -> &'static str {
         "transactions"
     }
 }
 
-impl ShouldExpand for BitcoinTransactionQuery {
+impl ShouldExpand for TransactionQuery {
     fn should_expand(query_params: &QueryParams) -> bool {
         query_params.expand_results
     }
 }
 
-impl ExpandResult for BitcoinTransactionQuery {
+impl ExpandResult for TransactionQuery {
     type Client = BitcoinCoreClient;
-    type Item = BitcoinTransaction;
+    type Item = Transaction;
 
     fn expand_result(
         result: &QueryResult,
         client: Arc<BitcoinCoreClient>,
-    ) -> Result<Vec<BitcoinTransaction>, Error> {
-        let mut expanded_result: Vec<BitcoinTransaction> = Vec::new();
+    ) -> Result<Vec<Transaction>, Error> {
+        let mut expanded_result: Vec<Transaction> = Vec::new();
         for tx_id in result.clone().0 {
             let tx_id = TransactionId::from_hex(tx_id.as_str()).map_err(|_| Error::InvalidHex)?;
 
@@ -55,21 +51,16 @@ impl ExpandResult for BitcoinTransactionQuery {
     }
 }
 
-fn default_confirmations() -> u32 {
-    1
-}
-
-impl Query<BitcoinTransaction> for BitcoinTransactionQuery {
-    fn matches(
+impl TransactionQuery {
+    pub fn matches(
         &self,
-        transaction: &BitcoinTransaction,
-    ) -> Box<dyn Future<Item = QueryMatchResult, Error = ()> + Send> {
+        transaction: &Transaction,
+    ) -> Box<dyn Future<Item = bool, Error = ()> + Send> {
         match self {
             Self {
                 to_address,
                 from_outpoint,
                 unlock_script,
-                confirmations_needed,
             } => {
                 let mut result = true;
 
@@ -90,55 +81,33 @@ impl Query<BitcoinTransaction> for BitcoinTransactionQuery {
                     };
 
                 if result {
-                    Box::new(futures::future::ok(
-                        QueryMatchResult::yes_with_confirmations(*confirmations_needed),
-                    ))
+                    Box::new(futures::future::ok(true))
                 } else {
-                    Box::new(futures::future::ok(QueryMatchResult::no()))
+                    Box::new(futures::future::ok(false))
                 }
             }
         }
     }
 }
 
-impl Transaction for BitcoinTransaction {
-    fn transaction_id(&self) -> String {
-        self.txid().to_string()
-    }
-}
-
-impl Block for BitcoinBlock {
-    type Transaction = BitcoinTransaction;
-
-    fn blockhash(&self) -> String {
-        format!("{:x}", self.as_ref().header.bitcoin_hash())
-    }
-    fn prev_blockhash(&self) -> String {
-        format!("{:x}", self.as_ref().header.prev_blockhash)
-    }
-    fn transactions(&self) -> &[BitcoinTransaction] {
-        self.as_ref().txdata.as_slice()
-    }
-}
-
 #[derive(Serialize, Deserialize, Clone, Default, Debug)]
-pub struct BitcoinBlockQuery {
+pub struct BlockQuery {
     pub min_height: Option<u32>,
 }
 
-impl QueryType for BitcoinBlockQuery {
+impl QueryType for BlockQuery {
     fn route() -> &'static str {
         "blocks"
     }
 }
 
-impl ShouldExpand for BitcoinBlockQuery {
+impl ShouldExpand for BlockQuery {
     fn should_expand(_: &QueryParams) -> bool {
         false
     }
 }
 
-impl ExpandResult for BitcoinBlockQuery {
+impl ExpandResult for BlockQuery {
     type Client = ();
     type Item = ();
 
@@ -147,22 +116,19 @@ impl ExpandResult for BitcoinBlockQuery {
     }
 }
 
-impl Query<BitcoinBlock> for BitcoinBlockQuery {
-    fn matches(
-        &self,
-        block: &BitcoinBlock,
-    ) -> Box<dyn Future<Item = QueryMatchResult, Error = ()> + Send> {
+impl BlockQuery {
+    pub fn matches(&self, block: &Block) -> Box<dyn Future<Item = bool, Error = ()> + Send> {
         Box::new(futures::future::ok(match self.min_height {
             Some(height) => {
                 if height <= block.height {
-                    QueryMatchResult::yes()
+                    true
                 } else {
-                    QueryMatchResult::no()
+                    false
                 }
             }
             None => {
                 warn!("min_height not set, nothing to compare");
-                QueryMatchResult::no()
+                false
             }
         }))
     }
@@ -172,16 +138,15 @@ impl Query<BitcoinBlock> for BitcoinBlockQuery {
 mod tests {
     use super::*;
     use bitcoin_support::{
-        serialize::deserialize, Block, BlockHeader, MinedBlock, Sha256dHash,
-        Transaction as BitcoinTransaction,
+        serialize::deserialize, Block, BlockHeader, MinedBlock, Sha256dHash, Transaction,
     };
     use spectral::prelude::*;
 
     const WITNESS_TX: &'static str = "0200000000010124e06fe5594b941d06c7385dc7307ec694a41f7d307423121855ee17e47e06ad0100000000ffffffff0137aa0b000000000017a914050377baa6e8c5a07aed125d0ef262c6d5b67a038705483045022100d780139514f39ed943179e4638a519101bae875ec1220b226002bcbcb147830b0220273d1efb1514a77ee3dd4adee0e896b7e76be56c6d8e73470ae9bd91c91d700c01210344f8f459494f74ebb87464de9b74cdba3709692df4661159857988966f94262f20ec9e9fb3c669b2354ea026ab3da82968a2e7ab9398d5cbed4e78e47246f2423e01015b63a82091d6a24697ed31932537ae598d3de3131e1fcd0641b9ac4be7afcb376386d71e8876a9149f4a0cf348b478336cb1d87ea4c8313a7ca3de1967029000b27576a91465252e57f727a27f32c77098e14d88d8dbec01816888ac00000000";
 
-    fn parse_raw_tx(raw_tx: &str) -> BitcoinTransaction {
+    fn parse_raw_tx(raw_tx: &str) -> Transaction {
         let hex_tx = hex::decode(raw_tx).unwrap();
-        let tx: Result<BitcoinTransaction, _> = deserialize(&hex_tx);
+        let tx: Result<Transaction, _> = deserialize(&hex_tx);
         tx.unwrap()
     }
 
@@ -215,12 +180,12 @@ mod tests {
             40,
         );
 
-        let query = BitcoinBlockQuery {
+        let query = BlockQuery {
             min_height: Some(42),
         };
 
         let result = exec_future(query.matches(&block));
-        assert_that(&result).is_equal_to(QueryMatchResult::no());
+        assert_that(&result).is_false();
     }
 
     #[test]
@@ -242,12 +207,12 @@ mod tests {
             42,
         );
 
-        let query = BitcoinBlockQuery {
+        let query = BlockQuery {
             min_height: Some(42),
         };
 
         let result = exec_future(query.matches(&block));
-        assert_that(&result).is_equal_to(QueryMatchResult::yes());
+        assert_that(&result).is_true();
     }
 
     #[test]
@@ -269,27 +234,26 @@ mod tests {
             45,
         );
 
-        let query = BitcoinBlockQuery {
+        let query = BlockQuery {
             min_height: Some(42),
         };
 
         let result = exec_future(query.matches(&block));
-        assert_that(&result).is_equal_to(QueryMatchResult::yes());
+        assert_that(&result).is_true();
     }
 
     #[test]
     fn given_transaction_with_to_then_to_address_query_matches() {
         let tx = parse_raw_tx(WITNESS_TX);
 
-        let query = BitcoinTransactionQuery {
+        let query = TransactionQuery {
             to_address: Some("329XTScM6cJgu8VZvaqYWpfuxT1eQDSJkP".parse().unwrap()),
             from_outpoint: None,
             unlock_script: None,
-            confirmations_needed: 0,
         };
 
         let result = exec_future(query.matches(&tx));
-        assert_that(&result).is_equal_to(QueryMatchResult::yes());
+        assert_that(&result).is_true();
     }
 
     #[test]
@@ -300,15 +264,14 @@ mod tests {
             "01",
         ]);
 
-        let query = BitcoinTransactionQuery {
+        let query = TransactionQuery {
             to_address: None,
             from_outpoint: None,
             unlock_script: Some(unlock_script),
-            confirmations_needed: 0,
         };
 
         let result = exec_future(query.matches(&tx));
-        assert_that(&result).is_equal_to(QueryMatchResult::yes());
+        assert_that(&result).is_true();
     }
 
     #[test]
@@ -317,15 +280,14 @@ mod tests {
         let tx = parse_raw_tx(WITNESS_TX);
         let unlock_script = create_unlock_script_stack(vec!["102030405060708090", "00"]);
 
-        let query = BitcoinTransactionQuery {
+        let query = TransactionQuery {
             to_address: None,
             from_outpoint: None,
             unlock_script: Some(unlock_script),
-            confirmations_needed: 0,
         };
 
         let result = exec_future(query.matches(&tx));
-        assert_that(&result).is_equal_to(QueryMatchResult::no());
+        assert_that(&result).is_false();
     }
 
     #[test]
@@ -340,22 +302,18 @@ mod tests {
             1u32,
         );
 
-        let query = BitcoinTransactionQuery {
+        let query = TransactionQuery {
             to_address: None,
             from_outpoint: Some(outpoint),
             unlock_script: Some(unlock_script),
-            confirmations_needed: 0,
         };
 
         let result = exec_future(query.matches(&tx));
-        assert_that(&result).is_equal_to(QueryMatchResult::yes());
+        assert_that(&result).is_true();
     }
 
-    fn exec_future(
-        future: Box<dyn Future<Item = QueryMatchResult, Error = ()> + Send>,
-    ) -> QueryMatchResult {
+    fn exec_future(future: Box<dyn Future<Item = bool, Error = ()> + Send>) -> bool {
         let mut runtime = tokio::runtime::Runtime::new().unwrap();
         runtime.block_on(future).map_err(|_| ()).unwrap()
     }
-
 }

--- a/application/ledger_query_service/src/ethereum/block_processor.rs
+++ b/application/ledger_query_service/src/ethereum/block_processor.rs
@@ -30,7 +30,7 @@ pub fn check_block_queries(
 
             if query.matches(&block) {
                 trace!("Query {:?} matches block {:?}", query_id, block_id);
-                Some((query_id, block_id.clone()))
+                Some(QueryMatch(query_id.into(), block_id.clone()))
             } else {
                 None
             }
@@ -65,7 +65,7 @@ pub fn check_transaction_queries(
                             query_id,
                             transaction_id
                         );
-                        Some((query_id, transaction_id.clone()))
+                        Some(QueryMatch(query_id.into(), transaction_id.clone()))
                     } else {
                         None
                     }
@@ -83,7 +83,7 @@ pub fn check_log_queries(
 
     let block_id = block.hash.map(|block_id| format!("{:x}", block_id));
 
-    let futures = log_queries
+    let result_futures = log_queries
         .all()
         .filter(|(_, query)| {
             trace!("Matching query {:#?} against block {:#?}", query, block);
@@ -111,7 +111,10 @@ pub fn check_log_queries(
                                 query_id
                             );
 
-                            Ok(Some((query_id, format!("{:x}", transaction_id))))
+                            Ok(Some(QueryMatch(
+                                query_id.into(),
+                                format!("{:x}", transaction_id),
+                            )))
                         }
                         Err(e) => {
                             error!(
@@ -126,5 +129,5 @@ pub fn check_log_queries(
         })
         .flatten();
 
-    stream::futures_ordered(futures).filter_map(|x| x)
+    stream::futures_ordered(result_futures).filter_map(|x| x)
 }

--- a/application/ledger_query_service/src/ethereum/block_processor.rs
+++ b/application/ledger_query_service/src/ethereum/block_processor.rs
@@ -1,7 +1,7 @@
 use crate::{
     ethereum::{BlockQuery, LogQuery, TransactionQuery},
     web3::types::{Block, Transaction},
-    ArcQueryRepository, QueryMatch, QueryMatchResult,
+    ArcQueryRepository, QueryMatch,
 };
 use ethereum_support::web3::{transports::Http, Web3};
 use futures::{
@@ -28,12 +28,11 @@ pub fn check_block_queries(
         .filter_map(move |(query_id, query, block_id)| {
             trace!("Matching query {:#?} against block {:#?}", query, block);
 
-            match query.matches(&block) {
-                QueryMatchResult::Yes { .. } => {
-                    trace!("Query {:?} matches block {:?}", query_id, block_id);
-                    Some((query_id, block_id))
-                }
-                _ => None,
+            if query.matches(&block) {
+                trace!("Query {:?} matches block {:?}", query_id, block_id);
+                Some((query_id, block_id.clone()))
+            } else {
+                None
             }
         })
 }
@@ -60,16 +59,15 @@ pub fn check_transaction_queries(
                         &transaction
                     );
 
-                    match query.matches(&transaction) {
-                        QueryMatchResult::Yes { .. } => {
-                            trace!(
-                                "Query {:?} matches transaction {:?}",
-                                query_id,
-                                transaction_id
-                            );
-                            Some((query_id, transaction_id.clone()))
-                        }
-                        _ => None,
+                    if query.matches(&transaction) {
+                        trace!(
+                            "Query {:?} matches transaction {:?}",
+                            query_id,
+                            transaction_id
+                        );
+                        Some((query_id, transaction_id.clone()))
+                    } else {
+                        None
                     }
                 })
         })

--- a/application/ledger_query_service/src/ethereum/queries.rs
+++ b/application/ledger_query_service/src/ethereum/queries.rs
@@ -213,11 +213,7 @@ impl BlockQuery {
         match self.min_timestamp_secs {
             Some(min_timestamp_secs) => {
                 let min_timestamp_secs = U256::from(min_timestamp_secs);
-                if min_timestamp_secs <= block.timestamp {
-                    true
-                } else {
-                    false
-                }
+                min_timestamp_secs <= block.timestamp
             }
             None => {
                 warn!("min_timestamp not set, nothing to compare");

--- a/application/ledger_query_service/src/ethereum/queries.rs
+++ b/application/ledger_query_service/src/ethereum/queries.rs
@@ -42,13 +42,6 @@ impl TransactionQuery {
     pub fn matches(&self, transaction: &Transaction) -> bool {
         match self {
             Self {
-                from_address: None,
-                to_address: None,
-                is_contract_creation: None,
-                transaction_data: None,
-                transaction_data_length: None,
-            } => false,
-            Self {
                 from_address,
                 to_address,
                 is_contract_creation,
@@ -140,7 +133,6 @@ fn clean_0x(s: &str) -> &str {
 impl LogQuery {
     pub fn matches_block(&self, block: &Block<Transaction>) -> bool {
         match self {
-            Self { topics, .. } if topics.is_empty() => false,
             Self { topics } => topics.iter().all(|topics| {
                 topics
                     .iter()
@@ -151,13 +143,11 @@ impl LogQuery {
 
     pub fn matches_transaction_receipt(&self, transaction_receipt: TransactionReceipt) -> bool {
         match self {
-            Self { topics } if topics.is_empty() => false,
             Self { topics } => topics.iter().all(|topics| {
-                !topics.is_empty()
-                    && transaction_receipt
-                        .logs
-                        .iter()
-                        .any(|tx_log| topics.iter().all(|topic| tx_log.topics.contains(topic)))
+                transaction_receipt
+                    .logs
+                    .iter()
+                    .any(|tx_log| topics.iter().all(|topic| tx_log.topics.contains(topic)))
             }),
         }
     }
@@ -210,16 +200,10 @@ impl ExpandResult for LogQuery {
 
 impl BlockQuery {
     pub fn matches(&self, block: &Block<Transaction>) -> bool {
-        match self.min_timestamp_secs {
-            Some(min_timestamp_secs) => {
-                let min_timestamp_secs = U256::from(min_timestamp_secs);
-                min_timestamp_secs <= block.timestamp
-            }
-            None => {
-                warn!("min_timestamp not set, nothing to compare");
-                false
-            }
-        }
+        self.min_timestamp_secs.map_or(true, |min_timestamp_secs| {
+            let min_timestamp_secs = U256::from(min_timestamp_secs);
+            min_timestamp_secs <= block.timestamp
+        })
     }
 }
 
@@ -395,24 +379,6 @@ mod tests {
         let receipt = transaction_receipt(vec![]);
 
         assert_that!(query.matches_transaction_receipt(receipt)).is_false()
-    }
-
-    #[test]
-    fn given_a_transaction_receipt_should_not_match_empty_query() {
-        let redeem_log_msg =
-            "0xB8CAC300E37F03AD332E581DEA21B2F0B84EAAADC184A295FEF71E81F44A7413".into();
-
-        let query1 = LogQuery {
-            topics: vec![vec![]],
-        };
-        let log1 = log(vec![redeem_log_msg]);
-        let receipt1 = transaction_receipt(vec![log1]);
-        assert_that!(query1.matches_transaction_receipt(receipt1)).is_false();
-
-        let query2 = LogQuery { topics: vec![] };
-        let log2 = log(vec![redeem_log_msg]);
-        let receipt2 = transaction_receipt(vec![log2]);
-        assert_that!(query2.matches_transaction_receipt(receipt2)).is_false()
     }
 
     #[test]
@@ -649,71 +615,5 @@ mod tests {
 
         let result = refund_query.matches(&transaction);
         assert_that(&result).is_false();
-    }
-
-    #[test]
-    fn given_query_transaction_data_is_empty_transaction_matches() {
-        let query_data = TransactionQuery {
-            from_address: None,
-            to_address: None,
-            is_contract_creation: None,
-            transaction_data: Some(Bytes::from(vec![])),
-            transaction_data_length: None,
-        };
-
-        let query_data_length = TransactionQuery {
-            from_address: None,
-            to_address: None,
-            is_contract_creation: None,
-            transaction_data: None,
-            transaction_data_length: Some(0),
-        };
-
-        let transaction = Transaction {
-            hash: H256::from(123),
-            nonce: U256::from(1),
-            block_hash: None,
-            block_number: None,
-            transaction_index: None,
-            from: "0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse().unwrap(),
-            to: Some("0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".parse().unwrap()),
-            value: U256::from(0),
-            gas_price: U256::from(0),
-            gas: U256::from(0),
-            input: Bytes::from(vec![]),
-        };
-
-        let result = query_data.matches(&transaction);
-        assert_that(&result).is_true();
-
-        let result = query_data_length.matches(&transaction);
-        assert_that(&result).is_true();
-    }
-
-    #[test]
-    fn given_no_conditions_in_query_transaction_fails() {
-        let query = TransactionQuery {
-            from_address: None,
-            to_address: None,
-            is_contract_creation: None,
-            transaction_data: None,
-            transaction_data_length: None,
-        };
-
-        let transaction = Transaction {
-            hash: H256::from(123),
-            nonce: U256::from(1),
-            block_hash: None,
-            block_number: None,
-            transaction_index: None,
-            from: "0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse().unwrap(),
-            to: Some("0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".parse().unwrap()),
-            value: U256::from(0),
-            gas_price: U256::from(0),
-            gas: U256::from(0),
-            input: Bytes::from(vec![1, 2, 3, 4, 5]),
-        };
-        let result = query.matches(&transaction);
-        assert_that(&result).is_false()
     }
 }

--- a/application/ledger_query_service/src/lib.rs
+++ b/application/ledger_query_service/src/lib.rs
@@ -23,18 +23,14 @@ pub use crate::{
     query_result_repository::*, route_factory::*, routes::*,
 };
 pub use ethereum_support::web3;
-use std::{cmp::Ordering, fmt::Debug, sync::Arc};
+use std::{cmp::Ordering, sync::Arc};
 
-#[derive(PartialEq)]
+#[derive(PartialEq, PartialOrd)]
 pub struct QueryId(pub u32);
 #[derive(PartialEq)]
 pub struct QueryMatch(pub QueryId, pub String);
 
 type ArcQueryRepository<Q> = Arc<dyn QueryRepository<Q>>;
-
-pub trait IsEmpty: Debug + 'static {
-    fn is_empty(&self) -> bool;
-}
 
 impl From<u32> for QueryId {
     fn from(item: u32) -> Self {
@@ -44,6 +40,6 @@ impl From<u32> for QueryId {
 
 impl PartialOrd for QueryMatch {
     fn partial_cmp(&self, other: &QueryMatch) -> Option<Ordering> {
-        Some((self.0).0.cmp(&(other.0).0))
+        self.0.partial_cmp(&other.0)
     }
 }

--- a/application/ledger_query_service/src/lib.rs
+++ b/application/ledger_query_service/src/lib.rs
@@ -23,8 +23,27 @@ pub use crate::{
     query_result_repository::*, route_factory::*, routes::*,
 };
 pub use ethereum_support::web3;
-use std::sync::Arc;
+use std::{cmp::Ordering, fmt::Debug, sync::Arc};
 
-type QueryId = u32;
-type QueryMatch = (QueryId, String);
+#[derive(PartialEq)]
+pub struct QueryId(pub u32);
+#[derive(PartialEq)]
+pub struct QueryMatch(pub QueryId, pub String);
+
 type ArcQueryRepository<Q> = Arc<dyn QueryRepository<Q>>;
+
+pub trait IsEmpty: Debug + 'static {
+    fn is_empty(&self) -> bool;
+}
+
+impl From<u32> for QueryId {
+    fn from(item: u32) -> Self {
+        Self(item)
+    }
+}
+
+impl PartialOrd for QueryMatch {
+    fn partial_cmp(&self, other: &QueryMatch) -> Option<Ordering> {
+        Some((self.0).0.cmp(&(other.0).0))
+    }
+}

--- a/application/ledger_query_service/src/lib.rs
+++ b/application/ledger_query_service/src/lib.rs
@@ -23,43 +23,8 @@ pub use crate::{
     query_result_repository::*, route_factory::*, routes::*,
 };
 pub use ethereum_support::web3;
-use futures::Future;
-use std::{fmt::Debug, sync::Arc};
+use std::sync::Arc;
 
 type QueryId = u32;
 type QueryMatch = (QueryId, String);
 type ArcQueryRepository<Q> = Arc<dyn QueryRepository<Q>>;
-type ArcQueryResultRepository<Q> = Arc<dyn QueryResultRepository<Q>>;
-
-pub trait BlockProcessor<B> {
-    fn process(
-        &mut self,
-        block: B,
-    ) -> Box<dyn Future<Item = (Vec<QueryMatch>, Vec<QueryMatch>), Error = ()> + Send>;
-}
-
-pub trait Query<O>: Debug + 'static {
-    fn matches(&self, object: &O) -> Box<dyn Future<Item = QueryMatchResult, Error = ()> + Send>;
-}
-
-#[derive(Debug, PartialEq)]
-pub enum QueryMatchResult {
-    Yes { confirmations_needed: u32 },
-    No,
-}
-
-impl QueryMatchResult {
-    pub fn yes() -> Self {
-        QueryMatchResult::Yes {
-            confirmations_needed: 0,
-        }
-    }
-    pub fn yes_with_confirmations(confirmations_needed: u32) -> Self {
-        QueryMatchResult::Yes {
-            confirmations_needed,
-        }
-    }
-    pub fn no() -> Self {
-        QueryMatchResult::No
-    }
-}


### PR DESCRIPTION
With #647, the ledger query service has been split up into two, since the implementations for bitcoin and ethereum cannot be easily generalised anymore. This PR removes all the unnecessary traits that were still hanging around in `ledger_query_service/src/bitcoin`.

Additionally, `PendingTransaction` has been removed, because the feature was not being used and was poorly implemented to begin with.

Resolves #646.