### PR TITLE
Add log_level option to settings

### DIFF
--- a/application/comit_node/config/development.toml
+++ b/application/comit_node/config/development.toml
@@ -1,3 +1,4 @@
 # This is should not be used in production
+log_level="debug"
 [bitcoin]
 transient_root_key="tprv8ZgxMBicQKsPcsbCVeqqF1KVdH7gwDJbxbzpCxDUsoXHdb6SnTPYxdwSAKhBzPJuE3CA2JAD79JGohP7F6x3TeXehf4rrMdLAD7cbwaWJ1f"

--- a/application/comit_node/src/bin/comit_node.rs
+++ b/application/comit_node/src/bin/comit_node.rs
@@ -23,8 +23,8 @@ use std::{env::var, net::SocketAddr, sync::Arc};
 
 // TODO: Make a nice command line interface here (using StructOpt f.e.) see #298
 fn main() -> Result<(), failure::Error> {
-    logging::set_up_logging();
     let settings = load_settings()?;
+    logging::set_up_logging(&settings);
 
     info!("Starting up with {:#?}", settings);
 

--- a/application/comit_node/src/logging.rs
+++ b/application/comit_node/src/logging.rs
@@ -1,3 +1,4 @@
+use crate::settings::ComitNodeSettings;
 use fern::{
     colors::{Color, ColoredLevelConfig},
     Dispatch, FormatCallback,
@@ -14,19 +15,14 @@ pub fn set_context<S: ToString>(input: &S) {
     });
 }
 
-pub fn set_up_logging() {
+pub fn set_up_logging(settings: &ComitNodeSettings) {
     Dispatch::new()
         .format(move |out, message, record| formatter(out, message, record))
-        // TODO: get level from config file once implemented with #136
-        .level(LevelFilter::Debug)
-        .level_for("comit_node", LevelFilter::Trace)
-        .level_for("bam", LevelFilter::Trace)
-        .level_for("comit_node::ledger_query_service", LevelFilter::Info)
+        .level(settings.log_level)
         .level_for("tokio_core::reactor", LevelFilter::Info)
         .level_for("tokio_reactor", LevelFilter::Info)
         .level_for("hyper", LevelFilter::Info)
         .level_for("warp", LevelFilter::Info)
-        // output to stdout
         .chain(stdout())
         .apply()
         .unwrap();

--- a/application/comit_node/src/settings/mod.rs
+++ b/application/comit_node/src/settings/mod.rs
@@ -1,8 +1,9 @@
 mod serde;
 
 use crate::seed::Seed;
-use ::serde::Deserialize;
 use config::{Config, ConfigError, File};
+use log::LevelFilter;
+
 use std::{
     ffi::OsStr,
     net::{IpAddr, SocketAddr},
@@ -15,6 +16,12 @@ pub struct ComitNodeSettings {
     pub comit: Comit,
     pub http_api: HttpApi,
     pub ledger_query_service: LedgerQueryService,
+    #[serde(with = "serde::log_level", default = "default_log")]
+    pub log_level: LevelFilter,
+}
+
+fn default_log() -> LevelFilter {
+    LevelFilter::Debug
 }
 
 #[derive(Debug, Deserialize)]

--- a/application/comit_node/src/settings/serde/log_level.rs
+++ b/application/comit_node/src/settings/serde/log_level.rs
@@ -1,0 +1,29 @@
+use log::LevelFilter;
+use serde::{de, export::fmt, Deserializer};
+use std::str::FromStr;
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<LevelFilter, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct Visitor;
+
+    impl<'de> de::Visitor<'de> for Visitor {
+        type Value = LevelFilter;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str(
+                "a log level (\"OFF\", \"ERROR\", \"WARN\", \"INFO\", \"DEBUG\", \"TRACE\")",
+            )
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<LevelFilter, E>
+        where
+            E: de::Error,
+        {
+            LevelFilter::from_str(value).map_err(E::custom)
+        }
+    }
+
+    deserializer.deserialize_str(Visitor)
+}

--- a/application/comit_node/src/settings/serde/mod.rs
+++ b/application/comit_node/src/settings/serde/mod.rs
@@ -1,2 +1,3 @@
 pub mod duration;
+pub mod log_level;
 pub mod url;


### PR DESCRIPTION
Fixes #711 

Adds a log_level (default: debug) under each heading in the settings and uses that to determine the relevant LogFilter in `logging.rs`.