### PR TITLE
Wait 1 second before ledger actions in tests

### DIFF
--- a/api_tests/lib/actor.ts
+++ b/api_tests/lib/actor.ts
@@ -192,6 +192,10 @@ export class Actor {
         if (network !== "regtest") {
             throw Error("Expected network regtest, found " + network);
         }
+
+        // ensure that both parties are watching for the action
+        await sleep(1000);
+
         switch (action.type) {
             case "bitcoin-send-amount-to-address": {
                 action.payload.should.include.all.keys("to", "amount");

--- a/api_tests/lib/actor.ts
+++ b/api_tests/lib/actor.ts
@@ -193,7 +193,9 @@ export class Actor {
             throw Error("Expected network regtest, found " + network);
         }
 
-        // ensure that both parties are watching for the action
+        // wait 1 second to make sure that both parties have created a btsieve
+        // query to watch for the action that is about to be performed. Should
+        // be removed with https://github.com/comit-network/comit-rs/issues/1289
         await sleep(1000);
 
         switch (action.type) {


### PR DESCRIPTION
The bug described in #1232 is most likely caused by Alice funding the ERC20 contract before Bob can create the btsieve query to watch for said action. Since ([for the time being](https://github.com/comit-network/comit-rs/issues/1289)) btsieve only considers incoming blocks for new queries, Bob will never learn that the contract on alpha ledger was funded, so the swap will not continue.

In our tests, to get around the possibility that a ledger action may happen before one of the parties has created the corresponding btsieve query, we sleep for 1 second before we perform any ledger action.

It is safe to assume that this will almost never happen outside of testing, since ledger actions on production blockchains generally take longer than creating a query on btsieve. Nevertheless, adding the ability to consider old blocks for btsieve queries will be tracked in a separate issue, as it would be a more robust fix to this problem.

Fixes #1232.

## Investigation
### Alice's cnd logs
```
[2019-07-22 02:56:54.631][DEBUG][comit_node::swap_protocols::rfc003::state_machine:337] Transitioning to AlphaDeployed
[2019-07-22 02:56:54.632][DEBUG][comit_node::btsieve::client:91] Creating Event { event_matchers: [EventMatcher { address: Some(0x9f5dbc07a1adfaffe95eec947985331a8afe2099), data: None, topics: [Some(Topic(0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef)), None, Some(Topic(0x0000000000000000000000000fecdc089c03f45d5263f9b9204972bea1ae012d))] }] } at http://localhost:8181/queries/ethereum/regtest/logs
[2019-07-22 02:56:54.634][DEBUG][reqwest::async_impl::response:45] Response: '201 Created' for http://localhost:8181/queries/ethereum/regtest/logs
[2019-07-22 02:56:54.634][INFO][comit_node::btsieve::client:143] Created new query at location http://localhost:8181/queries/ethereum/regtest/logs/1
[2019-07-22 02:56:54.638][DEBUG][reqwest::async_impl::response:45] Response: '200 OK' for http://localhost:8181/queries/ethereum/regtest/logs/1?return_as=transaction_and_receipt
[2019-07-22 02:56:55.138][DEBUG][http-api:299] Creating siren::Action from Fund(CallContract { to: 0x9f5dbc07a1adfaffe95eec947985331a8afe2099, data: Some(Bytes([169, 5, 156, 187, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15, 236, 220, 8, 156, 3, 244, 93, 82, 99, 249, 185, 32, 73, 114, 190, 161, 174, 1, 45, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 15, 12, 240, 100, 221, 89, 32, 0, 0])), gas_limit: 100000, network: Regtest, min_block_timestamp: None }) with HTTP method: GET, Media-Type: None, Name: fund, Fields: []
[2019-07-22 02:56:55.139][INFO][http:38] 127.0.0.1:40330 "GET /swaps/rfc003/04358e0f-7b5a-4cc9-9058-743b09728113 HTTP/1.1" 200 "-" "node-superagent/3.8.3" 1.803118ms
[2019-07-22 02:56:55.142][DEBUG][http-api:299] Creating siren::Action from Fund(CallContract { to: 0x9f5dbc07a1adfaffe95eec947985331a8afe2099, data: Some(Bytes([169, 5, 156, 187, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15, 236, 220, 8, 156, 3, 244, 93, 82, 99, 249, 185, 32, 73, 114, 190, 161, 174, 1, 45, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 15, 12, 240, 100, 221, 89, 32, 0, 0])), gas_limit: 100000, network: Regtest, min_block_timestamp: None }) with HTTP method: GET, Media-Type: None, Name: fund, Fields: []
[2019-07-22 02:56:55.143][INFO][http:38] 127.0.0.1:40332 "GET /swaps/rfc003/04358e0f-7b5a-4cc9-9058-743b09728113 HTTP/1.1" 200 "-" "node-superagent/3.8.3" 1.343762ms
[2019-07-22 02:56:55.146][INFO][http:38] 127.0.0.1:40334 "GET /swaps/rfc003/04358e0f-7b5a-4cc9-9058-743b09728113/fund HTTP/1.1" 200 "-" "node-superagent/3.8.3" 680.999µs
[2019-07-22 02:56:55.647][DEBUG][reqwest::async_impl::response:45] Response: '200 OK' for http://localhost:8181/queries/ethereum/regtest/logs/1?return_as=transaction_and_receipt
[2019-07-22 02:56:55.648][DEBUG][comit_node::swap_protocols::rfc003::state_machine:357] Transitioning to AlphaFunded
```

Alice has deployed the ERC20 contract. Her cnd learns this and transitions to `AlphaDeployed` at 02:56:54.631, creating a query on btsieve at 02:56:54.634 to watch for the funding of said ERC20 contract. Alice gets the fund action from her cnd at 02:56:55.146 and her cnd learns about the funding of the contract at 02:56:55.647, to then transition to `AlphaFunded` at 02:56:55.648. This means that Alice must have funded the contract between 02:56:55.146 and 02:56:55.647. The exact time is impossible to tell, as the btsieve query is polled on a 1 second interval.

### Bob's cnd logs

```
[2019-07-22 02:56:55.618][DEBUG][comit_node::swap_protocols::rfc003::state_machine:337] Transitioning to AlphaDeployed
[2019-07-22 02:56:55.618][DEBUG][comit_node::btsieve::client:91] Creating Event { event_matchers: [EventMatcher { address: Some(0x9f5dbc07a1adfaffe95eec947985331a8afe2099), data: None, topics: [Some(Topic(0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef)), None, Some(Topic(0x0000000000000000000000000fecdc089c03f45d5263f9b9204972bea1ae012d))] }] } at http://localhost:8181/queries/ethereum/regtest/logs
[2019-07-22 02:56:55.621][DEBUG][reqwest::async_impl::response:45] Response: '201 Created' for http://localhost:8181/queries/ethereum/regtest/logs
[2019-07-22 02:56:55.621][INFO][comit_node::btsieve::client:143] Created new query at location http://localhost:8181/queries/ethereum/regtest/logs/2
[2019-07-22 02:56:55.623][DEBUG][reqwest::async_impl::response:45] Response: '200 OK' for http://localhost:8181/queries/ethereum/regtest/logs/2?return_as=transaction_and_receipt
[2019-07-22 02:56:56.171][INFO][http:38] 127.0.0.1:44760 "GET /swaps/rfc003/d846b12f-40c0-4881-8977-44f6243b14bc HTTP/1.1" 200 "-" "node-superagent/3.8.3" 1.012161ms
[2019-07-22 02:56:56.625][DEBUG][reqwest::async_impl::response:45] Response: '200 OK' for http://localhost:8181/queries/ethereum/regtest/logs/2?return_as=transaction_and_receipt
```

Bob also sees that Alice has deployed the ERC20 contract, transitioning to `AlphaDeployed` at 02:56:55.618. The btsieve query to monitor the funding of the contract is created at 02:56:55.621. Bob polls this query until the test times out. Since Alice funds the contract between 02:56:55.146 and 02:56:55.647, it is highly likely that Bob's btsieve query is created **after** Alice's transaction to fund the contract is included in a block. If that were the case, Bob would never be able to learn about the alpha contract being funded, since btsieve queries only consider blocks received after their creation. This would cause the swap to get stuck.
