### PR TITLE
Ensure seeds cannot be printed

### DIFF
--- a/application/comit_node/src/seed.rs
+++ b/application/comit_node/src/seed.rs
@@ -10,7 +10,13 @@ pub struct Seed(#[serde(with = "hex_serde")] [u8; SEED_LENGTH]);
 
 impl fmt::Debug for Seed {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Seed")
+        write!(f, "do not implement")
+    }
+}
+
+impl fmt::Display for Seed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "do not implement")
     }
 }
 
@@ -67,5 +73,15 @@ mod tests {
         let random2 = Seed::new_random().unwrap();
 
         assert_ne!(random1, random2);
+    }
+
+    #[test]
+    fn test_display_and_debug_not_implemented() {
+        let seed = Seed::new_random().unwrap();
+
+        let out = format!("{}", seed);
+        assert_eq!(out, "do not implement".to_string());
+        let debug = format!("{:?}", seed);
+        assert_eq!(debug, "do not implement".to_string());
     }
 }

--- a/application/comit_node/src/seed.rs
+++ b/application/comit_node/src/seed.rs
@@ -10,13 +10,13 @@ pub struct Seed(#[serde(with = "hex_serde")] [u8; SEED_LENGTH]);
 
 impl fmt::Debug for Seed {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "do not implement")
+        write!(f, "Seed([*****])")
     }
 }
 
 impl fmt::Display for Seed {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "do not implement")
+        write!(f, "{:?}", self)
     }
 }
 
@@ -80,8 +80,8 @@ mod tests {
         let seed = Seed::new_random().unwrap();
 
         let out = format!("{}", seed);
-        assert_eq!(out, "do not implement".to_string());
+        assert_eq!(out, "Seed([*****])".to_string());
         let debug = format!("{:?}", seed);
-        assert_eq!(debug, "do not implement".to_string());
+        assert_eq!(debug, "Seed([*****])".to_string());
     }
 }


### PR DESCRIPTION
We don't want to display seeds (including debug output).   Implement dummy methods for
Display trait and Debug trait.  Add test to ensure the dummy implementations don't get
changed.

Fixes #722 