### PR TITLE
563 use new lqs features

### DIFF
--- a/application/comit_node/src/ledger_query_service/client.rs
+++ b/application/comit_node/src/ledger_query_service/client.rs
@@ -17,6 +17,7 @@ pub struct DefaultLedgerQueryServiceApiClient {
     create_bitcoin_block_query_endpoint: Url,
     create_ethereum_transaction_query_endpoint: Url,
     create_ethereum_block_query_endpoint: Url,
+    create_ethereum_event_query_endpoint: Url,
 }
 
 #[derive(Debug, Deserialize)]
@@ -39,6 +40,9 @@ impl DefaultLedgerQueryServiceApiClient {
                 .expect("invalid url"),
             create_ethereum_block_query_endpoint: endpoint
                 .join("queries/ethereum/blocks")
+                .expect("invalid url"),
+            create_ethereum_event_query_endpoint: endpoint
+                .join("queries/ethereum/logs")
                 .expect("invalid url"),
         }
     }
@@ -140,7 +144,7 @@ impl DefaultLedgerQueryServiceApiClient {
             .and_then(|mut response| response.json::<QueryResponse<L::Transaction>>())
             .map_err(move |e| {
                 Error::FailedRequest(format!(
-                    "Failed to fetch results for {:?} because {:?}",
+                    "Failed to fetch full results for {:?} because {:?}",
                     url, e
                 ))
             })
@@ -214,6 +218,7 @@ impl CreateQuery<Ethereum, EthereumQuery> for DefaultLedgerQueryServiceApiClient
                 self.create_ethereum_transaction_query_endpoint.clone()
             }
             EthereumQuery::Block { .. } => self.create_ethereum_block_query_endpoint.clone(),
+            EthereumQuery::Event { .. } => self.create_ethereum_event_query_endpoint.clone(),
         };
         self._create(endpoint, query)
     }

--- a/application/comit_node/src/ledger_query_service/ethereum.rs
+++ b/application/comit_node/src/ledger_query_service/ethereum.rs
@@ -101,7 +101,10 @@ mod tests {
             }],
         };
         let query = serde_json::to_string(&query).unwrap();
-        assert_eq!(query, r#"{"address":null,"data":null,"topics":[]}"#)
+        assert_eq!(
+            query,
+            r#"{"event_matchers":[{"address":null,"data":null,"topics":[]}]}"#
+        )
     }
 
     #[test]
@@ -116,6 +119,6 @@ mod tests {
             }],
         };
         let query = serde_json::to_string(&query).unwrap();
-        assert_eq!(query, r#"{"address":"0x8457037fcd80a8650c4692d7fcfc1d0a96b92867","data":"0x01","topics":["0x0000000000000000000000000000000000000000000000000000000000000001"]}"#)
+        assert_eq!(query, r#"{"event_matchers":[{"address":"0x8457037fcd80a8650c4692d7fcfc1d0a96b92867","data":"0x01","topics":["0x0000000000000000000000000000000000000000000000000000000000000001"]}]}"#)
     }
 }

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/mod.rs
@@ -13,6 +13,10 @@ mod queries;
 mod validation;
 
 pub use self::{actions::*, erc20_htlc::*, ether_htlc::*, queries::*};
+pub const REDEEM_LOG_MSG: &str =
+    "0xB8CAC300E37F03AD332E581DEA21B2F0B84EAAADC184A295FEF71E81F44A7413";
+pub const REFUND_LOG_MSG: &str =
+    "0x5D26862916391BF49478B2F5103B0720A842B45EF145A268F2CD1FB2AED55178";
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct ByteCode(pub String);

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/mod.rs
@@ -13,10 +13,14 @@ mod queries;
 mod validation;
 
 pub use self::{actions::*, erc20_htlc::*, ether_htlc::*, queries::*};
