### PR TITLE
Use Option for CallContract member 'data'

### DIFF
--- a/api_tests/lib/actor.ts
+++ b/api_tests/lib/actor.ts
@@ -204,10 +204,7 @@ export class Actor {
                     .sendToAddress(to, parseInt(amount, 10));
             }
             case "bitcoin-broadcast-signed-transaction": {
-                action.payload.should.include.all.keys(
-                    "hex",
-                    "min_median_block_time"
-                );
+                action.payload.should.include.all.keys("hex");
 
                 const fetchMedianTime = async () => {
                     const blockchainInfo = await bitcoin.getBlockchainInfo();
@@ -256,8 +253,7 @@ export class Actor {
                 action.payload.should.include.all.keys(
                     "contract_address",
                     "data",
-                    "gas_limit",
-                    "min_block_timestamp"
+                    "gas_limit"
                 );
 
                 const {
@@ -267,7 +263,10 @@ export class Actor {
                     min_block_timestamp,
                 } = action.payload;
 
-                if (seconds_until(min_block_timestamp) > 0) {
+                if (
+                    min_block_timestamp &&
+                    seconds_until(min_block_timestamp) > 0
+                ) {
                     // Ethereum needs a buffer, otherwise the contract code is run but doesn't transfer any funds,
                     // see https://github.com/comit-network/RFCs/issues/62
                     const buffer = 2;

--- a/api_tests/lib/actor.ts
+++ b/api_tests/lib/actor.ts
@@ -252,7 +252,6 @@ export class Actor {
             case "ethereum-call-contract": {
                 action.payload.should.include.all.keys(
                     "contract_address",
-                    "data",
                     "gas_limit"
                 );
 

--- a/api_tests/lib/actor.ts
+++ b/api_tests/lib/actor.ts
@@ -272,8 +272,9 @@ export class Actor {
                     const delay = seconds_until(min_block_timestamp) + buffer;
 
                     console.log(
-                        `Waiting for %d seconds before action can be executed.`,
-                        delay
+                        `Waiting for %d seconds before action can be executed to reach %d.`,
+                        delay,
+                        min_block_timestamp
                     );
 
                     await sleep(delay * 1000);

--- a/api_tests/lib/ethereum.ts
+++ b/api_tests/lib/ethereum.ts
@@ -147,7 +147,7 @@ export class EthereumWallet {
 
     public async sendEthTransactionTo(
         to: string,
-        data: string = "0x0",
+        data: string,
         value: BN | string | number = utils.toBN(0),
         gas_limit: string = "0x100000"
     ) {

--- a/comit_node/src/http_api/action.rs
+++ b/comit_node/src/http_api/action.rs
@@ -50,7 +50,7 @@ pub enum ActionResponseBody {
     },
     EthereumCallContract {
         contract_address: ethereum_support::Address,
-        data: ethereum_support::Bytes,
+        data: Option<ethereum_support::Bytes>,
         gas_limit: ethereum_support::U256,
         network: ethereum_support::Network,
         min_block_timestamp: Option<Timestamp>,

--- a/comit_node/src/http_api/action.rs
+++ b/comit_node/src/http_api/action.rs
@@ -40,6 +40,7 @@ pub enum ActionResponseBody {
     BitcoinBroadcastSignedTransaction {
         hex: String,
         network: bitcoin_support::Network,
+        #[serde(skip_serializing_if = "Option::is_none")]
         min_median_block_time: Option<Timestamp>,
     },
     EthereumDeployContract {
@@ -50,9 +51,11 @@ pub enum ActionResponseBody {
     },
     EthereumCallContract {
         contract_address: ethereum_support::Address,
+        #[serde(skip_serializing_if = "Option::is_none")]
         data: Option<ethereum_support::Bytes>,
         gas_limit: ethereum_support::U256,
         network: ethereum_support::Network,
+        #[serde(skip_serializing_if = "Option::is_none")]
         min_block_timestamp: Option<Timestamp>,
     },
     None,
@@ -295,6 +298,8 @@ impl IntoResponsePayload for Infallible {
 #[cfg(test)]
 mod test {
     use super::*;
+    use ethereum_support::*;
+    use std::str::FromStr;
 
     #[test]
     fn given_no_query_parameters_deserialize_to_none() {
@@ -317,4 +322,22 @@ mod test {
             })
         );
     }
+
+    #[test]
+    fn call_contract_serializes_correctly_to_json_with_none() {
+        let addr = Address::from_str("0A81e8be41b21f651a71aaB1A85c6813b8bBcCf8").unwrap();
+        let contract = ActionResponseBody::EthereumCallContract {
+            contract_address: addr,
+            data: None,
+            gas_limit: U256::from(1),
+            network: Network::Ropsten,
+            min_block_timestamp: None,
+        };
+        let serialized = serde_json::to_string(&contract).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"type":"ethereum-call-contract","payload":{"contract_address":"0x0a81e8be41b21f651a71aab1a85c6813b8bbccf8","gas_limit":"0x1","network":"ropsten"}}"#
+        );
+    }
+
 }

--- a/comit_node/src/swap_protocols/actions.rs
+++ b/comit_node/src/swap_protocols/actions.rs
@@ -61,3 +61,27 @@ pub mod ethereum {
         pub min_block_timestamp: Option<Timestamp>,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethereum_support::{web3::types::U256, Address, Network};
+    use std::str::FromStr;
+
+    #[test]
+    fn call_contract_serializes_correctly_to_json_with_none() {
+        let addr = Address::from_str("0A81e8be41b21f651a71aaB1A85c6813b8bBcCf8").unwrap();
+        let contract = ethereum::CallContract {
+            to: addr,
+            data: None,
+            gas_limit: U256::from(1),
+            network: Network::Ropsten,
+            min_block_timestamp: None,
+        };
+        let serialized = serde_json::to_string(&contract).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"to":"0x0a81e8be41b21f651a71aab1a85c6813b8bbccf8","gas_limit":"0x1","network":"ropsten"}"#,
+        );
+    }
+}

--- a/comit_node/src/swap_protocols/actions.rs
+++ b/comit_node/src/swap_protocols/actions.rs
@@ -42,10 +42,7 @@ pub mod bitcoin {
 pub mod ethereum {
     use crate::swap_protocols::Timestamp;
     use ethereum_support::{web3::types::U256, Address, Bytes, EtherQuantity, Network};
-    use serde::{
-        ser::{SerializeStruct, Serializer},
-        Serialize,
-    };
+    use serde::Serialize;
 
     #[derive(Debug, Clone, PartialEq, Serialize)]
     pub struct DeployContract {
@@ -62,50 +59,5 @@ pub mod ethereum {
         pub gas_limit: U256,
         pub network: Network,
         pub min_block_timestamp: Option<Timestamp>,
-    }
-
-    impl Serialize for CallContract {
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            let mut state = serializer.serialize_struct("CallContract", 5)?;
-
-            state.serialize_field("to", &self.to)?;
-            if let Some(data) = &self.data {
-                state.serialize_field("data", data)?;
-            }
-            state.serialize_field("gas_limit", &self.gas_limit)?;
-            state.serialize_field("network", &self.network)?;
-            if let Some(min_block_timestamp) = &self.min_block_timestamp {
-                state.serialize_field("min_block_timestamp", min_block_timestamp)?;
-            }
-
-            state.end()
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use ethereum_support::{web3::types::U256, Address, Network};
-    use std::str::FromStr;
-
-    #[test]
-    fn call_contract_serializes_correctly_to_json_with_none() {
-        let addr = Address::from_str("0A81e8be41b21f651a71aaB1A85c6813b8bBcCf8").unwrap();
-        let contract = ethereum::CallContract {
-            to: addr,
-            data: None,
-            gas_limit: U256::from(1),
-            network: Network::Ropsten,
-            min_block_timestamp: None,
-        };
-        let serialized = serde_json::to_string(&contract).unwrap();
-        assert_eq!(
-            serialized,
-            r#"{"to":"0x0a81e8be41b21f651a71aab1a85c6813b8bbccf8","gas_limit":"0x1","network":"ropsten"}"#,
-        );
     }
 }

--- a/comit_node/src/swap_protocols/actions.rs
+++ b/comit_node/src/swap_protocols/actions.rs
@@ -55,7 +55,7 @@ pub mod ethereum {
     #[derive(Debug, Clone, PartialEq, Serialize)]
     pub struct CallContract {
         pub to: Address,
-        pub data: Bytes,
+        pub data: Option<Bytes>,
         pub gas_limit: U256,
         pub network: Network,
         pub min_block_timestamp: Option<Timestamp>,

--- a/comit_node/src/swap_protocols/rfc003/actions/erc20.rs
+++ b/comit_node/src/swap_protocols/rfc003/actions/erc20.rs
@@ -19,12 +19,12 @@ pub fn fund_action(
     let network = htlc_params.ledger.network;
     let gas_limit = Erc20Htlc::fund_tx_gas_limit();
 
+    let data =
+        Erc20Htlc::transfer_erc20_tx_payload(htlc_params.asset.quantity.0, beta_htlc_location);
+
     CallContract {
         to: to_erc20_contract,
-        data: Erc20Htlc::transfer_erc20_tx_payload(
-            htlc_params.asset.quantity.0,
-            beta_htlc_location,
-        ),
+        data: Some(data),
         gas_limit,
         network,
         min_block_timestamp: None,
@@ -41,7 +41,7 @@ pub fn refund_action(
 
     CallContract {
         to: beta_htlc_location,
-        data,
+        data: Some(data),
         gas_limit,
         network,
         min_block_timestamp: Some(expiry),
@@ -58,7 +58,7 @@ pub fn redeem_action(
 
     CallContract {
         to: alpha_htlc_location,
-        data,
+        data: Some(data),
         gas_limit,
         network,
         min_block_timestamp: None,

--- a/comit_node/src/swap_protocols/rfc003/actions/ether.rs
+++ b/comit_node/src/swap_protocols/rfc003/actions/ether.rs
@@ -26,12 +26,11 @@ impl RefundAction<Ethereum, EtherQuantity> for (Ethereum, EtherQuantity) {
         htlc_location: EthereumAddress,
         _secret_source: &dyn SecretSource,
     ) -> Self::RefundActionOutput {
-        let data = Bytes::default();
         let gas_limit = EtherHtlc::tx_gas_limit();
 
         CallContract {
             to: htlc_location,
-            data,
+            data: None,
             gas_limit,
             network: htlc_params.ledger.network,
             min_block_timestamp: Some(htlc_params.expiry),
@@ -52,7 +51,7 @@ impl RedeemAction<Ethereum, EtherQuantity> for (Ethereum, EtherQuantity) {
 
         CallContract {
             to: htlc_location,
-            data,
+            data: Some(data),
             gas_limit,
             network: htlc_params.ledger.network,
             min_block_timestamp: None,


### PR DESCRIPTION
Currently we use `bytes.default()` to generate an empty value for byte array `data` member of the `CallContract` structure.  This results in the value `0x` being used (I do not know the exact reason why or where this `0x` is found, please see note below on testing).  Rust has options for such a case.

This needs testing, I have no idea what will now be expressed by the `None` in place of the original `0x`.

Fixes: #999 