### PR TITLE
Make sure we always run against node 11.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: rust
+language: minimal
 cache:
   yarn: true
   directories:
@@ -6,20 +6,21 @@ cache:
   - "$HOME/.cache/sccache"
   - "$TRAVIS_BUILD_DIR/api_tests/node_modules"
 sudo: required
-rust: nightly-2018-12-06
 addons:
   apt:
     sources:
     - sourceline: 'deb http://dl.yarnpkg.com/debian/ stable main'
       key_url: 'http://dl.yarnpkg.com/debian/pubkey.gpg'
+    - sourceline: 'deb https://deb.nodesource.com/node_11.x trusty main'
+      key_url: 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key'
     packages:
     - libzmq3-dev
     - yarn
-install: true
+    - nodejs=11.10*
 services: docker
-before_script:
-- which cargo-make || cargo install --debug cargo-make
-- nvm install 11
+install:
+  - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $(< rust-toolchain) && source $HOME/.cargo/env
+  - which cargo-make || cargo install --debug cargo-make
 script: cargo make travis
 notifications:
   email: false

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -140,6 +140,12 @@ script = [
 '''
 ]
 
+[tasks.travis]
+workspace = false
+# Even though we only have 2 cores on Travis, we mostly wait for containers in our tests. Doing that in parallel saves us some time! (8 is just an arbitrary number!)
+env = { "RUST_TEST_THREADS" = "8", "RUSTC_WRAPPER" = "${HOME}/.cargo/bin/sccache", "CAT_LOGS" = "true" }
+run_task = "ci-flow"
+
 [tasks.clean-registry]
 # The cargo registry cache grows continuously over time, making our build take longer and longer because it is cached on S3.
 # This command removes everything that is older than 30 days, thus keeping only very recent libraries.
@@ -153,7 +159,7 @@ linux_alias = "clean-registry-linux"
 condition = { platforms = ["linux"] }
 workspace = false
 private = true
-force = true
+ignore_errors = true
 script = [
 '''
 find $HOME/.cargo/registry/src $HOME/.cargo/registry/cache \
@@ -161,17 +167,11 @@ find $HOME/.cargo/registry/src $HOME/.cargo/registry/cache \
 '''
 ]
 
-[tasks.travis]
-workspace = false
-# Even though we only have 2 cores on Travis, we mostly wait for containers in our tests. Doing that in parallel saves us some time! (8 is just an arbitrary number!)
-env = { "RUST_TEST_THREADS" = "8", "RUSTC_WRAPPER" = "${HOME}/.cargo/bin/sccache", "CAT_LOGS" = "true" }
-run_task = "ci-flow"
-
 [tasks.clean-registry-mac]
 condition = { platforms = ["mac"] }
 workspace = false
 private = true
-force = true
+ignore_errors = true
 script = [
 '''
 find $HOME/.cargo/registry/src $HOME/.cargo/registry/cache \

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Contains crates specific to our application. Can depend on libraries located in 
 ## Setup testing/dev environment
 
 1. Install `docker` & `docker-compose`
-2. Install `nvm`, `npm` & `yarn`
+2. Install `node` (check the version required in package.json) & `yarn`
 3. Install `cargo-make`: `cargo install cargo-make`
 4. Run `cargo make` in the root folder of the repository, this will install various crates & tools such as rustfmt & clippy
    

--- a/api_tests/npm_wrapper.sh
+++ b/api_tests/npm_wrapper.sh
@@ -4,11 +4,6 @@ echo "Running $1";
 
 export TEST_DIR="$1";
 
-export NVM_SH=$([ -e $NVM_DIR/nvm.sh ] && \
-    echo "$NVM_DIR/nvm.sh" || echo /usr/local/opt/nvm/nvm.sh );
-. "$NVM_SH"
-nvm use 11.10.0 || (nvm install 11.10.0 && nvm use 11.10.0);
-
 cd "${ROOT}/api_tests";
 yarn install;
 

--- a/api_tests/package.json
+++ b/api_tests/package.json
@@ -6,6 +6,9 @@
     "scripts": {
         "test": "mocha --bail"
     },
+    "engines": {
+        "node": "11.10"
+    },
     "author": "CoBloX Team",
     "license": "ISC",
     "dependencies": {


### PR DESCRIPTION
This PR removes any usage of `nvm` from the project.

Instead, we fail the build if the available node version is not `11.10`. This means we now have to install that version in Travis.

This also means that *you* (@comit-network/rust-devs) have to setup your environment so that node version 11.10 is used inside the project directory. How you do that is left up to you :)

This hopefully fixes #802.