### PR TITLE
Second fix of network serialization for serde

### DIFF
--- a/vendor/bitcoin_support/src/network.rs
+++ b/vendor/bitcoin_support/src/network.rs
@@ -18,19 +18,19 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "lowercase")]
 pub enum Network {
     #[strum(serialize = "main")]
-    Mainnet,
+    Main,
     #[strum(serialize = "regtest")]
     Regtest,
     #[strum(serialize = "test")]
-    Testnet,
+    Test,
 }
 
 impl From<bitcoin::network::constants::Network> for Network {
     fn from(item: bitcoin::network::constants::Network) -> Network {
         match item {
-            bitcoin::network::constants::Network::Bitcoin => Network::Mainnet,
+            bitcoin::network::constants::Network::Bitcoin => Network::Main,
             bitcoin::network::constants::Network::Regtest => Network::Regtest,
-            bitcoin::network::constants::Network::Testnet => Network::Testnet,
+            bitcoin::network::constants::Network::Testnet => Network::Test,
         }
     }
 }
@@ -38,9 +38,9 @@ impl From<bitcoin::network::constants::Network> for Network {
 impl From<Network> for bitcoin::network::constants::Network {
     fn from(item: Network) -> bitcoin::network::constants::Network {
         match item {
-            Network::Mainnet => bitcoin::network::constants::Network::Bitcoin,
+            Network::Main => bitcoin::network::constants::Network::Bitcoin,
             Network::Regtest => bitcoin::network::constants::Network::Regtest,
-            Network::Testnet => bitcoin::network::constants::Network::Testnet,
+            Network::Test => bitcoin::network::constants::Network::Testnet,
         }
     }
 }
@@ -49,8 +49,8 @@ impl From<Network> for bitcoin_bech32::constants::Network {
     fn from(item: Network) -> bitcoin_bech32::constants::Network {
         match item {
             Network::Regtest => bitcoin_bech32::constants::Network::Regtest,
-            Network::Testnet => bitcoin_bech32::constants::Network::Testnet,
-            Network::Mainnet => bitcoin_bech32::constants::Network::Bitcoin,
+            Network::Test => bitcoin_bech32::constants::Network::Testnet,
+            Network::Main => bitcoin_bech32::constants::Network::Bitcoin,
         }
     }
 }
@@ -58,13 +58,14 @@ impl From<Network> for bitcoin_bech32::constants::Network {
 #[cfg(test)]
 mod test {
     use super::*;
+    use spectral::prelude::*;
     use std::fmt::Display;
 
     #[test]
     fn string_serialize() {
-        let mainnet: &'static str = Network::Mainnet.into();
+        let mainnet: &'static str = Network::Main.into();
         let regtest: &'static str = Network::Regtest.into();
-        let testnet: &'static str = Network::Testnet.into();
+        let testnet: &'static str = Network::Test.into();
 
         assert_eq!(mainnet, "main");
         assert_eq!(regtest, "regtest");
@@ -76,5 +77,18 @@ mod test {
     #[test]
     fn test_derives_display() {
         assert_display(Network::Regtest);
+    }
+
+    #[test]
+    fn string_serialize_using_serde() {
+        serialize_and_compare(Network::Main, "\"main\"");
+        serialize_and_compare(Network::Test, "\"test\"");
+        serialize_and_compare(Network::Regtest, "\"regtest\"");
+    }
+
+    fn serialize_and_compare(network: Network, expected_json: &str) {
+        let actual_json = serde_json::to_string(&network);
+
+        assert_that(&actual_json).is_ok_containing(expected_json.to_string());
     }
 }

--- a/vendor/bitcoin_support/src/pubkey.rs
+++ b/vendor/bitcoin_support/src/pubkey.rs
@@ -195,7 +195,7 @@ mod test {
         let private_key =
             PrivateKey::from_str("L4nZrdzNnawCtaEcYGWuPqagQA3dJxVPgN8ARTXaMLCxiYCy89wm").unwrap();
         let keypair: KeyPair = private_key.key.clone().into();
-        let address = keypair.public_key().into_p2wpkh_address(Network::Mainnet);
+        let address = keypair.public_key().into_p2wpkh_address(Network::Main);
 
         assert_eq!(
             address,

--- a/vendor/key_gen/src/main.rs
+++ b/vendor/key_gen/src/main.rs
@@ -17,12 +17,12 @@ fn main() {
     let public_key = keypair.public_key();
     let mainnet_private_key = PrivateKey {
         compressed: true,
-        network: Network::Mainnet.into(),
+        network: Network::Main.into(),
         key: secret_key,
     };
     let testnet_private_key = PrivateKey {
         compressed: true,
-        network: Network::Testnet.into(),
+        network: Network::Test.into(),
         key: secret_key,
     };
 
@@ -46,12 +46,12 @@ fn main() {
     let eth_address = public_key.to_ethereum_address();
     println!("eth_address: {:?}", eth_address);
     {
-        let btc_address_mainnet = public_key.into_p2wpkh_address(Network::Mainnet);
+        let btc_address_mainnet = public_key.into_p2wpkh_address(Network::Main);
         println!("btc_address_p2wpkh_mainnet: {:?}", btc_address_mainnet);
     }
 
     {
-        let btc_address_testnet = public_key.into_p2wpkh_address(Network::Testnet);
+        let btc_address_testnet = public_key.into_p2wpkh_address(Network::Test);
         println!("btc_address_p2wpkh_testnet: {:?}", btc_address_testnet);
     }
     {


### PR DESCRIPTION
Apparently serde and strum are using different ways for serialization, one was configured and one was derived from the enum variant