### PR TITLE
Remove TODO in bitcoin_rpc_test_helpers

### DIFF
--- a/vendor/bitcoin_rpc_test_helpers/src/lib.rs
+++ b/vendor/bitcoin_rpc_test_helpers/src/lib.rs
@@ -1,11 +1,9 @@
 #![warn(unused_extern_crates, missing_debug_implementations, rust_2018_idioms)]
 #![deny(unsafe_code)]
 
-// Place for putting common queries needed in tests
 use bitcoin_rpc_client::*;
 use bitcoin_support::{Address, BitcoinQuantity, IntoP2wpkhAddress, Network, Sha256dHash};
 
-// TODO: All of this should be under #[cfg(test)]
 pub trait RegtestHelperClient {
     fn find_utxo_at_tx_for_address(
         &self,

--- a/vendor/bitcoin_rpc_test_helpers/src/lib.rs
+++ b/vendor/bitcoin_rpc_test_helpers/src/lib.rs
@@ -25,10 +25,6 @@ pub trait RegtestHelperClient {
 }
 
 impl<Rpc: BitcoinRpcApi> RegtestHelperClient for Rpc {
-    fn enable_segwit(&self) {
-        self.generate(432).unwrap().unwrap();
-    }
-
     fn find_utxo_at_tx_for_address(
         &self,
         txid: &TransactionId,
@@ -64,6 +60,10 @@ impl<Rpc: BitcoinRpcApi> RegtestHelperClient for Rpc {
             .find(|txout| txout.script_pub_key.hex == address.script_pubkey())
             .unwrap()
             .clone()
+    }
+
+    fn enable_segwit(&self) {
+        self.generate(432).unwrap().unwrap();
     }
 
     fn create_p2wpkh_vout_at<D: IntoP2wpkhAddress>(


### PR DESCRIPTION
It tried to duplicate the code as mentioned in #699, but it is actually too much of a hassle. The functions are quite helpful.

I just think that the TODO is actually not valid. It is perfectly fine to have crates that are only used in testing (see `testcontainers`) and they still are not under `#[cfg(test)]`.

#699 will be closed with this PR being merged by the TODO bot.