### PR TITLE
845 Improve homogenous HTTP API naming

### DIFF
--- a/api_tests/e2e/rfc003/btc_eth-erc20/happy.ts
+++ b/api_tests/e2e/rfc003/btc_eth-erc20/happy.ts
@@ -93,22 +93,22 @@ declare var global: HarnessGlobal;
         {
             actor: alice,
             action: ActionKind.Fund,
-            waitUntil: state => state.alpha_ledger.status === "Funded",
+            waitUntil: state => state.alpha_ledger.status === "FUNDED",
         },
         {
             actor: bob,
             action: ActionKind.Deploy,
-            waitUntil: state => state.beta_ledger.status === "Deployed",
+            waitUntil: state => state.beta_ledger.status === "DEPLOYED",
         },
         {
             actor: bob,
             action: ActionKind.Fund,
-            waitUntil: state => state.beta_ledger.status === "Funded",
+            waitUntil: state => state.beta_ledger.status === "FUNDED",
         },
         {
             actor: alice,
             action: ActionKind.Redeem,
-            waitUntil: state => state.beta_ledger.status === "Redeemed",
+            waitUntil: state => state.beta_ledger.status === "REDEEMED",
             test: {
                 description:
                     "Should have received the beta asset after the redeem",
@@ -129,7 +129,7 @@ declare var global: HarnessGlobal;
         {
             actor: bob,
             action: ActionKind.Redeem,
-            waitUntil: state => state.alpha_ledger.status === "Redeemed",
+            waitUntil: state => state.alpha_ledger.status === "REDEEMED",
             test: {
                 description:
                     "Should have received the alpha asset after the redeem",

--- a/api_tests/e2e/rfc003/btc_eth-erc20/refund_beta.ts
+++ b/api_tests/e2e/rfc003/btc_eth-erc20/refund_beta.ts
@@ -87,17 +87,17 @@ declare var global: HarnessGlobal;
         {
             actor: alice,
             action: ActionKind.Fund,
-            waitUntil: state => state.alpha_ledger.status === "Funded",
+            waitUntil: state => state.alpha_ledger.status === "FUNDED",
         },
         {
             actor: bob,
             action: ActionKind.Deploy,
-            waitUntil: state => state.beta_ledger.status === "Deployed",
+            waitUntil: state => state.beta_ledger.status === "DEPLOYED",
         },
         {
             actor: bob,
             action: ActionKind.Fund,
-            waitUntil: state => state.beta_ledger.status === "Funded",
+            waitUntil: state => state.beta_ledger.status === "FUNDED",
             test: {
                 description: "Should have less beta asset after the funding",
                 callback: async () => {
@@ -114,7 +114,7 @@ declare var global: HarnessGlobal;
         {
             actor: bob,
             action: ActionKind.Refund,
-            waitUntil: state => state.beta_ledger.status === "Refunded",
+            waitUntil: state => state.beta_ledger.status === "REFUNDED",
             test: {
                 description:
                     "Should have received the beta asset after the refund",

--- a/api_tests/e2e/rfc003/btc_eth/happy.ts
+++ b/api_tests/e2e/rfc003/btc_eth/happy.ts
@@ -69,17 +69,17 @@ declare var global: HarnessGlobal;
         {
             actor: alice,
             action: ActionKind.Fund,
-            waitUntil: state => state.alpha_ledger.status === "Funded",
+            waitUntil: state => state.alpha_ledger.status === "FUNDED",
         },
         {
             actor: bob,
             action: ActionKind.Fund,
-            waitUntil: state => state.beta_ledger.status === "Funded",
+            waitUntil: state => state.beta_ledger.status === "FUNDED",
         },
         {
             actor: alice,
             action: ActionKind.Redeem,
-            waitUntil: state => state.beta_ledger.status === "Redeemed",
+            waitUntil: state => state.beta_ledger.status === "REDEEMED",
             test: {
                 description:
                     "Should have received the beta asset after the redeem",
@@ -99,7 +99,7 @@ declare var global: HarnessGlobal;
         {
             actor: bob,
             action: ActionKind.Redeem,
-            waitUntil: state => state.alpha_ledger.status === "Redeemed",
+            waitUntil: state => state.alpha_ledger.status === "REDEEMED",
             test: {
                 description:
                     "Should have received the alpha asset after the redeem",

--- a/api_tests/e2e/rfc003/btc_eth/inverted_refund.ts
+++ b/api_tests/e2e/rfc003/btc_eth/inverted_refund.ts
@@ -67,23 +67,23 @@ declare var global: HarnessGlobal;
         {
             actor: alice,
             action: ActionKind.Fund,
-            waitUntil: state => state.alpha_ledger.status === "Funded",
+            waitUntil: state => state.alpha_ledger.status === "FUNDED",
         },
         {
             actor: bob,
             action: ActionKind.Fund,
             waitUntil: state =>
-                state.alpha_ledger.status === "Funded" &&
-                state.beta_ledger.status === "Funded",
+                state.alpha_ledger.status === "FUNDED" &&
+                state.beta_ledger.status === "FUNDED",
         },
         {
             actor: alice,
             action: ActionKind.Refund,
-            waitUntil: state => state.alpha_ledger.status === "Refunded",
+            waitUntil: state => state.alpha_ledger.status === "REFUNDED",
         },
         {
             actor: bob,
-            waitUntil: state => state.alpha_ledger.status === "Refunded",
+            waitUntil: state => state.alpha_ledger.status === "REFUNDED",
         },
         {
             actor: alice,
@@ -92,7 +92,7 @@ declare var global: HarnessGlobal;
                 callback: async body => {
                     const status = body.properties.state.beta_ledger.status;
 
-                    expect(status).to.equal("Funded");
+                    expect(status).to.equal("FUNDED");
                 },
             },
         },
@@ -103,18 +103,18 @@ declare var global: HarnessGlobal;
                 callback: async body => {
                     const status = body.properties.state.beta_ledger.status;
 
-                    expect(status).to.equal("Funded");
+                    expect(status).to.equal("FUNDED");
                 },
             },
         },
         {
             actor: bob,
             action: ActionKind.Refund,
-            waitUntil: state => state.beta_ledger.status === "Refunded",
+            waitUntil: state => state.beta_ledger.status === "REFUNDED",
         },
         {
             actor: alice,
-            waitUntil: state => state.beta_ledger.status === "Refunded",
+            waitUntil: state => state.beta_ledger.status === "REFUNDED",
         },
     ];
 

--- a/api_tests/e2e/rfc003/btc_eth/overfunded_htlc.ts
+++ b/api_tests/e2e/rfc003/btc_eth/overfunded_htlc.ts
@@ -108,14 +108,14 @@ declare var global: HarnessGlobal;
         {
             actor: alice,
             waitUntil: state =>
-                state.alpha_ledger.status === "IncorrectlyFunded",
+                state.alpha_ledger.status === "INCORRECTLY_FUNDED",
         },
         // bob should not consider the HTLC to be funded and terminate with NOT_SWAPPED
         {
             actor: bob,
             waitUntil: state =>
-                state.alpha_ledger.status === "IncorrectlyFunded" &&
-                state.beta_ledger.status === "NotDeployed",
+                state.alpha_ledger.status === "INCORRECTLY_FUNDED" &&
+                state.beta_ledger.status === "NOT_DEPLOYED",
         },
         {
             actor: alice,
@@ -124,8 +124,8 @@ declare var global: HarnessGlobal;
         {
             actor: alice,
             waitUntil: state =>
-                state.alpha_ledger.status === "Refunded" &&
-                state.beta_ledger.status === "NotDeployed",
+                state.alpha_ledger.status === "REFUNDED" &&
+                state.beta_ledger.status === "NOT_DEPLOYED",
             test: {
                 description:
                     "Should have received the alpha asset after the refund",

--- a/api_tests/e2e/rfc003/btc_eth/refund.ts
+++ b/api_tests/e2e/rfc003/btc_eth/refund.ts
@@ -68,14 +68,14 @@ declare var global: HarnessGlobal;
         {
             actor: alice,
             action: ActionKind.Fund,
-            waitUntil: state => state.alpha_ledger.status === "Funded",
+            waitUntil: state => state.alpha_ledger.status === "FUNDED",
         },
         {
             actor: bob,
             action: ActionKind.Fund,
             waitUntil: state =>
-                state.alpha_ledger.status === "Funded" &&
-                state.beta_ledger.status === "Funded",
+                state.alpha_ledger.status === "FUNDED" &&
+                state.beta_ledger.status === "FUNDED",
             test: {
                 description: "Should have less beta asset after the funding",
                 callback: async () => {
@@ -90,7 +90,7 @@ declare var global: HarnessGlobal;
         {
             actor: bob,
             action: ActionKind.Refund,
-            waitUntil: state => state.beta_ledger.status === "Refunded",
+            waitUntil: state => state.beta_ledger.status === "REFUNDED",
             test: {
                 description:
                     "Should have received the beta asset after the refund",
@@ -110,8 +110,8 @@ declare var global: HarnessGlobal;
         {
             actor: alice,
             waitUntil: state =>
-                state.alpha_ledger.status === "Refunded" &&
-                state.beta_ledger.status === "Refunded",
+                state.alpha_ledger.status === "REFUNDED" &&
+                state.beta_ledger.status === "REFUNDED",
             test: {
                 description:
                     "Should have received the alpha asset after the refund",

--- a/api_tests/e2e/rfc003/btc_eth/underfunded_htlc.ts
+++ b/api_tests/e2e/rfc003/btc_eth/underfunded_htlc.ts
@@ -108,14 +108,14 @@ declare var global: HarnessGlobal;
         {
             actor: alice,
             waitUntil: state =>
-                state.alpha_ledger.status === "IncorrectlyFunded",
+                state.alpha_ledger.status === "INCORRECTLY_FUNDED",
         },
         // bob should not consider the HTLC to be funded and terminate with NOT_SWAPPED
         {
             actor: bob,
             waitUntil: state =>
-                state.alpha_ledger.status === "IncorrectlyFunded" &&
-                state.beta_ledger.status === "NotDeployed",
+                state.alpha_ledger.status === "INCORRECTLY_FUNDED" &&
+                state.beta_ledger.status === "NOT_DEPLOYED",
         },
         {
             actor: alice,
@@ -124,8 +124,8 @@ declare var global: HarnessGlobal;
         {
             actor: alice,
             waitUntil: state =>
-                state.alpha_ledger.status === "Refunded" &&
-                state.beta_ledger.status === "NotDeployed",
+                state.alpha_ledger.status === "REFUNDED" &&
+                state.beta_ledger.status === "NOT_DEPLOYED",
             test: {
                 description:
                     "Should have received the alpha asset after the refund",

--- a/api_tests/e2e/rfc003/eth-erc20_btc/happy.ts
+++ b/api_tests/e2e/rfc003/eth-erc20_btc/happy.ts
@@ -93,22 +93,22 @@ declare var global: HarnessGlobal;
         {
             actor: alice,
             action: ActionKind.Deploy,
-            waitUntil: state => state.alpha_ledger.status === "Deployed",
+            waitUntil: state => state.alpha_ledger.status === "DEPLOYED",
         },
         {
             actor: alice,
             action: ActionKind.Fund,
-            waitUntil: state => state.alpha_ledger.status === "Funded",
+            waitUntil: state => state.alpha_ledger.status === "FUNDED",
         },
         {
             actor: bob,
             action: ActionKind.Fund,
-            waitUntil: state => state.beta_ledger.status === "Funded",
+            waitUntil: state => state.beta_ledger.status === "FUNDED",
         },
         {
             actor: alice,
             action: ActionKind.Redeem,
-            waitUntil: state => state.beta_ledger.status === "Redeemed",
+            waitUntil: state => state.beta_ledger.status === "REDEEMED",
             test: {
                 description:
                     "Should have received the beta asset after the redeem",
@@ -128,7 +128,7 @@ declare var global: HarnessGlobal;
         {
             actor: bob,
             action: ActionKind.Redeem,
-            waitUntil: state => state.alpha_ledger.status === "Redeemed",
+            waitUntil: state => state.alpha_ledger.status === "REDEEMED",
             test: {
                 description:
                     "Should have received the alpha asset after the redeem",

--- a/api_tests/e2e/rfc003/eth-erc20_btc/refund.ts
+++ b/api_tests/e2e/rfc003/eth-erc20_btc/refund.ts
@@ -89,12 +89,12 @@ declare var global: HarnessGlobal;
         {
             actor: alice,
             action: ActionKind.Deploy,
-            waitUntil: state => state.alpha_ledger.status === "Deployed",
+            waitUntil: state => state.alpha_ledger.status === "DEPLOYED",
         },
         {
             actor: alice,
             action: ActionKind.Fund,
-            waitUntil: state => state.alpha_ledger.status === "Funded",
+            waitUntil: state => state.alpha_ledger.status === "FUNDED",
             test: {
                 description: "Should have less alpha asset after the funding",
                 callback: async () => {
@@ -111,13 +111,13 @@ declare var global: HarnessGlobal;
             actor: bob,
             action: ActionKind.Fund,
             waitUntil: state =>
-                state.alpha_ledger.status === "Funded" &&
-                state.beta_ledger.status === "Funded",
+                state.alpha_ledger.status === "FUNDED" &&
+                state.beta_ledger.status === "FUNDED",
         },
         {
             actor: bob,
             action: ActionKind.Refund,
-            waitUntil: state => state.beta_ledger.status === "Refunded",
+            waitUntil: state => state.beta_ledger.status === "REFUNDED",
             test: {
                 description:
                     "Should have received the beta asset after the refund",
@@ -137,7 +137,7 @@ declare var global: HarnessGlobal;
         {
             actor: alice,
             action: ActionKind.Refund,
-            waitUntil: state => state.alpha_ledger.status === "Refunded",
+            waitUntil: state => state.alpha_ledger.status === "REFUNDED",
             test: {
                 description:
                     "Should have received the alpha asset after the refund",

--- a/api_tests/e2e/rfc003/eth_btc/bitcoin_high_fee.ts
+++ b/api_tests/e2e/rfc003/eth_btc/bitcoin_high_fee.ts
@@ -87,12 +87,12 @@ declare var global: HarnessGlobal;
         {
             actor: alice,
             action: ActionKind.Fund,
-            waitUntil: state => state.alpha_ledger.status === "Funded",
+            waitUntil: state => state.alpha_ledger.status === "FUNDED",
         },
         {
             actor: bob,
             action: ActionKind.Fund,
-            waitUntil: state => state.beta_ledger.status === "Funded",
+            waitUntil: state => state.beta_ledger.status === "FUNDED",
         },
         {
             actor: alice,

--- a/api_tests/e2e/rfc003/eth_btc/happy.ts
+++ b/api_tests/e2e/rfc003/eth_btc/happy.ts
@@ -69,17 +69,17 @@ declare var global: HarnessGlobal;
         {
             actor: alice,
             action: ActionKind.Fund,
-            waitUntil: state => state.alpha_ledger.status === "Funded",
+            waitUntil: state => state.alpha_ledger.status === "FUNDED",
         },
         {
             actor: bob,
             action: ActionKind.Fund,
-            waitUntil: state => state.beta_ledger.status === "Funded",
+            waitUntil: state => state.beta_ledger.status === "FUNDED",
         },
         {
             actor: alice,
             action: ActionKind.Redeem,
-            waitUntil: state => state.beta_ledger.status === "Redeemed",
+            waitUntil: state => state.beta_ledger.status === "REDEEMED",
             test: {
                 description:
                     "Should have received the beta asset after the redeem",
@@ -99,7 +99,7 @@ declare var global: HarnessGlobal;
         {
             actor: bob,
             action: ActionKind.Redeem,
-            waitUntil: state => state.alpha_ledger.status === "Redeemed",
+            waitUntil: state => state.alpha_ledger.status === "REDEEMED",
             test: {
                 description:
                     "Should have received the alpha asset after the redeem",

--- a/api_tests/e2e/rfc003/eth_btc/refund_beta.ts
+++ b/api_tests/e2e/rfc003/eth_btc/refund_beta.ts
@@ -67,12 +67,12 @@ declare var global: HarnessGlobal;
         {
             actor: alice,
             action: ActionKind.Fund,
-            waitUntil: state => state.alpha_ledger.status === "Funded",
+            waitUntil: state => state.alpha_ledger.status === "FUNDED",
         },
         {
             actor: bob,
             action: ActionKind.Fund,
-            waitUntil: state => state.beta_ledger.status === "Funded",
+            waitUntil: state => state.beta_ledger.status === "FUNDED",
         },
         {
             actor: bob,
@@ -80,7 +80,7 @@ declare var global: HarnessGlobal;
         },
         {
             actor: bob,
-            waitUntil: state => state.beta_ledger.status === "Refunded",
+            waitUntil: state => state.beta_ledger.status === "REFUNDED",
             test: {
                 description:
                     "Should have received the beta asset after the refund",

--- a/api_tests/swap.schema.json
+++ b/api_tests/swap.schema.json
@@ -195,16 +195,16 @@
                         "status": {
                             "$id": "#/properties/state/properties/alpha_ledger/properties/status",
                             "enum": [
-                                "NotDeployed",
-                                "Deployed",
-                                "Funded",
-                                "Redeemed",
-                                "Refunded",
-                                "IncorrectlyFunded"
+                                "NOT_DEPLOYED",
+                                "DEPLOYED",
+                                "FUNDED",
+                                "REDEEMED",
+                                "REFUNDED",
+                                "INCORRECTLY_FUNDED"
                             ],
                             "description": "The status of the HTLC on the alpha ledger.",
                             "default": "",
-                            "examples": ["NotDeployed"]
+                            "examples": ["NOT_DEPLOYED"]
                         }
                     }
                 },
@@ -277,16 +277,16 @@
                         "status": {
                             "$id": "#/properties/state/properties/beta_ledger/properties/status",
                             "enum": [
-                                "NotDeployed",
-                                "Deployed",
-                                "Funded",
-                                "Redeemed",
-                                "Refunded",
-                                "IncorrectlyFunded"
+                                "NOT_DEPLOYED",
+                                "DEPLOYED",
+                                "FUNDED",
+                                "REDEEMED",
+                                "REFUNDED",
+                                "INCORRECTLY_FUNDED"
                             ],
                             "description": "The status of the HTLC on the beta ledger.",
                             "default": "",
-                            "examples": ["NotDeployed"]
+                            "examples": ["NOT_DEPLOYED"]
                         }
                     }
                 },

--- a/api_tests/swap.schema.json
+++ b/api_tests/swap.schema.json
@@ -199,7 +199,8 @@
                                 "Deployed",
                                 "Funded",
                                 "Redeemed",
-                                "Refunded"
+                                "Refunded",
+                                "IncorrectlyFunded"
                             ],
                             "description": "The status of the HTLC on the alpha ledger.",
                             "default": "",
@@ -280,7 +281,8 @@
                                 "Deployed",
                                 "Funded",
                                 "Redeemed",
-                                "Refunded"
+                                "Refunded",
+                                "IncorrectlyFunded"
                             ],
                             "description": "The status of the HTLC on the beta ledger.",
                             "default": "",

--- a/cnd/src/swap_protocols/rfc003/ledger_state.rs
+++ b/cnd/src/swap_protocols/rfc003/ledger_state.rs
@@ -5,7 +5,8 @@ use strum_macros::EnumDiscriminants;
 #[derive(Clone, Debug, PartialEq, EnumDiscriminants)]
 #[strum_discriminants(
     name(HtlcState),
-    derive(Serialize, rename_all = "SCREAMING_SNAKE_CASE")
+    derive(Serialize),
+    serde(rename_all = "SCREAMING_SNAKE_CASE")
 )]
 pub enum LedgerState<L: Ledger> {
     NotDeployed,

--- a/cnd/src/swap_protocols/rfc003/ledger_state.rs
+++ b/cnd/src/swap_protocols/rfc003/ledger_state.rs
@@ -57,3 +57,14 @@ impl quickcheck::Arbitrary for HtlcState {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn not_deployed_serializes_correctly_to_json() {
+        let state = HtlcState::NotDeployed;
+        let serialized = serde_json::to_string(&state).unwrap();
+        assert_eq!(serialized, r#""NOT_DEPLOYED""#);
+    }
+}


### PR DESCRIPTION
As described in the issue; the ledger status currently uses Pascal case (upper camel case).  This is not uniform with other fields in the HTTP API.  We should use SCREAMING_SNAKE_CASE so as to be uniform.

This PR also adds the recently added status field `IncorrectlyFunded` to the API test scheme (seems to have been omitted when added to cnd).  Next we change the API test scheme to use SCREAMING_SNAKE_CASE, making the dry tests fail.  We add a failing unit test.  Then in patch 4 we fix cnd to use SCREAMING_SNAKE_CASE.  Patch 5 updates the e2e tests to reflect the case change.

Fixes: #845 and feels good!