### PR TITLE
Enable the 'overflow_delimited_expr' rustfmt option

### DIFF
--- a/comit_node/src/http_api/mod.rs
+++ b/comit_node/src/http_api/mod.rs
@@ -183,10 +183,10 @@ impl<'de> Deserialize<'de> for DialInformation {
                             address_hint = Some(map.next_value()?)
                         }
                         _ => {
-                            return Err(de::Error::unknown_field(
-                                key,
-                                &["peer_id", "address_hint"],
-                            ));
+                            return Err(de::Error::unknown_field(key, &[
+                                "peer_id",
+                                "address_hint",
+                            ]));
                         }
                     }
                 }

--- a/comit_node/src/swap_protocols/rfc003/alice/spawner.rs
+++ b/comit_node/src/swap_protocols/rfc003/alice/spawner.rs
@@ -64,18 +64,15 @@ impl<T: MetadataStore<SwapId>, S: StateStore, C: Client> AliceSpawner
         let alice = alice::State::new(swap_request.clone(), swap_seed);
 
         self.metadata_store
-            .insert(
-                id,
-                Metadata {
-                    alpha_ledger: swap_request.alpha_ledger.into(),
-                    beta_ledger: swap_request.beta_ledger.into(),
-                    alpha_asset: swap_request.alpha_asset.into(),
-                    beta_asset: swap_request.beta_asset.into(),
-                    role: RoleKind::Alice,
-                    counterparty: bob_dial_info.peer_id.to_owned(),
-                    swap_id: id,
-                },
-            )
+            .insert(id, Metadata {
+                alpha_ledger: swap_request.alpha_ledger.into(),
+                beta_ledger: swap_request.beta_ledger.into(),
+                alpha_asset: swap_request.alpha_asset.into(),
+                beta_asset: swap_request.beta_asset.into(),
+                role: RoleKind::Alice,
+                counterparty: bob_dial_info.peer_id.to_owned(),
+                swap_id: id,
+            })
             .map_err(Error::Metadata)?;
 
         let (sender, receiver) = mpsc::unbounded();

--- a/comit_node/src/swap_protocols/rfc003/bob/spawner.rs
+++ b/comit_node/src/swap_protocols/rfc003/bob/spawner.rs
@@ -65,18 +65,15 @@ impl<T: MetadataStore<SwapId>, S: StateStore> BobSpawner
             .expect("This is always Some when Bob is created");
 
         self.metadata_store
-            .insert(
-                id,
-                Metadata {
-                    alpha_ledger: swap_request.alpha_ledger.into(),
-                    beta_ledger: swap_request.beta_ledger.into(),
-                    alpha_asset: swap_request.alpha_asset.into(),
-                    beta_asset: swap_request.beta_asset.into(),
-                    role: RoleKind::Bob,
-                    counterparty,
-                    swap_id: id,
-                },
-            )
+            .insert(id, Metadata {
+                alpha_ledger: swap_request.alpha_ledger.into(),
+                beta_ledger: swap_request.beta_ledger.into(),
+                alpha_asset: swap_request.alpha_asset.into(),
+                beta_asset: swap_request.beta_asset.into(),
+                role: RoleKind::Bob,
+                counterparty,
+                swap_id: id,
+            })
             .map_err(Error::Metadata)?;
 
         let (sender, receiver) = mpsc::unbounded();

--- a/comit_node/src/swap_protocols/rfc003/secret.rs
+++ b/comit_node/src/swap_protocols/rfc003/secret.rs
@@ -273,13 +273,10 @@ mod tests {
 
         assert!(result.is_err());
 
-        assert_eq!(
-            result.unwrap_err(),
-            FromErr::InvalidLength {
-                expected: 32,
-                got: 31
-            }
-        );
+        assert_eq!(result.unwrap_err(), FromErr::InvalidLength {
+            expected: 32,
+            got: 31
+        });
     }
 
     #[test]

