### PR TITLE
Add test where Alice refunds first

### DIFF
--- a/api_tests/e2e/rfc003/btc_eth-erc20/happy.ts
+++ b/api_tests/e2e/rfc003/btc_eth-erc20/happy.ts
@@ -28,7 +28,7 @@ declare var global: HarnessGlobal;
     const bobInitialErc20 = toBN(toWei("10000", "ether"));
     const alphaAssetQuantity = 100000000;
     const betaAssetQuantity = toBN(toWei("5000", "ether"));
-    const maxFeeInSatoshi = 5000;
+    const maxFeeInSatoshi = 50000;
 
     const alphaExpiry = new Date("2080-06-11T23:00:00Z").getTime() / 1000;
     const betaExpiry = new Date("2080-06-11T13:00:00Z").getTime() / 1000;

--- a/api_tests/e2e/rfc003/btc_eth/happy.ts
+++ b/api_tests/e2e/rfc003/btc_eth/happy.ts
@@ -24,7 +24,7 @@ declare var global: HarnessGlobal;
 
     const alphaAssetQuantity = 100000000;
     const betaAssetQuantity = toBN(toWei("10", "ether"));
-    const maxFeeInSatoshi = 5000;
+    const maxFeeInSatoshi = 50000;
 
     const alphaExpiry = new Date("2080-06-11T23:00:00Z").getTime() / 1000;
     const betaExpiry = new Date("2080-06-11T13:00:00Z").getTime() / 1000;

