### PR TITLE
Check format based on file suffix

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -20,7 +20,7 @@ done
 if (( $check_rs != 0 )); then
     cargo make check-rs-format
     ret=$?
-    if [ $? -ne 0 ]; then
+    if [ $ret -ne 0 ]; then
        exit $ret
     fi
 fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,7 +10,7 @@ if [ $? -eq 0 ]; then
     fi
 fi
 
-# Run check-rs-format if Typescript source files were modified.
+# Run check-ts-format if Typescript source files were modified.
 git status | egrep "*.{ts,json,yml}"
 if [ $? -eq 0 ]; then
     cargo make check-ts-format

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -19,10 +19,18 @@ done
 
 if (( $check_rs != 0 )); then
     cargo make check-rs-format
+    ret=$?
+    if [ $? -ne 0 ]; then
+       return $ret
+    fi
 fi
 
 if (( $check_ts != 0 )); then
     cargo make check-ts-format
+    ret=$?
+    if [ $? -ne 0 ]; then
+       return $ret
+    fi
 fi
 
 exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,32 +1,40 @@
 #!/usr/bin/env bash
 
-check_rs=0
-check_ts=0
+debug=0                         # Set to 1 to enable debugging, 0 to disable.
+do_check_rs=0
+do_check_ts=0
+
+check_rs_cmd="cargo make check-rs-format"
+check_ts_cmd="cargo make check-ts-format"
+if (( debug == 1 )); then
+    check_rs_cmd="echo check_rs ran"
+    check_ts_cmd="echo check_ts ran"
+fi
 
 declare -a extra_flags=("--" "--cached")
 
 for flag in ${extra_flags[@]}; do
     git diff --name-only $flag | grep '.rs$' > /dev/null 2>&1
     if [ $? -eq 0 ]; then
-        check_rs=1
+        do_check_rs=1
     fi
 
     git diff --name-only $flag | grep -E '.ts$|.json$|.yml$' > /dev/null 2>&1
     if [ $? -eq 0 ]; then
-        check_ts=1
+        do_check_ts=1
     fi
 done
 
-if (( $check_rs != 0 )); then
-    cargo make check-rs-format
+if (( $do_check_rs != 0 )); then
+    eval "$check_rs_cmd"
     ret=$?
     if [ $ret -ne 0 ]; then
        exit $ret
     fi
 fi
 
-if (( $check_ts != 0 )); then
-    cargo make check-ts-format
+if (( $do_check_ts != 0 )); then
+    eval "$check_ts_cmd"
     ret=$?
     if [ $ret -ne 0 ]; then
        exit $ret

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,19 +11,25 @@ if (( debug == 1 )); then
     check_ts_cmd="echo check_ts ran"
 fi
 
-declare -a extra_flags=("--" "--cached")
+git diff --name-only | grep '.rs$' > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    do_check_rs=1
+fi
 
-for flag in ${extra_flags[@]}; do
-    git diff --name-only $flag | grep '.rs$' > /dev/null 2>&1
-    if [ $? -eq 0 ]; then
-        do_check_rs=1
-    fi
+git diff --name-only --cached | grep '.rs$' > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    do_check_rs=1
+fi
 
-    git diff --name-only $flag | grep -E '.ts$|.json$|.yml$' > /dev/null 2>&1
-    if [ $? -eq 0 ]; then
-        do_check_ts=1
-    fi
-done
+git diff --name-only | grep -E '.ts$|.json$|.yml$' > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    do_check_ts=1
+fi
+
+git diff --name-only --cached | grep -E '.ts$|.json$|.yml$' > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    do_check_ts=1
+fi
 
 if (( $do_check_rs != 0 )); then
     eval "$check_rs_cmd"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -28,7 +28,9 @@ fi
 if (( $check_ts != 0 )); then
     cargo make check-ts-format
     ret=$?
-    exit $ret
+    if [ $ret -ne 0 ]; then
+       exit $ret
+    fi
 fi
 
 exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,23 @@
 #!/usr/bin/env bash
 
-cargo make check-rs-format && \
-cargo make check-ts-format
+# Run check-rs-format if Rust source files were modified.
+git status | egrep "*.rs"
+if [ $? -eq 0 ]; then
+    cargo make check-rs-format
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        exit $ret
+    fi
+fi
+
+# Run check-rs-format if Typescript source files were modified.
+git status | egrep "*.ts"
+if [ $? -eq 0 ]; then
+    cargo make check-ts-format
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        exit $ret
+    fi
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,10 +2,10 @@
 
 set -e                          # grep failure does not trigger exit.
 
