### PR TITLE
Add ability to specify private key as hex as argument to keygen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,8 +1213,6 @@ dependencies = [
  "bitcoin_support 0.1.0",
  "ethereum_support 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "pretty_env_logger 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1_support 0.1.0",
 ]

--- a/vendor/key_gen/Cargo.toml
+++ b/vendor/key_gen/Cargo.toml
@@ -8,8 +8,6 @@ edition = "2018"
 bitcoin_support  = { path = "../bitcoin_support" }
 ethereum_support = { path = "../ethereum_support" }
 hex = "0.3"
-log = "0.4"
-pretty_env_logger = "0.2"
 rand = "0.3"
 secp256k1_support = { path = "../secp256k1_support" }
 

--- a/vendor/key_gen/src/main.rs
+++ b/vendor/key_gen/src/main.rs
@@ -1,83 +1,56 @@
-use bitcoin_support::{
-    ChainCode, ChildNumber, ExtendedPrivKey, ExtendedPubKey, Fingerprint, IntoP2wpkhAddress,
-    Network, PrivateKey, PubkeyHash,
-};
+use bitcoin_support::{IntoP2wpkhAddress, Network, PrivateKey, PubkeyHash};
 use ethereum_support::ToEthereumAddress;
 use rand::OsRng;
-use secp256k1_support::{KeyPair, SecretKey, SECP};
-#[macro_use]
-extern crate log;
-extern crate pretty_env_logger;
+use secp256k1_support::KeyPair;
 use std::env;
 
 fn main() {
-    env::set_var("RUST_LOG", "info");
-    let _ = pretty_env_logger::try_init();
+    let keypair = match env::args().skip(1).next() {
+        Some(existing_key) => KeyPair::from_secret_key_hex(existing_key.as_ref()).unwrap(),
+        None => {
+            let mut rng = OsRng::new().unwrap();
+            KeyPair::new(&mut rng)
+        }
+    };
 
-    let mut rng = OsRng::new().unwrap();
-    let keypair = KeyPair::new(&mut rng);
     let secret_key = keypair.secret_key();
     let public_key = keypair.public_key();
-    let private_key = PrivateKey::from_secret_key(secret_key, true, Network::Mainnet.into());
+    let mainnet_private_key =
+        PrivateKey::from_secret_key(secret_key, true, Network::Mainnet.into());
+    let testnet_private_key =
+        PrivateKey::from_secret_key(secret_key, true, Network::Testnet.into());
 
-    info!("private_key: {}", hex::encode(&secret_key[..]));
-    info!("btc_base58_private_key: {}", private_key.to_string());
-    info!(
+    println!("private_key: {}", hex::encode(&secret_key[..]));
+    println!(
+        "WIF_mainnet_private_key: {}",
+        mainnet_private_key.to_string()
+    );
+    println!(
+        "WIF_testnet_private_key: {}",
+        testnet_private_key.to_string()
+    );
+    println!(
         "public_key: {}",
         hex::encode(&public_key.inner().serialize()[..])
     );
-    info!(
+    println!(
         "public_key_uncompressed: {}",
         hex::encode(&public_key.inner().serialize_uncompressed()[..])
     );
     let eth_address = public_key.to_ethereum_address();
-    info!("eth_address: {:?}", eth_address);
+    println!("eth_address: {:?}", eth_address);
     {
         let btc_address_mainnet = public_key.into_p2wpkh_address(Network::Mainnet);
-        info!("btc_address_p2wpkh_mainnet: {:?}", btc_address_mainnet);
+        println!("btc_address_p2wpkh_mainnet: {:?}", btc_address_mainnet);
     }
 
     {
         let btc_address_testnet = public_key.into_p2wpkh_address(Network::Testnet);
-        info!("btc_address_p2wpkh_testnet: {:?}", btc_address_testnet);
+        println!("btc_address_p2wpkh_testnet: {:?}", btc_address_testnet);
     }
     {
         let btc_address_regtest = public_key.into_p2wpkh_address(Network::Regtest);
-        info!("btc_address_p2wpkh_regtest: {:?}", btc_address_regtest);
+        println!("btc_address_p2wpkh_regtest: {:?}", btc_address_regtest);
     }
-    info!("pubkey_hash: {:?}", PubkeyHash::from(public_key));
-
-    {
-        let extended_privkey = extended_privkey_from_secret_key(secret_key, Network::Mainnet);
-        let extended_pubkey = ExtendedPubKey::from_private(&SECP, &extended_privkey);
-        info!("btc_extended_privkey_mainnet: {}", extended_privkey);
-        info!("btc_extended_pubkey_mainnet: {}", extended_pubkey);
-    }
-    {
-        let extended_privkey = extended_privkey_from_secret_key(secret_key, Network::Testnet);
-        let extended_pubkey = ExtendedPubKey::from_private(&SECP, &extended_privkey);
-        info!("btc_extended_privkey_testnet: {}", extended_privkey);
-        info!("btc_extended_pubkey_testnet: {}", extended_pubkey);
-    }
-    {
-        let extended_privkey = extended_privkey_from_secret_key(secret_key, Network::Regtest);
-        let extended_pubkey = ExtendedPubKey::from_private(&SECP, &extended_privkey);
-        info!("btc_extended_privkey_regtest: {}", extended_privkey);
-        info!("btc_extended_pubkey_regtest: {}", extended_pubkey);
-    }
-}
-
-fn extended_privkey_from_secret_key(
-    secret_key: SecretKey,
-    network: bitcoin_support::Network,
-) -> ExtendedPrivKey {
-    let chain_code = ChainCode::from(&[1u8; 32][..]);
-    ExtendedPrivKey {
-        network: network.into(),
-        depth: 0,
-        parent_fingerprint: Fingerprint::default(),
-        child_number: ChildNumber::from(0),
-        secret_key,
-        chain_code,
-    }
+    println!("pubkey_hash: {:x}", PubkeyHash::from(public_key));
 }

--- a/vendor/key_gen/src/main.rs
+++ b/vendor/key_gen/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 use bitcoin_support::{IntoP2wpkhAddress, Network, PrivateKey, PubkeyHash};
 use ethereum_support::ToEthereumAddress;
 use rand::OsRng;
@@ -5,7 +6,7 @@ use secp256k1_support::KeyPair;
 use std::env;
 
 fn main() {
-    let keypair = match env::args().skip(1).next() {
+    let keypair = match env::args().nth(1) {
         Some(existing_key) => KeyPair::from_secret_key_hex(existing_key.as_ref()).unwrap(),
         None => {
             let mut rng = OsRng::new().unwrap();


### PR DESCRIPTION
Add ability to specify private key as hex as argument to keygen

And:

- Stop logging the output
- Remove a bunch of unused stuff