### PR TITLE
Initial circle ci setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,17 +24,28 @@ jobs:
           name: Check formatting
           command: cargo make check-rs-format
       - restore_cache:
-          key: dependency-cache-{{ checksum "Cargo.lock" }}
+          key: dependency-rs-sccache
+      - restore_cache:
+          key: dependency-rs-cache-{{ checksum "Cargo.lock" }}
+      - restore_cache:
+          key: dependency-js-cache-{{ checksum "./api_tests/package.json" }}
       - run:
           name: Build using cargo make
           command: |
             cargo --version
             cargo make travis
       - save_cache:
-          key: dependency-cache-{{ checksum "Cargo.lock" }}
+          key: dependency-rs-sccache
+          paths:
+            - "~/.cache/sccache"
+      - save_cache:
+          key: dependency-rs-cache-{{ checksum "Cargo.lock" }}
           paths:
             - "~/.cargo"
             - "./target"
+      - save_cache:
+          key: dependency-js-cache-{{ checksum "./api_tests/package.json" }}
+          paths:
             - "./api_tests/node_modules"
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,6 @@ jobs:
       - run:
           name: Build using cargo make
           command: |
-            source $HOME/.cargo/env
             cargo --version
             cargo make travis
       - save_cache:
@@ -78,7 +77,6 @@ commands:
       - run:
           name: "Prints version for rust, etc"
           command: |
-             source $HOME/.cargo/env
              echo 'node --version' $(node --version)
              echo 'yarn --version' $(yarn --version)
              echo 'rustc --version' $(rustc --version)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,76 @@
+version: 2.1
+jobs:
+  build:
+    working_directory: ~/comit
+    machine:
+      image: ubuntu-1604:201903-01
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "Cargo.lock" }}
+      - setup_system
+      - setup_nodejs
+      - setup_rust
+      - print_current_versions
+      - run:
+          name: Build using cargo make
+          command: |
+            source $HOME/.cargo/env
+            cargo --version
+            cargo make ci
+      - save_cache:
+          key: dependency-cache-{{ checksum "Cargo.lock" }}
+          paths:
+            - "~/.cargo"
+            - "./target"
+
+
+commands:
+  setup_system:
+    steps:
+       - run:
+           name:  "Setup system environment"
+           command: |
+             wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+             curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+             echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+             sudo apt-get update
+             sudo apt-get install -y libzmq3-dev
+  setup_nodejs:
+    steps:
+       - run:
+           name:  "Install nodejs"
+           command: |
+             set +e
+             curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
+             export NVM_DIR="/opt/circleci/.nvm"
+             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+             nvm install v10.14.2
+             nvm alias default v10.14.2
+
+             # Each step uses the same `$BASH_ENV`, so need to modify it
+             echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
+             echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
+             sudo apt-get install yarn
+  setup_rust:
+    steps:
+       - run:
+           name:  "Setup rust environment"
+           command: |
+             curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $(< rust-toolchain) && source $HOME/.cargo/env
+             which cargo-make || cargo install --debug cargo-make
+  print_current_versions:
+    steps:
+      - run:
+          name: "Prints version for rust, etc"
+          command: |
+             source $HOME/.cargo/env
+             echo 'node --version' $(node --version)
+             echo 'yarn --version' $(yarn --version)
+             echo 'rustc --version' $(rustc --version)
+             echo 'cargo --version' $(cargo --version)
+             echo "pwd $(pwd)"
+             echo "whomai $(whoami)"
+             echo "CARGO_HOME" $CARGO_HOME
+             echo "RUSTUP_HOME" $RUSTUP_HOME

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,25 +5,38 @@ jobs:
     machine:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
+    environment:
+      # TODO remove the variable definition from Makefile.toml once travis is retired
+      RUST_TEST_THREADS: "8"
     steps:
       - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "Cargo.lock" }}
       - setup_system
       - setup_nodejs
       - setup_rust
+      - run:
+          name: Updating PATH and Define Environment Variable at Runtime
+          # Define variables that need interpolation
+          # As CircleCI starts a new shell for each `run` declaration, we need to export cargo home to $BASH_ENV
+          command: |
+            echo 'export PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH' >> $BASH_ENV
       - print_current_versions
+      - run:
+          name: Check formatting
+          command: cargo make check-rs-format
+      - restore_cache:
+          key: dependency-cache-{{ checksum "Cargo.lock" }}
       - run:
           name: Build using cargo make
           command: |
             source $HOME/.cargo/env
             cargo --version
