### PR TITLE
Remove waffle.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # COMIT-rs
 
 [![Build Status](https://travis-ci.com/comit-network/comit-rs.svg?branch=master)](https://travis-ci.com/comit-network/comit-rs)
-[![Waffle.io - Columns and their card count](https://badge.waffle.io/comit-network/comit-rs.svg?columns=all)](https://waffle.io/comit-network/comit-rs)
 
 COMIT is an open protocol facilitating trustless cross-blockchain applications.
 This is a reference implementation for the COMIT protocol. 


### PR DESCRIPTION
Bye bye waffle badge.
ZenHub's badge does not work currently, so no replacement for now. 

see: 
https://www.zenhub.com/faq
i.e. the following image cannot be found: 

<a href="https://zenhub.com"><img src="https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png"></a>
