### PR TITLE
Verify Bitcoin redeem transaction using transaction ID

### DIFF
--- a/api_tests/e2e/rfc003/btc_eth-erc20/test.js
+++ b/api_tests/e2e/rfc003/btc_eth-erc20/test.js
@@ -8,7 +8,6 @@ const ethereum = require("../../../lib/ethereum.js");
 const should = chai.should();
 const wallet = require("../../../lib/wallet.js");
 const sb = require("satoshi-bitcoin");
-const logger = global.harness.logger;
 
 const toby_wallet = wallet.create();
 
@@ -98,7 +97,6 @@ describe("RFC003: Bitcoin for ERC20", () => {
 
         res.should.have.status(201);
         swap_location = res.headers.location;
-        logger.info("Alice created a new swap at %s", swap_location);
         swap_location.should.be.a("string");
         alice_swap_href = swap_location;
     });
@@ -130,7 +128,6 @@ describe("RFC003: Bitcoin for ERC20", () => {
         swap_link.should.be.a("object");
         bob_swap_href = swap_link.self.href;
         bob_swap_href.should.be.a("string");
-        logger.info("Bob discovered a new swap at %s", bob_swap_href);
     });
 
     let bob_accept_href;
@@ -150,12 +147,6 @@ describe("RFC003: Bitcoin for ERC20", () => {
             beta_ledger_refund_identity: bob.wallet.eth().address(),
             alpha_ledger_redeem_identity: null,
         };
-
-        logger.info(
-            "Bob is accepting the swap via %s with the following parameters",
-            bob_accept_href,
-            bob_response
-        );
 
         let accept_res = await chai
             .request(bob.comit_node_url())
@@ -180,11 +171,6 @@ describe("RFC003: Bitcoin for ERC20", () => {
             .get(alice_fund_href);
         res.should.have.status(200);
         alice_fund_action = res.body;
-
-        logger.info(
-            "Alice retrieved the following funding parameters",
-            alice_fund_action
-        );
     });
 
     it("[Alice] Can execute the fund action", async () => {
@@ -209,11 +195,6 @@ describe("RFC003: Bitcoin for ERC20", () => {
         let res = await chai.request(bob.comit_node_url()).get(bob_deploy_href);
         res.should.have.status(200);
         bob_deploy_action = res.body;
-
-        logger.info(
-            "Bob retrieved the following deployment parameters",
-            bob_deploy_action
-        );
     });
 
     it("[Bob] Can execute the deploy action", async () => {
@@ -240,11 +221,6 @@ describe("RFC003: Bitcoin for ERC20", () => {
         let res = await chai.request(bob.comit_node_url()).get(bob_fund_href);
         res.should.have.status(200);
         bob_fund_action = res.body;
-
-        logger.info(
-            "Bob retrieved the following funding parameters",
-            bob_fund_action
-        );
     });
 
     it("[Bob] Can execute the fund action", async () => {
@@ -274,11 +250,6 @@ describe("RFC003: Bitcoin for ERC20", () => {
             .get(alice_redeem_href);
         res.should.have.status(200);
         alice_redeem_action = res.body;
-
-        logger.info(
-            "Alice retrieved the following redeem parameters",
-            alice_redeem_action
-        );
     });
 
     let alice_erc20_balance_before;
@@ -331,11 +302,6 @@ describe("RFC003: Bitcoin for ERC20", () => {
             );
         res.should.have.status(200);
         bob_redeem_action = res.body;
-
-        logger.info(
-            "Bob retrieved the following redeem parameters",
-            bob_redeem_action
-        );
     });
 
     it("[Bob] Can execute the redeem action", async function() {

--- a/api_tests/e2e/rfc003/btc_eth-erc20/test.js
+++ b/api_tests/e2e/rfc003/btc_eth-erc20/test.js
@@ -314,7 +314,7 @@ describe("RFC003: Bitcoin for ERC20", () => {
         let body = await bob.poll_comit_node_until(
             chai,
             bob_swap_href,
-            body => body.state.alpha_ledger.status == "Redeemed"
+            body => body.state.alpha_ledger.status === "Redeemed"
         );
         let bob_redeem_txid = body.state.alpha_ledger.redeem_tx;
 

--- a/api_tests/e2e/rfc003/btc_eth-erc20/test.js
+++ b/api_tests/e2e/rfc003/btc_eth-erc20/test.js
@@ -318,7 +318,7 @@ describe("RFC003: Bitcoin for ERC20", () => {
         );
         let bob_redeem_txid = body.state.alpha_ledger.redeem_tx;
 
-        let bob_satoshi_received = await bitcoin.get_satoshi_transferred_to(
+        let bob_satoshi_received = await bitcoin.get_first_utxo_value_transferred_to(
             bob_redeem_txid,
             bob_final_address
         );

--- a/api_tests/e2e/rfc003/btc_eth-erc20/test.js
+++ b/api_tests/e2e/rfc003/btc_eth-erc20/test.js
@@ -22,8 +22,8 @@ const bob_final_address =
     "bcrt1qs2aderg3whgu0m8uadn6dwxjf7j3wx97kk2qqtrum89pmfcxknhsf89pj0";
 const bob_comit_node_address = bob.config.comit.comit_listen;
 
-const alpha_asset_amount = 100000000;
-const beta_asset_amount = BigInt(Web3.utils.toWei("5000", "ether"));
+const alpha_asset_quantity = 100000000;
+const beta_asset_quantity = BigInt(Web3.utils.toWei("5000", "ether"));
 const alpha_max_fee = 5000; // Max 5000 satoshis fee
 
 const alpha_expiry = new Date("2080-06-11T23:00:00Z").getTime() / 1000;
@@ -81,11 +81,11 @@ describe("RFC003: Bitcoin for ERC20", () => {
                 },
                 alpha_asset: {
                     name: "Bitcoin",
-                    quantity: alpha_asset_amount.toString(),
+                    quantity: alpha_asset_quantity.toString(),
                 },
                 beta_asset: {
                     name: "ERC20",
-                    quantity: beta_asset_amount.toString(),
+                    quantity: beta_asset_quantity.toString(),
                     token_contract: token_contract_address,
                 },
                 beta_ledger_redeem_identity: alice_final_address,
@@ -275,7 +275,7 @@ describe("RFC003: Bitcoin for ERC20", () => {
         );
 
         let alice_erc20_balance_expected =
-            alice_erc20_balance_before + beta_asset_amount;
+            alice_erc20_balance_before + beta_asset_quantity;
         alice_erc20_balance_after
             .toString()
             .should.equal(alice_erc20_balance_expected.toString());
@@ -322,7 +322,7 @@ describe("RFC003: Bitcoin for ERC20", () => {
             bob_redeem_txid,
             bob_final_address
         );
-        const bob_satoshi_expected = alpha_asset_amount - alpha_max_fee;
+        const bob_satoshi_expected = alpha_asset_quantity - alpha_max_fee;
 
         bob_satoshi_received.should.be.at.least(bob_satoshi_expected);
     });

--- a/api_tests/e2e/rfc003/btc_eth-erc20/test.js
+++ b/api_tests/e2e/rfc003/btc_eth-erc20/test.js
@@ -318,7 +318,7 @@ describe("RFC003: Bitcoin for ERC20", () => {
         );
         let bob_redeem_txid = body.state.alpha_ledger.redeem_tx;
 
-        let bob_satoshi_received = await bitcoin.getSatoshiTransferredTo(
+        let bob_satoshi_received = await bitcoin.get_satoshi_transferred_to(
             bob_redeem_txid,
             bob_final_address
         );

--- a/api_tests/e2e/rfc003/btc_eth-erc20/test.js
+++ b/api_tests/e2e/rfc003/btc_eth-erc20/test.js
@@ -7,7 +7,6 @@ const ethutil = require("ethereumjs-util");
 const ethereum = require("../../../lib/ethereum.js");
 const should = chai.should();
 const wallet = require("../../../lib/wallet.js");
-const sb = require("satoshi-bitcoin");
 
 const toby_wallet = wallet.create();
 
@@ -318,13 +317,13 @@ describe("RFC003: Bitcoin for ERC20", () => {
             body => body.state.alpha_ledger.status == "Redeemed"
         );
         let bob_redeem_txid = body.state.alpha_ledger.redeem_tx;
-        let bob_redeem_tx = await bitcoin.getRawTransaction(bob_redeem_txid);
 
-        let receive_address = bob_redeem_tx.vout[0].scriptPubKey.addresses[0];
-        receive_address.should.be.equal(bob_final_address);
-
+        let bob_satoshi_received = await bitcoin.getSatoshiTransferredTo(
+            bob_redeem_txid,
+            bob_final_address
+        );
         const bob_satoshi_expected = alpha_asset_amount - alpha_max_fee;
-        let bob_satoshi_received = sb.toSatoshi(bob_redeem_tx.vout[0].value);
+
         bob_satoshi_received.should.be.at.least(bob_satoshi_expected);
     });
 });

--- a/api_tests/e2e/rfc003/btc_eth/test.js
+++ b/api_tests/e2e/rfc003/btc_eth/test.js
@@ -7,7 +7,6 @@ const actor = require("../../../lib/actor.js");
 const should = chai.should();
 const ethutil = require("ethereumjs-util");
 const sb = require("satoshi-bitcoin");
-const logger = global.harness.logger;
 
 const bob_initial_eth = "11";
 const alice_initial_eth = "0.1";
@@ -69,7 +68,6 @@ describe("RFC003: Bitcoin for Ether", () => {
             .then(res => {
                 res.should.have.status(201);
                 swap_location = res.headers.location;
-                logger.info("Alice created a new swap at %s", swap_location);
                 swap_location.should.be.a("string");
                 alice_swap_href = swap_location;
             });
@@ -102,8 +100,6 @@ describe("RFC003: Bitcoin for Ether", () => {
         swap_link.should.be.a("object");
         bob_swap_href = swap_link.self.href;
         bob_swap_href.should.be.a("string");
-
-        logger.info("Bob discovered a new swap at %s", bob_swap_href);
     });
 
     let bob_accept_href;
@@ -123,12 +119,6 @@ describe("RFC003: Bitcoin for Ether", () => {
             beta_ledger_refund_identity: bob.wallet.eth().address(),
             alpha_ledger_redeem_identity: null,
         };
-
-        logger.info(
-            "Bob is accepting the swap via %s with the following parameters",
-            bob_accept_href,
-            bob_response
-        );
 
         let accept_res = await chai
             .request(bob.comit_node_url())
@@ -153,11 +143,6 @@ describe("RFC003: Bitcoin for Ether", () => {
             .get(alice_fund_href);
         res.should.have.status(200);
         alice_fund_action = res.body;
-
-        logger.info(
-            "Alice retrieved the following funding parameters",
-            alice_fund_action
-        );
     });
 
     it("[Alice] Can execute the fund action", async function() {
@@ -186,11 +171,6 @@ describe("RFC003: Bitcoin for Ether", () => {
         let res = await chai.request(bob.comit_node_url()).get(bob_fund_href);
         res.should.have.status(200);
         bob_fund_action = res.body;
-
-        logger.info(
-            "Bob retrieved the following funding parameters",
-            bob_fund_action
-        );
     });
 
     it("[Bob] Can execute the fund action", async () => {
@@ -218,11 +198,6 @@ describe("RFC003: Bitcoin for Ether", () => {
             .get(alice_redeem_href);
         res.should.have.status(200);
         alice_redeem_action = res.body;
-
-        logger.info(
-            "Alice retrieved the following redeem parameters",
-            alice_redeem_action
-        );
     });
 
     let alice_eth_balance_before;
@@ -274,11 +249,6 @@ describe("RFC003: Bitcoin for Ether", () => {
             );
         res.should.have.status(200);
         bob_redeem_action = res.body;
-
-        logger.info(
-            "Bob retrieved the following redeem parameters",
-            bob_redeem_action
-        );
     });
 
     it("[Bob] Can execute the redeem action", async function() {

--- a/api_tests/e2e/rfc003/btc_eth/test.js
+++ b/api_tests/e2e/rfc003/btc_eth/test.js
@@ -266,7 +266,7 @@ describe("RFC003: Bitcoin for Ether", () => {
         );
         let bob_redeem_txid = body.state.alpha_ledger.redeem_tx;
 
-        let bob_satoshi_received = await bitcoin.get_satoshi_transferred_to(
+        let bob_satoshi_received = await bitcoin.get_first_utxo_value_transferred_to(
             bob_redeem_txid,
             bob_final_address
         );

--- a/api_tests/e2e/rfc003/btc_eth/test.js
+++ b/api_tests/e2e/rfc003/btc_eth/test.js
@@ -6,7 +6,6 @@ const Web3 = require("web3");
 const actor = require("../../../lib/actor.js");
 const should = chai.should();
 const ethutil = require("ethereumjs-util");
-const sb = require("satoshi-bitcoin");
 
 const bob_initial_eth = "11";
 const alice_initial_eth = "0.1";
@@ -266,13 +265,13 @@ describe("RFC003: Bitcoin for Ether", () => {
             body => body.state.alpha_ledger.status == "Redeemed"
         );
         let bob_redeem_txid = body.state.alpha_ledger.redeem_tx;
-        let bob_redeem_tx = await bitcoin.getRawTransaction(bob_redeem_txid);
 
-        let receive_address = bob_redeem_tx.vout[0].scriptPubKey.addresses[0];
-        receive_address.should.be.equal(bob_final_address);
-
+        let bob_satoshi_received = await bitcoin.getSatoshiTransferredTo(
+            bob_redeem_txid,
+            bob_final_address
+        );
         const bob_satoshi_expected = alpha_asset_amount - alpha_max_fee;
-        let bob_satoshi_received = sb.toSatoshi(bob_redeem_tx.vout[0].value);
+
         bob_satoshi_received.should.be.at.least(bob_satoshi_expected);
     });
 });

--- a/api_tests/e2e/rfc003/btc_eth/test.js
+++ b/api_tests/e2e/rfc003/btc_eth/test.js
@@ -266,7 +266,7 @@ describe("RFC003: Bitcoin for Ether", () => {
         );
         let bob_redeem_txid = body.state.alpha_ledger.redeem_tx;
 
-        let bob_satoshi_received = await bitcoin.getSatoshiTransferredTo(
+        let bob_satoshi_received = await bitcoin.get_satoshi_transferred_to(
             bob_redeem_txid,
             bob_final_address
         );

--- a/api_tests/e2e/rfc003/btc_eth/test.js
+++ b/api_tests/e2e/rfc003/btc_eth/test.js
@@ -18,8 +18,8 @@ const bob_final_address =
     "bcrt1qs2aderg3whgu0m8uadn6dwxjf7j3wx97kk2qqtrum89pmfcxknhsf89pj0";
 const bob_comit_node_address = bob.config.comit.comit_listen;
 
-const alpha_asset_amount = 100000000;
-const beta_asset_amount = BigInt(Web3.utils.toWei("10", "ether"));
+const alpha_asset_quantity = 100000000;
+const beta_asset_quantity = BigInt(Web3.utils.toWei("10", "ether"));
 const alpha_max_fee = 5000; // Max 5000 satoshis fee
 
 const alpha_expiry = new Date("2080-06-11T23:00:00Z").getTime() / 1000;
@@ -53,11 +53,11 @@ describe("RFC003: Bitcoin for Ether", () => {
                 },
                 alpha_asset: {
                     name: "Bitcoin",
-                    quantity: alpha_asset_amount.toString(),
+                    quantity: alpha_asset_quantity.toString(),
                 },
                 beta_asset: {
                     name: "Ether",
-                    quantity: beta_asset_amount.toString(),
+                    quantity: beta_asset_quantity.toString(),
                 },
                 beta_ledger_redeem_identity: alice_final_address,
                 alpha_expiry: alpha_expiry,
@@ -221,7 +221,7 @@ describe("RFC003: Bitcoin for Ether", () => {
         );
 
         let alice_eth_balance_expected =
-            alice_eth_balance_before + beta_asset_amount;
+            alice_eth_balance_before + beta_asset_quantity;
 
         alice_eth_balance_after
             .toString()
@@ -270,7 +270,7 @@ describe("RFC003: Bitcoin for Ether", () => {
             bob_redeem_txid,
             bob_final_address
         );
-        const bob_satoshi_expected = alpha_asset_amount - alpha_max_fee;
+        const bob_satoshi_expected = alpha_asset_quantity - alpha_max_fee;
 
         bob_satoshi_received.should.be.at.least(bob_satoshi_expected);
     });

--- a/api_tests/e2e/rfc003/btc_eth/test.js
+++ b/api_tests/e2e/rfc003/btc_eth/test.js
@@ -262,7 +262,7 @@ describe("RFC003: Bitcoin for Ether", () => {
         let body = await bob.poll_comit_node_until(
             chai,
             bob_swap_href,
-            body => body.state.alpha_ledger.status == "Redeemed"
+            body => body.state.alpha_ledger.status === "Redeemed"
         );
         let bob_redeem_txid = body.state.alpha_ledger.redeem_tx;
 

--- a/api_tests/e2e/rfc003/eth-erc20_btc/test.js
+++ b/api_tests/e2e/rfc003/eth-erc20_btc/test.js
@@ -268,7 +268,7 @@ describe("RFC003: ERC20 for Bitcoin", () => {
         let body = await alice.poll_comit_node_until(
             chai,
             alice_swap_href,
-            body => body.state.beta_ledger.status == "Redeemed"
+            body => body.state.beta_ledger.status === "Redeemed"
         );
         let alice_redeem_txid = body.state.beta_ledger.redeem_tx;
 

--- a/api_tests/e2e/rfc003/eth-erc20_btc/test.js
+++ b/api_tests/e2e/rfc003/eth-erc20_btc/test.js
@@ -6,7 +6,6 @@ const ethereum = require("../../../lib/ethereum.js");
 const bitcoin = require("../../../lib/bitcoin.js");
 const actor = require("../../../lib/actor.js");
 const should = chai.should();
-const sb = require("satoshi-bitcoin");
 
 const toby_wallet = wallet.create("toby");
 
@@ -272,17 +271,13 @@ describe("RFC003: ERC20 for Bitcoin", () => {
             body => body.state.beta_ledger.status == "Redeemed"
         );
         let alice_redeem_txid = body.state.beta_ledger.redeem_tx;
-        let alice_redeem_tx = await bitcoin.getRawTransaction(
-            alice_redeem_txid
+
+        let alice_satoshi_received = await bitcoin.getSatoshiTransferredTo(
+            alice_redeem_txid,
+            alice_final_address
         );
-
-        let receive_address = alice_redeem_tx.vout[0].scriptPubKey.addresses[0];
-        receive_address.should.be.equal(alice_final_address);
-
         const alice_satoshi_expected = beta_asset_amount - beta_max_fee;
-        let alice_satoshi_received = sb.toSatoshi(
-            alice_redeem_tx.vout[0].value
-        );
+
         alice_satoshi_received.should.be.at.least(alice_satoshi_expected);
     });
 

--- a/api_tests/e2e/rfc003/eth-erc20_btc/test.js
+++ b/api_tests/e2e/rfc003/eth-erc20_btc/test.js
@@ -272,7 +272,7 @@ describe("RFC003: ERC20 for Bitcoin", () => {
         );
         let alice_redeem_txid = body.state.beta_ledger.redeem_tx;
 
-        let alice_satoshi_received = await bitcoin.get_satoshi_transferred_to(
+        let alice_satoshi_received = await bitcoin.get_first_utxo_value_transferred_to(
             alice_redeem_txid,
             alice_final_address
         );

--- a/api_tests/e2e/rfc003/eth-erc20_btc/test.js
+++ b/api_tests/e2e/rfc003/eth-erc20_btc/test.js
@@ -20,9 +20,9 @@ const alice_final_address =
     "bcrt1qs2aderg3whgu0m8uadn6dwxjf7j3wx97kk2qqtrum89pmfcxknhsf89pj0";
 const bob_final_address = "0x00a329c0648769a73afac7f9381e08fb43dbea72";
 const bob_comit_node_address = bob.config.comit.comit_listen;
-const alpha_asset_amount = BigInt(Web3.utils.toWei("5000", "ether"));
+const alpha_asset_quantity = BigInt(Web3.utils.toWei("5000", "ether"));
 
-const beta_asset_amount = 100000000;
+const beta_asset_quantity = 100000000;
 const beta_max_fee = 5000; // Max 5000 satoshis fee
 const alpha_expiry = new Date("2080-06-11T23:00:00Z").getTime() / 1000;
 const beta_expiry = new Date("2080-06-11T13:00:00Z").getTime() / 1000;
@@ -79,12 +79,12 @@ describe("RFC003: ERC20 for Bitcoin", () => {
                 },
                 alpha_asset: {
                     name: "ERC20",
-                    quantity: alpha_asset_amount.toString(),
+                    quantity: alpha_asset_quantity.toString(),
                     token_contract: token_contract_address,
                 },
                 beta_asset: {
                     name: "Bitcoin",
-                    quantity: beta_asset_amount.toString(),
+                    quantity: beta_asset_quantity.toString(),
                 },
                 alpha_ledger_refund_identity: bob_final_address,
                 alpha_expiry: alpha_expiry,
@@ -276,7 +276,7 @@ describe("RFC003: ERC20 for Bitcoin", () => {
             alice_redeem_txid,
             alice_final_address
         );
-        const alice_satoshi_expected = beta_asset_amount - beta_max_fee;
+        const alice_satoshi_expected = beta_asset_quantity - beta_max_fee;
 
         alice_satoshi_received.should.be.at.least(alice_satoshi_expected);
     });
@@ -320,7 +320,7 @@ describe("RFC003: ERC20 for Bitcoin", () => {
         );
 
         let bob_erc20_balance_expected =
-            bob_erc20_balance_before + alpha_asset_amount;
+            bob_erc20_balance_before + alpha_asset_quantity;
 
         bob_erc20_balance_after
             .toString()

--- a/api_tests/e2e/rfc003/eth-erc20_btc/test.js
+++ b/api_tests/e2e/rfc003/eth-erc20_btc/test.js
@@ -272,7 +272,7 @@ describe("RFC003: ERC20 for Bitcoin", () => {
         );
         let alice_redeem_txid = body.state.beta_ledger.redeem_tx;
 
-        let alice_satoshi_received = await bitcoin.getSatoshiTransferredTo(
+        let alice_satoshi_received = await bitcoin.get_satoshi_transferred_to(
             alice_redeem_txid,
             alice_final_address
         );

--- a/api_tests/e2e/rfc003/eth-erc20_btc/test.js
+++ b/api_tests/e2e/rfc003/eth-erc20_btc/test.js
@@ -7,7 +7,6 @@ const bitcoin = require("../../../lib/bitcoin.js");
 const actor = require("../../../lib/actor.js");
 const should = chai.should();
 const sb = require("satoshi-bitcoin");
-const logger = global.harness.logger;
 
 const toby_wallet = wallet.create("toby");
 
@@ -96,7 +95,6 @@ describe("RFC003: ERC20 for Bitcoin", () => {
 
         res.should.have.status(201);
         swap_location = res.headers.location;
-        logger.info("Alice created a new swap at %s", swap_location);
         swap_location.should.be.a("string");
         alice_swap_href = swap_location;
     });
@@ -128,8 +126,6 @@ describe("RFC003: ERC20 for Bitcoin", () => {
         swap_link.should.be.a("object");
         bob_swap_href = swap_link.self.href;
         bob_swap_href.should.be.a("string");
-
-        logger.info("Bob discovered a new swap at %s", bob_swap_href);
     });
 
     let bob_accept_href;
@@ -149,12 +145,6 @@ describe("RFC003: ERC20 for Bitcoin", () => {
             beta_ledger_refund_identity: bob.wallet.eth().address(),
             alpha_ledger_redeem_identity: bob_final_address,
         };
-
-        logger.info(
-            "Bob is accepting the swap via %s with the following parameters",
-            bob_accept_href,
-            bob_response
-        );
 
         let accept_res = await chai
             .request(bob.comit_node_url())
@@ -179,11 +169,6 @@ describe("RFC003: ERC20 for Bitcoin", () => {
             .get(alice_deploy_href);
         res.should.have.status(200);
         alice_deploy_action = res.body;
-
-        logger.info(
-            "Alice retrieved the following deployment parameters",
-            alice_deploy_action
-        );
     });
 
     it("[Alice] Can execute the deploy action", async () => {
@@ -212,11 +197,6 @@ describe("RFC003: ERC20 for Bitcoin", () => {
             .get(alice_fund_href);
         res.should.have.status(200);
         alice_fund_action = res.body;
-
-        logger.info(
-            "Alice retrieved the following funding parameters",
-            alice_fund_action
-        );
     });
 
     it("[Alice] Can execute the fund action", async () => {
@@ -244,11 +224,6 @@ describe("RFC003: ERC20 for Bitcoin", () => {
         let res = await chai.request(bob.comit_node_url()).get(bob_fund_href);
         res.should.have.status(200);
         bob_fund_action = res.body;
-
-        logger.info(
-            "Bob retrieved the following funding parameters",
-            bob_fund_action
-        );
     });
 
     it("[Bob] Can execute the fund action", async () => {
@@ -281,11 +256,6 @@ describe("RFC003: ERC20 for Bitcoin", () => {
             );
         res.should.have.status(200);
         alice_redeem_action = res.body;
-
-        logger.info(
-            "Alice retrieved the following redeem parameters",
-            alice_redeem_action
-        );
     });
 
     it("[Alice] Can execute the redeem action", async function() {
@@ -329,11 +299,6 @@ describe("RFC003: ERC20 for Bitcoin", () => {
         let res = await chai.request(bob.comit_node_url()).get(bob_redeem_href);
         res.should.have.status(200);
         bob_redeem_action = res.body;
-
-        logger.info(
-            "Bob retrieved the following redeem parameters",
-            bob_redeem_action
-        );
     });
 
     let bob_erc20_balance_before;

--- a/api_tests/e2e/rfc003/eth_btc/test.js
+++ b/api_tests/e2e/rfc003/eth_btc/test.js
@@ -217,7 +217,7 @@ describe("RFC003: Ether for Bitcoin", () => {
         );
         let alice_redeem_txid = body.state.beta_ledger.redeem_tx;
 
-        let alice_satoshi_received = await bitcoin.get_satoshi_transferred_to(
+        let alice_satoshi_received = await bitcoin.get_first_utxo_value_transferred_to(
             alice_redeem_txid,
             alice_final_address
         );

--- a/api_tests/e2e/rfc003/eth_btc/test.js
+++ b/api_tests/e2e/rfc003/eth_btc/test.js
@@ -6,7 +6,6 @@ const ethereum = require("../../../lib/ethereum.js");
 const ethutil = require("ethereumjs-util");
 const should = chai.should();
 const Web3 = require("web3");
-const sb = require("satoshi-bitcoin");
 
 const bob_initial_eth = "0.1";
 const alice_initial_eth = "11";
@@ -217,17 +216,13 @@ describe("RFC003: Ether for Bitcoin", () => {
             body => body.state.beta_ledger.status == "Redeemed"
         );
         let alice_redeem_txid = body.state.beta_ledger.redeem_tx;
-        let alice_redeem_tx = await bitcoin.getRawTransaction(
-            alice_redeem_txid
+
+        let alice_satoshi_received = await bitcoin.getSatoshiTransferredTo(
+            alice_redeem_txid,
+            alice_final_address
         );
-
-        let receive_address = alice_redeem_tx.vout[0].scriptPubKey.addresses[0];
-        receive_address.should.be.equal(alice_final_address);
-
         const alice_satoshi_expected = beta_asset_amount - beta_max_fee;
-        let alice_satoshi_received = sb.toSatoshi(
-            alice_redeem_tx.vout[0].value
-        );
+
         alice_satoshi_received.should.be.at.least(alice_satoshi_expected);
     });
 

--- a/api_tests/e2e/rfc003/eth_btc/test.js
+++ b/api_tests/e2e/rfc003/eth_btc/test.js
@@ -213,7 +213,7 @@ describe("RFC003: Ether for Bitcoin", () => {
         let body = await alice.poll_comit_node_until(
             chai,
             alice_swap_href,
-            body => body.state.beta_ledger.status == "Redeemed"
+            body => body.state.beta_ledger.status === "Redeemed"
         );
         let alice_redeem_txid = body.state.beta_ledger.redeem_tx;
 

--- a/api_tests/e2e/rfc003/eth_btc/test.js
+++ b/api_tests/e2e/rfc003/eth_btc/test.js
@@ -7,7 +7,6 @@ const ethutil = require("ethereumjs-util");
 const should = chai.should();
 const Web3 = require("web3");
 const sb = require("satoshi-bitcoin");
-const logger = global.harness.logger;
 
 const bob_initial_eth = "0.1";
 const alice_initial_eth = "11";
@@ -70,7 +69,6 @@ describe("RFC003: Ether for Bitcoin", () => {
             .then(res => {
                 res.should.have.status(201);
                 swap_location = res.headers.location;
-                logger.info("Alice created a new swap at %s", swap_location);
                 swap_location.should.be.a("string");
                 alice_swap_href = swap_location;
             });
@@ -103,7 +101,6 @@ describe("RFC003: Ether for Bitcoin", () => {
         swap_link.should.be.a("object");
         bob_swap_href = swap_link.self.href;
         bob_swap_href.should.be.a("string");
-        logger.info("Bob discovered a new swap at %s", bob_swap_href);
     });
 
     let bob_accept_href;
@@ -123,12 +120,6 @@ describe("RFC003: Ether for Bitcoin", () => {
             beta_ledger_refund_identity: null,
             alpha_ledger_redeem_identity: bob_final_address,
         };
-
-        logger.info(
-            "Bob is accepting the swap via %s with the following parameters",
-            bob_accept_href,
-            bob_response
-        );
 
         let accept_res = await chai
             .request(bob.comit_node_url())
@@ -153,11 +144,6 @@ describe("RFC003: Ether for Bitcoin", () => {
             .get(alice_fund_href);
         res.should.have.status(200);
         alice_fund_action = res.body;
-
-        logger.info(
-            "Alice retrieved the following funding parameters",
-            alice_fund_action
-        );
     });
 
     it("[Alice] Can execute the fund action", async () => {
@@ -183,11 +169,6 @@ describe("RFC003: Ether for Bitcoin", () => {
         let res = await chai.request(bob.comit_node_url()).get(bob_fund_href);
         res.should.have.status(200);
         bob_fund_action = res.body;
-
-        logger.info(
-            "Bob retrieved the following funding parameters",
-            bob_fund_action
-        );
     });
 
     it("[Bob] Can execute the fund action", async () => {
@@ -220,11 +201,6 @@ describe("RFC003: Ether for Bitcoin", () => {
             );
         res.should.have.status(200);
         alice_redeem_action = res.body;
-
-        logger.info(
-            "Alice retrieved the following redeem parameters",
-            alice_redeem_action
-        );
     });
 
     it("[Alice] Can execute the redeem action", async function() {
@@ -268,11 +244,6 @@ describe("RFC003: Ether for Bitcoin", () => {
         let res = await chai.request(bob.comit_node_url()).get(bob_redeem_href);
         res.should.have.status(200);
         bob_redeem_action = res.body;
-
-        logger.info(
-            "Bob retrieved the following redeem parameters",
-            bob_redeem_action
-        );
     });
 
     let bob_eth_balance_before;

--- a/api_tests/e2e/rfc003/eth_btc/test.js
+++ b/api_tests/e2e/rfc003/eth_btc/test.js
@@ -217,7 +217,7 @@ describe("RFC003: Ether for Bitcoin", () => {
         );
         let alice_redeem_txid = body.state.beta_ledger.redeem_tx;
 
-        let alice_satoshi_received = await bitcoin.getSatoshiTransferredTo(
+        let alice_satoshi_received = await bitcoin.get_satoshi_transferred_to(
             alice_redeem_txid,
             alice_final_address
         );

--- a/api_tests/e2e/rfc003/eth_btc/test.js
+++ b/api_tests/e2e/rfc003/eth_btc/test.js
@@ -18,8 +18,8 @@ const alice_final_address =
 const bob_final_address = "0x03a329c0248369a73afac7f9381e02fb43d2ea72";
 const bob_comit_node_address = bob.config.comit.comit_listen;
 
-const alpha_asset_amount = BigInt(Web3.utils.toWei("10", "ether"));
-const beta_asset_amount = 100000000;
+const alpha_asset_quantity = BigInt(Web3.utils.toWei("10", "ether"));
+const beta_asset_quantity = 100000000;
 const beta_max_fee = 5000; // Max 5000 satoshis fee
 
 const alpha_expiry = new Date("2080-06-11T23:00:00Z").getTime() / 1000;
@@ -54,11 +54,11 @@ describe("RFC003: Ether for Bitcoin", () => {
                 },
                 alpha_asset: {
                     name: "Ether",
-                    quantity: alpha_asset_amount.toString(),
+                    quantity: alpha_asset_quantity.toString(),
                 },
                 beta_asset: {
                     name: "Bitcoin",
-                    quantity: beta_asset_amount.toString(),
+                    quantity: beta_asset_quantity.toString(),
                 },
                 alpha_ledger_refund_identity: alice.wallet.eth().address(),
                 alpha_expiry: alpha_expiry,
@@ -221,7 +221,7 @@ describe("RFC003: Ether for Bitcoin", () => {
             alice_redeem_txid,
             alice_final_address
         );
-        const alice_satoshi_expected = beta_asset_amount - beta_max_fee;
+        const alice_satoshi_expected = beta_asset_quantity - beta_max_fee;
 
         alice_satoshi_received.should.be.at.least(alice_satoshi_expected);
     });
@@ -261,7 +261,7 @@ describe("RFC003: Ether for Bitcoin", () => {
         );
 
         let bob_eth_balance_expected =
-            bob_eth_balance_before + alpha_asset_amount;
+            bob_eth_balance_before + alpha_asset_quantity;
         bob_eth_balance_after
             .toString()
             .should.equal(bob_eth_balance_expected.toString());

--- a/api_tests/lib/bitcoin.js
+++ b/api_tests/lib/bitcoin.js
@@ -32,33 +32,13 @@ module.exports.btc_activate_segwit = async function() {
     return create_bitcoin_rpc_client().generate(432);
 };
 
-module.exports.btc_import_address = async function(address) {
-    return create_bitcoin_rpc_client().importAddress(address);
-};
-
-async function btc_balance(address) {
-    let btc_balance = await _bitcoin_rpc_client.getReceivedByAddress(address);
-    return parseFloat(btc_balance) * 100000000;
+async function getRawTransaction(tx_id) {
+    let tx = await _bitcoin_rpc_client.getRawTransaction(tx_id, 1);
+    return tx;
 }
 
-module.exports.btc_balance = async function(address) {
-    return btc_balance(address);
-};
-
-module.exports.log_btc_balance = async function(
-    when,
-    player,
-    address,
-    address_type
-) {
-    global.harness.logger.info(
-        "%s the swap, %s has %s satoshis at the %s address %s",
-        when,
-        player,
-        await btc_balance(address),
-        address_type,
-        address
-    );
+module.exports.getRawTransaction = async function(tx_id) {
+    return getRawTransaction(tx_id);
 };
 
 class BitcoinWallet {

--- a/api_tests/lib/bitcoin.js
+++ b/api_tests/lib/bitcoin.js
@@ -48,9 +48,7 @@ async function get_satoshi_transferred_to(tx_id, address) {
     return satoshi;
 }
 
-module.exports.get_satoshi_transferred_to = async function(tx_id, address) {
-    return get_satoshi_transferred_to(tx_id, address);
-};
+module.exports.get_satoshi_transferred_to = get_satoshi_transferred_to;
 
 class BitcoinWallet {
     constructor() {

--- a/api_tests/lib/bitcoin.js
+++ b/api_tests/lib/bitcoin.js
@@ -33,7 +33,7 @@ module.exports.btc_activate_segwit = async function() {
     return create_bitcoin_rpc_client().generate(432);
 };
 
-async function getSatoshiTransferredTo(tx_id, address) {
+async function get_satoshi_transferred_to(tx_id, address) {
     let satoshi = 0;
     let tx = await _bitcoin_rpc_client.getRawTransaction(tx_id, 1);
     let vout = tx.vout[0];
@@ -48,8 +48,8 @@ async function getSatoshiTransferredTo(tx_id, address) {
     return satoshi;
 }
 
-module.exports.getSatoshiTransferredTo = async function(tx_id, address) {
-    return getSatoshiTransferredTo(tx_id, address);
+module.exports.get_satoshi_transferred_to = async function(tx_id, address) {
+    return get_satoshi_transferred_to(tx_id, address);
 };
 
 class BitcoinWallet {

--- a/api_tests/lib/bitcoin.js
+++ b/api_tests/lib/bitcoin.js
@@ -80,7 +80,7 @@ class BitcoinWallet {
         const fee = 2500;
         const change = input_amount - value - fee;
         txb.addInput(utxo.txid, utxo.vout, null, this.identity().output);
-        //TODO: Add it back to UTXOs after transaction is successful
+        // The remains of the utxo are NOT added back to the wallet
         txb.addOutput(this.identity().output, change);
         txb.addOutput(
             bitcoin.address.toOutputScript(to, bitcoin.networks.regtest),

--- a/api_tests/lib/bitcoin.js
+++ b/api_tests/lib/bitcoin.js
@@ -33,7 +33,7 @@ module.exports.btc_activate_segwit = async function() {
     return create_bitcoin_rpc_client().generate(432);
 };
 
-async function get_satoshi_transferred_to(tx_id, address) {
+async function get_first_utxo_value_transferred_to(tx_id, address) {
     let satoshi = 0;
     let tx = await _bitcoin_rpc_client.getRawTransaction(tx_id, 1);
     let vout = tx.vout[0];
@@ -48,7 +48,7 @@ async function get_satoshi_transferred_to(tx_id, address) {
     return satoshi;
 }
 
-module.exports.get_satoshi_transferred_to = get_satoshi_transferred_to;
+module.exports.get_first_utxo_value_transferred_to = get_first_utxo_value_transferred_to;
 
 class BitcoinWallet {
     constructor() {

--- a/api_tests/lib/bitcoin.js
+++ b/api_tests/lib/bitcoin.js
@@ -55,6 +55,7 @@ module.exports.getSatoshiTransferredTo = async function(tx_id, address) {
 class BitcoinWallet {
     constructor() {
         this.keypair = bitcoin.ECPair.makeRandom({ rng: util.test_rng });
+        // TODO: Use wallet instead of array to track Bitcoin UTXOs
         this.bitcoin_utxos = [];
         this._identity = bitcoin.payments.p2wpkh({
             pubkey: this.keypair.publicKey,
@@ -91,7 +92,6 @@ class BitcoinWallet {
         const fee = 2500;
         const change = input_amount - value - fee;
         txb.addInput(utxo.txid, utxo.vout, null, this.identity().output);
-        // The remains of the utxo are NOT added back to the wallet
         txb.addOutput(this.identity().output, change);
         txb.addOutput(
             bitcoin.address.toOutputScript(to, bitcoin.networks.regtest),

--- a/api_tests/lib/bitcoin.js
+++ b/api_tests/lib/bitcoin.js
@@ -1,5 +1,6 @@
 const bitcoin = require("bitcoinjs-lib");
 const BitcoinRpcClient = require("bitcoin-core");
+const sb = require("satoshi-bitcoin");
 const util = require("./util.js");
 
 let _bitcoin_rpc_client;
@@ -32,13 +33,23 @@ module.exports.btc_activate_segwit = async function() {
     return create_bitcoin_rpc_client().generate(432);
 };
 
-async function getRawTransaction(tx_id) {
+async function getSatoshiTransferredTo(tx_id, address) {
+    let satoshi = 0;
     let tx = await _bitcoin_rpc_client.getRawTransaction(tx_id, 1);
-    return tx;
+    let vout = tx.vout[0];
+
+    if (
+        vout.scriptPubKey.addresses.length === 1 &&
+        vout.scriptPubKey.addresses[0] === address
+    ) {
+        satoshi = sb.toSatoshi(vout.value);
+    }
+
+    return satoshi;
 }
 
-module.exports.getRawTransaction = async function(tx_id) {
-    return getRawTransaction(tx_id);
+module.exports.getSatoshiTransferredTo = async function(tx_id, address) {
+    return getSatoshiTransferredTo(tx_id, address);
 };
 
 class BitcoinWallet {

--- a/api_tests/lib/ethereum.js
+++ b/api_tests/lib/ethereum.js
@@ -20,22 +20,6 @@ module.exports.eth_balance = async function(address) {
     return eth_balance(address);
 };
 
-module.exports.log_eth_balance = async function(
-    when,
-    player,
-    address,
-    address_type
-) {
-    logger.info(
-        "%s the swap, %s has %s wei at the %s address %s",
-        when,
-        player,
-        await eth_balance(address),
-        address_type,
-        address
-    );
-};
-
 {
     const function_identifier = "40c10f19";
     module.exports.mint_erc20_tokens = (

--- a/api_tests/lib/ethereum.js
+++ b/api_tests/lib/ethereum.js
@@ -4,7 +4,6 @@ const EthereumTx = require("ethereumjs-tx");
 const fs = require("fs");
 const Web3 = require("web3");
 const util = require("./util.js");
-const logger = global.harness.logger;
 const eth_config = global.harness.ledgers_config.ethereum;
 const web3 = new Web3(new Web3.providers.HttpProvider(eth_config.rpc_url));
 
@@ -98,13 +97,6 @@ class EthereumWallet {
             chainId: 1,
         });
 
-        logger.trace(
-            "Transaction %s transfers %s wei to %s",
-            tx.hash().toString("hex"),
-            tx.value,
-            tx.to.toString("hex")
-        );
-
         return this.sign_and_send(tx);
     }
 
@@ -131,12 +123,6 @@ class EthereumWallet {
             receipt.contractAddress
         );
 
-        logger.trace(
-            "Contract deployed at %s holds %s wei",
-            receipt.contractAddress,
-            contract_balance
-        );
-
         return receipt;
     }
 
@@ -145,12 +131,6 @@ class EthereumWallet {
         const serializedTx = tx.serialize();
         let hex = "0x" + serializedTx.toString("hex");
         let receipt = await web3.eth.sendSignedTransaction(hex);
-
-        logger.trace(
-            "Receipt for transaction %s",
-            receipt.transactionHash,
-            receipt
-        );
 
         return receipt;
     }

--- a/api_tests/lib/wallet.js
+++ b/api_tests/lib/wallet.js
@@ -1,24 +1,11 @@
 const bitcoin = require("./bitcoin.js");
 const ethereum = require("./ethereum.js");
 
-const logger = global.harness.logger;
-
 class Wallet {
     constructor(owner) {
         this.owner = owner;
         this._eth_wallet = ethereum.create();
         this._btc_wallet = bitcoin.create_wallet();
-
-        logger.trace(
-            "Generated eth address for %s is %s",
-            this.owner,
-            this._eth_wallet.address()
-        );
-        logger.trace(
-            "Generated btc address for %s is %s",
-            this.owner,
-            this._btc_wallet.identity.address
-        );
     }
 
     eth() {

--- a/api_tests/package.json
+++ b/api_tests/package.json
@@ -20,6 +20,7 @@
         "log4js": "^3.0.6",
         "mocha": "^5.2.0",
         "prettier": "^1.15.2",
+        "satoshi-bitcoin": "^1.0.4",
         "toml": "^2.3.3",
         "typedarray-to-buffer": "^3.1.5",
         "web3": "^1.0.0-beta.36"

--- a/api_tests/yarn.lock
+++ b/api_tests/yarn.lock
@@ -181,6 +181,11 @@ bech32@^1.1.2:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.3.tgz#bd47a8986bbb3eec34a56a097a84b8d3e9a2dfcd"
   integrity sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg==
 
+big.js@^3.1.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
+  integrity sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==
+
 bignumber.js@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.1.0.tgz#db6f14067c140bd46624815a7916c92d9b6c24b1"
@@ -2408,6 +2413,13 @@ safe-json-stringify@~1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+satoshi-bitcoin@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/satoshi-bitcoin/-/satoshi-bitcoin-1.0.4.tgz#d002b677075d5cbbf2c211a8df3254bcdf50b1e4"
+  integrity sha1-0AK2dwddXLvywhGo3zJUvN9QseQ=
+  dependencies:
+    big.js "^3.1.3"
 
 sax@^1.2.4:
   version "1.2.4"


### PR DESCRIPTION
When verifying that a redeem transaction has been successful, instead of watching the recipient's Bitcoin address using a Bitcoin RPC client we now look at the transaction itself using `getRawTransaction(txid)`.

Also test suite logs have been removed because no one is looking at them anymore.

Resolves #698.
Resolves #681.