### PR TITLE
Remove bitcoin_support dependency from blockchain_contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,8 @@ dependencies = [
 name = "blockchain_contracts"
 version = "0.1.0"
 dependencies = [
+ "bitcoin 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin_hashes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin_rpc_test_helpers 0.1.0",
  "bitcoin_support 0.1.0",
  "bitcoin_witness 0.1.0",
@@ -446,6 +448,7 @@ dependencies = [
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1_support 0.1.0",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,8 +433,8 @@ version = "0.1.0"
 dependencies = [
  "bitcoin 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin_hashes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin_quantity 0.1.0 (git+https://github.com/coblox/bitcoin-quantity)",
  "bitcoin_rpc_test_helpers 0.1.0",
- "bitcoin_support 0.1.0",
  "bitcoin_witness 0.1.0",
  "bitcoincore-rpc 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cnd/src/swap_protocols/rfc003/bitcoin/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bitcoin/mod.rs
@@ -27,6 +27,6 @@ impl From<HtlcParams<Bitcoin, BitcoinQuantity>> for BitcoinHtlc {
 
 impl HtlcParams<Bitcoin, BitcoinQuantity> {
     pub fn compute_address(&self) -> Address {
-        BitcoinHtlc::from(self.clone()).compute_address(self.ledger.network)
+        BitcoinHtlc::from(self.clone()).compute_address(self.ledger.network.into())
     }
 }

--- a/vendor/blockchain_contracts/Cargo.toml
+++ b/vendor/blockchain_contracts/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 bitcoin = "0.18.0"
 bitcoin_hashes = "0.3.2"
-bitcoin_support = { path = "../../vendor/bitcoin_support" }
+bitcoin_quantity = { git = "https://github.com/coblox/bitcoin-quantity", features = ["serde"] }
 bitcoin_witness = { path = "../../vendor/bitcoin_witness" }
 byteorder = "1.3"
 hex = "0.3"

--- a/vendor/blockchain_contracts/Cargo.toml
+++ b/vendor/blockchain_contracts/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["CoBloX developers <team@coblox.tech>"]
 edition = "2018"
 
 [dependencies]
+bitcoin = "0.18.0"
+bitcoin_hashes = "0.3.2"
 bitcoin_support = { path = "../../vendor/bitcoin_support" }
 bitcoin_witness = { path = "../../vendor/bitcoin_witness" }
 byteorder = "1.3"
@@ -13,6 +15,7 @@ hex-literal = "0.2"
 itertools = "0.8.0"
 regex = "1.2"
 rust-crypto = "0.2"
+secp256k1 = { version = "0.12", features = ["rand"] }
 secp256k1_support = { path = "../../vendor/secp256k1_support" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/vendor/blockchain_contracts/src/bitcoin/mod.rs
+++ b/vendor/blockchain_contracts/src/bitcoin/mod.rs
@@ -1,1 +1,2 @@
 pub mod rfc003;
+pub mod pubkey_hash;

--- a/vendor/blockchain_contracts/src/bitcoin/mod.rs
+++ b/vendor/blockchain_contracts/src/bitcoin/mod.rs
@@ -1,2 +1,2 @@
-pub mod rfc003;
 pub mod pubkey_hash;
+pub mod rfc003;

--- a/vendor/blockchain_contracts/src/bitcoin/pubkey_hash.rs
+++ b/vendor/blockchain_contracts/src/bitcoin/pubkey_hash.rs
@@ -1,5 +1,5 @@
-pub use bitcoin_hashes::sha256d::Hash as TransactionId;
 use bitcoin_hashes::hash160;
+pub use bitcoin_hashes::sha256d::Hash as TransactionId;
 use secp256k1::PublicKey;
 
 // TODO: Contribute back to rust-bitcoin
@@ -15,9 +15,7 @@ impl From<hash160::Hash> for PubkeyHash {
 impl From<PublicKey> for PubkeyHash {
     fn from(public_key: PublicKey) -> PubkeyHash {
         PubkeyHash(
-            <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::hash(
-                &public_key.serialize(),
-            ),
+            <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::hash(&public_key.serialize()),
         )
     }
 }

--- a/vendor/blockchain_contracts/src/bitcoin/pubkey_hash.rs
+++ b/vendor/blockchain_contracts/src/bitcoin/pubkey_hash.rs
@@ -1,0 +1,39 @@
+pub use bitcoin_hashes::sha256d::Hash as TransactionId;
+use bitcoin_hashes::hash160;
+use secp256k1::PublicKey;
+
+// TODO: Contribute back to rust-bitcoin
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
+pub struct PubkeyHash(hash160::Hash);
+
+impl From<hash160::Hash> for PubkeyHash {
+    fn from(hash: hash160::Hash) -> PubkeyHash {
+        PubkeyHash(hash)
+    }
+}
+
+impl From<PublicKey> for PubkeyHash {
+    fn from(public_key: PublicKey) -> PubkeyHash {
+        PubkeyHash(
+            <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::hash(
+                &public_key.serialize(),
+            ),
+        )
+    }
+}
+
+impl From<secp256k1_support::PublicKey> for PubkeyHash {
+    fn from(public_key: secp256k1_support::PublicKey) -> PubkeyHash {
+        PubkeyHash(
+            <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::hash(
+                &public_key.inner().serialize(),
+            ),
+        )
+    }
+}
+
+impl From<PubkeyHash> for hash160::Hash {
+    fn from(pubkey_hash: PubkeyHash) -> Self {
+        pubkey_hash.0
+    }
+}

--- a/vendor/blockchain_contracts/src/bitcoin/rfc003/bitcoin_htlc.rs
+++ b/vendor/blockchain_contracts/src/bitcoin/rfc003/bitcoin_htlc.rs
@@ -49,7 +49,7 @@ impl BitcoinHtlc {
     }
 
     pub fn compute_address(&self, network: Network) -> Address {
-        Address::p2wsh(&Script::from(self.script.clone()), network.into())
+        Address::p2wsh(&Script::from(self.script.clone()), network)
     }
 
     pub fn unlock_with_secret(self, keypair: KeyPair, secret: [u8; 32]) -> UnlockParameters {

--- a/vendor/blockchain_contracts/src/bitcoin/rfc003/bitcoin_htlc.rs
+++ b/vendor/blockchain_contracts/src/bitcoin/rfc003/bitcoin_htlc.rs
@@ -2,10 +2,12 @@ use crate::{
     fit_into_placeholder_slice::{BitcoinTimestamp, FitIntoPlaceholderSlice},
     SecretHash,
 };
-use bitcoin_support::{Address, Hash160, Network, Script};
 use bitcoin_witness::{UnlockParameters, Witness, SEQUENCE_ALLOW_NTIMELOCK_NO_RBF};
 use hex_literal::hex;
 use secp256k1_support::KeyPair;
+use bitcoin::{Address, Script};
+use bitcoin::network::constants::Network;
+use bitcoin_hashes::hash160;
 
 // contract template RFC: https://github.com/comit-network/RFCs/blob/master/RFC-005-SWAP-Basic-Bitcoin.adoc#contract
 pub const CONTRACT_TEMPLATE: [u8;97] = hex!("6382012088a82010000000000000000000000000000000000000000000000000000000000000018876a9143000000000000000000000000000000000000003670420000002b17576a91440000000000000000000000000000000000000046888ac");
@@ -31,8 +33,8 @@ pub struct BitcoinHtlc {
 impl BitcoinHtlc {
     pub fn new(
         expiry: u32,
-        refund_identity: Hash160,
-        redeem_identity: Hash160,
+        refund_identity: hash160::Hash,
+        redeem_identity: hash160::Hash,
         secret_hash: [u8; 32],
     ) -> Self {
         let mut contract = CONTRACT_TEMPLATE.to_vec();
@@ -91,6 +93,7 @@ impl BitcoinHtlc {
 mod tests {
     use super::*;
     use regex::bytes::Regex;
+    use bitcoin_hashes::hash160;
 
     const SECRET_HASH: [u8; 32] = [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
@@ -101,7 +104,7 @@ mod tests {
 
     #[test]
     fn compiled_contract_is_same_length_as_template() {
-        let htlc = BitcoinHtlc::new(3000000, Hash160::default(), Hash160::default(), SECRET_HASH);
+        let htlc = BitcoinHtlc::new(3000000, hash160::Hash::default(), hash160::Hash::default(), SECRET_HASH);
 
         assert_eq!(
             htlc.script.len(),
@@ -114,8 +117,8 @@ mod tests {
     fn given_input_data_when_compiled_should_contain_given_data() {
         let htlc = BitcoinHtlc::new(
             2000000000,
-            Hash160::default(),
-            Hash160::default(),
+            hash160::Hash::default(),
+            hash160::Hash::default(),
             SECRET_HASH,
         );
 

--- a/vendor/blockchain_contracts/src/bitcoin/rfc003/bitcoin_htlc.rs
+++ b/vendor/blockchain_contracts/src/bitcoin/rfc003/bitcoin_htlc.rs
@@ -2,12 +2,11 @@ use crate::{
     fit_into_placeholder_slice::{BitcoinTimestamp, FitIntoPlaceholderSlice},
     SecretHash,
 };
+use bitcoin::{network::constants::Network, Address, Script};
+use bitcoin_hashes::hash160;
 use bitcoin_witness::{UnlockParameters, Witness, SEQUENCE_ALLOW_NTIMELOCK_NO_RBF};
 use hex_literal::hex;
 use secp256k1_support::KeyPair;
-use bitcoin::{Address, Script};
-use bitcoin::network::constants::Network;
-use bitcoin_hashes::hash160;
 
 // contract template RFC: https://github.com/comit-network/RFCs/blob/master/RFC-005-SWAP-Basic-Bitcoin.adoc#contract
 pub const CONTRACT_TEMPLATE: [u8;97] = hex!("6382012088a82010000000000000000000000000000000000000000000000000000000000000018876a9143000000000000000000000000000000000000003670420000002b17576a91440000000000000000000000000000000000000046888ac");
@@ -92,8 +91,8 @@ impl BitcoinHtlc {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use regex::bytes::Regex;
     use bitcoin_hashes::hash160;
+    use regex::bytes::Regex;
 
     const SECRET_HASH: [u8; 32] = [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
@@ -104,7 +103,12 @@ mod tests {
 
     #[test]
     fn compiled_contract_is_same_length_as_template() {
-        let htlc = BitcoinHtlc::new(3000000, hash160::Hash::default(), hash160::Hash::default(), SECRET_HASH);
+        let htlc = BitcoinHtlc::new(
+            3000000,
+            hash160::Hash::default(),
+            hash160::Hash::default(),
+            SECRET_HASH,
+        );
 
         assert_eq!(
             htlc.script.len(),

--- a/vendor/blockchain_contracts/src/fit_into_placeholder_slice.rs
+++ b/vendor/blockchain_contracts/src/fit_into_placeholder_slice.rs
@@ -1,6 +1,6 @@
-use bitcoin_support::Hash160;
 use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use web3::types::{Address, U256};
+use bitcoin_hashes::hash160;
 
 pub trait FitIntoPlaceholderSlice {
     fn fit_into_placeholder_slice(self, buf: &mut [u8]);
@@ -36,7 +36,7 @@ impl FitIntoPlaceholderSlice for SecretHash {
     }
 }
 
-impl FitIntoPlaceholderSlice for Hash160 {
+impl FitIntoPlaceholderSlice for hash160::Hash {
     fn fit_into_placeholder_slice(self, buf: &mut [u8]) {
         buf.copy_from_slice(&self[..]);
     }

--- a/vendor/blockchain_contracts/src/fit_into_placeholder_slice.rs
+++ b/vendor/blockchain_contracts/src/fit_into_placeholder_slice.rs
@@ -1,6 +1,6 @@
+use bitcoin_hashes::hash160;
 use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use web3::types::{Address, U256};
-use bitcoin_hashes::hash160;
 
 pub trait FitIntoPlaceholderSlice {
     fn fit_into_placeholder_slice(self, buf: &mut [u8]);

--- a/vendor/blockchain_contracts/tests/rfc003_bitcoin_htlc.rs
+++ b/vendor/blockchain_contracts/tests/rfc003_bitcoin_htlc.rs
@@ -6,21 +6,21 @@ pub mod htlc_harness;
 pub mod parity_client;
 
 use crate::htlc_harness::{CustomSizeSecret, Timestamp, SECRET, SECRET_HASH};
-use bitcoin_rpc_test_helpers::RegtestHelperClient;
-use bitcoin_support::{
-    BitcoinQuantity,
+use bitcoin::{
+    consensus::encode::serialize_hex, network::constants::Network, Address, OutPoint, PrivateKey,
 };
+use bitcoin_quantity::BitcoinQuantity;
+use bitcoin_rpc_test_helpers::RegtestHelperClient;
 use bitcoin_witness::{PrimedInput, PrimedTransaction, UnlockParameters, Witness};
 use bitcoincore_rpc::RpcApi;
-use blockchain_contracts::bitcoin::rfc003::bitcoin_htlc::BitcoinHtlc;
+use blockchain_contracts::bitcoin::{
+    pubkey_hash::{PubkeyHash, TransactionId},
+    rfc003::bitcoin_htlc::BitcoinHtlc,
+};
 use secp256k1_support::KeyPair;
 use spectral::prelude::*;
 use std::{str::FromStr, thread::sleep, time::Duration};
 use testcontainers::{clients::Cli, images::coblox_bitcoincore::BitcoinCore, Docker};
-use bitcoin::{Address, PrivateKey, OutPoint};
-use bitcoin::consensus::encode::serialize_hex;
-use blockchain_contracts::bitcoin::pubkey_hash::{PubkeyHash, TransactionId};
-use bitcoin::network::constants::Network;
 
 /// Mimic the functionality of [`BitcoinHtlc#unlock_with_secret`](method)
 /// except that we want to insert our "CustomSizeSecret" on the witness

--- a/vendor/blockchain_contracts/tests/rfc003_bitcoin_htlc.rs
+++ b/vendor/blockchain_contracts/tests/rfc003_bitcoin_htlc.rs
@@ -8,8 +8,7 @@ pub mod parity_client;
 use crate::htlc_harness::{CustomSizeSecret, Timestamp, SECRET, SECRET_HASH};
 use bitcoin_rpc_test_helpers::RegtestHelperClient;
 use bitcoin_support::{
-    serialize_hex, Address, BitcoinQuantity, Network, OutPoint, PrivateKey, PubkeyHash,
-    TransactionId,
+    BitcoinQuantity,
 };
 use bitcoin_witness::{PrimedInput, PrimedTransaction, UnlockParameters, Witness};
 use bitcoincore_rpc::RpcApi;
@@ -18,6 +17,10 @@ use secp256k1_support::KeyPair;
 use spectral::prelude::*;
 use std::{str::FromStr, thread::sleep, time::Duration};
 use testcontainers::{clients::Cli, images::coblox_bitcoincore::BitcoinCore, Docker};
+use bitcoin::{Address, PrivateKey, OutPoint};
+use bitcoin::consensus::encode::serialize_hex;
+use blockchain_contracts::bitcoin::pubkey_hash::{PubkeyHash, TransactionId};
+use bitcoin::network::constants::Network;
 
 /// Mimic the functionality of [`BitcoinHtlc#unlock_with_secret`](method)
 /// except that we want to insert our "CustomSizeSecret" on the witness

--- a/vendor/secp256k1_support/src/keypair.rs
+++ b/vendor/secp256k1_support/src/keypair.rs
@@ -2,6 +2,7 @@ use crate::public_key::PublicKey;
 use secp256k1::{self, rand::Rng, Error, Message, RecoverableSignature, SecretKey, Signature};
 use std::{convert::Into, str::FromStr};
 
+// TODO: Contribute back to secp256k1
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
 pub struct KeyPair {
     secret_key: SecretKey,


### PR DESCRIPTION
Related to coblox/blockchain_contracts#4

Note: Issue to be open to contribute the TODOs back, see coblox/blockchain_contracts#4.