--- a/comit_node/src/swap_protocols/rfc003/state_machine.rs
+++ b/comit_node/src/swap_protocols/rfc003/state_machine.rs
@@ -312,12 +312,9 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> PollSwap<AL, BL, AA, BA>
         let state = state.take();
 
         match response {
-            Ok(swap_accepted) => transition_save!(
-                context.state_repo,
-                Accepted {
-                    swap: OngoingSwap::new(state, swap_accepted),
-                }
-            ),
+            Ok(swap_accepted) => transition_save!(context.state_repo, Accepted {
+                swap: OngoingSwap::new(state, swap_accepted),
+            }),
             Err(rejection_type) => transition_save!(
                 context.state_repo,
                 Final(SwapOutcome::Rejected {
@@ -337,13 +334,10 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> PollSwap<AL, BL, AA, BA>
             .htlc_deployed(state.swap.alpha_htlc_params())
             .poll());
         let state = state.take();
-        transition_save!(
-            context.state_repo,
-            AlphaDeployed {
-                swap: state.swap,
-                alpha_deployed,
-            }
-        )
+        transition_save!(context.state_repo, AlphaDeployed {
+            swap: state.swap,
+            alpha_deployed,
+        })
     }
 
     fn poll_alpha_deployed<'s, 'c>(
@@ -360,14 +354,11 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> PollSwap<AL, BL, AA, BA>
             .asset
             .equal_or_greater_value(&state.swap.alpha_asset)
         {
-            transition_save!(
-                context.state_repo,
-                AlphaFunded {
-                    swap: state.swap,
-                    alpha_funded,
-                    alpha_deployed: state.alpha_deployed,
-                }
-            )
+            transition_save!(context.state_repo, AlphaFunded {
+                swap: state.swap,
+                alpha_funded,
+                alpha_deployed: state.alpha_deployed,
+            })
         } else {
             Err(rfc003::Error::InsufficientFunding)
         }
@@ -414,15 +405,12 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> PollSwap<AL, BL, AA, BA>
             .htlc_deployed(state.swap.beta_htlc_params())
             .poll());
         let state = state.take();
-        transition_save!(
-            context.state_repo,
-            AlphaFundedBetaDeployed {
-                swap: state.swap,
-                alpha_funded: state.alpha_funded,
-                alpha_deployed: state.alpha_deployed,
-                beta_deployed
-            }
-        )
+        transition_save!(context.state_repo, AlphaFundedBetaDeployed {
+            swap: state.swap,
+            alpha_funded: state.alpha_funded,
+            alpha_deployed: state.alpha_deployed,
+            beta_deployed
+        })
     }
 
     fn poll_alpha_funded_beta_deployed<'s, 'c>(
@@ -471,16 +459,13 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> PollSwap<AL, BL, AA, BA>
             .asset
             .equal_or_greater_value(&state.swap.beta_asset)
         {
-            transition_save!(
-                context.state_repo,
-                BothFunded {
-                    swap: state.swap,
-                    alpha_funded: state.alpha_funded,
-                    alpha_deployed: state.alpha_deployed,
-                    beta_deployed: state.beta_deployed,
-                    beta_funded
-                }
-            )
+            transition_save!(context.state_repo, BothFunded {
+                swap: state.swap,
+                alpha_funded: state.alpha_funded,
+                alpha_deployed: state.alpha_deployed,
+                beta_deployed: state.beta_deployed,
+                beta_funded
+            })
         } else {
             Err(rfc003::Error::InsufficientFunding)
         }
@@ -501,28 +486,26 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> PollSwap<AL, BL, AA, BA>
         {
             let state = state.take();
             match redeemed_or_refunded {
-                future::Either::A(beta_redeem_transaction) => transition_save!(
-                    context.state_repo,
-                    AlphaFundedBetaRedeemed {
+                future::Either::A(beta_redeem_transaction) => {
+                    transition_save!(context.state_repo, AlphaFundedBetaRedeemed {
                         swap: state.swap,
                         alpha_deployed: state.alpha_deployed,
                         alpha_funded: state.alpha_funded,
                         beta_deployed: state.beta_deployed,
                         beta_funded: state.beta_funded,
                         beta_redeem_transaction,
-                    }
-                ),
-                future::Either::B(beta_refund_transaction) => transition_save!(
-                    context.state_repo,
-                    AlphaFundedBetaRefunded {
+                    })
+                }
+                future::Either::B(beta_refund_transaction) => {
+                    transition_save!(context.state_repo, AlphaFundedBetaRefunded {
                         swap: state.swap,
                         alpha_deployed: state.alpha_deployed,
                         alpha_funded: state.alpha_funded,
                         beta_deployed: state.beta_deployed,
                         beta_funded: state.beta_funded,
                         beta_refund_transaction,
-                    }
-                ),
+                    })
+                }
             }
         }
 
@@ -537,31 +520,25 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> PollSwap<AL, BL, AA, BA>
         {
             future::Either::A(alpha_redeemed) => {
                 let state = state.take();
-                transition_save!(
-                    context.state_repo,
-                    AlphaRedeemedBetaFunded {
-                        swap: state.swap,
-                        alpha_deployed: state.alpha_deployed,
-                        alpha_funded: state.alpha_funded,
-                        beta_deployed: state.beta_deployed,
-                        beta_funded: state.beta_funded,
-                        alpha_redeemed,
-                    }
-                )
+                transition_save!(context.state_repo, AlphaRedeemedBetaFunded {
+                    swap: state.swap,
+                    alpha_deployed: state.alpha_deployed,
+                    alpha_funded: state.alpha_funded,
+                    beta_deployed: state.beta_deployed,
+                    beta_funded: state.beta_funded,
+                    alpha_redeemed,
+                })
             }
             future::Either::B(alpha_refunded) => {
                 let state = state.take();
-                transition_save!(
-                    context.state_repo,
-                    AlphaRefundedBetaFunded {
-                        swap: state.swap,
-                        alpha_deployed: state.alpha_deployed,
-                        alpha_funded: state.alpha_funded,
-                        beta_deployed: state.beta_deployed,
-                        beta_funded: state.beta_funded,
-                        alpha_refunded,
-                    }
-                )
+                transition_save!(context.state_repo, AlphaRefundedBetaFunded {
+                    swap: state.swap,
+                    alpha_deployed: state.alpha_deployed,
+                    alpha_funded: state.alpha_funded,
+                    beta_deployed: state.beta_deployed,
+                    beta_funded: state.beta_funded,
+                    alpha_refunded,
+                })
             }
         }
     }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -6,3 +6,4 @@ use_field_init_shorthand = true
 format_doc_comments = true
 normalize_comments = true
 wrap_comments = true
+overflow_delimited_expr = true

--- a/vendor/blockchain_contracts/tests/rfc003_erc20_htlc.rs
+++ b/vendor/blockchain_contracts/tests/rfc003_erc20_htlc.rs
@@ -175,13 +175,10 @@ fn given_deployed_erc20_htlc_when_expiry_time_not_yet_reached_and_wrong_secret_t
 ) {
     let docker = Cli::default();
     let (alice, bob, htlc_address, token_contract, token_amount, client, _handle, _container) =
-        erc20_harness(
-            &docker,
-            Erc20HarnessParams {
-                htlc_refund_timestamp: Timestamp::now().plus(1000000),
-                ..Default::default()
-            },
-        );
+        erc20_harness(&docker, Erc20HarnessParams {
+            htlc_refund_timestamp: Timestamp::now().plus(1000000),
+            ..Default::default()
+        });
 
     // fund erc20 htlc
     client.sign_and_send(|nonce, gas_price| UnsignedTransaction {
@@ -224,13 +221,10 @@ fn given_deployed_erc20_htlc_when_expiry_time_not_yet_reached_and_wrong_secret_t
 fn given_not_enough_tokens_when_redeemed_token_balances_dont_change() {
     let docker = Cli::default();
     let (alice, bob, htlc_address, token_contract, token_amount, client, _handle, _container) =
-        erc20_harness(
-            &docker,
-            Erc20HarnessParams {
-                alice_initial_tokens: U256::from(200),
-                ..Default::default()
-            },
-        );
+        erc20_harness(&docker, Erc20HarnessParams {
+            alice_initial_tokens: U256::from(200),
+            ..Default::default()
+        });
 
     // fund erc20 htlc
     client.sign_and_send(|nonce, gas_price| UnsignedTransaction {

--- a/vendor/blockchain_contracts/tests/rfc003_ether_htlc.rs
+++ b/vendor/blockchain_contracts/tests/rfc003_ether_htlc.rs
@@ -79,13 +79,11 @@ fn given_deployed_htlc_when_refunded_after_expiry_time_then_money_is_refunded() 
 #[test]
 fn given_htlc_and_refund_before_expiry_nothing_happens() {
     let docker = Cli::default();
-    let (_alice, bob, htlc, client, _handle, _container) = ether_harness(
-        &docker,
-        EtherHarnessParams {
+    let (_alice, bob, htlc, client, _handle, _container) =
+        ether_harness(&docker, EtherHarnessParams {
             htlc_refund_timestamp: Timestamp::now().plus(1000000),
             ..Default::default()
-        },
-    );
+        });
 
     assert_eq!(
         client.eth_balance_of(bob),


### PR DESCRIPTION
Formatting code this way seems to be more natural to me and also saves a few lines of code.