### PR TITLE
Unify the way we specify dependencies in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,2 @@
 [workspace]
-
-members = ["comit_node", "btsieve", "vendor/*",
-]
+members = ["comit_node", "btsieve", "vendor/*"]

--- a/btsieve/Cargo.toml
+++ b/btsieve/Cargo.toml
@@ -5,14 +5,19 @@ name = "btsieve"
 version = "0.1.0"
 
 [dependencies]
+
+bitcoin_support = { path = "../vendor/bitcoin_support" }
 bitcoincore-rpc = "0.6"
 byteorder = "1.2"
 chrono = { version = "0.4", features = ["serde"] }
+config = { version = "0.9", features = ["toml"] }
 debug_stub_derive = "0.3"
 derivative = "1"
 directories = "2.0"
 ethbloom = "0.5"
+ethereum_support = { path = "../vendor/ethereum_support" }
 failure = "0.1"
+fern = { version = "0.5", features = ["colored"] }
 futures = "0.1"
 hex = "0.3"
 http = "0.1"
@@ -30,29 +35,11 @@ url_serde = "0.2.0"
 warp = "0.1"
 zmq-rs = "0.1"
 
-[dependencies.bitcoin_support]
-path = "../vendor/bitcoin_support"
-
-[dependencies.config]
-features = ["toml"]
-version = "0.9"
-
-[dependencies.ethereum_support]
-path = "../vendor/ethereum_support"
-
-[dependencies.fern]
-features = ["colored"]
-version = "0.5"
-
 [dev-dependencies]
 env_logger = "0.6"
 hex = "0.3"
 rand = "0.6"
+secp256k1_support = { path = "../vendor/secp256k1_support" }
 spectral = "0.6"
+tc_web3_client = { path = "../vendor/tc_web3_client" }
 testcontainers = "0.7"
-
-[dev-dependencies.secp256k1_support]
-path = "../vendor/secp256k1_support"
-
-[dev-dependencies.tc_web3_client]
-path = "../vendor/tc_web3_client"

--- a/comit_node/Cargo.toml
+++ b/comit_node/Cargo.toml
@@ -5,15 +5,22 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+bam = { path = "../vendor/bam" }
 binary_macros = "0.6"
+bitcoin_support = { path = "../vendor/bitcoin_support" }
+bitcoin_witness = { path = "../vendor/bitcoin_witness" }
+blockchain_contracts = { path = "../vendor/blockchain_contracts" }
 chrono = { version = "0.4", features = ["serde"] }
+comit_i = { path = "../vendor/comit_i" }
 config = { version = "0.9", features = ["toml"] }
 debug_stub_derive = "0.3"
 derivative = "1"
 directories = "2.0"
 either = "1.5"
 enum-display-derive = "0.1"
+ethereum_support = { path = "../vendor/ethereum_support" }
 failure = "0.1"
+fern = { version = "0.5", features = ["colored"] }
 futures = "0.1"
 hex = "0.3"
 hex-serde = "0.1.0"
@@ -30,8 +37,11 @@ reqwest = "0.9"
 rlp = "0.3"
 rust-crypto = "0.2"
 rustic_hal = "0.2"
+secp256k1_support = { path = "../vendor/secp256k1_support" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+siren = { path = "../vendor/siren" }
+state_machine_future = { version = "0.2" }
 structopt = "0.2"
 strum = "0.15"
 strum_macros = "0.15"
@@ -39,52 +49,14 @@ tokio = "0.1"
 toml = "0.5"
 url = "1.7"
 url_serde = "0.2.0"
+uuid = { version = "0.7", features = ["serde", "v4"] }
 void = "1.0.2"
 warp = "0.1"
 
-[dependencies.bam]
-path = "../vendor/bam"
-
-[dependencies.siren]
-path = "../vendor/siren"
-
-[dependencies.bitcoin_rpc_test_helpers]
-path = "../vendor/bitcoin_rpc_test_helpers"
-
-[dependencies.bitcoin_support]
-path = "../vendor/bitcoin_support"
-
-[dependencies.bitcoin_witness]
-path = "../vendor/bitcoin_witness"
-
-[dependencies.comit_i]
-path = "../vendor/comit_i"
-
-[dependencies.ethereum_support]
-path = "../vendor/ethereum_support"
-
-[dependencies.fern]
-features = ["colored"]
-version = "0.5"
-
-[dependencies.secp256k1_support]
-path = "../vendor/secp256k1_support"
-
-[dependencies.state_machine_future]
-version = "0.2"
-
-[dependencies.tc_bitcoincore_client]
-path = "../vendor/tc_bitcoincore_client"
-
-[dependencies.blockchain_contracts]
-path = "../vendor/blockchain_contracts"
-
-[dependencies.uuid]
-features = ["serde", "v4"]
-version = "0.7"
-
 [dev-dependencies]
+bitcoin_rpc_test_helpers = { path = "../vendor/bitcoin_rpc_test_helpers" }
 bitcoincore-rpc = "0.6"
+key_gen = { path = "../vendor/key_gen" }
 lazy_static = "1"
 maplit = "1"
 memsocket = "0.1"
@@ -93,11 +65,8 @@ quickcheck = "0.8.5"
 quickcheck_macros = "0.8.0"
 serde_urlencoded = "0.5"
 spectral = "0.6"
+tc_bitcoincore_client = { path = "../vendor/tc_bitcoincore_client" }
+
+tc_web3_client = { path = "../vendor/tc_web3_client" }
 testcontainers = "0.7"
 tiny-keccak = "1.4"
-
-[dev-dependencies.key_gen]
-path = "../vendor/key_gen"
-
-[dev-dependencies.tc_web3_client]
-path = "../vendor/tc_web3_client"

--- a/vendor/key_gen/Cargo.toml
+++ b/vendor/key_gen/Cargo.toml
@@ -10,4 +10,3 @@ ethereum_support = { path = "../ethereum_support" }
 hex = "0.3"
 rand = "0.3"
 secp256k1_support = { path = "../secp256k1_support" }
-


### PR DESCRIPTION
Using the same notation for both, registry and path dependencies, allows us to:

1. Keep all of them alphabetically sorted
2. Reduce the length of the file

Both things should make it easier to maintain the manifest files.