### PR TITLE
Refactor actions to embed validity information

### DIFF
--- a/api_tests/btsieve/bitcoin_only/test.ts
+++ b/api_tests/btsieve/bitcoin_only/test.ts
@@ -27,7 +27,7 @@ setTimeout(async function() {
         let token_contract_address: string;
         before(async function() {
             this.timeout(5000);
-            await bitcoin.ensureSegwit();
+            await bitcoin.ensureFunding();
             await tobyWallet.btc().fund(5);
         });
 

--- a/api_tests/btsieve/bitcoin_only/test.ts
+++ b/api_tests/btsieve/bitcoin_only/test.ts
@@ -1,16 +1,11 @@
 import * as bitcoin from "../../lib/bitcoin";
 import { Wallet } from "../../lib/wallet";
 import * as chai from "chai";
+import { HarnessGlobal } from "../../lib/util";
+import { Btsieve, IdMatchResponse } from "../../lib/btsieve";
 import chaiHttp = require("chai-http");
-import * as ethereum from "../../lib/ethereum";
-import { HarnessGlobal, sleep } from "../../lib/util";
-import {
-    IdMatchResponse,
-    EthereumTransactionResponse,
-    Btsieve,
-} from "../../lib/btsieve";
 
-const should = chai.should();
+chai.should();
 chai.use(chaiHttp);
 
 declare var global: HarnessGlobal;
@@ -147,6 +142,8 @@ setTimeout(async function() {
                         });
                 });
 
+                const min_height = 200;
+                let location: string;
                 it("btsieve should respond not found when creating a bitcoin block query for an invalid network", async function() {
                     return chai
                         .request(btsieve.url())
@@ -159,8 +156,6 @@ setTimeout(async function() {
                         });
                 });
 
