### PR TITLE
Remove hard coded paths

### DIFF
--- a/btsieve/src/load_settings.rs
+++ b/btsieve/src/load_settings.rs
@@ -27,7 +27,9 @@ pub fn load_settings(opt: Opt) -> Result<Settings, ConfigError> {
                 "Unable to determine user's home directory".to_string(),
             )),
             Some(dirs) => {
-                let config_file = Path::join(dirs.home_dir(), ".config/comit/btsieve.toml");
+                let user_path_components: PathBuf =
+                    [".config", "comit", "btsieve.toml"].iter().collect();
+                let config_file = Path::join(dirs.home_dir(), user_path_components);
                 log::info!("Config file was not provided - looking up config file in default location at: {:?}", config_file);;
                 if config_file.exists() {
                     Settings::read(config_file)

--- a/comit_node/src/load_settings.rs
+++ b/comit_node/src/load_settings.rs
@@ -27,7 +27,9 @@ pub fn load_settings(opt: Opt) -> Result<ComitNodeSettings, ConfigError> {
                 "Unable to determine user's home directory".to_string(),
             )),
             Some(dirs) => {
-                let config_file = Path::join(dirs.home_dir(), ".config/comit/comit_node.toml");
+                let user_path_components: PathBuf =
+                    [".config", "comit", "comit_node.toml"].iter().collect();
+                let config_file = Path::join(dirs.home_dir(), user_path_components);
                 if config_file.exists() {
                     ComitNodeSettings::read(config_file)
                 } else {


### PR DESCRIPTION
We should not use hard coded paths.  This makes assumptions about the operating
system that COMIT runs on.  Rust provides `PathBuf` construction mechanisms so as
to be OS independent, we should use them.

Remove hard coded paths i.e. "path/to/foo" and construct the path using a
`PathBuf`.
