### PR TITLE
Use override for bitcoin_rpc_client to avoid git branch everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 [[package]]
 name = "bitcoin_rpc_client"
 version = "0.6.0"
-source = "git+https://github.com/coblox/bitcoinrpc-rust-client?branch=from-verboserawtx-to-bitcointx-0.6#505a9153395d887a0958ae246a5d3189bb2861f9"
+source = "git+https://github.com/coblox/bitcoinrpc-rust-client?branch=from-verboserawtx-to-bitcointx-0.6#d31e0493cfa43360b66aa520faf82a8409b716e7"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -224,10 +224,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin_rpc_client"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+replace = "bitcoin_rpc_client 0.6.0 (git+https://github.com/coblox/bitcoinrpc-rust-client?branch=from-verboserawtx-to-bitcointx-0.6)"
+
+[[package]]
 name = "bitcoin_rpc_test_helpers"
 version = "0.1.0"
 dependencies = [
- "bitcoin_rpc_client 0.6.0 (git+https://github.com/coblox/bitcoinrpc-rust-client?branch=from-verboserawtx-to-bitcointx-0.6)",
+ "bitcoin_rpc_client 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin_support 0.1.0",
  "testcontainers 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -255,7 +261,7 @@ dependencies = [
 name = "bitcoin_witness"
 version = "0.1.0"
 dependencies = [
- "bitcoin_rpc_client 0.6.0 (git+https://github.com/coblox/bitcoinrpc-rust-client?branch=from-verboserawtx-to-bitcointx-0.6)",
+ "bitcoin_rpc_client 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin_rpc_test_helpers 0.1.0",
  "bitcoin_support 0.1.0",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -309,7 +315,7 @@ dependencies = [
 name = "btsieve"
 version = "0.1.0"
 dependencies = [
- "bitcoin_rpc_client 0.6.0 (git+https://github.com/coblox/bitcoinrpc-rust-client?branch=from-verboserawtx-to-bitcointx-0.6)",
+ "bitcoin_rpc_client 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin_support 0.1.0",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -453,7 +459,7 @@ version = "0.1.0"
 dependencies = [
  "bam 0.1.0",
  "binary_macros 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitcoin_rpc_client 0.6.0 (git+https://github.com/coblox/bitcoinrpc-rust-client?branch=from-verboserawtx-to-bitcointx-0.6)",
+ "bitcoin_rpc_client 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin_rpc_test_helpers 0.1.0",
  "bitcoin_support 0.1.0",
  "bitcoin_witness 0.1.0",
@@ -2553,7 +2559,7 @@ dependencies = [
 name = "tc_bitcoincore_client"
 version = "0.1.0"
 dependencies = [
- "bitcoin_rpc_client 0.6.0 (git+https://github.com/coblox/bitcoinrpc-rust-client?branch=from-verboserawtx-to-bitcointx-0.6)",
+ "bitcoin_rpc_client 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testcontainers 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3400,6 +3406,7 @@ dependencies = [
 "checksum bitcoin_hashes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2b7a2e9773ee7ae7f2560f0426c938f57902dcb9e39321b0cbd608f47ed579a4"
 "checksum bitcoin_quantity 0.1.0 (git+https://github.com/coblox/bitcoin-quantity)" = "<none>"
 "checksum bitcoin_rpc_client 0.6.0 (git+https://github.com/coblox/bitcoinrpc-rust-client?branch=from-verboserawtx-to-bitcointx-0.6)" = "<none>"
+"checksum bitcoin_rpc_client 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f9eb6be87324ba28633d4dd6a253956ddcc31f8f313157a398c56251eeb1010"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 [[package]]
 name = "bitcoin_rpc_client"
 version = "0.6.0"
-source = "git+https://github.com/coblox/bitcoinrpc-rust-client?branch=from-verboserawtx-to-bitcointx-0.6#b2124c68d0544c5138895070c25176f9aed65d02"
+source = "git+https://github.com/coblox/bitcoinrpc-rust-client?branch=from-verboserawtx-to-bitcointx-0.6#505a9153395d887a0958ae246a5d3189bb2861f9"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ members = [
     "vendor/tc_web3_client",
     "vendor/noise_handshake"
 ]
+
+[replace]
+"bitcoin_rpc_client:0.6.0" = { git = "https://github.com/coblox/bitcoinrpc-rust-client", branch = "from-verboserawtx-to-bitcointx-0.6" }

--- a/application/btsieve/Cargo.toml
+++ b/application/btsieve/Cargo.toml
@@ -5,7 +5,7 @@ name = "btsieve"
 version = "0.1.0"
 
 [dependencies]
-bitcoin_rpc_client = { git = "https://github.com/coblox/bitcoinrpc-rust-client", branch = "from-verboserawtx-to-bitcointx-0.6" }
+bitcoin_rpc_client = "0.6"
 byteorder = "1.2"
 directories = "1.0"
 debug_stub_derive = "0.3"

--- a/application/comit_node/Cargo.toml
+++ b/application/comit_node/Cargo.toml
@@ -9,7 +9,7 @@ regex = "1"
 
 [dependencies]
 binary_macros = "0.6"
-bitcoin_rpc_client = { git = "https://github.com/coblox/bitcoinrpc-rust-client", branch = "from-verboserawtx-to-bitcointx-0.6" }
+bitcoin_rpc_client = "0.6"
 chrono = { version = "0.4", features = ["serde"] }
 config = { version = "0.9", features = ["toml"] }
 debug_stub_derive = "0.3"

--- a/vendor/bitcoin_rpc_test_helpers/Cargo.toml
+++ b/vendor/bitcoin_rpc_test_helpers/Cargo.toml
@@ -5,7 +5,7 @@ authors = [ "CoBloX developers <team@coblox.tech>" ]
 edition = "2018"
 
 [dependencies]
-bitcoin_rpc_client = { git = "https://github.com/coblox/bitcoinrpc-rust-client", branch = "from-verboserawtx-to-bitcointx-0.6" }
+bitcoin_rpc_client = "0.6"
 bitcoin_support = { path = "../bitcoin_support" }
 testcontainers = "0.6"
 

--- a/vendor/bitcoin_witness/Cargo.toml
+++ b/vendor/bitcoin_witness/Cargo.toml
@@ -10,7 +10,7 @@ secp256k1_support = { path = "../secp256k1_support" }
 failure = "0.1"
 
 [dev-dependencies]
-bitcoin_rpc_client = { git = "https://github.com/coblox/bitcoinrpc-rust-client", branch = "from-verboserawtx-to-bitcointx-0.6" }
+bitcoin_rpc_client = "0.6"
 bitcoin_rpc_test_helpers = { path = "../bitcoin_rpc_test_helpers" }
 env_logger = "0.6"
 hex = "0.3"

--- a/vendor/tc_bitcoincore_client/Cargo.toml
+++ b/vendor/tc_bitcoincore_client/Cargo.toml
@@ -5,5 +5,5 @@ authors = [ "CoBloX developers <team@coblox.tech>" ]
 edition = "2018"
 
 [dependencies]
-bitcoin_rpc_client = { git = "https://github.com/coblox/bitcoinrpc-rust-client", branch = "from-verboserawtx-to-bitcointx-0.6" }
+bitcoin_rpc_client = "0.6"
 testcontainers = "0.6"


### PR DESCRIPTION
Change now possible that bitcoin_rpc_client 0.6.0 is published