### PR TITLE
Remove noisy log messages

### DIFF
--- a/application/comit_node/src/swap_protocols/rfc003/bitcoin/htlc.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/bitcoin/htlc.rs
@@ -130,7 +130,7 @@ fn create_htlc(
     secret_hash: &[u8],
     redeem_block_height: u32,
 ) -> Script {
-    let script = Builder::new()
+    Builder::new()
         .push_opcode(OP_IF)
         .push_opcode(OP_SIZE)
         .push_int(i64::from(Secret::LENGTH_U8))
@@ -151,9 +151,7 @@ fn create_htlc(
         .push_opcode(OP_ENDIF)
         .push_opcode(OP_EQUALVERIFY)
         .push_opcode(OP_CHECKSIG)
-        .into_script();
-    trace!("BTC HTLC: {}", script);
-    script
+        .into_script()
 }
 
 #[cfg(test)]

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/erc20_htlc.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/erc20_htlc.rs
@@ -40,18 +40,14 @@ impl Erc20Htlc {
         token_contract_address: Address,
         amount: U256,
     ) -> Self {
-        let htlc = Erc20Htlc {
+        Self {
             refund_timeout,
             refund_address,
             redeem_address,
             secret_hash,
             token_contract_address,
             amount,
-        };
-
-        trace!("Created new ERC20 HTLC for ethereum: {:#?}", htlc);
-
-        htlc
+        }
     }
 
     /// Constructs the payload for funding an `Erc20` HTLC located at the given
@@ -112,8 +108,6 @@ impl Htlc for Erc20Htlc {
                 &token_contract_address,
             );
 
-        trace!("Final contract code: {}", &contract_code);
-
         let code_length = contract_code.len() / 2; // In hex, each byte is two chars
 
         let code_length_as_hex = format!("{:0>4x}", code_length);
@@ -129,12 +123,7 @@ impl Htlc for Erc20Htlc {
             )
             .replace(Self::CONTRACT_LENGTH_PLACEHOLDER, &code_length_as_hex);
 
-        trace!("Final contract code: {}", &contract_code);
-        trace!("Deploy header: {}", &deploy_header);
-
         let deployable_contract = deploy_header + &contract_code;
-
-        trace!("Deployable contract: {}", &deployable_contract);
 
         ByteCode(deployable_contract)
     }

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/ether_htlc.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/ether_htlc.rs
@@ -32,16 +32,12 @@ impl EtherHtlc {
         redeem_address: Address,
         secret_hash: SecretHash,
     ) -> Self {
-        let htlc = EtherHtlc {
+        Self {
             refund_timeout,
             refund_address,
             redeem_address,
             secret_hash,
-        };
-
-        trace!("Created new HTLC for ethereum: {:#?}", htlc);
-
-        htlc
+        }
     }
 
     pub fn deployment_gas_limit(&self) -> U256 {
@@ -86,12 +82,7 @@ impl Htlc for EtherHtlc {
             )
             .replace(Self::CONTRACT_LENGTH_PLACEHOLDER, &code_length_as_hex);
 
-        trace!("Final contract code: {}", &contract_code);
-        trace!("Deploy header: {}", &deploy_header);
-
         let deployable_contract = deploy_header + &contract_code;
-
-        trace!("Deployable contract: {}", &deployable_contract);
 
         ByteCode(deployable_contract)
     }


### PR DESCRIPTION
These log statements were introduced at a time where the COMIT node
would still deploy stuff by themselves. However, we no longer that.
Instead, we tell the user, what to do by returning "actions" over the
HTTP API. This means, whatever was logged here is actually returned
to the user and doesn't add any value in the log file.

Fixes #690.