### PR TITLE
Add CORS headers to comit_node HTTP API

### DIFF
--- a/api_tests/dry/sanity.js
+++ b/api_tests/dry/sanity.js
@@ -69,6 +69,16 @@ describe("Sanity tests", () => {
             });
     });
 
+    it("[Alice] Sets appropriate CORS headers", async () => {
+        let res = await chai
+            .request(alice.comit_node_url())
+            .get("/swaps")
+            .set("Origin", "localhost:3000");
+
+        res.should.have.status(200);
+        res.should.have.header("access-control-allow-origin", "localhost:3000");
+    });
+
     it("[Alice] Returns 400 bad request for malformed requests", async () => {
         await chai
             .request(alice.comit_node_url())

--- a/application/comit_node/src/http_api/route_factory.rs
+++ b/application/comit_node/src/http_api/route_factory.rs
@@ -80,6 +80,7 @@ pub fn create<T: MetadataStore<SwapId>, S: state_store::StateStore>(
         .or(get_swaps)
         .or(get_peers)
         .with(warp::log("http"))
+        .with(warp::cors().allow_any_origin())
         .recover(http_api::unpack_problem)
         .boxed()
 }


### PR DESCRIPTION
This allows any application to use the HTTP API of a COMIT node.