### PR TITLE
Introduce Cargo.toml formatting to avoid manual sorting

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -20,7 +20,16 @@ function check_ts() {
     fi
 }
 
+function check_cargo_toml() {
+    if (( dry == 0 )); then
+        cargo make check-cargo-toml-format
+    else
+        echo "check_cargo_toml ran"
+    fi
+}
+
 git status --untracked-files=no --short | grep -E '.rs$' > /dev/null 2>&1 && check_rs
 git status --untracked-files=no --short | grep -E '.ts$|.json$|.yml$' > /dev/null 2>&1 && check_ts
+git status --untracked-files=no --short | grep -E '.toml$' > /dev/null 2>&1 && check_cargo_toml
 
 exit 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,4 @@
 [workspace]
 
-members = [
-        "comit_node",
-        "btsieve",
-        "vendor/*",
+members = ["comit_node", "btsieve", "vendor/*",
 ]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -23,6 +23,7 @@ dependencies = [
     "check-rs-format",
     "check-ts-format",
     "check-ts",
+    "check-cargo-toml-format",
     "clippy"
 ]
 
@@ -150,6 +151,26 @@ description = "Runs tsc to validate TypeScript syntax."
 workspace = false
 install_script = ["(cd ./api_tests; yarn install;)"]
 script = ["cd api_tests; yarn run check"]
+
+[tasks.cargo-toml-format]
+description = "Runs cargo tomlfmt to format Cargo.toml files."
+workspace = false
+install_crate = { crate_name = "cargo-tomlfmt", binary = "cargo-tomlfmt", test_arg = "--help" }
+script = [
+'''
+find . -name Cargo.toml | xargs -n1 cargo tomlfmt -p
+'''
+]
+
+[tasks.check-cargo-toml-format]
+description = "Runs cargo tomlfmt to check appropriate Cargo.toml format."
+workspace = false
+install_crate = { crate_name = "cargo-tomlfmt", binary = "cargo-tomlfmt", test_arg = "--help" }
+script = [
+'''
+find . -name Cargo.toml | xargs -n1 cargo tomlfmt -d -p
+'''
+]
 
 [tasks.ci]
 workspace = false

--- a/vendor/bitcoin_rpc_test_helpers/Cargo.toml
+++ b/vendor/bitcoin_rpc_test_helpers/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 bitcoin_support = { path = "../bitcoin_support" }
-testcontainers = "0.7"
 bitcoincore-rpc = "0.6"
+testcontainers = "0.7"

--- a/vendor/bitcoin_support/Cargo.toml
+++ b/vendor/bitcoin_support/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 [dependencies]
 bigdecimal = "0.1.0"
 bitcoin = { version = "0.18", features = ["use-serde"] }
-bitcoin_hashes = "0.3.2"
 bitcoin-bech32 = "0.9"
+bitcoin_hashes = "0.3.2"
 bitcoin_quantity = { git = "https://github.com/coblox/bitcoin-quantity", features = ["serde"] }
 hex = "0.3"
 lazy_static = "1"

--- a/vendor/bitcoin_witness/Cargo.toml
+++ b/vendor/bitcoin_witness/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 
 [dependencies]
 bitcoin_support = { path = "../bitcoin_support" }
-secp256k1_support = { path = "../secp256k1_support" }
 failure = "0.1"
+secp256k1_support = { path = "../secp256k1_support" }
 
 [dev-dependencies]
-bitcoincore-rpc = "0.6"
 bitcoin_rpc_test_helpers = { path = "../bitcoin_rpc_test_helpers" }
+bitcoincore-rpc = "0.6"
 env_logger = "0.6"
 hex = "0.3"
 spectral = "0.6"

--- a/vendor/blockchain_contracts/Cargo.toml
+++ b/vendor/blockchain_contracts/Cargo.toml
@@ -31,7 +31,7 @@ log = "0.4"
 pretty_env_logger = "0.3"
 rlp = "0.3"
 spectral = "0.6"
-tc_bitcoincore_client = {path = "../../vendor/tc_bitcoincore_client"}
+tc_bitcoincore_client = { path = "../../vendor/tc_bitcoincore_client" }
 tc_web3_client = { path = "../../vendor/tc_web3_client" }
 testcontainers = "0.7"
 tiny-keccak = "1.4"

--- a/vendor/comit_i/Cargo.toml
+++ b/vendor/comit_i/Cargo.toml
@@ -13,6 +13,6 @@ doctest = false
 rust-embed = "4.4"
 
 [build-dependencies]
-unzip = "0.1"
 reqwest = "0.9"
 tempfile = "3"
+unzip = "0.1"

--- a/vendor/ethereum_support/Cargo.toml
+++ b/vendor/ethereum_support/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 bigdecimal = "0.1.0"
 byteorder = "1.2"
+extern_web3 = { package = "web3", version = "0.6" }
 lazy_static = "1"
 num = "0.2"
 regex = "1.1"
@@ -16,7 +17,6 @@ serde = { version = "1", features = ["derive"] }
 strum = "0.15"
 strum_macros = "0.15"
 tiny-keccak = "1.4"
-extern_web3 = { package = "web3", version = "0.6" }
 
 [dev-dependencies]
 hex = "0.3"

--- a/vendor/siren/Cargo.toml
+++ b/vendor/siren/Cargo.toml
@@ -5,11 +5,11 @@ authors = [ "CoBloX developers <team@coblox.tech>" ]
 edition = "2018"
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+derivative = "1.0.2"
 http = "0.1.17"
 readonly = "0.1"
-derivative = "1.0.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dev-dependencies]
 spectral = "0.6.0"

--- a/vendor/tc_bitcoincore_client/Cargo.toml
+++ b/vendor/tc_bitcoincore_client/Cargo.toml
@@ -5,5 +5,5 @@ authors = [ "CoBloX developers <team@coblox.tech>" ]
 edition = "2018"
 
 [dependencies]
-testcontainers = "0.7"
 bitcoincore-rpc = "0.6"
+testcontainers = "0.7"


### PR DESCRIPTION
Formatting is good, in case of Cargo.toml it helps with PR merging
when 2 concurrent PRs add dependencies.

Stealing from #771. Now acceptable that the list in root Cargo.toml is short.

Please note I also tried out https://crates.io/crates/toml-fmt but it messes with deps and is a pain to use.