-            cargo make ci
+            cargo make travis
       - save_cache:
           key: dependency-cache-{{ checksum "Cargo.lock" }}
           paths:
             - "~/.cargo"
             - "./target"
+            - "./api_tests/node_modules"
 
 
 commands:

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -16,13 +16,6 @@ dependencies = [
 ]
 
 # Overridden because: added dependencies
-[tasks.pre-ci-flow]
-workspace = false
-dependencies = [
-    "start-sccache",
-]
-
-# Overridden because: added dependencies
 [tasks.pre-build]
 workspace = false
 dependencies = [
@@ -42,7 +35,6 @@ dependencies = [
 [tasks.post-ci-flow]
 workspace = false
 dependencies = [
-    "stop-sccache",
     "clean-registry"
 ]
 
@@ -146,10 +138,10 @@ script = [
 '''
 ]
 
-[tasks.travis]
+[tasks.ci]
 workspace = false
 # Even though we only have 2 cores on Travis, we mostly wait for containers in our tests. Doing that in parallel saves us some time! (8 is just an arbitrary number!)
-env = { "RUST_TEST_THREADS" = "8", "RUSTC_WRAPPER" = "${HOME}/.cargo/bin/sccache"  }
+env = { "RUST_TEST_THREADS" = "8" }
 run_task = "ci-flow"
 
 [tasks.clean-registry]
@@ -184,23 +176,6 @@ find $HOME/.cargo/registry/src $HOME/.cargo/registry/cache \
     -depth 2 -type d -mtime +30d -exec rm -rf "{}" \;
 '''
 ]
-
-[tasks.start-sccache]
-description = "Setup & start sscache"
-workspace = false
-private = true
-install_script = ["which sccache || (unset RUSTC_WRAPPER; cargo install sccache)"]
-# Start sccache with limited cache size to avoid a constantly growing caches (and thus continuously slower builds)
-env = { "SCCACHE_CACHE_SIZE" = "400M" }
-command = "sccache"
-args = ["--start-server"]
-
-[tasks.stop-sccache]
-description = "Stop sscache"
-workspace = false
-private = true
-command = "sccache"
-args = ["--stop-server"]
 
 #############
 # api Tests #

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -16,6 +16,13 @@ dependencies = [
 ]
 
 # Overridden because: added dependencies
+[tasks.pre-ci-flow]
+workspace = false
+dependencies = [
+    "start-sccache",
+]
+
+# Overridden because: added dependencies
 [tasks.pre-build]
 workspace = false
 dependencies = [
@@ -35,6 +42,7 @@ dependencies = [
 [tasks.post-ci-flow]
 workspace = false
 dependencies = [
+    "stop-sccache",
     "clean-registry"
 ]
 
@@ -138,10 +146,10 @@ script = [
 '''
 ]
 
-[tasks.ci]
+[tasks.travis]
 workspace = false
 # Even though we only have 2 cores on Travis, we mostly wait for containers in our tests. Doing that in parallel saves us some time! (8 is just an arbitrary number!)
-env = { "RUST_TEST_THREADS" = "8" }
+env = { "RUST_TEST_THREADS" = "8", "RUSTC_WRAPPER" = "${HOME}/.cargo/bin/sccache"  }
 run_task = "ci-flow"
 
 [tasks.clean-registry]
@@ -176,6 +184,23 @@ find $HOME/.cargo/registry/src $HOME/.cargo/registry/cache \
     -depth 2 -type d -mtime +30d -exec rm -rf "{}" \;
 '''
 ]
+
+[tasks.start-sccache]
+description = "Setup & start sscache"
+workspace = false
+private = true
+install_script = ["which sccache || (unset RUSTC_WRAPPER; cargo install sccache)"]
+# Start sccache with limited cache size to avoid a constantly growing caches (and thus continuously slower builds)
+env = { "SCCACHE_CACHE_SIZE" = "400M" }
+command = "sccache"
+args = ["--start-server"]
+
+[tasks.stop-sccache]
+description = "Stop sscache"
+workspace = false
+private = true
+command = "sccache"
+args = ["--stop-server"]
 
 #############
 # api Tests #


### PR DESCRIPTION
Simple circle ci setup.
Last build duration: 17:48 minutes

Currently we are only able to go for machine executors.
The reason is, we would need docker in docker. This is generally supported by circle ci, however, they only provide a remote docker host, which is currently not supported by testcontainer-rs. 
If we fix this in testcontainer-rs, we can probably optimize the build time. 