### PR TITLE
Configure dependabot to update e2e tests dependencies

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,3 +10,13 @@ update_configs:
       - match:
           update_type: "all"
           dependency_type: "direct"
+  - package_manager: "javascript"
+    directory: "/api_tests"
+    update_schedule: "weekly"
+    default_labels:
+      - "dependencies"
+      - "automagically-mergify-this"
+    allowed_updates:
+      - match:
+          update_type: "all"
+          dependency_type: "direct"


### PR DESCRIPTION
Mainly to avoid having to do it manually.

Resolves #977 