-debug=0                         # Set to 1 to enable debugging, 0 to disable.
+dry=0                           # Set to 1 to enable dry run.
 
 function check_rs() {
-    if (( debug == 0 )); then
+    if (( dry == 0 )); then
         cargo make check-rs-format
     else
         echo "check_rs ran"
@@ -13,7 +13,7 @@ function check_rs() {
 }
 
 function check_ts() {
-    if (( debug == 0 )); then
+    if (( dry == 0 )); then
         cargo make check-ts-format
     else
         echo "check_ts ran"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -21,16 +21,14 @@ if (( $check_rs != 0 )); then
     cargo make check-rs-format
     ret=$?
     if [ $? -ne 0 ]; then
-       return $ret
+       exit $ret
     fi
 fi
 
 if (( $check_ts != 0 )); then
     cargo make check-ts-format
     ret=$?
-    if [ $? -ne 0 ]; then
-       return $ret
-    fi
+    exit $ret
 fi
 
 exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,7 +11,7 @@ if [ $? -eq 0 ]; then
 fi
 
 # Run check-rs-format if Typescript source files were modified.
-git status | egrep "*.ts"
+git status | egrep "*.{ts,json,yml}"
 if [ $? -eq 0 ]; then
     cargo make check-ts-format
     ret=$?

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,50 +1,26 @@
 #!/usr/bin/env bash
 
+set -e                          # grep failure does not trigger exit.
+
 debug=0                         # Set to 1 to enable debugging, 0 to disable.
-do_check_rs=0
-do_check_ts=0
 
-check_rs_cmd="cargo make check-rs-format"
-check_ts_cmd="cargo make check-ts-format"
-if (( debug == 1 )); then
-    check_rs_cmd="echo check_rs ran"
-    check_ts_cmd="echo check_ts ran"
-fi
-
-git diff --name-only | grep '.rs$' > /dev/null 2>&1
-if [ $? -eq 0 ]; then
-    do_check_rs=1
-fi
-
-git diff --name-only --cached | grep '.rs$' > /dev/null 2>&1
-if [ $? -eq 0 ]; then
-    do_check_rs=1
-fi
-
-git diff --name-only | grep -E '.ts$|.json$|.yml$' > /dev/null 2>&1
-if [ $? -eq 0 ]; then
-    do_check_ts=1
-fi
-
-git diff --name-only --cached | grep -E '.ts$|.json$|.yml$' > /dev/null 2>&1
-if [ $? -eq 0 ]; then
-    do_check_ts=1
-fi
-
-if (( $do_check_rs != 0 )); then
-    eval "$check_rs_cmd"
-    ret=$?
-    if [ $ret -ne 0 ]; then
-       exit $ret
+function check_rs() {
+    if (( debug == 0 )); then
+        cargo make check-rs-format
+    else
+        echo "check_rs ran"
     fi
-fi
+}
 
-if (( $do_check_ts != 0 )); then
-    eval "$check_ts_cmd"
-    ret=$?
-    if [ $ret -ne 0 ]; then
-       exit $ret
+function check_ts() {
+    if (( debug == 0 )); then
+        cargo make check-ts-format
+    else
+        echo "check_ts ran"
     fi
-fi
+}
+
+git status --untracked-files=no --short | grep -E '.rs$' > /dev/null 2>&1 && check_rs
+git status --untracked-files=no --short | grep -E '.ts$|.json$|.yml$' > /dev/null 2>&1 && check_ts
 
 exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,23 +1,28 @@
 #!/usr/bin/env bash
 
-# Run check-rs-format if Rust source files were modified.
-git status | egrep "*.rs"
-if [ $? -eq 0 ]; then
-    cargo make check-rs-format
-    ret=$?
-    if [ $ret -ne 0 ]; then
-        exit $ret
+check_rs=0
+check_ts=0
+
+declare -a extra_flags=("" "--cached")
+
+for flag in ${extra_flags[@]}; do
+    git diff --name-only $flag | grep '.rs$' > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        check_rs=1
     fi
+
+    git diff --name-only $flag | grep -E '.ts$|.json$|.yml$' > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        check_ts=1
+    fi
+done
+
+if (( $check_rs != 0 )); then
+    cargo make check-rs-format
 fi
 
-# Run check-ts-format if Typescript source files were modified.
-git status | egrep "*.{ts,json,yml}"
-if [ $? -eq 0 ]; then
+if (( $check_ts != 0 )); then
     cargo make check-ts-format
-    ret=$?
-    if [ $ret -ne 0 ]; then
-        exit $ret
-    fi
 fi
 
 exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,7 +3,7 @@
 check_rs=0
 check_ts=0
 
-declare -a extra_flags=("" "--cached")
+declare -a extra_flags=("--" "--cached")
 
 for flag in ${extra_flags[@]}; do
     git diff --name-only $flag | grep '.rs$' > /dev/null 2>&1


### PR DESCRIPTION
Currently our git pre-commit hook runs the Typescript format checker and the Rust format checker.  The Typescript checker is slow because it invokes `yarn`.  If a commit only modifies Rust source files there is no need to run the Typescript checker.  Also when modifying only Typescript it is unnecessary to check the format of the Rust code.

Add clause to the pre-commit hook shell script to only run language specific format checkers if source files of that language were modified.

Only tested on Linux `GNU bash, version 4.4.19(1)-release (x86_64-pc-linux-gnu)`