### PR TITLE
Use more-concise prettier configuration

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -115,7 +115,7 @@ workspace = false
 install_script = ["[[ -f ./api_tests/node_modules/.bin/prettier ]] || (cd ./api_tests; yarn install;)"]
 script = [
 '''
-find . -not -path '*/node_modules/*' -name '*.js' | xargs ./api_tests/node_modules/.bin/prettier --write
+(cd api_tests; yarn run prettier --write '**/*.js')
 '''
 ]
 
@@ -125,7 +125,7 @@ workspace = false
 install_script = ["[[ -f ./api_tests/node_modules/.bin/prettier ]] || (cd ./api_tests; yarn install;)"]
 script = [
 '''
-find . -not -path '*/node_modules/*' -name '*.js' | xargs ./api_tests/node_modules/.bin/prettier -l
+(cd api_tests; yarn run prettier --check '**/*.js')
 '''
 ]
 

--- a/api_tests/yarn.lock
+++ b/api_tests/yarn.lock
@@ -2157,9 +2157,9 @@ prepend-http@^1.0.1:
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
 prettier@^1.15.2:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.2.tgz#d31abe22afa4351efa14c7f8b94b58bb7452205e"
-  integrity sha512-YgPLFFA0CdKL4Eg2IHtUSjzj/BWgszDHiNQAe0VAIBse34148whfdzLagRL+QiKS+YfK5ftB6X4v/MBw8yCoug==
+  version "1.16.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
+  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
 
 process-nextick-args@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Prettier ignores node_modules by default so we can just pass a
glob string for all .js files to it.