### PR TITLE
Add automagically-mergify-this label by default

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,6 +3,9 @@ update_configs:
   - package_manager: "rust:cargo"
     directory: "/"
     update_schedule: "weekly"
+    default_labels:
+      - "dependencies"
+      - "automagically-mergify-this"
     allowed_updates:
       - match:
           update_type: "all"


### PR DESCRIPTION
Because if the tests pass and it is approved then there is no
reasons to not let mergify handle it.