### PR TITLE
Fix btsieve-client network bug

### DIFF
--- a/comit_node/src/btsieve/client.rs
+++ b/comit_node/src/btsieve/client.rs
@@ -55,10 +55,10 @@ struct QueryResponse<T> {
 impl BtsieveHttpClient {
     pub fn new(
         endpoint: &Url,
-        ethereum_poll_interval: Duration,
-        ethereum_network: &str,
         bitcoin_poll_interval: Duration,
-        bitcoin_network: &str,
+        bitcoin_network: bitcoin_support::Network,
+        ethereum_poll_interval: Duration,
+        ethereum_network: ethereum_support::Network,
     ) -> Self {
         Self {
             client: Client::new(),

--- a/comit_node/src/main.rs
+++ b/comit_node/src/main.rs
@@ -111,9 +111,9 @@ fn create_btsieve_api_client(settings: &ComitNodeSettings) -> BtsieveHttpClient 
     BtsieveHttpClient::new(
         &settings.btsieve.url,
         settings.btsieve.bitcoin.poll_interval_secs,
-        settings.btsieve.bitcoin.network.as_str(),
+        settings.btsieve.bitcoin.network,
         settings.btsieve.ethereum.poll_interval_secs,
-        settings.btsieve.ethereum.network.as_str(),
+        settings.btsieve.ethereum.network,
     )
 }
 

--- a/comit_node/src/settings/mod.rs
+++ b/comit_node/src/settings/mod.rs
@@ -49,11 +49,11 @@ impl Default for ComitNodeSettings {
                 url: btsieve_url,
                 bitcoin: PollParameters {
                     poll_interval_secs: Duration::from_secs(300),
-                    network: "regtest".into(),
+                    network: bitcoin_support::Network::Regtest,
                 },
                 ethereum: PollParameters {
                     poll_interval_secs: Duration::from_secs(20),
-                    network: "regtest".into(),
+                    network: ethereum_support::Network::Regtest,
                 },
             },
             web_gui: Some(HttpSocket {
@@ -103,15 +103,15 @@ pub struct HttpSocket {
 pub struct Btsieve {
     #[serde(with = "url_serde")]
     pub url: url::Url,
-    pub bitcoin: PollParameters,
-    pub ethereum: PollParameters,
+    pub bitcoin: PollParameters<bitcoin_support::Network>,
+    pub ethereum: PollParameters<ethereum_support::Network>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-pub struct PollParameters {
+pub struct PollParameters<T> {
     #[serde(with = "self::serde_duration")]
     pub poll_interval_secs: Duration,
-    pub network: String,
+    pub network: T,
 }
 
 impl ComitNodeSettings {

--- a/vendor/bitcoin_support/src/network.rs
+++ b/vendor/bitcoin_support/src/network.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
     Hash,
     strum_macros::IntoStaticStr,
     strum_macros::EnumString,
+    strum_macros::Display,
 )]
 #[serde(rename_all = "lowercase")]
 pub enum Network {
@@ -57,6 +58,7 @@ impl From<Network> for bitcoin_bech32::constants::Network {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::fmt::Display;
 
     #[test]
     fn string_serialize() {
@@ -67,5 +69,12 @@ mod test {
         assert_eq!(mainnet, "main");
         assert_eq!(regtest, "regtest");
         assert_eq!(testnet, "test");
+    }
+
+    fn assert_display<T: Display>(t: T) {}
+
+    #[test]
+    fn test_derives_display() {
+        assert_display(Network::Regtest);
     }
 }

--- a/vendor/ethereum_support/src/network.rs
+++ b/vendor/ethereum_support/src/network.rs
@@ -1,8 +1,16 @@
 use serde::{Deserialize, Serialize};
-use strum_macros::{IntoStaticStr, ToString};
 
 #[derive(
-    Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize, Hash, ToString, IntoStaticStr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    PartialEq,
+    Deserialize,
+    Serialize,
+    Hash,
+    strum_macros::IntoStaticStr,
+    strum_macros::Display,
 )]
 #[serde(rename_all = "lowercase")]
 pub enum Network {
@@ -30,6 +38,7 @@ impl Network {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::fmt::Display;
 
     #[test]
     fn string_serialize() {
@@ -60,5 +69,12 @@ mod test {
             Network::from_network_id(String::from("-1")),
             Network::Unknown
         );
+    }
+
+    fn assert_display<T: Display>(t: T) {}
+
+    #[test]
+    fn test_derives_display() {
+        assert_display(Network::Regtest);
     }
 }


### PR DESCRIPTION
Fixes the bug that btsieve client tried to get queries for bitcoin fro
`"queries/bitcoin/{}/transactions", ethereum_network` and ethereum from 
`"queries/ethereum/{}/transactions", bitcoin_network`. 

This wasn't an issue for regtest, but becomes critical for ropsten, i.e. we just had : get bitcoin transaction from `queries/bitcoin/ropsten/transactions` ... which obviously didn't work
