### PR TITLE
Use cross platform config directory

### DIFF
--- a/btsieve/src/load_settings.rs
+++ b/btsieve/src/load_settings.rs
@@ -12,16 +12,7 @@ pub struct Opt {
 
 pub fn load_settings(opt: Opt) -> Result<Settings, ConfigError> {
     match opt.config_file {
-        Some(config_file) => {
-            if config_file.exists() {
-                Settings::read(config_file)
-            } else {
-                Err(ConfigError::Message(format!(
-                    "Could not load config file: {:?}",
-                    config_file
-                )))
-            }
-        }
+        Some(file) => parse_config_file(file),
         None => match directories::UserDirs::new() {
             None => Err(ConfigError::Message(
                 "Unable to determine user's home directory".to_string(),
@@ -29,17 +20,21 @@ pub fn load_settings(opt: Opt) -> Result<Settings, ConfigError> {
             Some(dirs) => {
                 let user_path_components: PathBuf =
                     [".config", "comit", "btsieve.toml"].iter().collect();
-                let config_file = Path::join(dirs.home_dir(), user_path_components);
-                log::info!("Config file was not provided - looking up config file in default location at: {:?}", config_file);;
-                if config_file.exists() {
-                    Settings::read(config_file)
-                } else {
-                    Err(ConfigError::Message(format!(
-                        "Could not load config file: {:?}",
-                        config_file
-                    )))
-                }
+                let file = Path::join(dirs.home_dir(), user_path_components);
+                log::info!("Config file was not provided - looking up config file in default location at: {:?}", file);;
+                parse_config_file(file)
             }
         },
+    }
+}
+
+fn parse_config_file(file: PathBuf) -> Result<Settings, ConfigError> {
+    if file.exists() {
+        Settings::read(file)
+    } else {
+        Err(ConfigError::Message(format!(
+            "Could not load config file: {:?}",
+            file
+        )))
     }
 }

--- a/btsieve/src/load_settings.rs
+++ b/btsieve/src/load_settings.rs
@@ -12,22 +12,25 @@ pub struct Opt {
 }
 
 pub fn load_settings(opt: Opt) -> Result<Settings, ConfigError> {
-    match opt.config_file {
-        Some(file) => parse_config_file(file),
-        None => match ProjectDirs::from("tech", "CoBloX", "btsieve") {
-            // Linux: /home/<user>/.config/btsieve
-            // Windows: C:\Users\<user>\AppData\Roaming\CoBloX\btsieve\config
-            // OSX: /Users/<user>/Library/Preferences/tech.CoBloX.btsieve
-            Some(proj_dirs) => {
-                let file = Path::join(proj_dirs.config_dir(), "btsieve.toml");
-                log::info!("Config file was not provided - looking up config file in default location at: {:?}", file);;
-                parse_config_file(file)
-            }
-            None => Err(ConfigError::Message(
-                "Could not generate configuration directory".to_string(),
-            )),
-        },
+    if let Some(file) = opt.config_file {
+        return parse_config_file(file);
     }
+
+    // Linux: /home/<user>/.config/btsieve
+    // Windows: C:\Users\<user>\AppData\Roaming\comit-network\btsieve\config
+    // OSX: /Users/<user>/Library/Preferences/comit-network.btsieve
+    if let Some(proj_dirs) = ProjectDirs::from("", "comit-network", "btsieve") {
+        let file = Path::join(proj_dirs.config_dir(), "btsieve.toml");
+        log::info!(
+            "Config file was not provided - looking up config file in default location at: {:?}",
+            file
+        );
+        return parse_config_file(file);
+    }
+
+    Err(ConfigError::Message(
+        "Could not generate configuration directory".to_string(),
+    ))
 }
 
 fn parse_config_file(file: PathBuf) -> Result<Settings, ConfigError> {

--- a/btsieve/src/load_settings.rs
+++ b/btsieve/src/load_settings.rs
@@ -1,5 +1,6 @@
 use crate::settings::Settings;
 use config::ConfigError;
+use directories::ProjectDirs;
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
@@ -13,17 +14,18 @@ pub struct Opt {
 pub fn load_settings(opt: Opt) -> Result<Settings, ConfigError> {
     match opt.config_file {
         Some(file) => parse_config_file(file),
-        None => match directories::UserDirs::new() {
-            None => Err(ConfigError::Message(
-                "Unable to determine user's home directory".to_string(),
-            )),
-            Some(dirs) => {
-                let user_path_components: PathBuf =
-                    [".config", "comit", "btsieve.toml"].iter().collect();
-                let file = Path::join(dirs.home_dir(), user_path_components);
+        None => match ProjectDirs::from("tech", "CoBloX", "btsieve") {
+            // Linux: /home/<user>/.config/btsieve
+            // Windows: C:\Users\<user>\AppData\Roaming\CoBloX\btsieve\config
+            // OSX: /Users/<user>/Library/Preferences/tech.CoBloX.btsieve
+            Some(proj_dirs) => {
+                let file = Path::join(proj_dirs.config_dir(), "btsieve.toml");
                 log::info!("Config file was not provided - looking up config file in default location at: {:?}", file);;
                 parse_config_file(file)
             }
+            None => Err(ConfigError::Message(
+                "Could not generate configuration directory".to_string(),
+            )),
         },
     }
 }


### PR DESCRIPTION
Currently we hard code the `.config/` path.  We can be cross platform if we use the `directories` crate instead.

Implements solution to #1074 for btsieve.  cnd coming as a separate PR. 