### PR TITLE
Update link to contract template in RFC005

### DIFF
--- a/vendor/blockchain_contracts/src/bitcoin/rfc003/bitcoin_htlc.rs
+++ b/vendor/blockchain_contracts/src/bitcoin/rfc003/bitcoin_htlc.rs
@@ -7,7 +7,7 @@ use bitcoin_witness::{UnlockParameters, Witness, SEQUENCE_ALLOW_NTIMELOCK_NO_RBF
 use hex_literal::hex;
 use secp256k1_support::KeyPair;
 
-// contract template RFC: https://github.com/comit-network/RFCs/blob/master/RFC-005-SWAP-Basic-Bitcoin.md#contract
+// contract template RFC: https://github.com/comit-network/RFCs/blob/master/RFC-005-SWAP-Basic-Bitcoin.adoc#contract
 pub const CONTRACT_TEMPLATE: [u8;97] = hex!("6382012088a82010000000000000000000000000000000000000000000000000000000000000018876a9143000000000000000000000000000000000000003670420000002b17576a91440000000000000000000000000000000000000046888ac");
 
 #[derive(Debug)]


### PR DESCRIPTION
Moving the RFCs to AsciiDoc broke the link to the Bitcoin contract template in RFC005.