### PR TITLE
Fix LQS Client test

### DIFF
--- a/application/comit_node/src/ledger_query_service/client.rs
+++ b/application/comit_node/src/ledger_query_service/client.rs
@@ -21,6 +21,7 @@ pub struct DefaultLedgerQueryServiceApiClient {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct QueryResponse<T> {
     matches: Vec<T>,
 }
@@ -258,7 +259,8 @@ mod test {
 
     #[test]
     fn json_deserialize() {
-        let json = r#"{"query":{"to_address":"bcrt1qtfd0gvmdhx2uz267a8a3rpm4v55t8nuzgka2f5xzm4e06tg2d2dqxugdz7","confirmations_needed":1},"matches":["b29cb185d467b3a5faeb7a3f312175e336dbfcc8e9fecc8ad86e9106031315c2"]}"#;
+        let json =
+            r#"{"matches":["b29cb185d467b3a5faeb7a3f312175e336dbfcc8e9fecc8ad86e9106031315c2"]}"#;
 
         let _: QueryResponse<TransactionId> = serde_json::from_str(json).unwrap();
     }

--- a/application/comit_node/src/ledger_query_service/client.rs
+++ b/application/comit_node/src/ledger_query_service/client.rs
@@ -21,7 +21,6 @@ pub struct DefaultLedgerQueryServiceApiClient {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct QueryResponse<T> {
     matches: Vec<T>,
 }


### PR DESCRIPTION
So as I expected, this is a bad idea:
See https://travis-ci.com/comit-network/comit-rs/builds/100021198
```
[2019-02-07 01:07:54.483][comit_node::ledger_query_service::fetch_transaction_stream][WARN] Falling back to empty list of transactions because FailedRequest("Failed to fetch full results for \"http://localhost:8080/queries/bitcoin/transactions/1?expand_results=true\" because Inner { kind: Json(Error(\"unknown field `query`, expected `matches`\", line: 1, column: 8)), url: None }")
```

I will not make deserialization stricter, issue updated.

Resolves #727