### PR TITLE
Remove `groomed` as the default label from dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,7 +3,6 @@ update_configs:
   - package_manager: "rust:cargo"
     directory: "/"
     update_schedule: "weekly"
-    default_labels: ["groomed"]
     allowed_updates:
       - match:
           update_type: "all"


### PR DESCRIPTION
We are no longer using waffle and hence we deleted the label.