### PR TITLE
Add btsieve support for ledger networks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1591,6 +1591,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lock_api 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,6 +1617,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2429,7 +2450,7 @@ name = "tc_web3_client"
 version = "0.1.0"
 dependencies = [
  "testcontainers 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "web3 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2969,6 +2990,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "web3"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethabi 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-tls 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-uds 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "websocket 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "websocket"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3242,8 +3292,10 @@ dependencies = [
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4d05f1349491390b1730afba60bb20d55761bef489a954546b58b4b34e1e2ac"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
+"checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
 "checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
+"checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 "checksum phf 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "cec29da322b242f4c3098852c77a0ca261c9c01b806cae85a5572a1eb94db9a6"
@@ -3392,6 +3444,7 @@ dependencies = [
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
 "checksum warp 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2861682c6918c92c78d58edc336aaa1fdeda0167adce901bdf0c7057cb2d2ec1"
 "checksum web3 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "030a0ddd7602bd22a5880b49539df9e54b03a389a87d4d6aeea605783cac63cc"
+"checksum web3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "deff75304fe1d0aadb0debac42722c4e63a168619e71e077bc2def73c250db4e"
 "checksum websocket 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c9faed2bff8af2ea6b9f8b917d3d00b467583f6781fe3def174a9e33c879703"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1591,15 +1591,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lock_api 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "parking_lot_core"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,18 +1608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2450,7 +2429,7 @@ name = "tc_web3_client"
 version = "0.1.0"
 dependencies = [
  "testcontainers 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "web3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web3 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2990,35 +2969,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web3"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethabi 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper-tls 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-uds 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "websocket 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "websocket"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3292,10 +3242,8 @@ dependencies = [
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4d05f1349491390b1730afba60bb20d55761bef489a954546b58b4b34e1e2ac"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
-"checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
 "checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
-"checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 "checksum phf 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "cec29da322b242f4c3098852c77a0ca261c9c01b806cae85a5572a1eb94db9a6"
@@ -3444,7 +3392,6 @@ dependencies = [
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
 "checksum warp 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2861682c6918c92c78d58edc336aaa1fdeda0167adce901bdf0c7057cb2d2ec1"
 "checksum web3 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "030a0ddd7602bd22a5880b49539df9e54b03a389a87d4d6aeea605783cac63cc"
-"checksum web3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "deff75304fe1d0aadb0debac42722c4e63a168619e71e077bc2def73c250db4e"
 "checksum websocket 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c9faed2bff8af2ea6b9f8b917d3d00b467583f6781fe3def174a9e33c879703"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,8 @@ dependencies = [
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "spectral 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strum 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strum_macros 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -784,6 +786,8 @@ dependencies = [
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "spectral 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strum 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strum_macros 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "web3 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2255,6 +2259,22 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strum"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strum_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "subtle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3300,6 +3320,8 @@ dependencies = [
 "checksum state_machine_future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "530e1d624baae485bce12e6647acb76aafa253346ee8a16751974eed5a24b13d"
 "checksum static_slice 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "92a7e0c5e3dfb52e8fbe0e63a1b947bbb17b4036408b151353c4491374931362"
 "checksum string 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00caf261d6f90f588f8450b8e1230fa0d5be49ee6140fdfbcb55335aff350970"
+"checksum strum 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1810e25f576e7ffce1ff5243b37066da5ded0310b3274c20baaeccb1145b2806"
+"checksum strum_macros 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "572a2f4e53dd4c3483fd79e5cc10ddd773a3acb1169bbfe8762365e107110579"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "702662512f3ddeb74a64ce2fbbf3707ee1b6bb663d28bb054e0779bbc720d926"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"

--- a/api_tests/btsieve/test.js
+++ b/api_tests/btsieve/test.js
@@ -56,7 +56,19 @@ describe("Test btsieve API", () => {
             it("btsieve should respond not found when getting a non-existent bitcoin transaction query", async function() {
                 return chai
                     .request(btsieve.url())
-                    .get("/queries/bitcoin/transactions/1")
+                    .get("/queries/bitcoin/regtest/transactions/1")
+                    .then(res => {
+                        res.should.have.status(404);
+                    });
+            });
+
+            it("btsieve should respond not found when creating a bitcoin transaction query for an invalid network", async function() {
+                return chai
+                    .request(btsieve.url())
+                    .post("/queries/bitcoin/banananet/transactions")
+                    .send({
+                        to_address: to_address,
+                    })
                     .then(res => {
                         res.should.have.status(404);
                     });
@@ -67,7 +79,7 @@ describe("Test btsieve API", () => {
             it("btsieve should respond with location when creating a valid bitcoin transaction query", async function() {
                 return chai
                     .request(btsieve.url())
-                    .post("/queries/bitcoin/transactions")
+                    .post("/queries/bitcoin/regtest/transactions")
                     .send({
                         to_address: to_address,
                     })
@@ -141,7 +153,19 @@ describe("Test btsieve API", () => {
             it("btsieve should respond not found when getting a non-existent bitcoin block query", async function() {
                 return chai
                     .request(btsieve.url())
-                    .get("/queries/bitcoin/blocks/1")
+                    .get("/queries/bitcoin/regtest/blocks/1")
+                    .then(res => {
+                        res.should.have.status(404);
+                    });
+            });
+
+            it("btsieve should respond not found when creating a bitcoin block query for an invalid network", async function() {
+                return chai
+                    .request(btsieve.url())
+                    .post("/queries/bitcoin/banananet/blocks")
+                    .send({
+                        min_height: min_height,
+                    })
                     .then(res => {
                         res.should.have.status(404);
                     });
@@ -152,7 +176,7 @@ describe("Test btsieve API", () => {
             it("btsieve should respond with location when creating a valid bitcoin block query", async function() {
                 return chai
                     .request(btsieve.url())
-                    .post("/queries/bitcoin/blocks")
+                    .post("/queries/bitcoin/regtest/blocks")
                     .send({
                         min_height: min_height,
                     })
@@ -221,7 +245,19 @@ describe("Test btsieve API", () => {
             it("btsieve should respond not found when getting a non-existent ethereum transaction query", async function() {
                 return chai
                     .request(btsieve.url())
-                    .get("/queries/ethereum/transactions/1")
+                    .get("/queries/ethereum/regtest/transactions/1")
+                    .then(res => {
+                        res.should.have.status(404);
+                    });
+            });
+
+            it("btsieve should respond not found when creating an ethereum transaction query for an invalid network", async function() {
+                return chai
+                    .request(btsieve.url())
+                    .post("/queries/ethereum/banananet/transactions")
+                    .send({
+                        to_address: to_address,
+                    })
                     .then(res => {
                         res.should.have.status(404);
                     });
@@ -232,7 +268,7 @@ describe("Test btsieve API", () => {
             it("btsieve should respond with location when creating a valid ethereum transaction query", async function() {
                 return chai
                     .request(btsieve.url())
-                    .post("/queries/ethereum/transactions")
+                    .post("/queries/ethereum/regtest/transactions")
                     .send({
                         to_address: to_address,
                     })
@@ -294,7 +330,7 @@ describe("Test btsieve API", () => {
             it("btsieve should respond with no content when deleting an existing ethereum transaction query", async function() {
                 return chai
                     .request(btsieve.url())
-                    .delete("/queries/ethereum/transactions/1")
+                    .delete("/queries/ethereum/regtest/transactions/1")
                     .then(res => {
                         res.should.have.status(204);
                     });
@@ -305,7 +341,19 @@ describe("Test btsieve API", () => {
             it("btsieve should respond not found when getting a non-existent ethereum block query", async function() {
                 return chai
                     .request(btsieve.url())
-                    .get("/queries/ethereum/blocks/1")
+                    .get("/queries/ethereum/regtest/blocks/1")
+                    .then(res => {
+                        res.should.have.status(404);
+                    });
+            });
+
+            it("btsieve should respond not found when creating an ethereum block query for an invalid network", async function() {
+                return chai
+                    .request(btsieve.url())
+                    .post("/queries/ethereum/banananet/blocks")
+                    .send({
+                        min_timestamp_secs: min_timestamp_secs,
+                    })
                     .then(res => {
                         res.should.have.status(404);
                     });
@@ -318,7 +366,7 @@ describe("Test btsieve API", () => {
                 this.timeout(1000);
                 return chai
                     .request(btsieve.url())
-                    .post("/queries/ethereum/blocks")
+                    .post("/queries/ethereum/regtest/blocks")
                     .send({
                         min_timestamp_secs: min_timestamp_secs,
                     })
@@ -378,11 +426,11 @@ describe("Test btsieve API", () => {
             });
         });
 
-        describe("Logs", () => {
+        describe("Transaction Receipts", () => {
             it("btsieve should respond not found when getting a non-existent ethereum transaction receipt query", async function() {
                 return chai
                     .request(btsieve.url())
-                    .get("/queries/ethereum/logs/1")
+                    .get("/queries/ethereum/regtest/logs/1")
                     .then(res => {
                         res.should.have.status(404);
                     });
@@ -402,7 +450,7 @@ describe("Test btsieve API", () => {
                 this.timeout(1000);
                 return chai
                     .request(btsieve.url())
-                    .post("/queries/ethereum/logs")
+                    .post("/queries/ethereum/regtest/logs")
                     .send({
                         event_matchers: [
                             {

--- a/api_tests/harness.js
+++ b/api_tests/harness.js
@@ -92,7 +92,7 @@ class LedgerRunner {
                 `Waiting ${wait_time} for ${to_be_started.join(", ")} to start`
             );
 
-            await util.sleep(wait_time);
+            await util.sleep(10000);
 
             if (to_be_started.includes("bitcoin")) {
                 this.block_timers.bitcoin = setInterval(async () => {

--- a/api_tests/harness.js
+++ b/api_tests/harness.js
@@ -92,7 +92,7 @@ class LedgerRunner {
                 `Waiting ${wait_time} for ${to_be_started.join(", ")} to start`
             );
 
-            await util.sleep(10000);
+            await util.sleep(wait_time);
 
             if (to_be_started.includes("bitcoin")) {
                 this.block_timers.bitcoin = setInterval(async () => {

--- a/api_tests/regtest/alice/default.toml
+++ b/api_tests/regtest/alice/default.toml
@@ -11,5 +11,8 @@ logging=true
 url = "http://localhost:8080"
 [btsieve.bitcoin]
 poll_interval_secs = 1
+network = "regtest"
+
 [btsieve.ethereum]
 poll_interval_secs = 1
+network = "regtest"

--- a/api_tests/regtest/alice/default.toml
+++ b/api_tests/regtest/alice/default.toml
@@ -11,6 +11,8 @@ logging=true
 url = "http://localhost:8080"
 [btsieve.bitcoin]
 poll_interval_secs = 1
+network = "regtest"
 
 [btsieve.ethereum]
 poll_interval_secs = 1
+network = "regtest"

--- a/api_tests/regtest/alice/default.toml
+++ b/api_tests/regtest/alice/default.toml
@@ -11,8 +11,6 @@ logging=true
 url = "http://localhost:8080"
 [btsieve.bitcoin]
 poll_interval_secs = 1
-network = "regtest"
 
 [btsieve.ethereum]
 poll_interval_secs = 1
-network = "regtest"

--- a/api_tests/regtest/bob/default.toml
+++ b/api_tests/regtest/bob/default.toml
@@ -11,6 +11,9 @@ logging=true
 url = "http://localhost:8080"
 [btsieve.bitcoin]
 poll_interval_secs = 1
+network = "regtest"
+
 [btsieve.ethereum]
 poll_interval_secs = 1
+network = "regtest"
 

--- a/api_tests/regtest/bob/default.toml
+++ b/api_tests/regtest/bob/default.toml
@@ -11,9 +11,7 @@ logging=true
 url = "http://localhost:8080"
 [btsieve.bitcoin]
 poll_interval_secs = 1
-network = "regtest"
 
 [btsieve.ethereum]
 poll_interval_secs = 1
-network = "regtest"
 

--- a/api_tests/regtest/bob/default.toml
+++ b/api_tests/regtest/bob/default.toml
@@ -11,7 +11,9 @@ logging=true
 url = "http://localhost:8080"
 [btsieve.bitcoin]
 poll_interval_secs = 1
+network = "regtest"
 
 [btsieve.ethereum]
 poll_interval_secs = 1
+network = "regtest"
 

--- a/api_tests/regtest/btsieve/default.toml
+++ b/api_tests/regtest/btsieve/default.toml
@@ -8,6 +8,7 @@ zmq_endpoint = "tcp://127.0.0.1:28332"
 [ethereum]
 node_url = "http://localhost:8545"
 poll_interval_secs = 1
+network = "regtest"
 
 [http_api]
 address_bind="0.0.0.0"

--- a/api_tests/regtest/btsieve/default.toml
+++ b/api_tests/regtest/btsieve/default.toml
@@ -1,5 +1,4 @@
 [bitcoin]
-network = "regtest"
 node_url = "http://localhost:18443"
 node_username = "bitcoin"
 node_password = "54pLR_f7-G6is32LP-7nbhzZSbJs_2zSATtZV_r05yg="
@@ -8,7 +7,6 @@ zmq_endpoint = "tcp://127.0.0.1:28332"
 [ethereum]
 node_url = "http://localhost:8545"
 poll_interval_secs = 1
-network = "regtest"
 
 [http_api]
 address_bind="0.0.0.0"

--- a/api_tests/regtest/charlie/default.toml
+++ b/api_tests/regtest/charlie/default.toml
@@ -11,5 +11,8 @@ logging=true
 url = "http://localhost:8080"
 [btsieve.bitcoin]
 poll_interval_secs = 1
+network = "regtest"
+
 [btsieve.ethereum]
 poll_interval_secs = 1
+network = "regtest"

--- a/api_tests/regtest/charlie/default.toml
+++ b/api_tests/regtest/charlie/default.toml
@@ -11,6 +11,8 @@ logging=true
 url = "http://localhost:8080"
 [btsieve.bitcoin]
 poll_interval_secs = 1
+network = "regtest"
 
 [btsieve.ethereum]
 poll_interval_secs = 1
+network = "regtest"

--- a/api_tests/regtest/charlie/default.toml
+++ b/api_tests/regtest/charlie/default.toml
@@ -11,8 +11,6 @@ logging=true
 url = "http://localhost:8080"
 [btsieve.bitcoin]
 poll_interval_secs = 1
-network = "regtest"
 
 [btsieve.ethereum]
 poll_interval_secs = 1
-network = "regtest"

--- a/application/btsieve/config/default.toml
+++ b/application/btsieve/config/default.toml
@@ -1,5 +1,4 @@
 [bitcoin]
-network = "regtest"
 node_url = "http://localhost:18443"
 node_username = "bitcoin"
 node_password = "54pLR_f7-G6is32LP-7nbhzZSbJs_2zSATtZV_r05yg="
@@ -8,7 +7,6 @@ zmq_endpoint = "tcp://127.0.0.1:28332"
 [ethereum]
 node_url = "http://ethereum:8545"
 poll_interval_secs = 17
-network = "regtest"
 
 [http_api]
 address_bind="0.0.0.0"

--- a/application/btsieve/config/default.toml
+++ b/application/btsieve/config/default.toml
@@ -8,6 +8,7 @@ zmq_endpoint = "tcp://127.0.0.1:28332"
 [ethereum]
 node_url = "http://ethereum:8545"
 poll_interval_secs = 17
+network = "regtest"
 
 [http_api]
 address_bind="0.0.0.0"

--- a/application/btsieve/src/bin/btsieve.rs
+++ b/application/btsieve/src/bin/btsieve.rs
@@ -93,6 +93,7 @@ fn create_bitcoin_routes(
     let client = Arc::new(bitcoin_rpc_client);
 
     let ledger_name = "bitcoin";
+    let network: &'static str = settings.network.into();
 
     let transaction_routes = route_factory
         .create::<bitcoin::queries::transaction::ReturnAs, _, _, _, _>(
@@ -100,6 +101,7 @@ fn create_bitcoin_routes(
             transaction_query_result_repository,
             Arc::clone(&client),
             ledger_name,
+            network,
         );
 
     let block_routes = route_factory.create::<bitcoin::queries::block::ReturnAs, _, _, _, _>(
@@ -107,6 +109,7 @@ fn create_bitcoin_routes(
         block_query_result_repository,
         Arc::clone(&client),
         ledger_name,
+        network,
     );
 
     transaction_routes.or(block_routes).boxed()
@@ -181,6 +184,7 @@ fn create_ethereum_routes(
     }
 
     let ledger_name = "ethereum";
+    let network: &'static str = settings.network.into();
 
     let transaction_routes = route_factory
         .create::<ethereum::queries::transaction::ReturnAs, _, _, _, _>(
@@ -188,6 +192,7 @@ fn create_ethereum_routes(
             transaction_query_result_repository,
             Arc::clone(&web3_client),
             ledger_name,
+            network,
         );
 
     let block_routes = route_factory.create::<ethereum::queries::block::ReturnAs, _, _, _, _>(
@@ -195,6 +200,7 @@ fn create_ethereum_routes(
         block_query_result_repository,
         Arc::clone(&web3_client),
         ledger_name,
+        network,
     );
 
     let bloom_routes = route_factory.create::<ethereum::queries::event::ReturnAs, _, _, _, _>(
@@ -202,6 +208,7 @@ fn create_ethereum_routes(
         log_query_result_repository,
         Arc::clone(&web3_client),
         ledger_name,
+        network,
     );
 
     (

--- a/application/btsieve/src/bin/btsieve.rs
+++ b/application/btsieve/src/bin/btsieve.rs
@@ -4,6 +4,8 @@
 #[macro_use]
 extern crate log;
 
+use bitcoin_rpc_client::BitcoinRpcApi;
+use bitcoin_support::Network as BitcoinNetwork;
 use btsieve::{
     bitcoin::{self, bitcoind_zmq_listener::bitcoin_block_listener},
     ethereum::{self, ethereum_web3_block_poller::ethereum_block_listener},
@@ -61,6 +63,11 @@ fn create_bitcoin_routes(
         settings.node_password.as_str(),
     );
 
+    // TODO fix this unwrap
+    let blockchain_info = bitcoin_rpc_client.get_blockchain_info().unwrap().unwrap();
+
+    info!("Connected to Bitcoin: {:?}", blockchain_info);
+
     info!("Connect BitcoinZmqListener to {}", settings.zmq_endpoint);
 
     {
@@ -93,7 +100,8 @@ fn create_bitcoin_routes(
     let client = Arc::new(bitcoin_rpc_client);
 
     let ledger_name = "bitcoin";
-    let network = settings.network.into();
+    let network = BitcoinNetwork::from(blockchain_info.chain).into();
+    trace!("Setting up bitcoin routes to {:?}", network);
 
     let transaction_routes = route_factory
         .create::<bitcoin::queries::transaction::ReturnAs, _, _, _, _>(

--- a/application/btsieve/src/bin/btsieve.rs
+++ b/application/btsieve/src/bin/btsieve.rs
@@ -93,7 +93,7 @@ fn create_bitcoin_routes(
     let client = Arc::new(bitcoin_rpc_client);
 
     let ledger_name = "bitcoin";
-    let network: &'static str = settings.network.into();
+    let network = settings.network.into();
 
     let transaction_routes = route_factory
         .create::<bitcoin::queries::transaction::ReturnAs, _, _, _, _>(
@@ -184,7 +184,7 @@ fn create_ethereum_routes(
     }
 
     let ledger_name = "ethereum";
-    let network: &'static str = settings.network.into();
+    let network = settings.network.into();
 
     let transaction_routes = route_factory
         .create::<ethereum::queries::transaction::ReturnAs, _, _, _, _>(

--- a/application/btsieve/src/route_factory.rs
+++ b/application/btsieve/src/route_factory.rs
@@ -60,6 +60,7 @@ impl RouteFactory {
         query_result_repository: Arc<QRR>,
         client: Arc<C>,
         ledger_name: &'static str,
+        network: &'static str,
     ) -> BoxedFilter<(impl Reply,)>
     where
         for<'de> R: Deserialize<'de>,
@@ -70,6 +71,7 @@ impl RouteFactory {
 
         let path = warp::path("queries")
             .and(warp::path(ledger_name))
+            .and(warp::path(network))
             .and(warp::path(&route));
 
         let external_url = self.external_url.clone();
@@ -82,6 +84,7 @@ impl RouteFactory {
             .and(external_url.clone())
             .and(query_repository.clone())
             .and(warp::any().map(move || ledger_name))
+            .and(warp::any().map(move || network))
             .and(warp::any().map(move || route))
             .and(warp::body::json())
             .and_then(routes::create_query);

--- a/application/btsieve/src/routes.rs
+++ b/application/btsieve/src/routes.rs
@@ -71,6 +71,7 @@ pub fn create_query<Q: Send, QR: QueryRepository<Q>>(
     external_url: Url,
     query_repository: Arc<QR>,
     ledger_name: &'static str,
+    network: &'static str,
     query_type: &'static str,
     query: Q,
 ) -> Result<impl Reply, Rejection> {
@@ -79,7 +80,9 @@ pub fn create_query<Q: Send, QR: QueryRepository<Q>>(
     match result {
         Ok(id) => {
             let uri = external_url
-                .join(format!("/queries/{}/{}/{}", ledger_name, query_type, id).as_str())
+                .join(
+                    format!("/queries/{}/{}/{}/{}", ledger_name, network, query_type, id).as_str(),
+                )
                 .expect("Should be able to join urls")
                 .to_string();
             let reply = warp::reply::with_status(warp::reply(), warp::http::StatusCode::CREATED);

--- a/application/btsieve/src/settings/mod.rs
+++ b/application/btsieve/src/settings/mod.rs
@@ -1,8 +1,6 @@
 mod serde;
 
-use bitcoin_support::Network as BitcoinNetwork;
 use config::{Config, ConfigError, File};
-use ethereum_support::Network as EthereumNetwork;
 use std::{ffi::OsStr, net::IpAddr, path::Path, time::Duration};
 
 #[derive(Debug, Deserialize, Clone)]
@@ -22,7 +20,6 @@ pub struct HttpApi {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Bitcoin {
-    pub network: BitcoinNetwork,
     pub zmq_endpoint: String,
     // Below could be options
     #[serde(with = "serde::url")]
@@ -37,7 +34,6 @@ pub struct Ethereum {
     pub node_url: url::Url,
     #[serde(with = "serde::duration")]
     pub poll_interval_secs: Duration,
-    pub network: EthereumNetwork,
 }
 
 impl Settings {

--- a/application/btsieve/src/settings/mod.rs
+++ b/application/btsieve/src/settings/mod.rs
@@ -1,7 +1,8 @@
 mod serde;
 
-use bitcoin_support::Network;
+use bitcoin_support::Network as BitcoinNetwork;
 use config::{Config, ConfigError, File};
+use ethereum_support::Network as EthereumNetwork;
 use std::{ffi::OsStr, net::IpAddr, path::Path, time::Duration};
 
 #[derive(Debug, Deserialize, Clone)]
@@ -21,7 +22,7 @@ pub struct HttpApi {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Bitcoin {
-    pub network: Network,
+    pub network: BitcoinNetwork,
     pub zmq_endpoint: String,
     // Below could be options
     #[serde(with = "serde::url")]
@@ -36,6 +37,7 @@ pub struct Ethereum {
     pub node_url: url::Url,
     #[serde(with = "serde::duration")]
     pub poll_interval_secs: Duration,
+    pub network: EthereumNetwork,
 }
 
 impl Settings {

--- a/application/btsieve/src/settings/mod.rs
+++ b/application/btsieve/src/settings/mod.rs
@@ -21,7 +21,6 @@ pub struct HttpApi {
 #[derive(Debug, Deserialize, Clone)]
 pub struct Bitcoin {
     pub zmq_endpoint: String,
-    // Below could be options
     #[serde(with = "serde::url")]
     pub node_url: url::Url,
     pub node_username: String,

--- a/application/comit_node/config/default.toml
+++ b/application/comit_node/config/default.toml
@@ -7,8 +7,11 @@ secret_seed = "c1fd6fc5bde7fee2c2fb6d868dc0f40368051fede1d83f814839d562c210aa27"
 url = "http://localhost:8001"
 [btsieve.bitcoin]
 poll_interval_secs = 300
+network = "regtest"
+
 [btsieve.ethereum]
 poll_interval_secs = 20
+network = "regtest"
 
 [http_api]
 address="0.0.0.0"

--- a/application/comit_node/src/bin/comit_node.rs
+++ b/application/comit_node/src/bin/comit_node.rs
@@ -82,7 +82,9 @@ fn create_btsieve_api_client(settings: &ComitNodeSettings) -> BtsieveHttpClient 
     BtsieveHttpClient::new(
         &settings.btsieve.url,
         settings.btsieve.bitcoin.poll_interval_secs,
+        settings.btsieve.bitcoin.network.as_str(),
         settings.btsieve.ethereum.poll_interval_secs,
+        settings.btsieve.ethereum.network.as_str(),
     )
 }
 

--- a/application/comit_node/src/btsieve/client.rs
+++ b/application/comit_node/src/btsieve/client.rs
@@ -52,24 +52,26 @@ impl BtsieveHttpClient {
     pub fn new(
         endpoint: &Url,
         ethereum_poll_interval: Duration,
+        ethereum_network: &str,
         bitcoin_poll_interval: Duration,
+        bitcoin_network: &str,
     ) -> Self {
         Self {
             client: Client::new(),
             create_bitcoin_transaction_query_endpoint: endpoint
-                .join("queries/bitcoin/transactions")
+                .join(format!("queries/bitcoin/{}/transactions", bitcoin_network).as_ref())
                 .expect("invalid url"),
             create_bitcoin_block_query_endpoint: endpoint
-                .join("queries/bitcoin/blocks")
+                .join(format!("queries/bitcoin/{}/blocks", bitcoin_network).as_ref())
                 .expect("invalid url"),
             create_ethereum_transaction_query_endpoint: endpoint
-                .join("queries/ethereum/transactions")
+                .join(format!("queries/ethereum/{}/transactions", ethereum_network).as_ref())
                 .expect("invalid url"),
             create_ethereum_block_query_endpoint: endpoint
-                .join("queries/ethereum/blocks")
+                .join(format!("queries/ethereum/{}/blocks", ethereum_network).as_ref())
                 .expect("invalid url"),
             create_ethereum_event_query_endpoint: endpoint
-                .join("queries/ethereum/logs")
+                .join(format!("queries/ethereum/{}/logs", ethereum_network).as_ref())
                 .expect("invalid url"),
             ethereum_poll_interval,
             bitcoin_poll_interval,

--- a/application/comit_node/src/settings/mod.rs
+++ b/application/comit_node/src/settings/mod.rs
@@ -49,6 +49,7 @@ pub struct Btsieve {
 pub struct PollParameters {
     #[serde(with = "serde::duration")]
     pub poll_interval_secs: Duration,
+    pub network: String,
 }
 
 impl ComitNodeSettings {

--- a/vendor/bitcoin_support/Cargo.toml
+++ b/vendor/bitcoin_support/Cargo.toml
@@ -14,6 +14,8 @@ lazy_static = "1"
 secp256k1_support = { path = "../secp256k1_support" }
 serde = "1"
 serde_derive = "1"
+strum = "0.14.0"
+strum_macros = "0.14.0"
 
 [dev-dependencies]
 serde_json = "1"

--- a/vendor/bitcoin_support/src/lib.rs
+++ b/vendor/bitcoin_support/src/lib.rs
@@ -3,6 +3,8 @@
 
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
+extern crate strum_macros;
 
 pub use bitcoin::{
     blockdata::{

--- a/vendor/bitcoin_support/src/network.rs
+++ b/vendor/bitcoin_support/src/network.rs
@@ -1,11 +1,14 @@
 use bitcoin;
 use bitcoin_bech32;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize, Hash, IntoStaticStr)]
 #[serde(rename_all = "lowercase")]
 pub enum Network {
+    #[strum(serialize = "mainnet")]
     Mainnet,
+    #[strum(serialize = "regtest")]
     Regtest,
+    #[strum(serialize = "testnet")]
     Testnet,
 }
 
@@ -36,5 +39,21 @@ impl From<Network> for bitcoin_bech32::constants::Network {
             Network::Testnet => bitcoin_bech32::constants::Network::Testnet,
             Network::Mainnet => bitcoin_bech32::constants::Network::Bitcoin,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn string_deserialize() {
+        let mainnet: &'static str = Network::Mainnet.into();
+        let regtest: &'static str = Network::Regtest.into();
+        let testnet: &'static str = Network::Testnet.into();
+
+        assert_eq!(mainnet, "mainnet");
+        assert_eq!(regtest, "regtest");
+        assert_eq!(testnet, "testnet");
     }
 }

--- a/vendor/bitcoin_support/src/network.rs
+++ b/vendor/bitcoin_support/src/network.rs
@@ -47,7 +47,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn string_deserialize() {
+    fn string_serialize() {
         let mainnet: &'static str = Network::Mainnet.into();
         let regtest: &'static str = Network::Regtest.into();
         let testnet: &'static str = Network::Testnet.into();

--- a/vendor/ethereum_support/Cargo.toml
+++ b/vendor/ethereum_support/Cargo.toml
@@ -14,6 +14,8 @@ rlp = "0.2"
 secp256k1_support = { path = "../secp256k1_support" }
 serde = "1.0.70"
 serde_derive = "1.0"
+strum = "0.14.0"
+strum_macros = "0.14.0"
 tiny-keccak = "1.4"
 extern_web3 = { package = "web3", version = "0.5" }
 

--- a/vendor/ethereum_support/src/lib.rs
+++ b/vendor/ethereum_support/src/lib.rs
@@ -5,6 +5,8 @@
 extern crate lazy_static;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
+extern crate strum_macros;
 
 pub use crate::{
     contract_address::*, erc20_quantity::*, erc20_token::*, ether_quantity::*, key::*, network::*,

--- a/vendor/ethereum_support/src/network.rs
+++ b/vendor/ethereum_support/src/network.rs
@@ -14,7 +14,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn string_deserialize() {
+    fn string_serialize() {
         let mainnet: &'static str = Network::Mainnet.into();
         let regtest: &'static str = Network::Regtest.into();
         let ropsten: &'static str = Network::Ropsten.into();

--- a/vendor/ethereum_support/src/network.rs
+++ b/vendor/ethereum_support/src/network.rs
@@ -7,6 +7,19 @@ pub enum Network {
     Regtest,
     #[strum(serialize = "ropsten")]
     Ropsten,
+    #[strum(serialize = "unknown")]
+    Unknown,
+}
+
+impl Network {
+    pub fn from_network_id(s: String) -> Self {
+        match s.as_str() {
+            "1" => Network::Mainnet,
+            "3" => Network::Ropsten,
+            "17" => Network::Regtest,
+            _ => Network::Unknown,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -22,5 +35,25 @@ mod test {
         assert_eq!(mainnet, "mainnet");
         assert_eq!(regtest, "regtest");
         assert_eq!(ropsten, "ropsten");
+    }
+
+    #[test]
+    fn from_version() {
+        assert_eq!(
+            Network::from_network_id(String::from("1")),
+            Network::Mainnet
+        );
+        assert_eq!(
+            Network::from_network_id(String::from("3")),
+            Network::Ropsten
+        );
+        assert_eq!(
+            Network::from_network_id(String::from("17")),
+            Network::Regtest
+        );
+        assert_eq!(
+            Network::from_network_id(String::from("-1")),
+            Network::Unknown
+        );
     }
 }

--- a/vendor/ethereum_support/src/network.rs
+++ b/vendor/ethereum_support/src/network.rs
@@ -1,4 +1,6 @@
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize, Hash, IntoStaticStr)]
+#[derive(
+    Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize, Hash, ToString, IntoStaticStr,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum Network {
     #[strum(serialize = "mainnet")]

--- a/vendor/ethereum_support/src/network.rs
+++ b/vendor/ethereum_support/src/network.rs
@@ -1,7 +1,26 @@
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize, Hash, IntoStaticStr)]
 #[serde(rename_all = "lowercase")]
 pub enum Network {
+    #[strum(serialize = "mainnet")]
     Mainnet,
+    #[strum(serialize = "regtest")]
     Regtest,
+    #[strum(serialize = "ropsten")]
     Ropsten,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn string_deserialize() {
+        let mainnet: &'static str = Network::Mainnet.into();
+        let regtest: &'static str = Network::Regtest.into();
+        let ropsten: &'static str = Network::Ropsten.into();
+
+        assert_eq!(mainnet, "mainnet");
+        assert_eq!(regtest, "regtest");
+        assert_eq!(ropsten, "ropsten");
+    }
 }

--- a/vendor/tc_web3_client/Cargo.toml
+++ b/vendor/tc_web3_client/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 testcontainers = "0.6"
-web3 = "0.5"
+web3 = "0.6"

--- a/vendor/tc_web3_client/Cargo.toml
+++ b/vendor/tc_web3_client/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 testcontainers = "0.6"
-web3 = "0.6"
+web3 = "0.5"


### PR DESCRIPTION
btsieve supports now a ledger network e.g. 
`/queries/bitcoin/regtest/*` or `/queries/ethereum/regtest/*`, ... 

I decided for a path param as the `network` is part of the ledger and not part of the query, i.e. if you create a query for `/queries/ethereum/transactions` with an additional field or a query param, we would need to check on the btsieve side manually while using the path param a 404 is automatically returned if the network is not supported. 

This network is part of the ledger configuration in the config file of btsieve. 

Resolves #815