### PR TITLE
Replace our bitcoin-rpc-client with bitcoincore-rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,15 @@ dependencies = [
  "secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_test 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strason 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitcoin-amount"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -309,34 +318,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin_rpc_client"
-version = "0.6.0"
-source = "git+https://github.com/coblox/bitcoinrpc-rust-client?branch=from-verboserawtx-to-bitcointx-0.6#d31e0493cfa43360b66aa520faf82a8409b716e7"
-dependencies = [
- "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitcoin 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitcoin_hashes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitcoin_quantity 0.1.0 (git+https://github.com/coblox/bitcoin-quantity)",
- "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc_client 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "bitcoin_rpc_client"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-replace = "bitcoin_rpc_client 0.6.0 (git+https://github.com/coblox/bitcoinrpc-rust-client?branch=from-verboserawtx-to-bitcointx-0.6)"
-
-[[package]]
 name = "bitcoin_rpc_test_helpers"
 version = "0.1.0"
 dependencies = [
- "bitcoin_rpc_client 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin_support 0.1.0",
+ "bitcoincore-rpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testcontainers 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -363,9 +349,9 @@ dependencies = [
 name = "bitcoin_witness"
 version = "0.1.0"
 dependencies = [
- "bitcoin_rpc_client 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin_rpc_test_helpers 0.1.0",
  "bitcoin_support 0.1.0",
+ "bitcoincore-rpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -373,6 +359,39 @@ dependencies = [
  "spectral 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tc_bitcoincore_client 0.1.0",
  "testcontainers 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitcoincore-rpc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitcoin 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-amount 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin_hashes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoincore-rpc-json 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitcoincore-rpc-json"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitcoin 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-amount 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin_hashes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -484,8 +503,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "btsieve"
 version = "0.1.0"
 dependencies = [
- "bitcoin_rpc_client 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin_support 0.1.0",
+ "bitcoincore-rpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -666,10 +685,10 @@ version = "0.1.0"
 dependencies = [
  "bam 0.1.0",
  "binary_macros 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitcoin_rpc_client 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin_rpc_test_helpers 0.1.0",
  "bitcoin_support 0.1.0",
  "bitcoin_witness 0.1.0",
+ "bitcoincore-rpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blockchain_contracts 0.1.0",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "comit_i 0.1.0",
@@ -1591,6 +1610,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "jsonrpc-core"
 version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,6 +2390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3217,6 +3248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3504,6 +3536,14 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strason"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "stream-cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3610,7 +3650,7 @@ dependencies = [
 name = "tc_bitcoincore_client"
 version = "0.1.0"
 dependencies = [
- "bitcoin_rpc_client 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoincore-rpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testcontainers 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4716,13 +4756,14 @@ dependencies = [
 "checksum binary_macros_impl 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5732223e917a7b7495e1df95d2c80e69278f944d4dc40a59d7931259a0fc5a41"
 "checksum bitcoin 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "804b37d4fcadce0ebf4cf87e0a60e71db95d5fac70d0c2cda8aae88a4d830d31"
 "checksum bitcoin 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "381b74ae6480c4da21dccdf6fdf7400250710fc891af8d82376cb5c03e5f6f1d"
+"checksum bitcoin-amount 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0bd5ae6712113fac4edfa917b1d865801f476b021a108e6749ce20d3057abb9e"
 "checksum bitcoin-bech32 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f0a5cfe5abcb5040b36d4ea8acba95288fefebd7959b59475f2c4ec705974b4c"
 "checksum bitcoin-bech32 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4e67e8ccfc663811145e6cabdb9a2a6978877f72b048516e83eb95622e9b2554"
 "checksum bitcoin_hashes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2b7a2e9773ee7ae7f2560f0426c938f57902dcb9e39321b0cbd608f47ed579a4"
 "checksum bitcoin_quantity 0.1.0 (git+https://github.com/coblox/bitcoin-quantity)" = "<none>"
 "checksum bitcoin_rpc_client 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9a2d0c475b7be56319076a952a880f9c2c8f7ed04f76151e45552a1784c6da7"
-"checksum bitcoin_rpc_client 0.6.0 (git+https://github.com/coblox/bitcoinrpc-rust-client?branch=from-verboserawtx-to-bitcointx-0.6)" = "<none>"
-"checksum bitcoin_rpc_client 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f9eb6be87324ba28633d4dd6a253956ddcc31f8f313157a398c56251eeb1010"
+"checksum bitcoincore-rpc 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "45fe4b5d9b93cc53fb7480e25806a16ff13611b3ac825820c3d631dad1d947f4"
+"checksum bitcoincore-rpc-json 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1587c10a8435fd21bb5dd617bcf0c509fa4debfaccec5d720fb984a42ec3ac21"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91721a6330935673395a0607df4d49a9cb90ae12d259f1b3e0a3f6e1d486872e"
@@ -4842,6 +4883,7 @@ dependencies = [
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum js-sys 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e9c0d432259f651d765d888e30164c096ddbae13c89e56dd1d02a719e020efa8"
+"checksum jsonrpc 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "436f3455a8a4e9c7b14de9f1206198ee5d0bdc2db1b560339d2141093d7dd389"
 "checksum jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ddf83704f4e79979a424d1082dd2c1e52683058056c9280efa19ac5f6bc9033c"
 "checksum jsonrpc_client 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "623bdf64ab1bb4df6331864dd1712ef5398b98174dae9eef3ecac52b3737559e"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
@@ -5033,6 +5075,7 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum state_machine_future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "530e1d624baae485bce12e6647acb76aafa253346ee8a16751974eed5a24b13d"
 "checksum static_slice 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "92a7e0c5e3dfb52e8fbe0e63a1b947bbb17b4036408b151353c4491374931362"
+"checksum strason 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dcd1098ae32c583b8d538072380c340a01e46fbca379d6248ff77721373e2cef"
 "checksum stream-cipher 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8861bc80f649f5b4c9bd38b696ae9af74499d479dbfb327f0607de6b326a36bc"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,3 @@ members = [
     "vendor/tc_bitcoincore_client",
     "vendor/tc_web3_client",
 ]
-
-[replace]
-"bitcoin_rpc_client:0.6.0" = { git = "https://github.com/coblox/bitcoinrpc-rust-client", branch = "from-verboserawtx-to-bitcointx-0.6" }

--- a/application/btsieve/Cargo.toml
+++ b/application/btsieve/Cargo.toml
@@ -5,7 +5,7 @@ name = "btsieve"
 version = "0.1.0"
 
 [dependencies]
-bitcoin_rpc_client = "0.6"
+bitcoincore-rpc = "0.6"
 byteorder = "1.2"
 chrono = { version = "0.4", features = ["serde"] }
 debug_stub_derive = "0.3"

--- a/application/btsieve/src/bitcoin/queries/block.rs
+++ b/application/btsieve/src/bitcoin/queries/block.rs
@@ -3,7 +3,6 @@ use crate::{
     query_result_repository::QueryResult,
     route_factory::{Error, QueryType, ToHttpPayload},
 };
-use bitcoin_rpc_client::BitcoinCoreClient;
 use bitcoin_support::MinedBlock;
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
@@ -28,13 +27,13 @@ pub enum ReturnAs {
 }
 
 impl ToHttpPayload<ReturnAs> for QueryResult {
-    type Client = BitcoinCoreClient;
+    type Client = bitcoincore_rpc::Client;
     type Item = PayloadKind;
 
     fn to_http_payload(
         &self,
         return_as: &ReturnAs,
-        _: &BitcoinCoreClient,
+        _: &bitcoincore_rpc::Client,
     ) -> Result<Vec<Self::Item>, Error> {
         Ok(self
             .0

--- a/application/btsieve/src/route_factory.rs
+++ b/application/btsieve/src/route_factory.rs
@@ -12,8 +12,7 @@ use warp::{self, filters::BoxedFilter, Filter, Reply};
 
 #[derive(Debug)]
 pub enum Error {
-    BitcoinRpcConnection(bitcoin_rpc_client::ClientError),
-    BitcoinRpcResponse(bitcoin_rpc_client::RpcError),
+    BitcoinRpc(bitcoincore_rpc::Error),
     Web3(web3::Error),
     MissingTransaction(H256),
 }

--- a/application/comit_node/Cargo.toml
+++ b/application/comit_node/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 binary_macros = "0.6"
-bitcoin_rpc_client = "0.6"
 chrono = { version = "0.4", features = ["serde"] }
 config = { version = "0.9", features = ["toml"] }
 debug_stub_derive = "0.3"
@@ -85,6 +84,7 @@ features = ["serde", "v4"]
 version = "0.7"
 
 [dev-dependencies]
+bitcoincore-rpc = "0.6"
 lazy_static = "1"
 maplit = "1"
 memsocket = "0.1"

--- a/vendor/bitcoin_rpc_test_helpers/Cargo.toml
+++ b/vendor/bitcoin_rpc_test_helpers/Cargo.toml
@@ -5,7 +5,6 @@ authors = [ "CoBloX developers <team@coblox.tech>" ]
 edition = "2018"
 
 [dependencies]
-bitcoin_rpc_client = "0.6"
 bitcoin_support = { path = "../bitcoin_support" }
 testcontainers = "0.7"
-
+bitcoincore-rpc = "0.6"

--- a/vendor/bitcoin_support/src/network.rs
+++ b/vendor/bitcoin_support/src/network.rs
@@ -1,9 +1,19 @@
 use bitcoin;
 use bitcoin_bech32;
 use serde::{Deserialize, Serialize};
-use strum_macros::IntoStaticStr;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize, Hash, IntoStaticStr)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    PartialEq,
+    Deserialize,
+    Serialize,
+    Hash,
+    strum_macros::IntoStaticStr,
+    strum_macros::EnumString,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum Network {
     #[strum(serialize = "mainnet")]

--- a/vendor/bitcoin_witness/Cargo.toml
+++ b/vendor/bitcoin_witness/Cargo.toml
@@ -10,7 +10,7 @@ secp256k1_support = { path = "../secp256k1_support" }
 failure = "0.1"
 
 [dev-dependencies]
-bitcoin_rpc_client = "0.6"
+bitcoincore-rpc = "0.6"
 bitcoin_rpc_test_helpers = { path = "../bitcoin_rpc_test_helpers" }
 env_logger = "0.6"
 hex = "0.3"

--- a/vendor/bitcoin_witness/tests/p2wpkh.rs
+++ b/vendor/bitcoin_witness/tests/p2wpkh.rs
@@ -1,7 +1,7 @@
-use bitcoin_rpc_client::*;
 use bitcoin_rpc_test_helpers::RegtestHelperClient;
-use bitcoin_support::{serialize_hex, Address, BitcoinQuantity, OutPoint, PrivateKey};
+use bitcoin_support::{serialize_hex, Address, BitcoinQuantity, PrivateKey};
 use bitcoin_witness::{PrimedInput, PrimedTransaction, UnlockP2wpkh};
+use bitcoincore_rpc::RpcApi;
 use secp256k1_support::KeyPair;
 use spectral::prelude::*;
 use std::str::FromStr;
@@ -20,15 +20,15 @@ fn redeem_single_p2wpkh() {
         PrivateKey::from_str("L4nZrdzNnawCtaEcYGWuPqagQA3dJxVPgN8ARTXaMLCxiYCy89wm").unwrap();
     let keypair: KeyPair = private_key.key.clone().into();
 
-    let (txid, vout) = client.create_p2wpkh_vout_at(keypair.public_key().clone(), input_amount);
+    let (_, outpoint) = client.create_p2wpkh_vout_at(keypair.public_key().clone(), input_amount);
 
-    let alice_addr: Address = client.get_new_address().unwrap().unwrap().into();
+    let alice_addr: Address = client.get_new_address(None, None).unwrap().into();
 
     let fee = BitcoinQuantity::from_satoshi(1000);
 
     let redeem_tx = PrimedTransaction {
         inputs: vec![PrimedInput::new(
-            OutPoint { txid, vout: vout.n },
+            outpoint,
             input_amount,
             keypair.p2wpkh_unlock_parameters(),
         )],
@@ -38,22 +38,17 @@ fn redeem_single_p2wpkh() {
 
     let redeem_tx_hex = serialize_hex(&redeem_tx);
 
-    let raw_redeem_tx = rpc::SerializedRawTransaction(redeem_tx_hex);
+    let rpc_redeem_txid = client.send_raw_transaction(redeem_tx_hex).unwrap();
 
-    let rpc_redeem_txid = client
-        .send_raw_transaction(raw_redeem_tx.clone())
-        .unwrap()
-        .unwrap();
-
-    client.generate(1).unwrap().unwrap();
+    client.generate(1, None).unwrap();
 
     let actual_amount = client
         .find_utxo_at_tx_for_address(&rpc_redeem_txid, &alice_addr)
         .unwrap()
-        .amount;
-    let expected_amount = (input_amount - fee).bitcoin();
+        .value;
+    let expected_amount = (input_amount - fee).satoshi();
 
-    assert_that(&actual_amount).is_close_to(expected_amount, 0.000_000_01);
+    assert_that(&actual_amount).is_equal_to(expected_amount);
 }
 
 #[test]
@@ -71,33 +66,17 @@ fn redeem_two_p2wpkh() {
         PrivateKey::from_str("L1dDXCRQuNuhinf5SHbAmNUncovqFdA6ozJP4mbT7Mg53tWFFMFL").unwrap();
     let keypair_2: KeyPair = private_key_2.key.clone().into();
 
-    let (txid_1, vout_1) =
-        client.create_p2wpkh_vout_at(keypair_1.public_key().clone(), input_amount);
-    let (txid_2, vout_2) =
-        client.create_p2wpkh_vout_at(keypair_2.public_key().clone(), input_amount);
+    let (_, vout_1) = client.create_p2wpkh_vout_at(keypair_1.public_key().clone(), input_amount);
+    let (_, vout_2) = client.create_p2wpkh_vout_at(keypair_2.public_key().clone(), input_amount);
 
-    let alice_addr: Address = client.get_new_address().unwrap().unwrap().into();
+    let alice_addr: Address = client.get_new_address(None, None).unwrap().into();
 
     let fee = BitcoinQuantity::from_satoshi(1000);
 
     let redeem_tx = PrimedTransaction {
         inputs: vec![
-            PrimedInput::new(
-                OutPoint {
-                    txid: txid_1,
-                    vout: vout_1.n,
-                },
-                input_amount,
-                keypair_1.p2wpkh_unlock_parameters(),
-            ),
-            PrimedInput::new(
-                OutPoint {
-                    txid: txid_2,
-                    vout: vout_2.n,
-                },
-                input_amount,
-                keypair_2.p2wpkh_unlock_parameters(),
-            ),
+            PrimedInput::new(vout_1, input_amount, keypair_1.p2wpkh_unlock_parameters()),
+            PrimedInput::new(vout_2, input_amount, keypair_2.p2wpkh_unlock_parameters()),
         ],
         output_address: alice_addr.clone(),
     }
@@ -105,21 +84,16 @@ fn redeem_two_p2wpkh() {
 
     let redeem_tx_hex = serialize_hex(&redeem_tx);
 
-    let raw_redeem_tx = rpc::SerializedRawTransaction(redeem_tx_hex);
+    let rpc_redeem_txid = client.send_raw_transaction(redeem_tx_hex).unwrap();
 
-    let rpc_redeem_txid = client
-        .send_raw_transaction(raw_redeem_tx.clone())
-        .unwrap()
-        .unwrap();
-
-    client.generate(1).unwrap().unwrap();
+    client.generate(1, None).unwrap();
 
     let actual_amount = client
         .find_utxo_at_tx_for_address(&rpc_redeem_txid, &alice_addr)
         .unwrap()
-        .amount;
+        .value;
     let expected_amount =
-        BitcoinQuantity::from_satoshi(input_amount.satoshi() * 2 - fee.satoshi()).bitcoin();
+        BitcoinQuantity::from_satoshi(input_amount.satoshi() * 2 - fee.satoshi()).satoshi();
 
-    assert_that(&actual_amount).is_close_to(&expected_amount, 0.000_000_01);
+    assert_that(&actual_amount).is_equal_to(&expected_amount);
 }

--- a/vendor/bitcoin_witness/tests/sign_with_rate.rs
+++ b/vendor/bitcoin_witness/tests/sign_with_rate.rs
@@ -1,7 +1,7 @@
-use bitcoin_rpc_client::*;
 use bitcoin_rpc_test_helpers::RegtestHelperClient;
-use bitcoin_support::{serialize_hex, Address, BitcoinQuantity, OutPoint, PrivateKey};
+use bitcoin_support::{serialize_hex, Address, BitcoinQuantity, PrivateKey};
 use bitcoin_witness::{PrimedInput, PrimedTransaction, UnlockP2wpkh};
+use bitcoincore_rpc::RpcApi;
 use secp256k1_support::KeyPair;
 use std::str::FromStr;
 use testcontainers::{clients::Cli, images::coblox_bitcoincore::BitcoinCore, Docker};
@@ -19,15 +19,15 @@ fn sign_with_rate() {
         PrivateKey::from_str("L4nZrdzNnawCtaEcYGWuPqagQA3dJxVPgN8ARTXaMLCxiYCy89wm").unwrap();
     let keypair: KeyPair = private_key.key.clone().into();
 
-    let (txid, vout) = client.create_p2wpkh_vout_at(keypair.public_key().clone(), input_amount);
+    let (_, outpoint) = client.create_p2wpkh_vout_at(keypair.public_key().clone(), input_amount);
 
-    let alice_addr: Address = client.get_new_address().unwrap().unwrap().into();
+    let alice_addr: Address = client.get_new_address(None, None).unwrap().into();
 
     let rate = 42.0;
 
     let primed_tx = PrimedTransaction {
         inputs: vec![PrimedInput::new(
-            OutPoint { txid, vout: vout.n },
+            outpoint,
             input_amount,
             keypair.p2wpkh_unlock_parameters(),
         )],
@@ -38,14 +38,9 @@ fn sign_with_rate() {
 
     let redeem_tx_hex = serialize_hex(&redeem_tx);
 
-    let raw_redeem_tx = rpc::SerializedRawTransaction(redeem_tx_hex);
+    let rpc_redeem_txid = client.send_raw_transaction(redeem_tx_hex).unwrap();
 
-    let rpc_redeem_txid = client
-        .send_raw_transaction(raw_redeem_tx.clone())
-        .unwrap()
-        .unwrap();
-
-    client.generate(1).unwrap().unwrap();
+    client.generate(1, None).unwrap();
 
     assert!(client
         .find_utxo_at_tx_for_address(&rpc_redeem_txid, &alice_addr)

--- a/vendor/tc_bitcoincore_client/Cargo.toml
+++ b/vendor/tc_bitcoincore_client/Cargo.toml
@@ -5,5 +5,5 @@ authors = [ "CoBloX developers <team@coblox.tech>" ]
 edition = "2018"
 
 [dependencies]
-bitcoin_rpc_client = "0.6"
 testcontainers = "0.7"
+bitcoincore-rpc = "0.6"

--- a/vendor/tc_bitcoincore_client/src/lib.rs
+++ b/vendor/tc_bitcoincore_client/src/lib.rs
@@ -1,14 +1,17 @@
-#![warn(unused_extern_crates, missing_debug_implementations, rust_2018_idioms)]
+#![warn(missing_debug_implementations, rust_2018_idioms)]
 #![deny(unsafe_code)]
 
-use bitcoin_rpc_client::BitcoinCoreClient;
 use testcontainers::{images::coblox_bitcoincore::BitcoinCore, Container, Docker};
 
-pub fn new<D: Docker>(container: &Container<'_, D, BitcoinCore>) -> BitcoinCoreClient {
+pub fn new<D: Docker>(container: &Container<'_, D, BitcoinCore>) -> bitcoincore_rpc::Client {
     let port = container.get_host_port(18443).unwrap();
     let auth = container.image().auth();
 
     let endpoint = format!("http://localhost:{}", port);
 
-    BitcoinCoreClient::new(&endpoint, auth.username(), auth.password())
+    bitcoincore_rpc::Client::new(
+        endpoint,
+        bitcoincore_rpc::Auth::UserPass(auth.username().to_owned(), auth.password().to_owned()),
+    )
+    .unwrap()
 }


### PR DESCRIPTION
Fixes: #680.

Post-merge tasks:

- [ ] Archive the old repository
- [ ] Released a new version with a README update that support has been discontinued and link to `bitcoincore-rpc` crate.