### PR TITLE
Use class property in siren entities

### DIFF
--- a/application/comit_node/src/http_api/routes/index/handlers/get_swaps.rs
+++ b/application/comit_node/src/http_api/routes/index/handlers/get_swaps.rs
@@ -8,7 +8,7 @@ pub fn handle_get_swaps<T: MetadataStore<SwapId>, S: StateStore>(
     metadata_store: &T,
     state_store: &S,
 ) -> Result<siren::Entity, HttpApiProblem> {
-    let mut entity = siren::Entity::default().with_class_member(String::from("swaps"));
+    let mut entity = siren::Entity::default().with_class_member("swaps");
 
     for (id, metadata) in metadata_store.all()?.into_iter() {
         let sub_entity = build_rfc003_siren_entity(state_store, id, metadata, IncludeState::No)?;

--- a/application/comit_node/src/http_api/routes/index/handlers/get_swaps.rs
+++ b/application/comit_node/src/http_api/routes/index/handlers/get_swaps.rs
@@ -8,7 +8,7 @@ pub fn handle_get_swaps<T: MetadataStore<SwapId>, S: StateStore>(
     metadata_store: &T,
     state_store: &S,
 ) -> Result<siren::Entity, HttpApiProblem> {
-    let mut entity = siren::Entity::default();
+    let mut entity = siren::Entity::default().with_class_member(String::from("swaps"));
 
     for (id, metadata) in metadata_store.all()?.into_iter() {
         let sub_entity = build_rfc003_siren_entity(state_store, id, metadata, IncludeState::No)?;

--- a/application/comit_node/src/http_api/swap_resource.rs
+++ b/application/comit_node/src/http_api/swap_resource.rs
@@ -118,6 +118,7 @@ pub fn build_rfc003_siren_entity<S: StateStore>(
             };
 
             let entity = siren::Entity::default()
+                .with_class_member(String::from("swap"))
                 .with_properties(swap)
                 .map_err(|e| {
                     log::error!("failed to set properties of entity: {:?}", e);

--- a/application/comit_node/src/http_api/swap_resource.rs
+++ b/application/comit_node/src/http_api/swap_resource.rs
@@ -118,7 +118,7 @@ pub fn build_rfc003_siren_entity<S: StateStore>(
             };
 
             let entity = siren::Entity::default()
-                .with_class_member(String::from("swap"))
+                .with_class_member("swap")
                 .with_properties(swap)
                 .map_err(|e| {
                     log::error!("failed to set properties of entity: {:?}", e);

--- a/vendor/siren/src/types.rs
+++ b/vendor/siren/src/types.rs
@@ -72,6 +72,12 @@ impl Entity {
         }
     }
 
+    pub fn with_class_member(mut self, class_member: String) -> Self {
+        self.class.push(class_member);
+
+        self
+    }
+
     pub fn with_link(mut self, link: NavigationalLink) -> Self {
         self.links.push(link);
 
@@ -253,21 +259,21 @@ mod tests {
         let siren_document = r#"
         {
           "class": [ "order" ],
-          "properties": { 
-              "orderNumber": 42, 
+          "properties": {
+              "orderNumber": 42,
               "itemCount": 3,
               "status": "pending"
           },
           "entities": [
-            { 
-              "class": [ "items", "collection" ], 
-              "rel": [ "http://x.io/rels/order-items" ], 
+            {
+              "class": [ "items", "collection" ],
+              "rel": [ "http://x.io/rels/order-items" ],
               "href": "http://api.x.io/orders/42/items"
             },
             {
               "class": [ "info", "customer" ],
-              "rel": [ "http://x.io/rels/customer" ], 
-              "properties": { 
+              "rel": [ "http://x.io/rels/customer" ],
+              "properties": {
                 "customerId": "pj123",
                 "name": "Peter Joseph"
               },

--- a/vendor/siren/src/types.rs
+++ b/vendor/siren/src/types.rs
@@ -72,8 +72,8 @@ impl Entity {
         }
     }
 
-    pub fn with_class_member(mut self, class_member: String) -> Self {
-        self.class.push(class_member);
+    pub fn with_class_member<S: Into<String>>(mut self, class_member: S) -> Self {
+        self.class.push(class_member.into());
 
         self
     }


### PR DESCRIPTION
- Add method to `siren::Entity` which inserts an element in an entity's class property.
- Use new method when building `GET /swaps` and `GET /swaps/rfc003/:id` responses.

Added to be able to realise comit-network/comit-i#61.
