### PR TITLE
Use correct bitcoin network names

### DIFF
--- a/vendor/bitcoin_support/src/network.rs
+++ b/vendor/bitcoin_support/src/network.rs
@@ -16,11 +16,11 @@ use serde::{Deserialize, Serialize};
 )]
 #[serde(rename_all = "lowercase")]
 pub enum Network {
-    #[strum(serialize = "mainnet")]
+    #[strum(serialize = "main")]
     Mainnet,
     #[strum(serialize = "regtest")]
     Regtest,
-    #[strum(serialize = "testnet")]
+    #[strum(serialize = "test")]
     Testnet,
 }
 
@@ -64,8 +64,8 @@ mod test {
         let regtest: &'static str = Network::Regtest.into();
         let testnet: &'static str = Network::Testnet.into();
 
-        assert_eq!(mainnet, "mainnet");
+        assert_eq!(mainnet, "main");
         assert_eq!(regtest, "regtest");
-        assert_eq!(testnet, "testnet");
+        assert_eq!(testnet, "test");
     }
 }


### PR DESCRIPTION
Using the correct bitcoin network version in btsieve. 

Btsieve tries to bind its query URLs to the actual blockchain network. For that, it fetches `getblockchaininfo` and retrieves: 

```
{
  "chain": "test",
  "blocks": 1570022,
  "headers": 1570022,
  "bestblockhash": "0000000000000312fecacee42bf7197da55c3db7c9c0002972cc0df9419302ee",
  "difficulty": 4729661.074040298,
  "mediantime": 1563758058,
  "verificationprogress": 0.9999930258427291,
  "initialblockdownload": false,
  "chainwork": "00000000000000000000000000000000000000000000011fc91b669192dd70b1",
  "size_on_disk": 24779445613,
  "pruned": false,
  "softforks": [
    {
      "id": "bip34",
      "version": 2,
      "reject": {
        "status": true
      }
    },
    {
      "id": "bip66",
      "version": 3,
      "reject": {
        "status": true
      }
    },
    {
      "id": "bip65",
      "version": 4,
      "reject": {
        "status": true
      }
    }
  ],
  "bip9_softforks": {
    "csv": {
      "status": "active",
      "startTime": 1456790400,
      "timeout": 1493596800,
      "since": 770112
    },
    "segwit": {
      "status": "active",
      "startTime": 1462060800,
      "timeout": 1493596800,
      "since": 834624
    }
  },
  "warnings": "Warning: unknown new rules activated (versionbit 28)"
}
```

as one can see, the field value for `chain` is called `test` and not `testnet`. Hence this PR. 

Currently, btsieve will just fail with an error as it can't resolve the `chain`.