### PR TITLE
Update setup in README to current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ Contains crates specific to our application. Can depend on libraries located in 
 
 1. `cargo build` (do `export SOLC_BIN=/usr/bin/solc` if `solc` is installed locally)
 2. Put a [`default.toml`](application/comit_node/config/default.toml) config file into `~/.config/comit_node` or set `COMIT_NODE_CONFIG_PATH` as folder path to where the `default.toml` is located.
-3. Put a [`default.toml`](application/comit_node/config/default.toml) config file into `~/.config/btsieve` or set `BTSIEVE_CONFIG_PATH` as folder path to where the `default.toml` is located
+3. Put a [`default.toml`](application/btsieve/config/default.toml) config file into `~/.config/btsieve` or set `BTSIEVE_CONFIG_PATH` as folder path to where the `default.toml` is located
 4. startup bitcoin node (port to be set according to btsieve configuration)
 5. startup ethereum node (port to be set according to btsieve configuration)
 6. startup btsieve: `cargo run --bin btsieve`
 7. startup comit_node: `cargo run --bin comit_node`
 
-If the `[web_gui]` section is specified in the configuration the current release of the user interface [comit-i](https://github.com/comit-network/comit-i) will be served once the commit node started up (served at `localhost:8080` as default).
+If the `[web_gui]` section is specified in the configuration the current release of the user interface [comit-i](https://github.com/comit-network/comit-i) will be served once the comit node started up (served at `localhost:8080` as default).
 
 In order to do a swap you will have to start two comit nodes. 
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,16 @@ Contains crates specific to our application. Can depend on libraries located in 
 ## Build & Run
 
 1. `cargo build` (do `export SOLC_BIN=/usr/bin/solc` if `solc` is installed locally)
-2. Put a [`default.toml`](application/comit_node/config/default.toml) config file into `~/.config/comit_node` or set `COMIT_NODE_CONFIG_PATH` to wherever the config file is located.
-3. `./target/release/comit_node`
-4. TODO: similar documentation for `btsieve`
+2. Put a [`default.toml`](application/comit_node/config/default.toml) config file into `~/.config/comit_node` or set `COMIT_NODE_CONFIG_PATH` as folder path to where the `default.toml` is located.
+3. Put a [`default.toml`](application/comit_node/config/default.toml) config file into `~/.config/btsieve` or set `BTSIEVE_CONFIG_PATH` as folder path to where the `default.toml` is located
+4. startup bitcoin node (port to be set according to btsieve configuration)
+5. startup ethereum node (port to be set according to btsieve configuration)
+6. startup btsieve: `cargo run --bin btsieve`
+7. startup comit_node: `cargo run --bin comit_node`
 
+Once the comit node was started the user interface is served as specified in the comit_node configuration file, default is `localhost:8008`.
+
+In order to do a swap you will have to start two comit nodes. 
 
 ## Setup testing/dev environment
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Contains crates specific to our application. Can depend on libraries located in 
 6. startup btsieve: `cargo run --bin btsieve`
 7. startup comit_node: `cargo run --bin comit_node`
 
-Once the comit node was started the user interface is served as specified in the comit_node configuration file, default is `localhost:8008`.
+If the `[web_gui]` section is specified in the configuration the current release of the user interface [comit-i](https://github.com/comit-network/comit-i) will be served once the commit node started up (served at `localhost:8080` as default).
 
 In order to do a swap you will have to start two comit nodes. 
 

--- a/application/btsieve/config/default.toml
+++ b/application/btsieve/config/default.toml
@@ -5,7 +5,7 @@ node_password = "54pLR_f7-G6is32LP-7nbhzZSbJs_2zSATtZV_r05yg="
 zmq_endpoint = "tcp://127.0.0.1:28332"
 
 [ethereum]
-node_url = "http://ethereum:8545"
+node_url = "http://localhost:8545"
 poll_interval_secs = 17
 
 [http_api]


### PR DESCRIPTION
Updates `Build & Run` section. 
Related fix for the `default.toml` of `btsieve`. 