### PR TITLE
Add actions to GET swaps

### DIFF
--- a/api_tests/dry/multiple_peers.js
+++ b/api_tests/dry/multiple_peers.js
@@ -104,8 +104,8 @@ it("[Alice] Should be IN_PROGRESS and SENT after sending the swap request to Cha
         chai,
         alice_swap_with_charlie_href,
         body =>
-            body.status == "IN_PROGRESS" &&
-            body.state.communication.status == "SENT"
+            body.status === "IN_PROGRESS" &&
+            body.state.communication.status === "SENT"
     );
 });
 

--- a/api_tests/dry/rfc003_swap_reject.js
+++ b/api_tests/dry/rfc003_swap_reject.js
@@ -235,8 +235,8 @@ it("[Bob] Shows the swaps as Start in /swaps", async () => {
     for (let swap of swaps) {
         swap.protocol.should.equal("rfc003");
         swap.status.should.equal("IN_PROGRESS");
-        swap._links.accept.href.should.be.a("string");
-        swap._links.decline.href.should.be.a("string");
+        swap._links.accept.should.be.a("object");
+        swap._links.decline.should.be.a("object");
     }
 
     let swap_1_link = swaps[0]._links.self;

--- a/api_tests/dry/rfc003_swap_reject.js
+++ b/api_tests/dry/rfc003_swap_reject.js
@@ -227,7 +227,7 @@ it("[Bob] Shows the swaps as Start in /swaps", async () => {
     let body = await bob.poll_comit_node_until(
         chai,
         "/swaps",
-        body => body._embedded.swaps.length == 2
+        body => body._embedded.swaps.length === 2
     );
 
     let swaps = body._embedded.swaps;
@@ -252,7 +252,7 @@ it("[Bob] Shows the swaps as Start in /swaps", async () => {
     let swap_2 = await chai.request(bob.comit_node_url()).get(swap_2_href);
 
     if (
-        swap_1.body.parameters.alpha_asset.quantity ==
+        swap_1.body.parameters.alpha_asset.quantity ===
         parseInt(alpha_asset_stingy_quantity)
     ) {
         bob_stingy_swap_href = swap_1_href;
@@ -306,7 +306,7 @@ it("[Bob] Should be in the Rejected State after declining a swap request providi
     await bob.poll_comit_node_until(
         chai,
         bob_stingy_swap_href,
-        body => body.state.communication.status == "REJECTED"
+        body => body.state.communication.status === "REJECTED"
     );
 });
 
@@ -314,7 +314,7 @@ it("[Alice] Should be in the Rejected State after Bob declines a swap request pr
     await alice.poll_comit_node_until(
         chai,
         alice_stingy_swap_href,
-        body => body.state.communication.status == "REJECTED"
+        body => body.state.communication.status === "REJECTED"
     );
 });
 
@@ -344,7 +344,7 @@ it("[Bob] Should be in the Rejected State after declining a swap request without
     await bob.poll_comit_node_until(
         chai,
         bob_reasonable_swap_href,
-        body => body.state.communication.status == "REJECTED"
+        body => body.state.communication.status === "REJECTED"
     );
 });
 
@@ -352,6 +352,6 @@ it("[Alice] Should be in the Rejected State after Bob declines a swap request wi
     await alice.poll_comit_node_until(
         chai,
         alice_reasonable_swap_href,
-        body => body.state.communication.status == "REJECTED"
+        body => body.state.communication.status === "REJECTED"
     );
 });

--- a/api_tests/dry/rfc003_swap_reject.js
+++ b/api_tests/dry/rfc003_swap_reject.js
@@ -252,7 +252,7 @@ it("[Bob] Shows the swaps as Start in /swaps", async () => {
     let swap_2 = await chai.request(bob.comit_node_url()).get(swap_2_href);
 
     if (
-        swap_1.body.parameters.alpha_asset.quantity ===
+        parseInt(swap_1.body.parameters.alpha_asset.quantity) ===
         parseInt(alpha_asset_stingy_quantity)
     ) {
         bob_stingy_swap_href = swap_1_href;
@@ -263,7 +263,7 @@ it("[Bob] Shows the swaps as Start in /swaps", async () => {
     }
 });
 
-let bob_decline_href_1;
+let bob_decline_href_stingy;
 
 it("[Bob] Has the accept and decline actions when GETing the swap", async () => {
     await chai
@@ -284,8 +284,10 @@ it("[Bob] Has the accept and decline actions when GETing the swap", async () => 
             );
 
             action_links.decline.should.be.a("object");
-            bob_decline_href_1 = action_links.decline.href;
-            bob_decline_href_1.should.equal(bob_stingy_swap_href + "/decline");
+            bob_decline_href_stingy = action_links.decline.href;
+            bob_decline_href_stingy.should.equal(
+                bob_stingy_swap_href + "/decline"
+            );
         });
 });
 
@@ -296,7 +298,7 @@ it("[Bob] Can execute a decline action providing a reason", async () => {
 
     let decline_res = await chai
         .request(bob.comit_node_url())
-        .post(bob_decline_href_1)
+        .post(bob_decline_href_stingy)
         .send(bob_response);
 
     decline_res.should.have.status(200);

--- a/api_tests/dry/rfc003_swap_reject.js
+++ b/api_tests/dry/rfc003_swap_reject.js
@@ -235,6 +235,8 @@ it("[Bob] Shows the swaps as Start in /swaps", async () => {
     for (let swap of swaps) {
         swap.protocol.should.equal("rfc003");
         swap.status.should.equal("IN_PROGRESS");
+        swap._links.accept.href.should.be.a("string");
+        swap._links.decline.href.should.be.a("string");
     }
 
     let swap_1_link = swaps[0]._links.self;

--- a/api_tests/dry/rfc003_swap_reject.js
+++ b/api_tests/dry/rfc003_swap_reject.js
@@ -169,11 +169,47 @@ it("[Alice] Shows the swaps as IN_PROGRESS in GET /swaps", async () => {
             let swaps = embedded.swaps;
             let reasonable_swap_in_swaps = {
                 _links: { self: { href: alice_reasonable_swap_href } },
+                parameters: {
+                    alpha_asset: {
+                        name: "Bitcoin",
+                        quantity: "100000000",
+                    },
+                    alpha_ledger: {
+                        name: "Bitcoin",
+                        network: "regtest",
+                    },
+                    beta_asset: {
+                        name: "Ether",
+                        quantity: "10000000000000000000",
+                    },
+                    beta_ledger: {
+                        name: "Ethereum",
+                        network: "regtest",
+                    },
+                },
                 protocol: "rfc003",
                 status: "IN_PROGRESS",
             };
             let stingy_swap_in_swaps = {
                 _links: { self: { href: alice_stingy_swap_href } },
+                parameters: {
+                    alpha_asset: {
+                        name: "Bitcoin",
+                        quantity: "100",
+                    },
+                    alpha_ledger: {
+                        name: "Bitcoin",
+                        network: "regtest",
+                    },
+                    beta_asset: {
+                        name: "Ether",
+                        quantity: "10000000000000000000",
+                    },
+                    beta_ledger: {
+                        name: "Ethereum",
+                        network: "regtest",
+                    },
+                },
                 protocol: "rfc003",
                 status: "IN_PROGRESS",
             };

--- a/api_tests/e2e/rfc003/btc_eth-erc20/test.js
+++ b/api_tests/e2e/rfc003/btc_eth-erc20/test.js
@@ -112,8 +112,8 @@ describe("RFC003: Bitcoin for ERC20", () => {
             chai,
             alice_swap_href,
             body =>
-                body.status == "IN_PROGRESS" &&
-                body.state.communication.status == "SENT"
+                body.status === "IN_PROGRESS" &&
+                body.state.communication.status === "SENT"
         );
     });
 

--- a/api_tests/e2e/rfc003/btc_eth/test.js
+++ b/api_tests/e2e/rfc003/btc_eth/test.js
@@ -164,8 +164,8 @@ describe("RFC003: Bitcoin for Ether", () => {
             chai,
             alice_swap_href,
             body =>
-                body.status == "IN_PROGRESS" &&
-                body.state.communication.status == "SENT"
+                body.status === "IN_PROGRESS" &&
+                body.state.communication.status === "SENT"
         );
     });
 

--- a/api_tests/e2e/rfc003/eth-erc20_btc/test.js
+++ b/api_tests/e2e/rfc003/eth-erc20_btc/test.js
@@ -108,8 +108,8 @@ describe("RFC003: ERC20 for Bitcoin", () => {
             chai,
             alice_swap_href,
             body =>
-                body.status == "IN_PROGRESS" &&
-                body.state.communication.status == "SENT"
+                body.status === "IN_PROGRESS" &&
+                body.state.communication.status === "SENT"
         );
     });
 

--- a/api_tests/e2e/rfc003/eth_btc/test.js
+++ b/api_tests/e2e/rfc003/eth_btc/test.js
@@ -164,8 +164,8 @@ describe("RFC003: Ether for Bitcoin", () => {
             chai,
             alice_swap_href,
             body =>
-                body.status == "IN_PROGRESS" &&
-                body.state.communication.status == "SENT"
+                body.status === "IN_PROGRESS" &&
+                body.state.communication.status === "SENT"
         );
     });
 

--- a/application/comit_node/src/http_api/mod.rs
+++ b/application/comit_node/src/http_api/mod.rs
@@ -1,6 +1,5 @@
 pub mod rfc003;
 pub mod route_factory;
-
 #[macro_use]
 pub mod ledger;
 #[macro_use]

--- a/application/comit_node/src/http_api/problem.rs
+++ b/application/comit_node/src/http_api/problem.rs
@@ -1,6 +1,9 @@
-use crate::swap_protocols::{
-    metadata_store,
-    rfc003::{self, state_store},
+use crate::{
+    http_api::rfc003::action::Action,
+    swap_protocols::{
+        metadata_store,
+        rfc003::{self, state_store},
+    },
 };
 use http::StatusCode;
 use http_api_problem::{HttpApiProblem, HttpStatusCode};
@@ -60,8 +63,14 @@ pub fn not_yet_implemented(feature: &str) -> HttpApiProblem {
         .set_detail(format!("{} is not yet implemented! Sorry :(", feature))
 }
 
-pub fn action_already_taken() -> HttpApiProblem {
-    HttpApiProblem::new("action-already-taken").set_status(400)
+pub fn action_already_done(action: Action) -> HttpApiProblem {
+    error!("{} action has already been done", action);
+    HttpApiProblem::new("action-already-done").set_status(400)
+}
+
+pub fn invalid_action(action: Action) -> HttpApiProblem {
+    error!("{} action is invalid for this swap", action);
+    HttpApiProblem::new("invalid-action").set_status(404)
 }
 
 impl From<state_store::Error> for HttpApiProblem {

--- a/application/comit_node/src/http_api/problem.rs
+++ b/application/comit_node/src/http_api/problem.rs
@@ -65,12 +65,12 @@ pub fn not_yet_implemented(feature: &str) -> HttpApiProblem {
 
 pub fn action_already_done(action: Action) -> HttpApiProblem {
     error!("{} action has already been done", action);
-    HttpApiProblem::new("action-already-done").set_status(400)
+    HttpApiProblem::new("action-already-done").set_status(409)
 }
 
 pub fn invalid_action(action: Action) -> HttpApiProblem {
     error!("{} action is invalid for this swap", action);
-    HttpApiProblem::new("invalid-action").set_status(404)
+    HttpApiProblem::new("invalid-action").set_status(400)
 }
 
 impl From<state_store::Error> for HttpApiProblem {

--- a/application/comit_node/src/http_api/rfc003/action.rs
+++ b/application/comit_node/src/http_api/rfc003/action.rs
@@ -73,6 +73,12 @@ impl FromStr for Action {
     }
 }
 
+impl From<Action> for String {
+    fn from(action: Action) -> Self {
+        action.to_string()
+    }
+}
+
 impl Display for Action {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         let s = match self {
@@ -87,7 +93,7 @@ impl Display for Action {
     }
 }
 
-pub fn new_hal_link(id: &SwapId, action: Action) -> HalLink {
+pub fn new_action_link(id: &SwapId, action: Action) -> HalLink {
     let route = format!("{}/{}", swap_path(*id), action);
     route.into()
 }

--- a/application/comit_node/src/http_api/rfc003/action.rs
+++ b/application/comit_node/src/http_api/rfc003/action.rs
@@ -5,7 +5,7 @@ use crate::{
         SwapId,
     },
 };
-use rustic_hal::HalResource;
+use rustic_hal::HalLink;
 use std::{
     fmt::{Display, Formatter},
     str::FromStr,
@@ -87,16 +87,7 @@ impl Display for Action {
     }
 }
 
-// SwapId may not be the right type to use here
-pub trait AddLinks<T> {
-    fn add_links(&mut self, id: &SwapId, links: Vec<T>);
-}
-
-impl AddLinks<Action> for HalResource {
-    fn add_links(&mut self, id: &SwapId, actions: Vec<Action>) {
-        for action in actions {
-            let route = format!("{}/{}", swap_path(*id), action);
-            self.with_link(action.to_string(), route);
-        }
-    }
+pub fn new_hal_link(id: &SwapId, action: Action) -> HalLink {
+    let route = format!("{}/{}", swap_path(*id), action);
+    route.into()
 }

--- a/application/comit_node/src/http_api/rfc003/action.rs
+++ b/application/comit_node/src/http_api/rfc003/action.rs
@@ -1,0 +1,102 @@
+use crate::{
+    http_api::route_factory::swap_path,
+    swap_protocols::{
+        rfc003::{alice, bob},
+        SwapId,
+    },
+};
+use rustic_hal::HalResource;
+use std::{
+    fmt::{Display, Formatter},
+    str::FromStr,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Action {
+    Accept,
+    Decline,
+    Fund,
+    Deploy,
+    Redeem,
+    Refund,
+}
+
+// This should probably live one level up
+pub trait ToAction {
+    fn to_action(&self) -> Action;
+}
+
+impl<Deploy, Fund, Redeem, Refund> ToAction for alice::ActionKind<Deploy, Fund, Redeem, Refund> {
+    fn to_action(&self) -> Action {
+        use self::alice::ActionKind::*;
+        match *self {
+            Deploy(_) => Action::Deploy,
+            Fund(_) => Action::Fund,
+            Redeem(_) => Action::Redeem,
+            Refund(_) => Action::Refund,
+        }
+    }
+}
+
+impl<Accept, Decline, Deploy, Fund, Redeem, Refund> ToAction
+    for bob::ActionKind<Accept, Decline, Deploy, Fund, Redeem, Refund>
+{
+    fn to_action(&self) -> Action {
+        use self::bob::ActionKind::*;
+        match *self {
+            Accept(_) => Action::Accept,
+            Decline(_) => Action::Decline,
+            Deploy(_) => Action::Deploy,
+            Fund(_) => Action::Fund,
+            Redeem(_) => Action::Redeem,
+            Refund(_) => Action::Refund,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct UnknownAction(String);
+
+impl FromStr for Action {
+    type Err = UnknownAction;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "accept" => Action::Accept,
+            "decline" => Action::Decline,
+            "fund" => Action::Fund,
+            "deploy" => Action::Deploy,
+            "redeem" => Action::Redeem,
+            "refund" => Action::Refund,
+            s => return Err(UnknownAction(s.to_string())),
+        })
+    }
+}
+
+impl Display for Action {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        let s = match self {
+            Action::Accept => "accept",
+            Action::Decline => "decline",
+            Action::Fund => "fund",
+            Action::Deploy => "deploy",
+            Action::Redeem => "redeem",
+            Action::Refund => "refund",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+// SwapId may not be the right type to use here
+pub trait AddLinks<T> {
+    fn add_links(&mut self, id: &SwapId, links: Vec<T>);
+}
+
+impl AddLinks<Action> for HalResource {
+    fn add_links(&mut self, id: &SwapId, actions: Vec<Action>) {
+        for action in actions {
+            let route = format!("{}/{}", swap_path(*id), action);
+            self.with_link(action.to_string(), route);
+        }
+    }
+}

--- a/application/comit_node/src/http_api/rfc003/handlers/get_action.rs
+++ b/application/comit_node/src/http_api/rfc003/handlers/get_action.rs
@@ -53,10 +53,7 @@ pub fn handle_get_action<T: MetadataStore<SwapId>, S: StateStore>(
                         None
                     }
                 })
-                .unwrap_or_else(|| {
-                    Err(HttpApiProblem::with_title_and_type_from_status(400)
-                        .set_detail("Requested action is not supported for this swap"))
-                })
+                .unwrap_or_else(|| Err(problem::invalid_action(action)))
         })
     )
 }

--- a/application/comit_node/src/http_api/rfc003/handlers/get_swap.rs
+++ b/application/comit_node/src/http_api/rfc003/handlers/get_swap.rs
@@ -151,7 +151,7 @@ pub enum HtlcState {
 }
 
 impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> SwapParameters<AL, BL, AA, BA> {
-    fn new(request: rfc003::messages::Request<AL, BL, AA, BA>) -> Self {
+    pub fn new(request: rfc003::messages::Request<AL, BL, AA, BA>) -> Self {
         Self {
             alpha_ledger: Http(request.alpha_ledger),
             alpha_asset: Http(request.alpha_asset),

--- a/application/comit_node/src/http_api/rfc003/handlers/get_swaps.rs
+++ b/application/comit_node/src/http_api/rfc003/handlers/get_swaps.rs
@@ -1,23 +1,32 @@
 use crate::{
     http_api::{
-        rfc003::handlers::get_swap::SwapStatus,
+        rfc003::handlers::get_swap::{SwapParameters, SwapStatus},
         route_factory::{swap_path, RFC003},
+        Http,
     },
     swap_protocols::{
         ledger::{Bitcoin, Ethereum},
         metadata_store::RoleKind,
-        rfc003::state_store::StateStore,
+        rfc003::{state_store::StateStore, Ledger},
         Metadata, MetadataStore, SwapId,
     },
 };
 use ethereum_support::Erc20Token;
 use http_api_problem::HttpApiProblem;
 use rustic_hal::HalResource;
+use serde::Serialize;
 
 #[derive(Serialize, Debug)]
-pub struct EmbeddedSwapResource {
+#[serde(
+    bound = "Http<AL>: Serialize, Http<BL>: Serialize, Http<AA>: Serialize, Http<BA>: Serialize,\
+             Http<AL::Identity>: Serialize, Http<BL::Identity>: Serialize,\
+             Http<AL::HtlcLocation>: Serialize, Http<BL::HtlcLocation>: Serialize,\
+             Http<AL::Transaction>: Serialize, Http<BL::Transaction>: Serialize"
+)]
+pub struct EmbeddedSwapResource<AL: Ledger, BL: Ledger, AA, BA> {
     status: SwapStatus,
     protocol: String,
+    parameters: SwapParameters<AL, BL, AA, BA>,
 }
 
 pub fn handle_get_swaps<T: MetadataStore<SwapId>, S: StateStore>(
@@ -37,6 +46,7 @@ pub fn handle_get_swaps<T: MetadataStore<SwapId>, S: StateStore>(
                         let communication = state.swap_communication.clone().into();
                         let alpha_ledger = state.alpha_ledger_state.clone().into();
                         let beta_ledger = state.beta_ledger_state.clone().into();
+                        let parameters = SwapParameters::new(state.clone().request());
                         let error = state.error;
                         let status = SwapStatus::new::<AL, BL>(
                             &communication,
@@ -48,6 +58,7 @@ pub fn handle_get_swaps<T: MetadataStore<SwapId>, S: StateStore>(
                         let swap = EmbeddedSwapResource {
                             status,
                             protocol: RFC003.into(),
+                            parameters,
                         };
 
                         let mut hal_resource = HalResource::new(swap);

--- a/application/comit_node/src/http_api/rfc003/handlers/get_swaps.rs
+++ b/application/comit_node/src/http_api/rfc003/handlers/get_swaps.rs
@@ -1,7 +1,7 @@
 use crate::{
     http_api::{
         rfc003::{
-            action::{Action, AddLinks, ToAction},
+            action::{new_hal_link, Action, ToAction},
             handlers::get_swap::{SwapParameters, SwapStatus},
         },
         route_factory::{swap_path, RFC003},
@@ -72,7 +72,10 @@ pub fn handle_get_swaps<T: MetadataStore<SwapId>, S: StateStore>(
                         let mut hal_resource = HalResource::new(swap);
                         hal_resource.with_link("self", swap_path(id));
 
-                        hal_resource.add_links(&id, actions);
+                        for action in actions {
+                            let link = new_hal_link(&id, action);
+                            hal_resource.with_link(action.to_string(), link);
+                        }
 
                         resources.push(hal_resource);
                     }

--- a/application/comit_node/src/http_api/rfc003/handlers/get_swaps.rs
+++ b/application/comit_node/src/http_api/rfc003/handlers/get_swaps.rs
@@ -1,7 +1,7 @@
 use crate::{
     http_api::{
         rfc003::{
-            action::{new_hal_link, Action, ToAction},
+            action::{new_action_link, Action, ToAction},
             handlers::get_swap::{SwapParameters, SwapStatus},
         },
         route_factory::{swap_path, RFC003},
@@ -73,8 +73,8 @@ pub fn handle_get_swaps<T: MetadataStore<SwapId>, S: StateStore>(
                         hal_resource.with_link("self", swap_path(id));
 
                         for action in actions {
-                            let link = new_hal_link(&id, action);
-                            hal_resource.with_link(action.to_string(), link);
+                            let link = new_action_link(&id, action);
+                            hal_resource.with_link(action, link);
                         }
 
                         resources.push(hal_resource);

--- a/application/comit_node/src/http_api/rfc003/handlers/mod.rs
+++ b/application/comit_node/src/http_api/rfc003/handlers/mod.rs
@@ -5,7 +5,7 @@ mod post_action;
 mod post_swap;
 
 pub use self::{
-    get_action::{handle_get_action, GetAction, GetActionQueryParams},
+    get_action::{handle_get_action, GetActionQueryParams},
     get_swap::handle_get_swap,
     get_swaps::handle_get_swaps,
     post_action::{handle_post_action, PostAction},

--- a/application/comit_node/src/http_api/rfc003/handlers/mod.rs
+++ b/application/comit_node/src/http_api/rfc003/handlers/mod.rs
@@ -8,6 +8,6 @@ pub use self::{
     get_action::{handle_get_action, GetActionQueryParams},
     get_swap::handle_get_swap,
     get_swaps::handle_get_swaps,
-    post_action::{handle_post_action, PostAction},
+    post_action::handle_post_action,
     post_swap::{handle_post_swap, SwapRequestBodyKind},
 };

--- a/application/comit_node/src/http_api/rfc003/mod.rs
+++ b/application/comit_node/src/http_api/rfc003/mod.rs
@@ -1,6 +1,7 @@
 mod socket_addr;
 #[macro_use]
 mod with_swap_types;
+pub mod action;
 pub mod handlers;
 pub mod routes;
 

--- a/application/comit_node/src/http_api/rfc003/routes.rs
+++ b/application/comit_node/src/http_api/rfc003/routes.rs
@@ -1,4 +1,4 @@
-pub use crate::http_api::rfc003::handlers::{GetActionQueryParams, PostAction};
+pub use crate::http_api::rfc003::handlers::GetActionQueryParams;
 use crate::{
     http_api::{
         problem::HttpApiProblemStdError,
@@ -75,7 +75,7 @@ pub fn post_action<T: MetadataStore<SwapId>, S: StateStore>(
     metadata_store: Arc<T>,
     state_store: Arc<S>,
     id: SwapId,
-    action: PostAction,
+    action: Action,
     body: serde_json::Value,
 ) -> Result<impl Reply, Rejection> {
     handle_post_action(

--- a/application/comit_node/src/http_api/rfc003/routes.rs
+++ b/application/comit_node/src/http_api/rfc003/routes.rs
@@ -1,10 +1,13 @@
-pub use crate::http_api::rfc003::handlers::{GetAction, GetActionQueryParams, PostAction};
+pub use crate::http_api::rfc003::handlers::{GetActionQueryParams, PostAction};
 use crate::{
     http_api::{
         problem::HttpApiProblemStdError,
-        rfc003::handlers::{
-            handle_get_action, handle_get_swap, handle_get_swaps, handle_post_action,
-            handle_post_swap, SwapRequestBodyKind,
+        rfc003::{
+            action::{Action, AddLinks},
+            handlers::{
+                handle_get_action, handle_get_swap, handle_get_swaps, handle_post_action,
+                handle_post_swap, SwapRequestBodyKind,
+            },
         },
         route_factory::swap_path,
     },
@@ -47,10 +50,7 @@ pub fn get_swap<T: MetadataStore<SwapId>, S: StateStore>(
     handle_get_swap(&metadata_store, &state_store, id)
         .map(|(swap_resource, actions)| {
             let mut response = HalResource::new(swap_resource);
-            for action in actions {
-                let route = format!("{}/{}", swap_path(id), action);
-                response.with_link(action, route);
-            }
+            response.add_links(&id, actions);
             Ok(warp::reply::json(&response))
         })
         .map_err(into_rejection)
@@ -94,7 +94,7 @@ pub fn get_action<T: MetadataStore<SwapId>, S: StateStore>(
     metadata_store: Arc<T>,
     state_store: Arc<S>,
     id: SwapId,
-    action: GetAction,
+    action: Action,
     query_params: GetActionQueryParams,
 ) -> Result<impl Reply, Rejection> {
     handle_get_action(

--- a/application/comit_node/src/http_api/rfc003/routes.rs
+++ b/application/comit_node/src/http_api/rfc003/routes.rs
@@ -3,7 +3,7 @@ use crate::{
     http_api::{
         problem::HttpApiProblemStdError,
         rfc003::{
-            action::{Action, AddLinks},
+            action::{new_hal_link, Action},
             handlers::{
                 handle_get_action, handle_get_swap, handle_get_swaps, handle_post_action,
                 handle_post_swap, SwapRequestBodyKind,
@@ -50,7 +50,11 @@ pub fn get_swap<T: MetadataStore<SwapId>, S: StateStore>(
     handle_get_swap(&metadata_store, &state_store, id)
         .map(|(swap_resource, actions)| {
             let mut response = HalResource::new(swap_resource);
-            response.add_links(&id, actions);
+            for action in actions {
+                let link = new_hal_link(&id, action);
+                response.with_link(action.to_string(), link);
+            }
+
             Ok(warp::reply::json(&response))
         })
         .map_err(into_rejection)

--- a/application/comit_node/src/http_api/rfc003/routes.rs
+++ b/application/comit_node/src/http_api/rfc003/routes.rs
@@ -3,7 +3,7 @@ use crate::{
     http_api::{
         problem::HttpApiProblemStdError,
         rfc003::{
-            action::{new_hal_link, Action},
+            action::{new_action_link, Action},
             handlers::{
                 handle_get_action, handle_get_swap, handle_get_swaps, handle_post_action,
                 handle_post_swap, SwapRequestBodyKind,
@@ -51,8 +51,8 @@ pub fn get_swap<T: MetadataStore<SwapId>, S: StateStore>(
         .map(|(swap_resource, actions)| {
             let mut response = HalResource::new(swap_resource);
             for action in actions {
-                let link = new_hal_link(&id, action);
-                response.with_link(action.to_string(), link);
+                let link = new_action_link(&id, action);
+                response.with_link(action, link);
             }
 
             Ok(warp::reply::json(&response))

--- a/application/comit_node/src/http_api/route_factory.rs
+++ b/application/comit_node/src/http_api/route_factory.rs
@@ -61,7 +61,7 @@ pub fn create<T: MetadataStore<SwapId>, S: state_store::StateStore>(
         .and(metadata_store.clone())
         .and(state_store.clone())
         .and(warp::path::param::<SwapId>())
-        .and(warp::path::param::<http_api::rfc003::routes::GetAction>())
+        .and(warp::path::param::<http_api::rfc003::action::Action>())
         .and(warp::query::<GetActionQueryParams>())
         .and(warp::get2())
         .and(warp::path::end())

--- a/application/comit_node/src/http_api/route_factory.rs
+++ b/application/comit_node/src/http_api/route_factory.rs
@@ -51,7 +51,7 @@ pub fn create<T: MetadataStore<SwapId>, S: state_store::StateStore>(
         .and(metadata_store.clone())
         .and(state_store.clone())
         .and(warp::path::param::<SwapId>())
-        .and(warp::path::param::<http_api::rfc003::routes::PostAction>())
+        .and(warp::path::param::<http_api::rfc003::action::Action>())
         .and(warp::post2())
         .and(warp::path::end())
         .and(warp::body::json().or(empty_json_body).unify())

--- a/application/comit_node/src/swap_protocols/rfc003/alice/actions/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/alice/actions/mod.rs
@@ -10,15 +10,3 @@ pub enum ActionKind<Deploy, Fund, Redeem, Refund> {
     Redeem(Redeem),
     Refund(Refund),
 }
-
-impl<Deploy, Fund, Redeem, Refund> ActionKind<Deploy, Fund, Redeem, Refund> {
-    pub fn name(&self) -> String {
-        use self::ActionKind::*;
-        match *self {
-            Deploy(_) => String::from("deploy"),
-            Fund(_) => String::from("fund"),
-            Redeem(_) => String::from("redeem"),
-            Refund(_) => String::from("refund"),
-        }
-    }
-}

--- a/application/comit_node/src/swap_protocols/rfc003/bob/actions/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/bob/actions/mod.rs
@@ -21,22 +21,6 @@ pub enum ActionKind<Accept, Decline, Deploy, Fund, Redeem, Refund> {
     Refund(Refund),
 }
 
-impl<Accept, Decline, Deploy, Fund, Redeem, Refund>
-    ActionKind<Accept, Decline, Deploy, Fund, Redeem, Refund>
-{
-    pub fn name(&self) -> String {
-        use self::ActionKind::*;
-        match *self {
-            Accept(_) => String::from("accept"),
-            Decline(_) => String::from("decline"),
-            Deploy(_) => String::from("deploy"),
-            Fund(_) => String::from("fund"),
-            Redeem(_) => String::from("redeem"),
-            Refund(_) => String::from("refund"),
-        }
-    }
-}
-
 #[derive(Clone)]
 #[allow(missing_debug_implementations)]
 pub struct Accept<AL: Ledger, BL: Ledger> {


### PR DESCRIPTION
Add parameters and actions to `GET swapS` response.
Also "fix" tests to test for type (using `===`).

Resolves #776 