-pub const REDEEM_LOG_MSG: &str =
-    "0xB8CAC300E37F03AD332E581DEA21B2F0B84EAAADC184A295FEF71E81F44A7413";
-pub const REFUND_LOG_MSG: &str =
-    "0x5D26862916391BF49478B2F5103B0720A842B45EF145A268F2CD1FB2AED55178";
+
+// keccak256(Redeemed())
+const REDEEM_LOG_MSG: &str = "0xB8CAC300E37F03AD332E581DEA21B2F0B84EAAADC184A295FEF71E81F44A7413";
+// keccak256(Refunded())
+const REFUND_LOG_MSG: &str = "0x5D26862916391BF49478B2F5103B0720A842B45EF145A268F2CD1FB2AED55178";
+// keccak('Transfer(address,address,uint256)')
+pub const TRANSFER_LOG_MSG: &str =
+    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct ByteCode(pub String);

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/queries.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/queries.rs
@@ -1,15 +1,15 @@
 use crate::{
-    ledger_query_service::EthereumQuery,
+    ledger_query_service::{EthereumQuery, EventMatcher, Topic},
     swap_protocols::{
         ledger::Ethereum,
         rfc003::{
+            ethereum::{REDEEM_LOG_MSG, REFUND_LOG_MSG},
             events::{NewHtlcFundedQuery, NewHtlcRedeemedQuery, NewHtlcRefundedQuery},
             state_machine::HtlcParams,
-            Secret,
         },
     },
 };
