### PR TITLE
Implement HTTP serialization macro

### DIFF
--- a/application/comit_node/src/http_api/impl_serialize_http.rs
+++ b/application/comit_node/src/http_api/impl_serialize_http.rs
@@ -31,3 +31,16 @@ macro_rules! impl_serialize_type_name_with_fields {
         }
     };
 }
+
+macro_rules! impl_serialize_http {
+    ($type:ty) => {
+        impl Serialize for Http<$type> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                self.0.serialize(serializer)
+            }
+        }
+    };
+}

--- a/application/comit_node/src/http_api/impl_serialize_http.rs
+++ b/application/comit_node/src/http_api/impl_serialize_http.rs
@@ -3,7 +3,7 @@ macro_rules! _count {
     ($x:tt $($xs:tt)*) => (1usize + _count!($($xs)*));
 }
 
-macro_rules! impl_serialize_http {
+macro_rules! impl_serialize_type_name_with_fields {
     ($type:ty $(:= $name:tt)? { $($field_name:tt $(=> $field_value:ident)?),* }) => {
         impl Serialize for Http<$type> {
 

--- a/application/comit_node/src/http_api/mod.rs
+++ b/application/comit_node/src/http_api/mod.rs
@@ -43,9 +43,9 @@ use serde::{
 #[derive(Debug)]
 pub struct Http<I>(pub I);
 
-impl_serialize_http!(Bitcoin { "network" => network });
+impl_serialize_type_name_with_fields!(Bitcoin { "network" => network });
 impl_from_http_ledger!(Bitcoin { network });
-impl_serialize_http!(BitcoinQuantity := "bitcoin" { "quantity" });
+impl_serialize_type_name_with_fields!(BitcoinQuantity := "bitcoin" { "quantity" });
 impl_from_http_quantity_asset!(BitcoinQuantity, Bitcoin);
 
 impl Serialize for Http<bitcoin_support::Transaction> {
@@ -66,10 +66,10 @@ impl Serialize for Http<bitcoin_support::PubkeyHash> {
     }
 }
 
-impl_serialize_http!(Ethereum { "network" => network });
+impl_serialize_type_name_with_fields!(Ethereum { "network" => network });
 impl_from_http_ledger!(Ethereum { network });
-impl_serialize_http!(EtherQuantity := "ether" { "quantity" });
-impl_serialize_http!(Erc20Token := "erc20" { "quantity" => quantity, "token_contract" => token_contract });
+impl_serialize_type_name_with_fields!(EtherQuantity := "ether" { "quantity" });
+impl_serialize_type_name_with_fields!(Erc20Token := "erc20" { "quantity" => quantity, "token_contract" => token_contract });
 impl_from_http_quantity_asset!(EtherQuantity, Ether);
 
 impl FromHttpAsset for Erc20Token {

--- a/application/comit_node/src/http_api/mod.rs
+++ b/application/comit_node/src/http_api/mod.rs
@@ -57,15 +57,6 @@ impl Serialize for Http<bitcoin_support::Transaction> {
     }
 }
 
-impl Serialize for Http<bitcoin_support::PubkeyHash> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.0.serialize(serializer)
-    }
-}
-
 impl_serialize_type_name_with_fields!(Ethereum { "network" => network });
 impl_from_http_ledger!(Ethereum { network });
 impl_serialize_type_name_with_fields!(EtherQuantity := "ether" { "quantity" });
@@ -92,23 +83,10 @@ impl Serialize for Http<ethereum_support::Transaction> {
     }
 }
 
-impl Serialize for Http<ethereum_support::H160> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.0.serialize(serializer)
-    }
-}
-
-impl Serialize for Http<bitcoin_support::OutPoint> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.0.serialize(serializer)
-    }
-}
+impl_serialize_http!(bitcoin_support::PubkeyHash);
+impl_serialize_http!(bitcoin_support::OutPoint);
+impl_serialize_http!(ethereum_support::H160);
+impl_serialize_http!(SwapId);
 
 impl Serialize for Http<SwapProtocol> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -156,15 +134,6 @@ impl<'de> Deserialize<'de> for Http<PeerId> {
         }
 
         deserializer.deserialize_str(Visitor)
-    }
-}
-
-impl Serialize for Http<SwapId> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.0.serialize(serializer)
     }
 }
 


### PR DESCRIPTION
We currently have some duplicate code when implementing `Serialize` for `Http<T>` types in the REST API code.  We can reduce code duplication by defining a macro.

This PR renames the current `impl_serialize_http` to `impl_serialize_type_name_with_fields` then implements a new version of `impl_serialize_http` for the simple case where we just serialize `self.0`.