--- a/api_tests/e2e/rfc003/btc_eth/inverted-refund.ts
+++ b/api_tests/e2e/rfc003/btc_eth/inverted-refund.ts
@@ -84,7 +84,7 @@ declare var global: HarnessGlobal;
         {
             actor: bob,
             test: {
-                description: "Should should see that Alice refunded",
+                description: "Should see that Alice refunded",
                 callback: async body => {
                     let status = body.properties.state.alpha_ledger.status;
 

--- a/api_tests/e2e/rfc003/btc_eth/inverted-refund.ts
+++ b/api_tests/e2e/rfc003/btc_eth/inverted-refund.ts
@@ -1,0 +1,139 @@
+import * as bitcoin from "../../../lib/bitcoin";
+import { Actor } from "../../../lib/actor";
+import { ActionKind, SwapRequest } from "../../../lib/comit";
+import { toBN, toWei } from "web3-utils";
+import { HarnessGlobal } from "../../../lib/util";
+import { Step, createTests } from "../../test_creator";
+import { expect } from "chai";
+import "chai/register-should";
+import "../../../lib/setupChai";
+
+declare var global: HarnessGlobal;
+
+(async function() {
+    const alice = new Actor("alice", global.config, global.project_root, {
+        ethereumNodeConfig: global.ledgers_config.ethereum,
+        bitcoinNodeConfig: global.ledgers_config.bitcoin,
+        addressForIncomingBitcoinPayments:
+            "bcrt1qs2aderg3whgu0m8uadn6dwxjf7j3wx97kk2qqtrum89pmfcxknhsf89pj0",
+    });
+    const bob = new Actor("bob", global.config, global.project_root, {
+        ethereumNodeConfig: global.ledgers_config.ethereum,
+        bitcoinNodeConfig: global.ledgers_config.bitcoin,
+        addressForIncomingBitcoinPayments: null,
+    });
+
+    const alphaAssetQuantity = 100000000;
+    const betaAssetQuantity = toBN(toWei("10", "ether"));
+
+    const alphaExpiry = Math.round(Date.now() / 1000) + 13;
+    const betaExpiry = Math.round(Date.now() / 1000) + 8;
+
+    await bitcoin.ensureFunding();
+    await bob.wallet.eth().fund("11");
+    await alice.wallet.eth().fund("0.1");
+    await alice.wallet.btc().fund(10);
+    await bitcoin.generate();
+
+    let swapRequest: SwapRequest = {
+        alpha_ledger: {
+            name: "bitcoin",
+            network: "regtest",
+        },
+        beta_ledger: {
+            name: "ethereum",
+            network: "regtest",
+        },
+        alpha_asset: {
+            name: "bitcoin",
+            quantity: alphaAssetQuantity.toString(),
+        },
+        beta_asset: {
+            name: "ether",
+            quantity: betaAssetQuantity.toString(),
+        },
+        beta_ledger_redeem_identity: alice.wallet.eth().address(),
+        alpha_expiry: alphaExpiry,
+        beta_expiry: betaExpiry,
+        peer: await bob.peerId(),
+    };
+
+    const steps: Step[] = [
+        {
+            actor: bob,
+            action: ActionKind.Accept,
+            waitUntil: state => state.communication.status === "ACCEPTED",
+        },
+        {
+            actor: alice,
+            action: ActionKind.Fund,
+            waitUntil: state => state.alpha_ledger.status === "Funded",
+        },
+        {
+            actor: bob,
+            action: ActionKind.Fund,
+            waitUntil: state =>
+                state.alpha_ledger.status === "Funded" &&
+                state.beta_ledger.status === "Funded",
+        },
+        {
+            actor: alice,
+            action: ActionKind.Refund,
+            waitUntil: state => state.alpha_ledger.status === "Refunded",
+        },
+        {
+            actor: bob,
+            test: {
+                description: "Should should see that Alice refunded",
+                callback: async body => {
+                    let status = body.properties.state.alpha_ledger.status;
+
+                    expect(status).to.equal("Refunded");
+                },
+            },
+        },
+        {
+            actor: alice,
+            test: {
+                description: "Should see that beta is still funded",
+                callback: async body => {
+                    let status = body.properties.state.beta_ledger.status;
+
+                    expect(status).to.equal("Funded");
+                },
+            },
+        },
+        {
+            actor: bob,
+            test: {
+                description: "Should see that beta is still funded",
+                callback: async body => {
+                    let status = body.properties.state.beta_ledger.status;
+
+                    expect(status).to.equal("Funded");
+                },
+            },
+        },
+        {
+            actor: bob,
+            action: ActionKind.Refund,
+            waitUntil: state => state.beta_ledger.status === "Refunded",
+        },
+        {
+            actor: alice,
+            test: {
+                description: "Should see that Bob refunded",
+                callback: async body => {
+                    let status = body.properties.state.beta_ledger.status;
+
+                    expect(status).to.equal("Refunded");
+                },
+            },
+        },
+    ];
+
+    describe("RFC003: Alice can refund before Bob", async () => {
+        createTests(alice, bob, steps, "/swaps/rfc003", "/swaps", swapRequest);
+    });
+    run();
+})();

--- a/api_tests/e2e/rfc003/btc_eth/inverted-refund.ts
+++ b/api_tests/e2e/rfc003/btc_eth/inverted-refund.ts
@@ -83,14 +83,7 @@ declare var global: HarnessGlobal;
         },
         {
             actor: bob,
-            test: {
-                description: "Should see that Alice refunded",
-                callback: async body => {
-                    let status = body.properties.state.alpha_ledger.status;
-
-                    expect(status).to.equal("Refunded");
-                },
-            },
+            waitUntil: state => state.alpha_ledger.status === "Refunded",
         },
         {
             actor: alice,

--- a/api_tests/e2e/rfc003/btc_eth/inverted-refund.ts
+++ b/api_tests/e2e/rfc003/btc_eth/inverted-refund.ts
@@ -121,14 +121,7 @@ declare var global: HarnessGlobal;
         },
         {
             actor: alice,
-            test: {
-                description: "Should see that Bob refunded",
-                callback: async body => {
-                    let status = body.properties.state.beta_ledger.status;
-
-                    expect(status).to.equal("Refunded");
-                },
-            },
+            waitUntil: state => state.beta_ledger.status === "Refunded",
         },
     ];
 

--- a/api_tests/e2e/rfc003/btc_eth/refund.ts
+++ b/api_tests/e2e/rfc003/btc_eth/refund.ts
@@ -23,7 +23,7 @@ declare var global: HarnessGlobal;
 
     const alphaAssetQuantity = 100000000;
     const betaAssetQuantity = toBN(toWei("10", "ether"));
-    const maxFeeInSatoshi = 5000;
+    const maxFeeInSatoshi = 50000;
 
     const alphaExpiry = Math.round(Date.now() / 1000) + 13;
     const betaExpiry = Math.round(Date.now() / 1000) + 8;

--- a/api_tests/e2e/rfc003/eth-erc20_btc/happy.ts
+++ b/api_tests/e2e/rfc003/eth-erc20_btc/happy.ts
@@ -28,7 +28,7 @@ declare var global: HarnessGlobal;
     const aliceInitialErc20 = toBN(toWei("10000", "ether"));
     const alphaAssetQuantity = toBN(toWei("5000", "ether"));
     const betaAssetQuantity = 100000000;
-    const maxFeeInSatoshi = 5000;
+    const maxFeeInSatoshi = 50000;
 
     const alphaExpiry = new Date("2080-06-11T23:00:00Z").getTime() / 1000;
     const betaExpiry = new Date("2080-06-11T13:00:00Z").getTime() / 1000;

--- a/api_tests/e2e/rfc003/eth-erc20_btc/refund.ts
+++ b/api_tests/e2e/rfc003/eth-erc20_btc/refund.ts
@@ -28,7 +28,7 @@ declare var global: HarnessGlobal;
     const aliceInitialErc20 = toBN(toWei("10000", "ether"));
     const alphaAssetQuantity = toBN(toWei("5000", "ether"));
     const betaAssetQuantity = 100000000;
-    const maxFeeInSatoshi = 5000;
+    const maxFeeInSatoshi = 50000;
 
     const alphaExpiry = Math.round(Date.now() / 1000) + 13;
     const betaExpiry = Math.round(Date.now() / 1000) + 8;

--- a/api_tests/e2e/rfc003/eth_btc/happy.ts
+++ b/api_tests/e2e/rfc003/eth_btc/happy.ts
@@ -23,7 +23,7 @@ declare var global: HarnessGlobal;
 
     const alphaAssetQuantity = toBN(toWei("10", "ether"));
     const betaAssetQuantity = 100000000;
-    const maxFeeInSatoshi = 5000;
+    const maxFeeInSatoshi = 50000;
 
     const alphaExpiry = new Date("2080-06-11T23:00:00Z").getTime() / 1000;
     const betaExpiry = new Date("2080-06-11T13:00:00Z").getTime() / 1000;

--- a/api_tests/e2e/rfc003/eth_btc/refund_beta.ts
+++ b/api_tests/e2e/rfc003/eth_btc/refund_beta.ts
@@ -23,7 +23,7 @@ declare var global: HarnessGlobal;
 
     const alphaAssetQuantity = toBN(toWei("10", "ether"));
     const betaAssetQuantity = 100000000;
-    const maxFeeInSatoshi = 5000;
+    const maxFeeInSatoshi = 50000;
 
     const alphaExpiry = new Date("2080-06-11T23:00:00Z").getTime() / 1000;
     const betaExpiry = Math.round(Date.now() / 1000) + 9;

--- a/api_tests/e2e/test_creator.ts
+++ b/api_tests/e2e/test_creator.ts
@@ -107,20 +107,24 @@ export function createTests(
             });
         }
 
-        let body: Entity = null;
         if (waitUntil) {
             it(`[${actor.name}] transitions to correct state`, async function() {
                 this.timeout(10000);
-                body = await actor.pollComitNodeUntil(
+                await actor.pollComitNodeUntil(
                     swapLocations[actor.name],
                     body => waitUntil(body.properties.state)
                 );
             });
         }
 
-        if (test && body) {
+        if (test) {
             it(`[${actor.name}] ${test.description}`, async function() {
                 this.timeout(10000);
+
+                const body = await actor.pollComitNodeUntil(
+                    swapLocations[actor.name],
+                    () => true
+                );
 
                 return test.callback(body);
             });


### PR DESCRIPTION
While investigating #1026 (closed, found to be invalid) it was discovered that the e2e test runner did not correctly handle running tests due to an asynchronous call.   Commit 1 fixes this issue.  Commit 2 adds a passing test that verifies that Alice can refund first (even though this is _not_ the expected order of refunds).