-use ethereum_support::{web3::types::Address, Bytes, EtherQuantity};
+use ethereum_support::{web3::types::Address, EtherQuantity};
 
 impl NewHtlcFundedQuery<Ethereum, EtherQuantity> for EthereumQuery {
     fn new_htlc_funded_query(htlc_params: &HtlcParams<Ethereum, EtherQuantity>) -> Self {
@@ -28,12 +28,12 @@ impl NewHtlcRefundedQuery<Ethereum, EtherQuantity> for EthereumQuery {
         _htlc_params: &HtlcParams<Ethereum, EtherQuantity>,
         htlc_location: &Address,
     ) -> Self {
-        EthereumQuery::Transaction {
-            from_address: None,
-            to_address: Some(*htlc_location),
-            is_contract_creation: Some(false),
-            transaction_data: Some(Bytes::from(vec![])),
-            transaction_data_length: None,
+        EthereumQuery::Event {
+            event_matchers: vec![EventMatcher {
+                address: Some(*htlc_location),
+                data: None,
+                topics: vec![Some(Topic(REFUND_LOG_MSG.into()))],
+            }],
         }
     }
 }
@@ -43,12 +43,12 @@ impl NewHtlcRedeemedQuery<Ethereum, EtherQuantity> for EthereumQuery {
         _htlc_params: &HtlcParams<Ethereum, EtherQuantity>,
         htlc_location: &Address,
     ) -> Self {
-        EthereumQuery::Transaction {
-            from_address: None,
-            to_address: Some(*htlc_location),
-            is_contract_creation: Some(false),
-            transaction_data: None,
-            transaction_data_length: Some(Secret::LENGTH),
+        EthereumQuery::Event {
+            event_matchers: vec![EventMatcher {
+                address: Some(*htlc_location),
+                data: None,
+                topics: vec![Some(Topic(REDEEM_LOG_MSG.into()))],
+            }],
         }
     }
 }
@@ -83,22 +83,22 @@ pub mod erc20 {
     }
 
     pub fn new_htlc_refunded_query(htlc_location: &Address) -> EthereumQuery {
-        EthereumQuery::Transaction {
-            from_address: None,
-            to_address: Some(*htlc_location),
-            is_contract_creation: Some(false),
-            transaction_data: Some(Bytes::from(vec![])),
-            transaction_data_length: None,
+        EthereumQuery::Event {
+            event_matchers: vec![EventMatcher {
+                address: Some(*htlc_location),
+                data: None,
+                topics: vec![Some(Topic(REFUND_LOG_MSG.into()))],
+            }],
         }
     }
 
     pub fn new_htlc_redeemed_query(htlc_location: &Address) -> EthereumQuery {
-        EthereumQuery::Transaction {
-            from_address: None,
-            to_address: Some(*htlc_location),
-            is_contract_creation: Some(false),
-            transaction_data: None,
-            transaction_data_length: Some(Secret::LENGTH),
+        EthereumQuery::Event {
+            event_matchers: vec![EventMatcher {
+                address: Some(*htlc_location),
+                data: None,
+                topics: vec![Some(Topic(REDEEM_LOG_MSG.into()))],
+            }],
         }
     }
 }

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/queries.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/queries.rs
@@ -55,6 +55,7 @@ impl NewHtlcRedeemedQuery<Ethereum, EtherQuantity> for EthereumQuery {
 
 pub mod erc20 {
     use super::*;
+    use crate::swap_protocols::rfc003::ethereum::TRANSFER_LOG_MSG;
     use ethereum_support::Erc20Quantity;
 
     pub fn new_htlc_deployed_query(
@@ -73,12 +74,16 @@ pub mod erc20 {
         htlc_params: &HtlcParams<Ethereum, Erc20Quantity>,
         htlc_location: &Address,
     ) -> EthereumQuery {
-        EthereumQuery::Transaction {
-            from_address: None,
-            to_address: Some(htlc_params.asset.token_contract()),
-            is_contract_creation: None,
-            transaction_data: Some(htlc_params.funding_tx_payload(*htlc_location)),
-            transaction_data_length: None,
+        EthereumQuery::Event {
+            event_matchers: vec![EventMatcher {
+                address: Some(htlc_params.asset.token_contract()),
+                data: None,
+                topics: vec![
+                    Some(Topic(TRANSFER_LOG_MSG.into())),
+                    None,
+                    Some(Topic(htlc_location.into())),
+                ],
+            }],
         }
     }
 

--- a/application/ledger_query_service/src/ethereum/queries/event_query.rs
+++ b/application/ledger_query_service/src/ethereum/queries/event_query.rs
@@ -6,7 +6,7 @@ use ethbloom::Input;
 use ethereum_support::{
     web3::{
         transports::Http,
-        types::{TransactionReceipt, H256},
+        types::{TransactionId, TransactionReceipt, H256},
         Web3,
     },
     Address, Block, Bytes, Transaction,
@@ -122,8 +122,12 @@ impl ShouldExpand for EventQuery {
 
 impl ExpandResult for EventQuery {
     type Client = Web3<Http>;
-    type Item = TransactionReceipt;
+    type Item = Transaction;
 
+    // TODO: return TransactionReceipt and not Transaction.
+    // Temporarily return the transaction and not the transaction receipt as the
+    // secret is currently only available in the transaction call data but not
+    // in the receipt. This needs to be fixed with https://github.com/comit-network/comit-rs/issues/638
     fn expand_result(
         result: &QueryResult,
         client: Arc<Web3<Http>>,
@@ -141,7 +145,7 @@ impl ExpandResult for EventQuery {
             .map(|id| {
                 client
                     .eth()
-                    .transaction_receipt(H256::from_slice(id.as_ref()))
+                    .transaction(TransactionId::Hash(H256::from_slice(id.as_ref())))
                     .map_err(Error::Web3)
             })
             .collect();


### PR DESCRIPTION
With this PR the COMIT node makes use of the new LQS features. 
In detail:
* check for logs if ERC20/ETH HTLC has been redeemed
* check for logs if ERC20/ETH HTLC has been refunded
* check for logs if funded

for the first one I had to make a small change on the LQS side: the `expand` now returns a `Transaction` and not a `TransactionReceipt` as the secret is not yet emitted in the logs. 
This needs to be fixed when doing #638.

Fixes #563