### PR TITLE
Fixes offset print order

### DIFF
--- a/vendor/blockchain_contracts/src/bin/calculate_offsets/ethereum/rfc003/offset.rs
+++ b/vendor/blockchain_contracts/src/bin/calculate_offsets/ethereum/rfc003/offset.rs
@@ -30,7 +30,7 @@ pub fn to_markdown(offsets: Vec<Offset>) -> String {
     let mut res = String::from("| Name | Byte Range | Length (bytes) |\n|:--- |:--- |:--- |");
     for offset in offsets
         .iter()
-        .sorted_by(|a, b| Ord::cmp(&b.start, &a.start))
+        .sorted_by(|a, b| Ord::cmp(&a.start, &b.start))
     {
         res = format!("{}\n{}", res, offset.row_format())
     }


### PR DESCRIPTION
Correct output now is:
```
### RFC003 ###
** Ether on Ethereum **
Contract template:
 6120026110016000396120026000f336156051576020361415605c57602060006000376020602160206000600060026048f17f1000000000000000000000000000000000000000000000000000000000000001602151141660625760006000f35b42632000000210609f575b60006000f35b7fb8cac300e37f03ad332e581dea21b2f0b84eaaadc184a295fef71e81f44a741360206000a1733000000000000000000000000000000000000003ff5b7f5d26862916391bf49478b2f5103b0720a842b45ef145a268f2cd1fb2aed5517860006000a1734000000000000000000000000000000000000004ff
| Name | Byte Range | Length (bytes) |
|:--- |:--- |:--- |
| `secret_hash` | 51..83 | 32 |
| `refund_timestamp` | 99..103 | 4 |
| `redeem_address` | 153..173 | 20 |
| `refund_address` | 214..234 | 20 |
** ERC20 on Ethereum **
Contract template:
 6120026110016000396120026000f3361561005457602036141561006057602060006000376020602160206000600060026048f17f100000000000000000000000000000000000000000000000000000000000000160215114166100665760006000f35b426320000002106100a9575b60006000f35b7fb8cac300e37f03ad332e581dea21b2f0b84eaaadc184a295fef71e81f44a741360206000a17330000000000000000000000000000000000000036020526100ec565b7f5d26862916391bf49478b2f5103b0720a842b45ef145a268f2cd1fb2aed5517860006000a17340000000000000000000000000000000000000046020526100ec565b63a9059cbb6000527f5000000000000000000000000000000000000000000000000000000000000005604052602060606044601c6000736000000000000000000000000000000000000006620186a05a03f150602051ff
| Name | Byte Range | Length (bytes) |
|:--- |:--- |:--- |
| `secret_hash` | 53..85 | 32 |
| `refund_timestamp` | 102..106 | 4 |
| `redeem_address` | 157..177 | 20 |
| `refund_address` | 224..244 | 20 |
| `amount` | 261..293 | 32 |
| `token_contract_address` | 307..327 | 20 |
```
