### PR TITLE
[WIP] Reject non standard transactions

### DIFF
--- a/api_tests/regtest/docker-compose.yml
+++ b/api_tests/regtest/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       -debug=1
       -zmqpubrawblock=tcp://*:28332
       -zmqpubrawtx=tcp://*:28333
+      -acceptnonstdtxn=0
     ports:
       - "18443:18443"
       - "28332:28332"


### PR DESCRIPTION
Just realised that in regtest/testnet `-acceptnonstdtxn` is activated by default.
Best to deactivate it to ensure our code would work in mainnet. 
Need to look at doing the same in testcontainers.