-                const min_height = 600;
-                let location: string;
                 it("btsieve should respond with location when creating a valid bitcoin block query", async function() {
                     return chai
                         .request(btsieve.url())

--- a/api_tests/btsieve/bitcoin_only/test.ts
+++ b/api_tests/btsieve/bitcoin_only/test.ts
@@ -19,7 +19,6 @@ const tobyWallet = new Wallet("toby", {
 
 setTimeout(async function() {
     describe("Test btsieve API - bitcoin", () => {
-        let token_contract_address: string;
         before(async function() {
             this.timeout(5000);
             await bitcoin.ensureFunding();

--- a/api_tests/btsieve/ethereum_only/test.ts
+++ b/api_tests/btsieve/ethereum_only/test.ts
@@ -1,15 +1,15 @@
 import { Wallet } from "../../lib/wallet";
 import * as chai from "chai";
-import chaiHttp = require("chai-http");
 import * as ethereum from "../../lib/ethereum";
 import { HarnessGlobal, sleep } from "../../lib/util";
 import {
-    IdMatchResponse,
-    EthereumTransactionResponse,
     Btsieve,
+    EthereumTransactionResponse,
+    IdMatchResponse,
 } from "../../lib/btsieve";
+import chaiHttp = require("chai-http");
 
-const should = chai.should();
+chai.should();
 chai.use(chaiHttp);
 
 declare var global: HarnessGlobal;

--- a/api_tests/btsieve/no_ledger/test.ts
+++ b/api_tests/btsieve/no_ledger/test.ts
@@ -1,9 +1,9 @@
 import * as chai from "chai";
-import chaiHttp = require("chai-http");
 import { HarnessGlobal } from "../../lib/util";
 import { Btsieve } from "../../lib/btsieve";
+import chaiHttp = require("chai-http");
 
-const should = chai.should();
+chai.should();
 chai.use(chaiHttp);
 
 declare var global: HarnessGlobal;

--- a/api_tests/dry/multiple_peers.ts
+++ b/api_tests/dry/multiple_peers.ts
@@ -1,17 +1,14 @@
-import { Actor, TestConfig } from "../lib/actor";
-import { EthConfig } from "../lib/ethereum";
+import { Actor } from "../lib/actor";
 import * as chai from "chai";
 import { SwapResponse } from "../lib/comit";
-import { BtcConfig } from "../lib/bitcoin";
 import * as utils from "web3-utils";
 import { HarnessGlobal } from "../lib/util";
-
 import chaiHttp = require("chai-http");
 
 declare var global: HarnessGlobal;
 
 chai.use(chaiHttp);
-const should = chai.should();
+chai.should();
 
 const alpha_ledger_name = "bitcoin";
 const alpha_ledger_network = "regtest";
@@ -41,7 +38,6 @@ const charlie = new Actor("charlie", global.config, global.project_root, {
 });
 
 const alice_final_address = "0x00a329c0648769a73afac7f9381e08fb43dbea72";
-const alice_comit_node_address = alice.comitNodeConfig.comit.comit_listen;
 const bob_comit_node_address = bob.comitNodeConfig.comit.comit_listen;
 const charlie_comit_node_address = charlie.comitNodeConfig.comit.comit_listen;
 

--- a/api_tests/dry/rfc003_swap_reject.ts
+++ b/api_tests/dry/rfc003_swap_reject.ts
@@ -1,11 +1,11 @@
 import { Actor } from "../lib/actor";
 import * as util from "../lib/util";
-import * as chai from "chai";
-import { SwapResponse, SwapsResponse, Swap } from "../lib/comit";
-import * as utils from "web3-utils";
 import { HarnessGlobal } from "../lib/util";
-import chaiHttp = require("chai-http");
+import * as chai from "chai";
 import { expect } from "chai";
+import { Swap, SwapResponse, SwapsResponse } from "../lib/comit";
+import * as utils from "web3-utils";
+import chaiHttp = require("chai-http");
 
 chai.use(chaiHttp);
 chai.should();

--- a/api_tests/dry/rfc003_swap_reject.ts
+++ b/api_tests/dry/rfc003_swap_reject.ts
@@ -4,11 +4,12 @@ import * as chai from "chai";
 import { SwapResponse, SwapsResponse, Swap } from "../lib/comit";
 import * as utils from "web3-utils";
 import { HarnessGlobal } from "../lib/util";
-
 import chaiHttp = require("chai-http");
+import { expect } from "chai";
 
 chai.use(chaiHttp);
-const should = chai.should();
+chai.should();
+
 declare var global: HarnessGlobal;
 
 const alpha_ledger_name = "bitcoin";
@@ -245,20 +246,23 @@ setTimeout(async function() {
                     state.beta_ledger.should.be.a("object");
 
                     let communication = state.communication;
-                    communication.should.be.a("object");
 
-                    communication.status.should.equal("SENT");
+                    expect(communication).to.be.a("object");
+                    expect(communication.status).to.equal("SENT");
 
-                    communication.alpha_expiry.should.be.a("number");
-                    should.not.exist(communication.alpha_redeem_identity);
-                    communication.alpha_refund_identity.should.be.a("string");
+                    expect(communication.alpha_expiry).to.be.a("number");
+                    expect(communication.alpha_redeem_identity).to.be.null;
+                    expect(communication.alpha_refund_identity).to.be.a(
+                        "string"
+                    );
 
-                    communication.beta_expiry.should.be.a("number");
-                    communication.beta_redeem_identity.should.equal(
+                    expect(communication.beta_expiry).to.be.a("number");
+                    expect(communication.beta_redeem_identity).to.equal(
                         alice_final_address
                     );
-                    should.not.exist(communication.beta_refund_identity);
-                    communication.secret_hash.should.be.a("string");
+                    expect(communication.beta_refund_identity).to.be.null;
+
+                    expect(communication.secret_hash).to.be.a("string");
                 });
         });
 

--- a/api_tests/dry/sanity.ts
+++ b/api_tests/dry/sanity.ts
@@ -2,12 +2,11 @@
 // They are mostly about checking invalid request responses
 import { Actor } from "../lib/actor";
 import * as chai from "chai";
-import { HarnessGlobal, sleep } from "../lib/util";
-
+import { HarnessGlobal } from "../lib/util";
 import chaiHttp = require("chai-http");
 
 chai.use(chaiHttp);
-const should = chai.should();
+chai.should();
 
 declare var global: HarnessGlobal;
 

--- a/api_tests/e2e/rfc003/btc_eth-erc20/happy.ts
+++ b/api_tests/e2e/rfc003/btc_eth-erc20/happy.ts
@@ -47,7 +47,7 @@ declare var global: HarnessGlobal;
     const initialUrl = "/swaps/rfc003";
     const listUrl = "/swaps";
 
-    await bitcoin.ensureSegwit();
+    await bitcoin.ensureFunding();
     await tobyWallet.eth().fund(tobyInitialEth);
     await bob.wallet.eth().fund(bobInitialEth);
     await alice.wallet.btc().fund(10);

--- a/api_tests/e2e/rfc003/btc_eth-erc20/happy.ts
+++ b/api_tests/e2e/rfc003/btc_eth-erc20/happy.ts
@@ -2,14 +2,14 @@ import * as bitcoin from "../../../lib/bitcoin";
 import * as chai from "chai";
 import * as ethereum from "../../../lib/ethereum";
 import { Actor } from "../../../lib/actor";
-import { ActionKind, SwapRequest, SwapResponse } from "../../../lib/comit";
+import { ActionKind, SwapRequest } from "../../../lib/comit";
 import { Wallet } from "../../../lib/wallet";
 import { BN, toBN, toWei } from "web3-utils";
 import { HarnessGlobal } from "../../../lib/util";
 import { createTests } from "../../test_creator";
 import chaiHttp = require("chai-http");
 
-const should = chai.should();
+chai.should();
 chai.use(chaiHttp);
 
 declare var global: HarnessGlobal;

--- a/api_tests/e2e/rfc003/btc_eth-erc20/refund_beta.ts
+++ b/api_tests/e2e/rfc003/btc_eth-erc20/refund_beta.ts
@@ -48,7 +48,7 @@ declare var global: HarnessGlobal;
     const initialUrl = "/swaps/rfc003";
     const listUrl = "/swaps";
 
-    await bitcoin.ensureSegwit();
+    await bitcoin.ensureFunding();
     await tobyWallet.eth().fund(tobyInitialEth);
     await bob.wallet.eth().fund(bobInitialEth);
     await alice.wallet.btc().fund(10);

--- a/api_tests/e2e/rfc003/btc_eth-erc20/refund_beta.ts
+++ b/api_tests/e2e/rfc003/btc_eth-erc20/refund_beta.ts
@@ -2,14 +2,14 @@ import * as bitcoin from "../../../lib/bitcoin";
 import * as chai from "chai";
 import * as ethereum from "../../../lib/ethereum";
 import { Actor } from "../../../lib/actor";
-import { ActionKind, SwapRequest, SwapResponse } from "../../../lib/comit";
+import { ActionKind, SwapRequest } from "../../../lib/comit";
 import { Wallet } from "../../../lib/wallet";
-import { BN, toBN, toWei } from "web3-utils";
-import { HarnessGlobal, sleep } from "../../../lib/util";
+import { toBN, toWei } from "web3-utils";
+import { HarnessGlobal } from "../../../lib/util";
 import { createTests } from "../../test_creator";
 import chaiHttp = require("chai-http");
 
-const should = chai.should();
+chai.should();
 chai.use(chaiHttp);
 
 declare var global: HarnessGlobal;
@@ -33,13 +33,10 @@ declare var global: HarnessGlobal;
     });
 
     const aliceFinalAddress = "0x00a329c0648769a73afac7f9381e08fb43dbea72";
-    const bobFinalAddress =
-        "bcrt1qs2aderg3whgu0m8uadn6dwxjf7j3wx97kk2qqtrum89pmfcxknhsf89pj0";
     const bobComitNodeAddress = bob.comitNodeConfig.comit.comit_listen;
 
     const alphaAssetQuantity = 100000000;
     const betaAssetQuantity = toBN(toWei("5000", "ether"));
-    const alphaMaxFee = 5000; // Max 5000 satoshis fee
 
     const alphaExpiry: number =
         new Date("2080-06-11T13:00:00Z").getTime() / 1000;
@@ -100,11 +97,6 @@ declare var global: HarnessGlobal;
     );
 
     erc20Balance.eq(bobInitialErc20).should.equal(true);
-
-    let aliceErc20BalanceBefore: BN = await ethereum.erc20Balance(
-        aliceFinalAddress,
-        tokenContractAddress
-    );
 
     const actions = [
         {

--- a/api_tests/e2e/rfc003/btc_eth/happy.ts
+++ b/api_tests/e2e/rfc003/btc_eth/happy.ts
@@ -41,7 +41,7 @@ declare var global: HarnessGlobal;
     const initialUrl = "/swaps/rfc003";
     const listUrl = "/swaps";
 
-    await bitcoin.ensureSegwit();
+    await bitcoin.ensureFunding();
     await bob.wallet.eth().fund(bobInitialEth);
     await alice.wallet.eth().fund(aliceInitialEth);
     await alice.wallet.btc().fund(10);

--- a/api_tests/e2e/rfc003/btc_eth/happy.ts
+++ b/api_tests/e2e/rfc003/btc_eth/happy.ts
@@ -2,13 +2,13 @@ import * as bitcoin from "../../../lib/bitcoin";
 import * as chai from "chai";
 import * as ethereum from "../../../lib/ethereum";
 import { Actor } from "../../../lib/actor";
-import { ActionKind, SwapRequest, SwapResponse } from "../../../lib/comit";
+import { ActionKind, SwapRequest } from "../../../lib/comit";
 import { BN, toBN, toWei } from "web3-utils";
 import { HarnessGlobal } from "../../../lib/util";
 import { createTests } from "../../test_creator";
 import chaiHttp = require("chai-http");
 
-const should = chai.should();
+chai.should();
 chai.use(chaiHttp);
 
 declare var global: HarnessGlobal;

--- a/api_tests/e2e/rfc003/btc_eth/refund.ts
+++ b/api_tests/e2e/rfc003/btc_eth/refund.ts
@@ -41,7 +41,7 @@ declare var global: HarnessGlobal;
     const initialUrl = "/swaps/rfc003";
     const listUrl = "/swaps";
 
-    await bitcoin.ensureSegwit();
+    await bitcoin.ensureFunding();
     await bob.wallet.eth().fund(bobInitialEth);
     await alice.wallet.eth().fund(aliceInitialEth);
     await alice.wallet.btc().fund(10);

--- a/api_tests/e2e/rfc003/btc_eth/refund.ts
+++ b/api_tests/e2e/rfc003/btc_eth/refund.ts
@@ -2,13 +2,13 @@ import * as bitcoin from "../../../lib/bitcoin";
 import * as chai from "chai";
 import * as ethereum from "../../../lib/ethereum";
 import { Actor } from "../../../lib/actor";
-import { ActionKind, SwapRequest, SwapResponse } from "../../../lib/comit";
-import { BN, toBN, toWei } from "web3-utils";
-import { HarnessGlobal, sleep } from "../../../lib/util";
+import { ActionKind, SwapRequest } from "../../../lib/comit";
+import { toBN, toWei } from "web3-utils";
+import { HarnessGlobal } from "../../../lib/util";
 import { createTests } from "../../test_creator";
 import chaiHttp = require("chai-http");
 
-const should = chai.should();
+chai.should();
 chai.use(chaiHttp);
 
 declare var global: HarnessGlobal;

--- a/api_tests/e2e/rfc003/eth-erc20_btc/happy.ts
+++ b/api_tests/e2e/rfc003/eth-erc20_btc/happy.ts
@@ -47,7 +47,7 @@ declare var global: HarnessGlobal;
     const initialUrl = "/swaps/rfc003";
     const listUrl = "/swaps";
 
-    await bitcoin.ensureSegwit();
+    await bitcoin.ensureFunding();
     await tobyWallet.eth().fund(tobyInitialEth);
     await alice.wallet.eth().fund(aliceInitialEth);
     await bob.wallet.btc().fund(10);

--- a/api_tests/e2e/rfc003/eth-erc20_btc/happy.ts
+++ b/api_tests/e2e/rfc003/eth-erc20_btc/happy.ts
@@ -2,14 +2,14 @@ import * as bitcoin from "../../../lib/bitcoin";
 import * as chai from "chai";
 import * as ethereum from "../../../lib/ethereum";
 import { Actor } from "../../../lib/actor";
-import { ActionKind, SwapRequest, SwapResponse } from "../../../lib/comit";
+import { ActionKind, SwapRequest } from "../../../lib/comit";
 import { Wallet } from "../../../lib/wallet";
 import { BN, toBN, toWei } from "web3-utils";
 import { HarnessGlobal } from "../../../lib/util";
 import { createTests } from "../../test_creator";
 import chaiHttp = require("chai-http");
 
-const should = chai.should();
+chai.should();
 chai.use(chaiHttp);
 
 declare var global: HarnessGlobal;

--- a/api_tests/e2e/rfc003/eth-erc20_btc/refund.ts
+++ b/api_tests/e2e/rfc003/eth-erc20_btc/refund.ts
@@ -2,14 +2,14 @@ import * as bitcoin from "../../../lib/bitcoin";
 import * as chai from "chai";
 import * as ethereum from "../../../lib/ethereum";
 import { Actor } from "../../../lib/actor";
-import { ActionKind, SwapRequest, SwapResponse } from "../../../lib/comit";
+import { ActionKind, SwapRequest } from "../../../lib/comit";
 import { Wallet } from "../../../lib/wallet";
-import { BN, toBN, toWei } from "web3-utils";
-import { HarnessGlobal, sleep } from "../../../lib/util";
+import { toBN, toWei } from "web3-utils";
+import { HarnessGlobal } from "../../../lib/util";
 import { createTests } from "../../test_creator";
 import chaiHttp = require("chai-http");
 
-const should = chai.should();
+chai.should();
 chai.use(chaiHttp);
 
 declare var global: HarnessGlobal;

--- a/api_tests/e2e/rfc003/eth-erc20_btc/refund.ts
+++ b/api_tests/e2e/rfc003/eth-erc20_btc/refund.ts
@@ -47,7 +47,7 @@ declare var global: HarnessGlobal;
     const initialUrl = "/swaps/rfc003";
     const listUrl = "/swaps";
 
-    await bitcoin.ensureSegwit();
+    await bitcoin.ensureFunding();
     await tobyWallet.eth().fund(tobyInitialEth);
     await alice.wallet.eth().fund(aliceInitialEth);
     await bob.wallet.btc().fund(10);

--- a/api_tests/e2e/rfc003/eth_btc/happy.ts
+++ b/api_tests/e2e/rfc003/eth_btc/happy.ts
@@ -41,7 +41,7 @@ declare var global: HarnessGlobal;
     const initialUrl = "/swaps/rfc003";
     const listUrl = "/swaps";
 
-    await bitcoin.ensureSegwit();
+    await bitcoin.ensureFunding();
     await alice.wallet.eth().fund(aliceInitialEth);
     await alice.wallet.btc().fund(0.1);
     await bob.wallet.eth().fund(bobInitialEth);

--- a/api_tests/e2e/rfc003/eth_btc/happy.ts
+++ b/api_tests/e2e/rfc003/eth_btc/happy.ts
@@ -2,13 +2,13 @@ import * as bitcoin from "../../../lib/bitcoin";
 import * as chai from "chai";
 import * as ethereum from "../../../lib/ethereum";
 import { Actor } from "../../../lib/actor";
-import { ActionKind, SwapRequest, SwapResponse } from "../../../lib/comit";
+import { ActionKind, SwapRequest } from "../../../lib/comit";
 import { BN, toBN, toWei } from "web3-utils";
 import { HarnessGlobal } from "../../../lib/util";
 import { createTests } from "../../test_creator";
 import chaiHttp = require("chai-http");
 
-const should = chai.should();
+chai.should();
 chai.use(chaiHttp);
 
 declare var global: HarnessGlobal;

--- a/api_tests/e2e/rfc003/eth_btc/refund_beta.ts
+++ b/api_tests/e2e/rfc003/eth_btc/refund_beta.ts
@@ -41,7 +41,7 @@ declare var global: HarnessGlobal;
     const initialUrl = "/swaps/rfc003";
     const listUrl = "/swaps";
 
-    await bitcoin.ensureSegwit();
+    await bitcoin.ensureFunding();
     await alice.wallet.eth().fund(aliceInitialEth);
     await alice.wallet.btc().fund(0.1);
     await bob.wallet.eth().fund(bobInitialEth);

--- a/api_tests/e2e/rfc003/eth_btc/refund_beta.ts
+++ b/api_tests/e2e/rfc003/eth_btc/refund_beta.ts
@@ -1,14 +1,13 @@
 import * as bitcoin from "../../../lib/bitcoin";
 import * as chai from "chai";
-import * as ethereum from "../../../lib/ethereum";
 import { Actor } from "../../../lib/actor";
-import { ActionKind, SwapRequest, SwapResponse } from "../../../lib/comit";
-import { BN, toBN, toWei } from "web3-utils";
-import { HarnessGlobal, sleep } from "../../../lib/util";
+import { ActionKind, SwapRequest } from "../../../lib/comit";
+import { toBN, toWei } from "web3-utils";
+import { HarnessGlobal } from "../../../lib/util";
 import { createTests } from "../../test_creator";
 import chaiHttp = require("chai-http");
 
-const should = chai.should();
+chai.should();
 chai.use(chaiHttp);
 
 declare var global: HarnessGlobal;

--- a/api_tests/e2e/test_creator.ts
+++ b/api_tests/e2e/test_creator.ts
@@ -11,7 +11,7 @@ import * as chai from "chai";
 import { Actor } from "../lib/actor";
 import * as URI from "urijs";
 
-const should = chai.should();
+chai.should();
 
 interface Test {
     /**

--- a/api_tests/e2e/test_creator.ts
+++ b/api_tests/e2e/test_creator.ts
@@ -1,7 +1,7 @@
 import {
     AcceptRequestBody,
-    ActionKind,
     Action,
+    ActionKind,
     getMethod,
     HalResource,
     Method,
@@ -9,7 +9,6 @@ import {
 } from "../lib/comit";
 import * as chai from "chai";
 import { Actor } from "../lib/actor";
-import { sleep } from "../lib/util";
 import * as URI from "urijs";
 
 const should = chai.should();
@@ -44,7 +43,6 @@ interface ActionTrigger {
     action?: ActionKind;
     requestBody?: AcceptRequestBody;
     uriQuery?: object;
-    timeout?: number;
     state?: (state: any) => boolean;
     test?: Test;
 }
@@ -78,16 +76,6 @@ async function getAction(
         return [href, payload];
     }
     return [href, null];
-}
-
-function seconds_until(time: number): number {
-    const diff = time - Math.floor(Date.now() / 1000);
-
-    if (diff > 0) {
-        return diff;
-    } else {
-        return 0;
-    }
 }
 
 async function executeAction(
@@ -162,66 +150,46 @@ export async function createTests(
         let action = actions.shift();
         let actionHref: string = null;
         let actionDirective: Action = null;
-        const timeout = action.timeout || 10000;
         if (action.action) {
-            it(
-                "[" +
-                    action.actor.name +
-                    "] Can get the " +
-                    action.action +
-                    " action",
-                async function() {
-                    this.timeout(timeout);
-                    [actionHref, actionDirective] = await getAction(
-                        swapLocations[action.actor.name],
-                        action
-                    );
-                }
-            );
+            it(`[${action.actor.name}] Can get the ${
+                action.action
+            } action`, async function() {
+                this.timeout(5000);
+                [actionHref, actionDirective] = await getAction(
+                    swapLocations[action.actor.name],
+                    action
+                );
+            });
 
-            it(
-                "[" +
-                    action.actor.name +
-                    "] Can execute the " +
-                    action.action +
-                    " action",
-                async function() {
-                    if (actionDirective && actionDirective.invalid_until) {
-                        const to_wait =
-                            seconds_until(actionDirective.invalid_until) *
-                                1000 +
-                            1000; // Add an extra second for good measure
-                        console.log(
-                            `Waiting ${to_wait}ms for ${
-                                action.actor.name
-                            }'s  ‘${action.action}’ action to be ready`
-                        );
-                        this.timeout(to_wait + timeout);
-                        await sleep(to_wait);
-                    }
-
-                    await executeAction(
-                        action.actor,
-                        action,
-                        actionHref,
-                        actionDirective
-                    );
+            it(`[${action.actor.name}] Can execute the ${
+                action.action
+            } action`, async function() {
+                if (action.action == ActionKind.Refund) {
+                    this.timeout(30000);
+                } else {
+                    this.timeout(5000);
                 }
-            );
+
+                await executeAction(
+                    action.actor,
+                    action,
+                    actionHref,
+                    actionDirective
+                );
+            });
         }
 
         let body: any = null;
         if (action.state) {
-            it(
-                "[" + action.actor.name + "] transitions to correct state",
-                async function() {
-                    this.timeout(timeout);
-                    body = (await action.actor.pollComitNodeUntil(
-                        swapLocations[action.actor.name],
-                        body => action.state(body.state)
-                    )) as HalResource;
-                }
-            );
+            it(`[${
+                action.actor.name
+            }] transitions to correct state`, async function() {
+                this.timeout(10000);
+                body = (await action.actor.pollComitNodeUntil(
+                    swapLocations[action.actor.name],
+                    body => action.state(body.state)
+                )) as HalResource;
+            });
         }
 
         const test = action.test;

--- a/api_tests/harness.ts
+++ b/api_tests/harness.ts
@@ -182,6 +182,8 @@ async function run_tests(test_files: string[]) {
         node_runner.stopComitNodes();
         btsieve_runner.stopBtsieves();
     }
+
+    process.exit(0);
 }
 
 let test_files = commander.args;

--- a/api_tests/harness.ts
+++ b/api_tests/harness.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env ./api_tests/node_modules/.bin/ts-node --project api_tests/tsconfig.json
 
-import { ChildProcess, execSync } from "child_process";
-import { spawn } from "child_process";
+import { ChildProcess, execSync, spawn } from "child_process";
 import { HarnessGlobal, sleep } from "./lib/util";
 import { MetaComitNodeConfig } from "./lib/comit";
 import * as toml from "toml";
@@ -152,7 +151,7 @@ async function run_tests(test_files: string[]) {
         }
 
         if (config.btsieve) {
-            await btsieve_runner.ensureBtsievesRunning(
+            btsieve_runner.ensureBtsievesRunning(
                 Object.entries(config.btsieve)
             );
         }

--- a/api_tests/harness.ts
+++ b/api_tests/harness.ts
@@ -169,7 +169,7 @@ async function run_tests(test_files: string[]) {
             );
         }
 
-        let test_finish = new Promise((res, rej) => {
+        let test_finish = new Promise(res => {
             mocha.run(async (failures: number) => {
                 res(failures);
             });

--- a/api_tests/lib/actor.ts
+++ b/api_tests/lib/actor.ts
@@ -114,7 +114,10 @@ export class Actor {
                 return this.wallet.btc().sendToAddress(to, parseInt(amount));
             }
             case "bitcoin-broadcast-signed-transaction": {
-                action.payload.should.include.all.keys("hex", "locktime");
+                action.payload.should.include.all.keys(
+                    "hex",
+                    "min_median_time"
+                );
 
                 let fetchMedianTime = async () => {
                     let blockchainInfo = await bitcoin.getBlockchainInfo();

--- a/api_tests/lib/actor.ts
+++ b/api_tests/lib/actor.ts
@@ -115,7 +115,7 @@ export class Actor {
             case "bitcoin-broadcast-signed-transaction": {
                 action.payload.should.include.all.keys(
                     "hex",
-                    "min_median_time"
+                    "min_median_block_time"
                 );
 
                 let fetchMedianTime = async () => {
@@ -123,27 +123,28 @@ export class Actor {
                     return blockchainInfo.mediantime;
                 };
 
-                let { hex, min_median_time } = action.payload;
+                let { hex, min_median_block_time } = action.payload;
 
-                if (min_median_time) {
-                    let medianTime = await fetchMedianTime();
-                    let diff = min_median_time - medianTime;
+                if (min_median_block_time) {
+                    let currentMedianBlockTime = await fetchMedianTime();
+                    let diff = min_median_block_time - currentMedianBlockTime;
 
                     if (diff > 0) {
                         console.log(
                             `Waiting for median time to pass %d`,
-                            min_median_time
+                            min_median_block_time
                         );
 
                         while (diff > 0) {
                             await sleep(1000);
 
-                            medianTime = await fetchMedianTime();
-                            diff = min_median_time - medianTime;
+                            currentMedianBlockTime = await fetchMedianTime();
+                            diff =
+                                min_median_block_time - currentMedianBlockTime;
 
                             console.log(
                                 `Current median time:            %d`,
-                                medianTime
+                                currentMedianBlockTime
                             );
                         }
                     }

--- a/api_tests/lib/actor.ts
+++ b/api_tests/lib/actor.ts
@@ -1,18 +1,17 @@
-import { WalletConfig, Wallet } from "./wallet";
+import { Wallet, WalletConfig } from "./wallet";
 import * as chai from "chai";
 import {
     Action,
-    SwapResponse,
     ComitNodeConfig,
     MetaComitNodeConfig,
+    SwapResponse,
 } from "./comit";
 import * as bitcoin from "./bitcoin";
 import * as toml from "toml";
 import * as fs from "fs";
-
-import chaiHttp = require("chai-http");
 import { seconds_until, sleep } from "./util";
 import { MetaBtsieveConfig } from "./btsieve";
+import chaiHttp = require("chai-http");
 
 chai.use(chaiHttp);
 

--- a/api_tests/lib/actor.ts
+++ b/api_tests/lib/actor.ts
@@ -121,27 +121,29 @@ export class Actor {
                     return blockchainInfo.mediantime;
                 };
 
-                let { hex, locktime } = action.payload;
+                let { hex, min_median_time } = action.payload;
 
-                // If it is equal, it is rejected by bitcoin-core :(
-                locktime += 1;
+                if (min_median_time) {
+                    let medianTime = await fetchMedianTime();
+                    let diff = min_median_time - medianTime;
 
-                let medianTime = await fetchMedianTime();
-                let diff = locktime - medianTime;
-
-                if (locktime && diff > 0) {
-                    console.log(`Waiting for median time to pass %d`, locktime);
-
-                    while (diff > 0) {
-                        await sleep(1000);
-
-                        medianTime = await fetchMedianTime();
-                        diff = locktime - medianTime;
-
+                    if (diff > 0) {
                         console.log(
-                            `Current median time:            %d`,
-                            medianTime
+                            `Waiting for median time to pass %d`,
+                            min_median_time
                         );
+
+                        while (diff > 0) {
+                            await sleep(1000);
+
+                            medianTime = await fetchMedianTime();
+                            diff = min_median_time - medianTime;
+
+                            console.log(
+                                `Current median time:            %d`,
+                                medianTime
+                            );
+                        }
                     }
                 }
 

--- a/api_tests/lib/bitcoin.ts
+++ b/api_tests/lib/bitcoin.ts
@@ -1,11 +1,11 @@
 import {
-    Transaction,
+    address,
     ECPair,
+    networks,
     Out,
     payments,
-    networks,
+    Transaction,
     TransactionBuilder,
-    address,
 } from "bitcoinjs-lib";
 import { test_rng } from "./util";
 

--- a/api_tests/lib/bitcoin.ts
+++ b/api_tests/lib/bitcoin.ts
@@ -97,8 +97,6 @@ export async function getBlockchainInfo() {
     return createBitcoinRpcClient(_bitcoinConfig).getBlockchainInfo();
 }
 
-module.exports.generate = generate;
-
 export async function ensureFunding() {
     const blockHeight = await createBitcoinRpcClient(
         _bitcoinConfig
@@ -109,8 +107,6 @@ export async function ensureFunding() {
         );
     }
 }
-
-module.exports.ensureSegwit = ensureFunding;
 
 export async function getFirstUtxoValueTransferredTo(
     txId: string,
@@ -132,8 +128,6 @@ export async function getFirstUtxoValueTransferredTo(
 
     return satoshi;
 }
-
-module.exports.getFirstUtxoValueTransferredTo = getFirstUtxoValueTransferredTo;
 
 export async function sendRawTransaction(hexString: string) {
     return createBitcoinRpcClient(_bitcoinConfig).sendRawTransaction(hexString);

--- a/api_tests/lib/btsieve.ts
+++ b/api_tests/lib/btsieve.ts
@@ -1,13 +1,11 @@
 import * as chai from "chai";
-
-import chaiHttp = require("chai-http");
-chai.use(chaiHttp);
-
-import { Transaction } from "web3-core";
-import { TransactionReceipt } from "web3-core";
+import { Transaction, TransactionReceipt } from "web3-core";
 import * as toml from "toml";
 import * as fs from "fs";
 import { TestConfig } from "./actor";
+import chaiHttp = require("chai-http");
+
+chai.use(chaiHttp);
 
 export interface IdMatchResponse {
     query: any;

--- a/api_tests/lib/btsieve_runner.ts
+++ b/api_tests/lib/btsieve_runner.ts
@@ -41,7 +41,7 @@ export class BtsieveRunner {
         }
     }
 
-    async stopBtsieves() {
+    stopBtsieves() {
         let names = Object.keys(this.running_btsieves);
 
         if (names.length > 0) {

--- a/api_tests/lib/btsieve_runner.ts
+++ b/api_tests/lib/btsieve_runner.ts
@@ -15,7 +15,7 @@ export class BtsieveRunner {
         this.project_root = project_root;
     }
 
-    async ensureBtsievesRunning(btsieves: [string, MetaBtsieveConfig][]) {
+    ensureBtsievesRunning(btsieves: [string, MetaBtsieveConfig][]) {
         for (let [name, btsieve_config] of btsieves) {
             console.log("Starting Btsieve: " + name);
 
@@ -23,7 +23,7 @@ export class BtsieveRunner {
                 continue;
             }
 
-            this.running_btsieves[name] = await spawn(this.btsieve_bin, [], {
+            this.running_btsieves[name] = spawn(this.btsieve_bin, [], {
                 cwd: this.project_root,
                 env: btsieve_config.env,
                 stdio: [

--- a/api_tests/lib/comit.ts
+++ b/api_tests/lib/comit.ts
@@ -25,7 +25,7 @@ export type Action =
       }
     | {
           type: "bitcoin-broadcast-signed-transaction";
-          payload: { hex: string; network: string; locktime?: number };
+          payload: { hex: string; network: string; min_median_time?: number };
       }
     | {
           type: "ethereum-deploy-contract";

--- a/api_tests/lib/comit.ts
+++ b/api_tests/lib/comit.ts
@@ -18,11 +18,35 @@ export interface SwapResponse extends HalResource {
     status: string;
 }
 
-export interface Action {
-    type: string;
-    invalid_until?: number;
-    payload: any;
-}
+export type Action =
+    | {
+          type: "bitcoin-send-amount-to-address";
+          payload: { to: string; amount: string; network: string };
+      }
+    | {
+          type: "bitcoin-broadcast-signed-transaction";
+          payload: { hex: string; network: string; locktime?: number };
+      }
+    | {
+          type: "ethereum-deploy-contract";
+          payload: {
+              data: string;
+              amount: string;
+              gas_limit: string;
+              network: string;
+          };
+      }
+    | {
+          type: "ethereum-invoke-contract";
+          payload: {
+              contract_address: string;
+              data: string;
+              amount: string;
+              gas_limit: string;
+              network: string;
+              min_block_timestamp?: number;
+          };
+      };
 
 export interface SwapsResponse extends HalResource {
     _embedded: {

--- a/api_tests/lib/comit.ts
+++ b/api_tests/lib/comit.ts
@@ -25,7 +25,11 @@ export type Action =
       }
     | {
           type: "bitcoin-broadcast-signed-transaction";
-          payload: { hex: string; network: string; min_median_time?: number };
+          payload: {
+              hex: string;
+              network: string;
+              min_median_block_time?: number;
+          };
       }
     | {
           type: "ethereum-deploy-contract";

--- a/api_tests/lib/ethereum.ts
+++ b/api_tests/lib/ethereum.ts
@@ -1,10 +1,9 @@
 import { ECPair } from "bitcoinjs-lib";
 import * as util from "./util";
 import { HttpProvider } from "web3-providers";
-import { BN } from "web3-utils";
 import * as utils from "web3-utils";
+import { BN } from "web3-utils";
 import * as fs from "fs";
-
 import EthereumTx = require("ethereumjs-tx");
 
 const Web3 = require("web3");

--- a/api_tests/lib/ledger_runner.ts
+++ b/api_tests/lib/ledger_runner.ts
@@ -72,7 +72,7 @@ export class LedgerRunner {
                 bitcoin.init(this.ledgers_config.bitcoin);
                 this.block_timers["bitcoin"] = setInterval(async () => {
                     await bitcoin.generate();
-                }, 3000);
+                }, 1000);
             }
         }
     }

--- a/api_tests/lib/util.ts
+++ b/api_tests/lib/util.ts
@@ -15,6 +15,16 @@ export async function sleep(time: number) {
     });
 }
 
+export function seconds_until(time: number): number {
+    const diff = time - Math.floor(Date.now() / 1000);
+
+    if (diff > 0) {
+        return diff;
+    } else {
+        return 0;
+    }
+}
+
 /// This is needed to use the global variable in TypeScript
 import Global = NodeJS.Global;
 

--- a/api_tests/lib/util.ts
+++ b/api_tests/lib/util.ts
@@ -10,7 +10,7 @@ export function test_rng() {
 }
 
 export async function sleep(time: number) {
-    return new Promise((res, rej) => {
+    return new Promise(res => {
         setTimeout(res, time);
     });
 }

--- a/api_tests/lib/wallet.ts
+++ b/api_tests/lib/wallet.ts
@@ -1,5 +1,5 @@
 import { BitcoinWallet, BtcConfig } from "./bitcoin";
-import { EthereumWallet, EthConfig } from "./ethereum";
+import { EthConfig, EthereumWallet } from "./ethereum";
 
 export interface WalletConfig {
     ethConfig?: EthConfig;

--- a/api_tests/tsconfig.json
+++ b/api_tests/tsconfig.json
@@ -10,6 +10,8 @@
       "es2017",
       "es6",
       "dom"
-    ]
+    ],
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   }
 }

--- a/api_tests/webgui/webgui.ts
+++ b/api_tests/webgui/webgui.ts
@@ -4,11 +4,10 @@
 import { Actor } from "../lib/actor";
 import * as chai from "chai";
 import { HarnessGlobal } from "../lib/util";
-
 import chaiHttp = require("chai-http");
 
 chai.use(chaiHttp);
-const should = chai.should();
+chai.should();
 
 declare var global: HarnessGlobal;
 

--- a/application/comit_node/src/http_api/routes/rfc003/action.rs
+++ b/application/comit_node/src/http_api/routes/rfc003/action.rs
@@ -1,7 +1,7 @@
 use crate::{
     http_api::route_factory::swap_path,
     swap_protocols::{
-        rfc003::{alice, bob, Action},
+        rfc003::{alice, bob},
         SwapId,
     },
 };
@@ -27,11 +27,11 @@ pub trait ToActionName {
 }
 
 impl<Deploy, Fund, Redeem, Refund> ToActionName
-    for Action<alice::ActionKind<Deploy, Fund, Redeem, Refund>>
+    for alice::ActionKind<Deploy, Fund, Redeem, Refund>
 {
     fn to_action_name(&self) -> ActionName {
         use self::alice::ActionKind::*;
-        match self.inner {
+        match self {
             Deploy(_) => ActionName::Deploy,
             Fund(_) => ActionName::Fund,
             Redeem(_) => ActionName::Redeem,
@@ -41,11 +41,11 @@ impl<Deploy, Fund, Redeem, Refund> ToActionName
 }
 
 impl<Accept, Decline, Deploy, Fund, Redeem, Refund> ToActionName
-    for Action<bob::ActionKind<Accept, Decline, Deploy, Fund, Redeem, Refund>>
+    for bob::ActionKind<Accept, Decline, Deploy, Fund, Redeem, Refund>
 {
     fn to_action_name(&self) -> ActionName {
         use self::bob::ActionKind::*;
-        match self.inner {
+        match self {
             Accept(_) => ActionName::Accept,
             Decline(_) => ActionName::Decline,
             Deploy(_) => ActionName::Deploy,

--- a/application/comit_node/src/http_api/routes/rfc003/handlers/get_action.rs
+++ b/application/comit_node/src/http_api/routes/rfc003/handlers/get_action.rs
@@ -112,7 +112,7 @@ impl ActionResponseBody {
         };
 
         ActionResponseBody::BitcoinBroadcastSignedTransaction {
-            hex: serialize_hex(&transaction),
+            hex: serialize_hex(transaction),
             network,
             min_median_time,
         }

--- a/application/comit_node/src/http_api/routes/rfc003/handlers/get_action.rs
+++ b/application/comit_node/src/http_api/routes/rfc003/handlers/get_action.rs
@@ -82,7 +82,7 @@ pub enum ActionResponseBody {
     BitcoinBroadcastSignedTransaction {
         hex: String,
         network: bitcoin_support::Network,
-        min_median_time: Option<Timestamp>,
+        min_median_block_time: Option<Timestamp>,
     },
     EthereumDeployContract {
         data: ethereum_support::Bytes,
@@ -102,19 +102,19 @@ pub enum ActionResponseBody {
 
 impl ActionResponseBody {
     fn bitcoin_broadcast_signed_transaction(transaction: &Transaction, network: Network) -> Self {
-        let min_median_time = if transaction.lock_time == 0 {
+        let min_median_block_time = if transaction.lock_time == 0 {
             None
         } else {
             // The first time a tx with lock_time can be broadcasted is when
             // mediantime == locktime + 1
-            let min_median_time = transaction.lock_time + 1;
-            Some(Timestamp::from(min_median_time))
+            let min_median_block_time = transaction.lock_time + 1;
+            Some(Timestamp::from(min_median_block_time))
         };
 
         ActionResponseBody::BitcoinBroadcastSignedTransaction {
             hex: serialize_hex(transaction),
             network,
-            min_median_time,
+            min_median_block_time,
         }
     }
 }

--- a/application/comit_node/src/http_api/routes/rfc003/handlers/post_action.rs
+++ b/application/comit_node/src/http_api/routes/rfc003/handlers/post_action.rs
@@ -51,7 +51,7 @@ pub fn handle_post_action<T: MetadataStore<SwapId>, S: StateStore>(
                         state
                             .actions()
                             .into_iter()
-                            .find_map(move |action| match action.inner {
+                            .find_map(move |action| match action {
                                 bob::ActionKind::Accept(accept) => Some(Ok(accept)),
                                 _ => None,
                             })
@@ -81,7 +81,7 @@ pub fn handle_post_action<T: MetadataStore<SwapId>, S: StateStore>(
                             state
                                 .actions()
                                 .into_iter()
-                                .find_map(move |action| match action.inner {
+                                .find_map(move |action| match action {
                                     bob::ActionKind::Decline(decline) => Some(Ok(decline)),
                                     _ => None,
                                 })

--- a/application/comit_node/src/swap_protocols/rfc003/actions/erc20.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/erc20.rs
@@ -3,7 +3,7 @@ use crate::swap_protocols::{
     rfc003::{
         ethereum::{self, Erc20Htlc},
         state_machine::HtlcParams,
-        Secret,
+        Secret, Timestamp,
     },
 };
 use ethereum_support::{Bytes, Erc20Token, EtherQuantity, Network};
@@ -27,11 +27,13 @@ pub fn fund_action(
         gas_limit,
         amount: EtherQuantity::zero(),
         network,
+        min_block_timestamp: None,
     }
 }
 
 pub fn refund_action(
     network: Network,
+    expiry: Timestamp,
     beta_htlc_location: ethereum_support::Address,
 ) -> ethereum::SendTransaction {
     let data = Bytes::default();
@@ -43,6 +45,7 @@ pub fn refund_action(
         gas_limit,
         amount: EtherQuantity::zero(),
         network,
+        min_block_timestamp: Some(expiry),
     }
 }
 
@@ -60,5 +63,6 @@ pub fn redeem_action(
         gas_limit,
         amount: EtherQuantity::zero(),
         network,
+        min_block_timestamp: None,
     }
 }

--- a/application/comit_node/src/swap_protocols/rfc003/actions/ether.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/ether.rs
@@ -34,6 +34,7 @@ impl RefundAction<Ethereum, EtherQuantity> for (Ethereum, EtherQuantity) {
             gas_limit,
             amount: EtherQuantity::zero(),
             network: htlc_params.ledger.network,
+            min_block_timestamp: Some(htlc_params.expiry),
         }
     }
 }
@@ -55,6 +56,7 @@ impl RedeemAction<Ethereum, EtherQuantity> for (Ethereum, EtherQuantity) {
             gas_limit,
             amount: EtherQuantity::zero(),
             network: htlc_params.ledger.network,
+            min_block_timestamp: None,
         }
     }
 }

--- a/application/comit_node/src/swap_protocols/rfc003/actions/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/actions/mod.rs
@@ -1,6 +1,6 @@
 use crate::swap_protocols::{
     asset::Asset,
-    rfc003::{secret_source::SecretSource, state_machine::HtlcParams, Ledger, Secret, Timestamp},
+    rfc003::{secret_source::SecretSource, state_machine::HtlcParams, Ledger, Secret},
 };
 
 pub mod bitcoin;
@@ -10,22 +10,7 @@ pub mod ether;
 pub trait Actions {
     type ActionKind;
 
-    fn actions(&self) -> Vec<Action<Self::ActionKind>>;
-}
-
-#[derive(Debug)]
-pub struct Action<ActionKind> {
-    pub invalid_until: Option<Timestamp>,
-    pub inner: ActionKind,
-}
-
-impl<ActionKind> Action<ActionKind> {
-    pub fn with_invalid_until(self, invalid_until: Timestamp) -> Self {
-        Action {
-            invalid_until: Some(invalid_until),
-            ..self
-        }
-    }
+    fn actions(&self) -> Vec<Self::ActionKind>;
 }
 
 pub trait FundAction<L: Ledger, A: Asset> {

--- a/application/comit_node/src/swap_protocols/rfc003/alice/actions/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/alice/actions/mod.rs
@@ -1,5 +1,3 @@
-use crate::swap_protocols::rfc003::actions::Action;
-
 mod erc20;
 mod generic_impl;
 
@@ -9,13 +7,4 @@ pub enum ActionKind<Deploy, Fund, Redeem, Refund> {
     Fund(Fund),
     Redeem(Redeem),
     Refund(Refund),
-}
-
-impl<Deploy, Fund, Redeem, Refund> ActionKind<Deploy, Fund, Redeem, Refund> {
-    fn into_action(self) -> Action<ActionKind<Deploy, Fund, Redeem, Refund>> {
-        Action {
-            inner: self,
-            invalid_until: None,
-        }
-    }
 }

--- a/application/comit_node/src/swap_protocols/rfc003/bob/actions/erc20.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/bob/actions/erc20.rs
@@ -10,7 +10,7 @@ use crate::swap_protocols::{
         },
         ethereum,
         state_machine::HtlcParams,
-        Action, Ledger, LedgerState,
+        Ledger, LedgerState,
     },
 };
 use ethereum_support::Erc20Token;
@@ -32,7 +32,7 @@ where
         ethereum::SendTransaction,
     >;
 
-    fn actions(&self) -> Vec<Action<Self::ActionKind>> {
+    fn actions(&self) -> Vec<Self::ActionKind> {
         let (request, response) = match &self.swap_communication {
             SwapCommunication::Proposed {
                 pending_response, ..
@@ -41,10 +41,8 @@ where
                     bob::ActionKind::Accept(Accept::new(
                         pending_response.sender.clone(),
                         Arc::clone(&self.secret_source),
-                    ))
-                    .into_action(),
-                    bob::ActionKind::Decline(Decline::new(pending_response.sender.clone()))
-                        .into_action(),
+                    )),
+                    bob::ActionKind::Decline(Decline::new(pending_response.sender.clone())),
                 ];
             }
             SwapCommunication::Accepted {
@@ -59,41 +57,34 @@ where
 
         use self::LedgerState::*;
 
-        let mut actions =
-            match (alpha_state, beta_state, self.secret) {
-                (Funded { htlc_location, .. }, _, Some(secret)) => {
-                    vec![bob::ActionKind::Redeem(<(AL, AA)>::redeem_action(
-                        HtlcParams::new_alpha_params(request, response),
-                        htlc_location.clone(),
-                        &*self.secret_source,
-                        secret,
-                    ))
-                    .into_action()]
-                }
-                (Funded { .. }, NotDeployed, _) => vec![bob::ActionKind::Deploy(
-                    erc20::deploy_action(HtlcParams::new_beta_params(request, response)),
-                )
-                .into_action()],
-                (Funded { .. }, Deployed { htlc_location, .. }, _) => {
-                    vec![bob::ActionKind::Fund(erc20::fund_action(
-                        HtlcParams::new_beta_params(request, response),
-                        request.beta_asset.token_contract,
-                        *htlc_location,
-                    ))
-                    .into_action()]
-                }
-                _ => vec![],
-            };
+        let mut actions = match (alpha_state, beta_state, self.secret) {
+            (Funded { htlc_location, .. }, _, Some(secret)) => {
+                vec![bob::ActionKind::Redeem(<(AL, AA)>::redeem_action(
+                    HtlcParams::new_alpha_params(request, response),
+                    htlc_location.clone(),
+                    &*self.secret_source,
+                    secret,
+                ))]
+            }
+            (Funded { .. }, NotDeployed, _) => vec![bob::ActionKind::Deploy(erc20::deploy_action(
+                HtlcParams::new_beta_params(request, response),
+            ))],
+            (Funded { .. }, Deployed { htlc_location, .. }, _) => {
+                vec![bob::ActionKind::Fund(erc20::fund_action(
+                    HtlcParams::new_beta_params(request, response),
+                    request.beta_asset.token_contract,
+                    *htlc_location,
+                ))]
+            }
+            _ => vec![],
+        };
 
         if let Funded { htlc_location, .. } = beta_state {
-            actions.push(
-                bob::ActionKind::Refund(erc20::refund_action(
-                    request.beta_ledger.network,
-                    *htlc_location,
-                ))
-                .into_action()
-                .with_invalid_until(request.beta_expiry),
-            );
+            actions.push(bob::ActionKind::Refund(erc20::refund_action(
+                request.beta_ledger.network,
+                request.beta_expiry,
+                *htlc_location,
+            )));
         }
         actions
     }
@@ -116,7 +107,7 @@ where
         <(BL, BA) as RefundAction<BL, BA>>::RefundActionOutput,
     >;
 
-    fn actions(&self) -> Vec<Action<Self::ActionKind>> {
+    fn actions(&self) -> Vec<Self::ActionKind> {
         let (request, response) = match &self.swap_communication {
             SwapCommunication::Proposed {
                 pending_response, ..
@@ -125,10 +116,8 @@ where
                     bob::ActionKind::Accept(Accept::new(
                         pending_response.sender.clone(),
                         Arc::clone(&self.secret_source),
-                    ))
-                    .into_action(),
-                    bob::ActionKind::Decline(Decline::new(pending_response.sender.clone()))
-                        .into_action(),
+                    )),
+                    bob::ActionKind::Decline(Decline::new(pending_response.sender.clone())),
                 ];
             }
             SwapCommunication::Accepted {
@@ -142,29 +131,22 @@ where
         let beta_state = &self.beta_ledger_state;
 
         use self::LedgerState::*;
-        let mut actions =
-            match (alpha_state, beta_state, self.secret) {
-                (Funded { htlc_location, .. }, _, Some(secret)) => vec![bob::ActionKind::Redeem(
-                    erc20::redeem_action(*htlc_location, secret, request.alpha_ledger.network),
-                )
-                .into_action()],
-                (Funded { .. }, NotDeployed, _) => vec![bob::ActionKind::Fund(
-                    <(BL, BA)>::fund_action(HtlcParams::new_beta_params(request, response)),
-                )
-                .into_action()],
-                _ => vec![],
-            };
+        let mut actions = match (alpha_state, beta_state, self.secret) {
+            (Funded { htlc_location, .. }, _, Some(secret)) => vec![bob::ActionKind::Redeem(
+                erc20::redeem_action(*htlc_location, secret, request.alpha_ledger.network),
+            )],
+            (Funded { .. }, NotDeployed, _) => vec![bob::ActionKind::Fund(
+                <(BL, BA)>::fund_action(HtlcParams::new_beta_params(request, response)),
+            )],
+            _ => vec![],
+        };
 
         if let Funded { htlc_location, .. } = beta_state {
-            actions.push(
-                bob::ActionKind::Refund(<(BL, BA)>::refund_action(
-                    HtlcParams::new_beta_params(request, response),
-                    htlc_location.clone(),
-                    &*self.secret_source,
-                ))
-                .into_action()
-                .with_invalid_until(request.beta_expiry),
-            )
+            actions.push(bob::ActionKind::Refund(<(BL, BA)>::refund_action(
+                HtlcParams::new_beta_params(request, response),
+                htlc_location.clone(),
+                &*self.secret_source,
+            )))
         }
         actions
     }

--- a/application/comit_node/src/swap_protocols/rfc003/bob/actions/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/bob/actions/mod.rs
@@ -4,8 +4,7 @@ mod generic_impl;
 use crate::{
     comit_client::{SwapDeclineReason, SwapReject},
     swap_protocols::rfc003::{
-        actions::Action, bob::ResponseSender, messages::ToAcceptResponseBody,
-        secret_source::SecretSource, Ledger,
+        bob::ResponseSender, messages::ToAcceptResponseBody, secret_source::SecretSource, Ledger,
     },
 };
 use std::sync::Arc;
@@ -18,17 +17,6 @@ pub enum ActionKind<Accept, Decline, Deploy, Fund, Redeem, Refund> {
     Fund(Fund),
     Redeem(Redeem),
     Refund(Refund),
-}
-
-impl<Accept, Decline, Deploy, Fund, Redeem, Refund>
-    ActionKind<Accept, Decline, Deploy, Fund, Redeem, Refund>
-{
-    fn into_action(self) -> Action<ActionKind<Accept, Decline, Deploy, Fund, Redeem, Refund>> {
-        Action {
-            inner: self,
-            invalid_until: None,
-        }
-    }
 }
 
 #[derive(Clone)]

--- a/application/comit_node/src/swap_protocols/rfc003/ethereum/actions.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/ethereum/actions.rs
@@ -3,6 +3,7 @@ use crate::swap_protocols::{
     rfc003::{
         ethereum::{Erc20Htlc, EtherHtlc, Htlc},
         state_machine::HtlcParams,
+        Timestamp,
     },
 };
 use ethereum_support::{web3::types::U256, Address, Bytes, Erc20Token, EtherQuantity, Network};
@@ -23,6 +24,7 @@ pub struct SendTransaction {
     pub amount: EtherQuantity,
     pub gas_limit: U256,
     pub network: Network,
+    pub min_block_timestamp: Option<Timestamp>,
 }
 
 impl From<HtlcParams<Ethereum, EtherQuantity>> for ContractDeploy {

--- a/application/comit_node/src/swap_protocols/rfc003/mod.rs
+++ b/application/comit_node/src/swap_protocols/rfc003/mod.rs
@@ -23,7 +23,7 @@ mod timestamp;
 mod create_ledger_events;
 
 pub use self::{
-    actions::{Action, Actions},
+    actions::Actions,
     actor_state::ActorState,
     create_ledger_events::CreateLedgerEvents,
     error::Error,


### PR DESCRIPTION
Instead of a generic invalid_until field, we embed the mediantime timestamp for Bitcoin and the block timestamp for Ethereum directly into the actions.

This allows us to implement customized "wait" strategies depending on the ledger.

- For Bitcoin, we check the mediantime from the getblockchaininfo RPC call and wait until it passes the locktime threshold.

- For Ethereum, it is enough to wait until our local systemtime passes the given timestamp.
