### PR TITLE
Allow config dir path to be passed via command line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +601,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "clear_on_drop"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +697,7 @@ dependencies = [
  "siren 0.1.0",
  "spectral 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "state_machine_future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tc_bitcoincore_client 0.1.0",
@@ -3293,6 +3316,31 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "structopt"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strum"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3513,6 +3561,14 @@ dependencies = [
  "tc_postgres 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tc_redis 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tc_trufflesuite_ganachecli 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3933,6 +3989,11 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4017,6 +4078,11 @@ dependencies = [
 [[package]]
 name = "vcpkg"
 version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -4370,6 +4436,7 @@ dependencies = [
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
 "checksum aio-limited 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f10b352bc3fc08ae24dc5d2d3ddcac153678533986122dc283d747b12071000"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum asn1_der 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9893d63fc3b1c44231e667da6836a33f27d8b6b3bdc82f83da5dfd579d1b6528"
@@ -4417,6 +4484,7 @@ dependencies = [
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum chacha20-poly1305-aead 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77d2058ba29594f69c75e8a9018e0485e3914ca5084e3613cd64529042f5423b"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
+"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum colored 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6e9a455e156a4271e12fd0246238c380b1e223e3736663c7a18ed8b6362028a9"
@@ -4688,6 +4756,9 @@ dependencies = [
 "checksum stdweb-internal-runtime 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d52317523542cc0af5b7e31017ad0f7d1e78da50455e38d5657cd17754f617da"
 "checksum stream-cipher 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8861bc80f649f5b4c9bd38b696ae9af74499d479dbfb327f0607de6b326a36bc"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
+"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
+"checksum structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6"
 "checksum strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
 "checksum strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cd23f5c7dee395a00fa20135e2ec0fffcdfa151c56182966d7a3261343432e"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
@@ -4710,6 +4781,7 @@ dependencies = [
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"
 "checksum testcontainers 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "edef250e8b003a58f8adb51cd945dcd3923d15390f416307effe4318b7af9a82"
+"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
@@ -4751,6 +4823,7 @@ dependencies = [
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 "checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
+"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unsigned-varint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2c64cdf40b4a9645534a943668681bcb219faf51874d4b65d2e0abda1b10a2ab"
@@ -4764,6 +4837,7 @@ dependencies = [
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"

--- a/README.md
+++ b/README.md
@@ -37,10 +37,7 @@ Contains crates specific to our application. Can depend on libraries located in 
 ## Build & Run
 
 1. `cargo build` (do `export SOLC_BIN=/usr/bin/solc` if `solc` is installed locally)
-2. Put a [`default.toml`](application/comit_node/config/default.toml) config file into `~/.config/comit_node`
-   - or pass `--config <config_path>`
-   - or set `COMIT_NODE_CONFIG_PATH=<config_path>`
-    With `<config_path>` as the folder path to where the `default.toml` is located.
+2. Put a [`default.toml`](application/comit_node/config/default.toml) config file into `~/.config/comit_node` or pass `--config <config_path>` with `<config_path>` as the folder path to where the `default.toml` is located.
 3. Put a [`default.toml`](application/btsieve/config/default.toml) config file into `~/.config/btsieve` or set `BTSIEVE_CONFIG_PATH` as folder path to where the `default.toml` is located
 4. startup bitcoin node (port to be set according to btsieve configuration)
 5. startup ethereum node (port to be set according to btsieve configuration)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ Contains crates specific to our application. Can depend on libraries located in 
 ## Build & Run
 
 1. `cargo build` (do `export SOLC_BIN=/usr/bin/solc` if `solc` is installed locally)
-2. Put a [`default.toml`](application/comit_node/config/default.toml) config file into `~/.config/comit_node` or set `COMIT_NODE_CONFIG_PATH` as folder path to where the `default.toml` is located.
+2. Put a [`default.toml`](application/comit_node/config/default.toml) config file into `~/.config/comit_node`
+   - or pass `--config <config_path>`
+   - or set `COMIT_NODE_CONFIG_PATH=<config_path>`
+    With `<config_path>` as the folder path to where the `default.toml` is located.
 3. Put a [`default.toml`](application/btsieve/config/default.toml) config file into `~/.config/btsieve` or set `BTSIEVE_CONFIG_PATH` as folder path to where the `default.toml` is located
 4. startup bitcoin node (port to be set according to btsieve configuration)
 5. startup ethereum node (port to be set according to btsieve configuration)

--- a/api_tests/harness.ts
+++ b/api_tests/harness.ts
@@ -64,7 +64,6 @@ class ComitRunner {
                 ["--config", comit_config.config_dir],
                 {
                     cwd: project_root,
-                    env: null,
                     stdio: [
                         "ignore",
                         fs.openSync(

--- a/api_tests/harness.ts
+++ b/api_tests/harness.ts
@@ -61,10 +61,10 @@ class ComitRunner {
 
             this.running_nodes[name] = await spawn(
                 project_root + "/target/debug/comit_node",
-                [],
+                ["--config", comit_config.config_dir],
                 {
                     cwd: project_root,
-                    env: { COMIT_NODE_CONFIG_PATH: comit_config.config_dir },
+                    env: null,
                     stdio: [
                         "ignore",
                         fs.openSync(

--- a/api_tests/lib/actor.ts
+++ b/api_tests/lib/actor.ts
@@ -40,12 +40,11 @@ export class Actor {
             }
 
             this.host = metaComitNodeConfig.host;
+
+            const envConfigDir = metaComitNodeConfig.config_dir;
             this.comitNodeConfig = toml.parse(
                 fs.readFileSync(
-                    root +
-                        "/" +
-                        metaComitNodeConfig.config_dir +
-                        "/default.toml",
+                    root + "/" + envConfigDir + "/default.toml",
                     "utf8"
                 )
             );

--- a/application/comit_node/Cargo.toml
+++ b/application/comit_node/Cargo.toml
@@ -33,6 +33,7 @@ rust-crypto = "0.2"
 rustic_hal = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+structopt = "0.2"
 strum = "0.15"
 strum_macros = "0.15"
 tokio = "0.1"

--- a/application/comit_node/src/lib.rs
+++ b/application/comit_node/src/lib.rs
@@ -8,9 +8,26 @@ pub mod comit_client;
 pub mod comit_i_routes;
 pub mod http_api;
 pub mod libp2p_bam;
+pub mod load_settings;
 pub mod logging;
 pub mod network;
 pub mod node_id;
 pub mod seed;
 pub mod settings;
 pub mod swap_protocols;
+
+fn var_or_default(name: &str, default: String) -> String {
+    match std::env::var(name) {
+        Ok(value) => {
+            log::info!("Set {}={}", name, value);
+            value
+        }
+        Err(_) => {
+            eprintln!(
+                "{} is not set, falling back to default: '{}' ",
+                name, default
+            );
+            default
+        }
+    }
+}

--- a/application/comit_node/src/lib.rs
+++ b/application/comit_node/src/lib.rs
@@ -23,9 +23,10 @@ fn var_or_default(name: &str, default: String) -> String {
             value
         }
         Err(_) => {
-            eprintln!(
+            log::warn!(
                 "{} is not set, falling back to default: '{}' ",
-                name, default
+                name,
+                default
             );
             default
         }

--- a/application/comit_node/src/load_settings.rs
+++ b/application/comit_node/src/load_settings.rs
@@ -1,0 +1,47 @@
+use crate::settings::ComitNodeSettings;
+use config::ConfigError;
+use std::path::{Path, PathBuf};
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub struct Opt {
+    /// Path to configuration folder
+    #[structopt(short = "c", long = "config", parse(from_os_str))]
+    config_path: Option<PathBuf>,
+}
+
+pub fn load_settings(opt: Opt) -> Result<ComitNodeSettings, ConfigError> {
+    let config_path = match opt.config_path {
+        Some(config_path) => validate_path(config_path),
+        None => match directories::UserDirs::new() {
+            None => Err(ConfigError::Message(
+                "Unable to determine user's home directory".to_string(),
+            )),
+            Some(dirs) => Ok(Path::join(dirs.home_dir(), ".config/comit_node")),
+        },
+    }?;
+    let run_mode_config = crate::var_or_default("RUN_MODE", "development".into());
+    let default_config = Path::join(&config_path, "default");
+    let run_mode_config = Path::join(&config_path, run_mode_config);
+    let settings = ComitNodeSettings::create(default_config, run_mode_config)?;
+    Ok(settings)
+}
+
+fn validate_path(path: PathBuf) -> Result<PathBuf, ConfigError> {
+    match std::fs::metadata(path.clone()) {
+        Ok(metadata) => {
+            if metadata.is_dir() {
+                Ok(path)
+            } else {
+                Err(ConfigError::Message(format!(
+                    "Config path is expected to be a directory: {:?}",
+                    path
+                )))
+            }
+        }
+        Err(e) => Err(ConfigError::Message(format!(
+            "Cannot access config path {:?}: {:?}",
+            path, e
+        ))),
+    }
+}


### PR DESCRIPTION
If no argument passed, it falls back to ~/.config/comit_node

Once this is approved/merged, I'll also do it for btsieve

Resolves #876