### PR TITLE
Don't rebase to update a branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,5 +11,5 @@ pull_request_rules:
       merge:
         method: merge
         strict: smart
-        strict_method: rebase
+        strict_method: merge
       delete_head_branch:


### PR DESCRIPTION
Two reasons:
- rebase destroys commit signatures
- rebases spam the history of pull requests on GitHub
- in most cases, there should only be one merge commit because mergify queues up PRs

Resolves https://github.com/comit-network/comit-rs/issues/1018.