### PR TITLE
FIX CIRCLE-CI: Run `restore_caches` and `setup_rust` steps before `setup_system`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,10 @@ jobs:
       RUST_TEST_THREADS: "8"
     steps:
       - checkout
-      - setup_system
-      - print_current_versions
       - restore_caches
       - setup_rust
+      - setup_system
+      - print_current_versions
 
       - run:
           name: Build using cargo make


### PR DESCRIPTION
We want to delay all the `apt` stuff as long as possible so that we don't run into issues with other parts of the system having a lock on it.