### PR TITLE
Add TAGS file to gitignore (emacs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ fabric.properties
 
 # vi swap files
 *.swp
+
+# Emacs
+TAGS


### PR DESCRIPTION
Tooling (Emacs) generates an artifact 'TAGS'.  We don't want this in version
control, direct git to ignore it.
