### PR TITLE
Add setup instructions for SSL (Linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Contains crates specific to our application. Can depend on libraries located in 
 2. Install libzmq:
    - Ubuntu/Debian: `apt install libzmq3-dev`
    - Mac ([Homebrew](https://brew.sh/)) `brew install zeromq`
+3. Install OpenSSL:
+   - Ubuntu/Debion: `apt install libssl-dev pkg-config`
 
 ## Build & Run
 


### PR DESCRIPTION
comit-rs depends on OpenSSL.  We recently removed the instruction, lets add it
back in.

Add setup instruction for Ubuntu to install OpenSSL.
