### PR TITLE
Use draft PR instead of WIP title

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,18 +12,3 @@ pull_request_rules:
         strict: smart
         strict_method: rebase
       delete_head_branch:
-  - name: auto add wip (and remove review)
-    conditions:
-      - title~=^.?(wip|WIP).*
-      - label=review
-    actions:
-      label:
-        add: ["work-in-progress"]
-        remove: ["review"]
-  - name: auto add wip (no review)
-    conditions:
-      - title~=^.?(wip|WIP).*
-      - label!=review
-    actions:
-      label:
-        add: ["work-in-progress"]


### PR DESCRIPTION
We should use draft PRs instead of "WIP" in title.

Remove mergify rules that messes up with labels when "WIP" is in label

Resolves #780 