### PR TITLE
Use Network::Mainnet instead of Network::Bitcoin

### DIFF
--- a/application/comit_node/src/swap_protocols/rfc003/bitcoin/htlc.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/bitcoin/htlc.rs
@@ -62,7 +62,7 @@ impl Htlc {
     }
 
     pub fn compute_address(&self, network: Network) -> Address {
-        Address::p2wsh(&self.script, network)
+        Address::p2wsh(&self.script, network.into())
     }
 
     pub fn can_be_unlocked_with(

--- a/vendor/bitcoin_support/src/lib.rs
+++ b/vendor/bitcoin_support/src/lib.rs
@@ -11,7 +11,7 @@ pub use bitcoin::{
         script::{self, Script},
         transaction::{OutPoint, SigHashType, Transaction, TxIn, TxOut},
     },
-    network::{constants::Network, serialize},
+    network::serialize,
     util::{
         bip143::SighashComponents,
         bip32::{self, ChainCode, ChildNumber, ExtendedPrivKey, ExtendedPubKey, Fingerprint},
@@ -25,6 +25,7 @@ pub use bitcoin::{
 pub use crate::{
     blocks::*,
     mined_block::*,
+    network::*,
     pubkey::*,
     transaction::*,
     weight::{Error as WeightError, *},
@@ -33,6 +34,7 @@ pub use bitcoin_quantity::*;
 
 mod blocks;
 mod mined_block;
+mod network;
 mod pubkey;
 mod transaction;
 mod weight;

--- a/vendor/bitcoin_support/src/network.rs
+++ b/vendor/bitcoin_support/src/network.rs
@@ -1,5 +1,4 @@
-use bitcoin::network::constants::Network as ExternNetwork;
-use serde::Deserialize;
+use bitcoin;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize, Hash)]
 #[serde(rename_all = "lowercase")]
@@ -9,22 +8,22 @@ pub enum Network {
     Testnet,
 }
 
-impl From<ExternNetwork> for Network {
+impl From<bitcoin::network::constants::Network> for Network {
     fn from(item: ExternNetwork) -> Network {
         match item {
-            ExternNetwork::Bitcoin => Network::Mainnet,
-            ExternNetwork::Regtest => Network::Regtest,
-            ExternNetwork::Testnet => Network::Testnet,
+            bitcoin::network::constants::Network::Bitcoin => Network::Mainnet,
+            bitcoin::network::constants::Network::Regtest => Network::Regtest,
+            bitcoin::network::constants::Network::Testnet => Network::Testnet,
         }
     }
 }
 
-impl From<Network> for ExternNetwork {
-    fn from(item: Network) -> ExternNetwork {
+impl From<Network> for bitcoin::network::constants::Network {
+    fn from(item: Network) -> bitcoin::network::constants::Network {
         match item {
-            Network::Mainnet => ExternNetwork::Bitcoin,
-            Network::Regtest => ExternNetwork::Regtest,
-            Network::Testnet => ExternNetwork::Testnet,
+            Network::Mainnet => bitcoin::network::constants::Network::Bitcoin,
+            Network::Regtest => bitcoin::network::constants::Network::Regtest,
+            Network::Testnet => bitcoin::network::constants::Network::Testnet,
         }
     }
 }

--- a/vendor/bitcoin_support/src/network.rs
+++ b/vendor/bitcoin_support/src/network.rs
@@ -1,0 +1,30 @@
+use bitcoin::network::constants::Network as ExternNetwork;
+use serde::Deserialize;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum Network {
+    Mainnet,
+    Regtest,
+    Testnet,
+}
+
+impl From<ExternNetwork> for Network {
+    fn from(item: ExternNetwork) -> Network {
+        match item {
+            ExternNetwork::Bitcoin => Network::Mainnet,
+            ExternNetwork::Regtest => Network::Regtest,
+            ExternNetwork::Testnet => Network::Testnet,
+        }
+    }
+}
+
+impl From<Network> for ExternNetwork {
+    fn from(item: Network) -> ExternNetwork {
+        match item {
+            Network::Mainnet => ExternNetwork::Bitcoin,
+            Network::Regtest => ExternNetwork::Regtest,
+            Network::Testnet => ExternNetwork::Testnet,
+        }
+    }
+}

--- a/vendor/bitcoin_support/src/network.rs
+++ b/vendor/bitcoin_support/src/network.rs
@@ -1,4 +1,5 @@
 use bitcoin;
+use bitcoin_bech32;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize, Hash)]
 #[serde(rename_all = "lowercase")]
@@ -9,7 +10,7 @@ pub enum Network {
 }
 
 impl From<bitcoin::network::constants::Network> for Network {
-    fn from(item: ExternNetwork) -> Network {
+    fn from(item: bitcoin::network::constants::Network) -> Network {
         match item {
             bitcoin::network::constants::Network::Bitcoin => Network::Mainnet,
             bitcoin::network::constants::Network::Regtest => Network::Regtest,
@@ -24,6 +25,16 @@ impl From<Network> for bitcoin::network::constants::Network {
             Network::Mainnet => bitcoin::network::constants::Network::Bitcoin,
             Network::Regtest => bitcoin::network::constants::Network::Regtest,
             Network::Testnet => bitcoin::network::constants::Network::Testnet,
+        }
+    }
+}
+
+impl From<Network> for bitcoin_bech32::constants::Network {
+    fn from(item: Network) -> bitcoin_bech32::constants::Network {
+        match item {
+            Network::Regtest => bitcoin_bech32::constants::Network::Regtest,
+            Network::Testnet => bitcoin_bech32::constants::Network::Testnet,
+            Network::Mainnet => bitcoin_bech32::constants::Network::Bitcoin,
         }
     }
 }

--- a/vendor/bitcoin_support/src/pubkey.rs
+++ b/vendor/bitcoin_support/src/pubkey.rs
@@ -29,11 +29,7 @@ impl IntoP2wpkhAddress for PubkeyHash {
                 bitcoin_bech32::WitnessProgram::new(
                     bitcoin_bech32::u5::try_from_u8(0).expect("0 is a valid u5"),
                     self.as_ref().to_vec(),
-                    match network {
-                        Network::Regtest => bitcoin_bech32::constants::Network::Regtest,
-                        Network::Testnet => bitcoin_bech32::constants::Network::Testnet,
-                        Network::Mainnet => bitcoin_bech32::constants::Network::Bitcoin,
-                    },
+                    network.into(),
                 )
                 .expect("Any pubkeyhash will succeed in conversion to WitnessProgram"),
             ),

--- a/vendor/bitcoin_support/src/pubkey.rs
+++ b/vendor/bitcoin_support/src/pubkey.rs
@@ -1,5 +1,5 @@
+use crate::network::Network;
 use bitcoin::{
-    network::constants::Network,
     util::{address::Payload, hash::Hash160},
     Address,
 };
@@ -18,7 +18,7 @@ pub trait IntoP2wpkhAddress {
 
 impl IntoP2wpkhAddress for PublicKey {
     fn into_p2wpkh_address(self, network: Network) -> Address {
-        Address::p2wpkh(&self.into(), network)
+        Address::p2wpkh(&self.into(), network.into())
     }
 }
 
@@ -32,12 +32,12 @@ impl IntoP2wpkhAddress for PubkeyHash {
                     match network {
                         Network::Regtest => bitcoin_bech32::constants::Network::Regtest,
                         Network::Testnet => bitcoin_bech32::constants::Network::Testnet,
-                        Network::Bitcoin => bitcoin_bech32::constants::Network::Bitcoin,
+                        Network::Mainnet => bitcoin_bech32::constants::Network::Bitcoin,
                     },
                 )
                 .expect("Any pubkeyhash will succeed in conversion to WitnessProgram"),
             ),
-            network,
+            network: network.into(),
         }
     }
 }
@@ -156,7 +156,7 @@ mod test {
         let private_key =
             PrivateKey::from_str("L4nZrdzNnawCtaEcYGWuPqagQA3dJxVPgN8ARTXaMLCxiYCy89wm").unwrap();
         let keypair: KeyPair = private_key.secret_key().clone().into();
-        let address = keypair.public_key().into_p2wpkh_address(Network::Bitcoin);
+        let address = keypair.public_key().into_p2wpkh_address(Network::Mainnet);
 
         assert_eq!(
             address,

--- a/vendor/key_gen/src/main.rs
+++ b/vendor/key_gen/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
     let keypair = KeyPair::new(&mut rng);
     let secret_key = keypair.secret_key();
     let public_key = keypair.public_key();
-    let private_key = PrivateKey::from_secret_key(secret_key, true, Network::Bitcoin);
+    let private_key = PrivateKey::from_secret_key(secret_key, true, Network::Mainnet.into());
 
     info!("private_key: {}", hex::encode(&secret_key[..]));
     info!("btc_base58_private_key: {}", private_key.to_string());
@@ -33,7 +33,7 @@ fn main() {
     let eth_address = public_key.to_ethereum_address();
     info!("eth_address: {:?}", eth_address);
     {
-        let btc_address_mainnet = public_key.into_p2wpkh_address(Network::Bitcoin);
+        let btc_address_mainnet = public_key.into_p2wpkh_address(Network::Mainnet);
         info!("btc_address_p2wpkh_mainnet: {:?}", btc_address_mainnet);
     }
 
@@ -48,7 +48,7 @@ fn main() {
     info!("pubkey_hash: {:?}", PubkeyHash::from(public_key));
 
     {
-        let extended_privkey = extended_privkey_from_secret_key(secret_key, Network::Bitcoin);
+        let extended_privkey = extended_privkey_from_secret_key(secret_key, Network::Mainnet);
         let extended_pubkey = ExtendedPubKey::from_private(&SECP, &extended_privkey);
         info!("btc_extended_privkey_mainnet: {}", extended_privkey);
         info!("btc_extended_pubkey_mainnet: {}", extended_pubkey);
@@ -73,7 +73,7 @@ fn extended_privkey_from_secret_key(
 ) -> ExtendedPrivKey {
     let chain_code = ChainCode::from(&[1u8; 32][..]);
     ExtendedPrivKey {
-        network,
+        network: network.into(),
         depth: 0,
         parent_fingerprint: Fingerprint::default(),
         child_number: ChildNumber::from(0),


### PR DESCRIPTION
Replace `rust-bitcoin::Network` with own `Network` enum so that mainnet is called mainnet and not bitcoin...

Resolves #644.