### PR TITLE
Install sccache from crates.io

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -172,10 +172,9 @@ find $HOME/.cargo/registry/src $HOME/.cargo/registry/cache \
 description = "Setup & start sscache"
 workspace = false
 private = true
-install_script = ["which sccache || (unset RUSTC_WRAPPER; cargo install --git https://github.com/mozilla/sccache.git --rev 9d30660a6f5a94bc7a8e4d2a125c8677b9e08129)"]
+install_script = ["which sccache || (unset RUSTC_WRAPPER; cargo install sccache)"]
+# Start sccache with limited cache size to avoid a constantly growing caches (and thus continuously slower builds)
 env = { "SCCACHE_CACHE_SIZE" = "400M" }
-# Start sccache with limited cache size to avoid a constantly
-# growing caches (and thus continuously slower builds)
 command = "sccache"
 args = ["--start-server"]
 


### PR DESCRIPTION
This PR installs sccache from crates.io again since there is now a new version released (https://github.com/mozilla/sccache/issues/355).

As soon as this PR is merged, the caches on travis should be cleared.

Resolves #697.