### PR TITLE
Fix log_level parsing for btsieve

### DIFF
--- a/api_tests/regtest/btsieve/bitcoin_only/btsieve.toml
+++ b/api_tests/regtest/btsieve/bitcoin_only/btsieve.toml
@@ -7,3 +7,6 @@ zmq_endpoint = "tcp://127.0.0.1:28332"
 [http_api]
 address_bind="0.0.0.0"
 port_bind=8181
+
+[log_levels]
+btsieve="DEBUG"

--- a/api_tests/regtest/btsieve/btsieve.toml
+++ b/api_tests/regtest/btsieve/btsieve.toml
@@ -12,4 +12,6 @@ poll_interval_secs = 1
 address_bind="0.0.0.0"
 port_bind=8181
 
-log_level="DEBUG"
+[log_levels]
+btsieve="DEBUG"
+

--- a/api_tests/regtest/btsieve/ethereum_only/btsieve.toml
+++ b/api_tests/regtest/btsieve/ethereum_only/btsieve.toml
@@ -5,3 +5,6 @@ poll_interval_secs = 1
 [http_api]
 address_bind="0.0.0.0"
 port_bind=8181
+
+[log_levels]
+btsieve="DEBUG"

--- a/api_tests/regtest/btsieve/no_ledger/btsieve.toml
+++ b/api_tests/regtest/btsieve/no_ledger/btsieve.toml
@@ -1,3 +1,6 @@
 [http_api]
 address_bind="0.0.0.0"
 port_bind=8181
+
+[log_levels]
+btsieve="DEBUG"

--- a/application/btsieve/config/btsieve.toml
+++ b/application/btsieve/config/btsieve.toml
@@ -12,4 +12,5 @@ poll_interval_secs = 17
 address_bind="0.0.0.0"
 port_bind=8181
 
-log_level="INFO"
+[log_levels]
+btsieve="DEBUG"

--- a/application/btsieve/src/logging.rs
+++ b/application/btsieve/src/logging.rs
@@ -6,7 +6,7 @@ use std::{fmt::Arguments, io::stdout};
 pub fn set_up_logging(settings: &Settings) {
     Dispatch::new()
         .format(move |out, message, record| formatter(out, message, record))
-        .level(settings.log_level)
+        .level(settings.log_levels.btsieve)
         .level_for("warp", LevelFilter::Info)
         .chain(stdout())
         .apply()


### PR DESCRIPTION
The log level of btsieve was not parsed correctly due to the missing header. 