### PR TITLE
Add unit tests for HTTP API primitive types

### DIFF
--- a/application/comit_node/src/http_api/mod.rs
+++ b/application/comit_node/src/http_api/mod.rs
@@ -217,6 +217,7 @@ mod tests {
     use ethereum_support::{
         self, Address, Bytes, Erc20Quantity, Erc20Token, EtherQuantity, H160, H256, U256,
     };
+    use libp2p::PeerId;
     use std::{convert::TryFrom, str::FromStr};
 
     #[test]
@@ -375,5 +376,17 @@ mod tests {
             swap_id_serialized,
             r#""ad2652ca-ecf2-4cc6-b35c-b4351ac28a34""#
         )
+    }
+
+    #[test]
+    fn http_peer_id_serializes_correctly_to_json() {
+        let peer_id = PeerId::from_str("QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY").unwrap();
+        let peer_id = Http(peer_id);
+
+        let serialized = serde_json::to_string(&peer_id).unwrap();
+        assert_eq!(
+            serialized,
+            r#""QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY""#
+        );
     }
 }

--- a/application/comit_node/src/http_api/mod.rs
+++ b/application/comit_node/src/http_api/mod.rs
@@ -208,7 +208,7 @@ mod tests {
         http_api::Http,
         swap_protocols::{
             ledger::{Bitcoin, Ethereum},
-            SwapId,
+            SwapId, SwapProtocol,
         },
     };
     use bitcoin_support::{
@@ -355,6 +355,14 @@ mod tests {
             &bitcoin_htlc_location_serialized,
             r#"{"txid":"ad067ee417ee5518122374307d1fa494c67e30c75d38c7061d944b59e56fe024","vout":1}"#
         );
+    }
+
+    #[test]
+    fn http_swap_protocol_serializes_correctly_to_json() {
+        let protocol = SwapProtocol::Rfc003;
+        let protocol = Http(protocol);
+        let serialized = serde_json::to_string(&protocol).unwrap();
+        assert_eq!(serialized, r#""rfc003""#);
     }
 
     #[test]

--- a/application/comit_node/src/http_api/mod.rs
+++ b/application/comit_node/src/http_api/mod.rs
@@ -208,7 +208,7 @@ mod tests {
         http_api::Http,
         swap_protocols::{
             ledger::{Bitcoin, Ethereum},
-            SwapId, SwapProtocol,
+            HashFunction, SwapId, SwapProtocol,
         },
     };
     use bitcoin_support::{
@@ -360,7 +360,7 @@ mod tests {
 
     #[test]
     fn http_swap_protocol_serializes_correctly_to_json() {
-        let protocol = SwapProtocol::Rfc003;
+        let protocol = SwapProtocol::Rfc003(HashFunction::Sha256);
         let protocol = Http(protocol);
         let serialized = serde_json::to_string(&protocol).unwrap();
         assert_eq!(serialized, r#""rfc003""#);


### PR DESCRIPTION
We would like to test that the HTTP API primitive types serialize as expected.  Here we add unit tests that test the serialization as it is now (i.e. passing tests).  This makes the format on the wire explicit and if the serialization code changes ever these tests will catch the change.

Fixes #766
