### PR TITLE
Use port 9939 for cnd

### DIFF
--- a/api_tests/regtest/alice/cnd.toml
+++ b/api_tests/regtest/alice/cnd.toml
@@ -3,7 +3,7 @@ secret_seed = "f87165e305b0f7c4824d3806434f9d0909610a25641ab8773cf92a48c9d77670"
 
 [network]
 listen = [
-    "/ip4/0.0.0.0/tcp/8001"
+    "/ip4/0.0.0.0/tcp/9938"
 ]
 
 [http_api]

--- a/api_tests/regtest/bob/cnd.toml
+++ b/api_tests/regtest/bob/cnd.toml
@@ -3,7 +3,7 @@ secret_seed = "1a1707bb54e5fb4deddd19f07adcb4f1e022ca7879e3c8348da8d4fa496ae8e2"
 
 [network]
 listen = [
-    "/ip4/0.0.0.0/tcp/8011"
+    "/ip4/0.0.0.0/tcp/9939"
 ]
 
 [http_api]

--- a/cnd/src/config/config_file.rs
+++ b/cnd/src/config/config_file.rs
@@ -31,7 +31,7 @@ pub struct ConfigFile {
 
 impl ConfigFile {
     pub fn default<R: Rng>(rand: R) -> Self {
-        let comit_listen = "/ip4/0.0.0.0/tcp/8011"
+        let comit_listen = "/ip4/0.0.0.0/tcp/9939"
             .parse()
             .expect("cnd listen address could not be parsed");
         let btsieve_url =


### PR DESCRIPTION
The default port for comit_node is 8011 which is just "can't use 8000 so let's
add 10 and then 1".

Change the default port to 9939 which is the value for the utf-8 "chains" emoji:
chains Reason: COMIT is here to facilitate cross-chains applications.

Fixes: #1012