### PR TITLE
No longer drop it like it's hot

### DIFF
--- a/api_tests/dry/peers_using_ip.ts
+++ b/api_tests/dry/peers_using_ip.ts
@@ -9,8 +9,12 @@ declare var global: HarnessGlobal;
 (async () => {
     const alice = new Actor("alice", global.config, global.project_root);
     const bob = new Actor("bob", global.config, global.project_root);
+    const charlie = new Actor("charlie", global.config, global.project_root);
+    const alicePeerId = await alice.peerId();
     const bobPeerId = await bob.peerId();
     const bobMultiAddress = bob.comitNodeNetworkListenAddress();
+    const charliePeerId = await charlie.peerId();
+    const charlieMultiAddress = charlie.comitNodeNetworkListenAddress();
 
     describe("SWAP request with address", () => {
         it("[Alice] Should not yet see Bob's peer id in her list of peers", async () => {
@@ -24,7 +28,7 @@ declare var global: HarnessGlobal;
             ]);
         });
 
-        it("[Alice] Should be able to make a swap request via HTTP api using a peer id and an ip address", async () => {
+        it("[Alice] Should be able to make a swap request via HTTP api to Bob using a random peer id and a correct ip address", async () => {
             let res = await request(alice.comitNodeHttpApiUrl())
                 .post("/swaps/rfc003")
                 .send({
@@ -74,11 +78,88 @@ declare var global: HarnessGlobal;
             ]);
         });
 
-        it("[Bob] Should see a new peer in his list of peers after receiving a swap request from Alice", async () => {
+        it("[Bob] Should see Alice's peer ID in his list of peers after receiving a swap request from Alice", async () => {
             let res = await request(bob.comitNodeHttpApiUrl()).get("/peers");
 
             expect(res.status).to.equal(200);
-            expect(res.body.peers).to.have.length(1);
+            expect(res.body.peers).to.containSubset([
+                {
+                    id: alicePeerId,
+                },
+            ]);
+        });
+
+        it("[Alice] Should not yet see Charlie's peer id in her list of peers", async () => {
+            let res = await request(alice.comitNodeHttpApiUrl()).get("/peers");
+
+            expect(res.status).to.equal(200);
+            expect(res.body.peers).to.not.containSubset([
+                {
+                    id: charliePeerId,
+                },
+            ]);
+        });
+
+        it("[Alice] Should be able to make a swap request via HTTP api to Charlie using his peer ID and his ip address", async () => {
+            let res = await request(alice.comitNodeHttpApiUrl())
+                .post("/swaps/rfc003")
+                .send({
+                    alpha_ledger: {
+                        name: "bitcoin",
+                        network: "regtest",
+                    },
+                    beta_ledger: {
+                        name: "ethereum",
+                        network: "regtest",
+                    },
+                    alpha_asset: {
+                        name: "bitcoin",
+                        quantity: "100000000",
+                    },
+                    beta_asset: {
+                        name: "ether",
+                        quantity: toWei("10", "ether"),
+                    },
+                    beta_ledger_redeem_identity:
+                        "0x00a329c0648769a73afac7f9381e08fb43dbea72",
+                    alpha_expiry:
+                        new Date("2080-06-11T23:00:00Z").getTime() / 1000,
+                    beta_expiry:
+                        new Date("2080-06-11T13:00:00Z").getTime() / 1000,
+                    peer: {
+                        peer_id: charliePeerId,
+                        address_hint: charlieMultiAddress,
+                    },
+                });
+
+            expect(res.error).to.be.false;
+            expect(res.status).to.equal(201);
+            expect(res.header.location).to.be.a("string");
+        });
+
+        it("[Alice] Should see Charlie's peer id in her list of peers after sending a swap request to him using his ip address", async () => {
+            await sleep(1000);
+            let res = await request(alice.comitNodeHttpApiUrl()).get("/peers");
+
+            expect(res.status).to.equal(200);
+            expect(res.body.peers).to.containSubset([
+                {
+                    id: charliePeerId,
+                },
+            ]);
+        });
+
+        it("[Charlie] Should see Alice's peer ID in his list of peers after receiving a swap request from Alice", async () => {
+            let res = await request(charlie.comitNodeHttpApiUrl()).get(
+                "/peers"
+            );
+
+            expect(res.status).to.equal(200);
+            expect(res.body.peers).to.containSubset([
+                {
+                    id: alicePeerId,
+                },
+            ]);
         });
     });
 

--- a/api_tests/dry/peers_using_ip.ts
+++ b/api_tests/dry/peers_using_ip.ts
@@ -1,6 +1,6 @@
 import { Actor } from "../lib/actor";
 import { HarnessGlobal, sleep } from "../lib/util";
-import { request, expect } from "chai";
+import { expect, request } from "chai";
 import { toWei } from "web3-utils";
 import "../lib/setupChai";
 
@@ -11,7 +11,6 @@ declare var global: HarnessGlobal;
     const bob = new Actor("bob", global.config, global.project_root);
     const charlie = new Actor("charlie", global.config, global.project_root);
     const alicePeerId = await alice.peerId();
-    const bobPeerId = await bob.peerId();
     const bobMultiAddress = bob.comitNodeNetworkListenAddress();
     const charliePeerId = await charlie.peerId();
     const charlieMultiAddress = charlie.comitNodeNetworkListenAddress();
@@ -21,14 +20,10 @@ declare var global: HarnessGlobal;
             let res = await request(alice.comitNodeHttpApiUrl()).get("/peers");
 
             expect(res.status).to.equal(200);
-            expect(res.body.peers).to.not.containSubset([
-                {
-                    id: bobPeerId,
-                },
-            ]);
+            expect(res.body.peers).to.be.empty;
         });
 
-        it("[Alice] Should be able to make a swap request via HTTP api to Bob using a random peer id and a correct ip address", async () => {
+        it("[Alice] Should be able to make a swap request via HTTP api using a random peer id and Bob's ip address", async () => {
             let res = await request(alice.comitNodeHttpApiUrl())
                 .post("/swaps/rfc003")
                 .send({
@@ -66,27 +61,19 @@ declare var global: HarnessGlobal;
             expect(res.header.location).to.be.a("string");
         });
 
-        it("[Alice] Should see Bob's peer id in her list of peers after sending a swap request to him using his ip address", async () => {
+        it("[Alice] Should not see any peers because the address did not resolve to the given PeerID", async () => {
             await sleep(1000);
             let res = await request(alice.comitNodeHttpApiUrl()).get("/peers");
 
             expect(res.status).to.equal(200);
-            expect(res.body.peers).to.containSubset([
-                {
-                    id: bobPeerId,
-                },
-            ]);
+            expect(res.body.peers).to.be.empty;
         });
 
-        it("[Bob] Should see Alice's peer ID in his list of peers after receiving a swap request from Alice", async () => {
+        it("[Bob] Should not see Alice's PeerID because she dialed to a different PeerID", async () => {
             let res = await request(bob.comitNodeHttpApiUrl()).get("/peers");
 
             expect(res.status).to.equal(200);
-            expect(res.body.peers).to.containSubset([
-                {
-                    id: alicePeerId,
-                },
-            ]);
+            expect(res.body.peers).to.be.empty;
         });
 
         it("[Alice] Should not yet see Charlie's peer id in her list of peers", async () => {

--- a/application/comit_node/src/network.rs
+++ b/application/comit_node/src/network.rs
@@ -109,7 +109,7 @@ where
     fn bam_peers(&self) -> Box<dyn Iterator<Item = (PeerId, Vec<Multiaddr>)> + Send + 'static> {
         let mut swarm = self.lock().unwrap();
 
-        Box::new(swarm.bam.peer_addresses())
+        Box::new(swarm.bam.connected_peers())
     }
 
     fn listen_addresses(&self) -> Vec<Multiaddr> {


### PR DESCRIPTION
Introducing the "dial to IP feature" actually introduced a bug into the network layer where we are dropping connections because we dial twice to the same node.

By revising how we are using the address hint, we solve this problem and actually get the behavior @LLFourn was vouching for: Not connecting to a node if the we supply an address that doesn't resolve to the given ID.