### PR TITLE
Refactor btsieve

### DIFF
--- a/btsieve/src/cli.rs
+++ b/btsieve/src/cli.rs
@@ -1,0 +1,9 @@
+use std::path::PathBuf;
+
+#[derive(structopt::StructOpt, Debug)]
+#[structopt(name = "COMIT btsieve daemon")]
+pub struct Options {
+    /// Path to configuration file
+    #[structopt(short = "c", long = "config", parse(from_os_str))]
+    pub config_file: Option<PathBuf>,
+}

--- a/btsieve/src/load_settings.rs
+++ b/btsieve/src/load_settings.rs
@@ -4,19 +4,11 @@ use crate::settings::Settings;
 use config::ConfigError;
 use directories::ProjectDirs;
 use std::path::{Path, PathBuf};
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
-pub struct Opt {
-    /// Path to configuration folder
-    #[structopt(short = "c", long = "config", parse(from_os_str))]
-    config_file: Option<PathBuf>,
-}
-
-pub fn load_settings(opt: Opt) -> Result<Settings, ConfigError> {
-    if let Some(file) = opt.config_file {
-        println!("Using config file at {:?}", file);
-        return parse_config_file(file);
+pub fn load_settings(config_file: Option<PathBuf>) -> Result<Settings, ConfigError> {
+    // Allow config_file to override the default configuration file.
+    if let Some(config_file) = config_file {
+        return parse_config_file(config_file);
     }
 
     let path = config_dir()

--- a/btsieve/src/load_settings.rs
+++ b/btsieve/src/load_settings.rs
@@ -19,21 +19,18 @@ pub fn load_settings(opt: Opt) -> Result<Settings, ConfigError> {
         return parse_config_file(file);
     }
 
-    // Linux: /home/<user>/.config/btsieve
-    // Windows: C:\Users\<user>\AppData\Roaming\comit-network\btsieve\config
-    // OSX: /Users/<user>/Library/Preferences/comit-network.btsieve
-    if let Some(proj_dirs) = ProjectDirs::from("", "comit-network", "btsieve") {
-        let file = Path::join(proj_dirs.config_dir(), "btsieve.toml");
-        println!(
-            "Config file was not provided - looking up config file in default location at: {:?}",
-            file
-        );
-        return parse_config_file(file);
-    }
+    let path = config_dir()
+        .map(|dir| Path::join(&dir, "btsieve.toml"))
+        .ok_or_else(|| {
+            ConfigError::Message("Could not generate default configuration path".to_string())
+        })?;
 
-    Err(ConfigError::Message(
-        "Could not generate configuration directory".to_string(),
-    ))
+    log::info!(
+        "Config file was not provided - looking up config file in default location at: {:?}",
+        path
+    );
+
+    parse_config_file(path)
 }
 
 fn parse_config_file(file: PathBuf) -> Result<Settings, ConfigError> {
@@ -45,4 +42,12 @@ fn parse_config_file(file: PathBuf) -> Result<Settings, ConfigError> {
             file
         )))
     }
+}
+
+// Linux: /home/<user>/.config/btsieve/
+// Windows: C:\Users\<user>\AppData\Roaming\comit-network\btsieve\config\
+// OSX: /Users/<user>/Library/Preferences/comit-network.btsieve/
+fn config_dir() -> Option<PathBuf> {
+    ProjectDirs::from("", "comit-network", "btsieve")
+        .map(|proj_dirs| proj_dirs.config_dir().to_path_buf())
 }

--- a/btsieve/src/load_settings.rs
+++ b/btsieve/src/load_settings.rs
@@ -36,10 +36,9 @@ fn parse_config_file(file: PathBuf) -> Result<Settings, ConfigError> {
     }
 }
 
-// Linux: /home/<user>/.config/btsieve/
-// Windows: C:\Users\<user>\AppData\Roaming\comit-network\btsieve\config\
-// OSX: /Users/<user>/Library/Preferences/comit-network.btsieve/
+// Linux: /home/<user>/.config/comit/
+// Windows: C:\Users\<user>\AppData\Roaming\comit\config\
+// OSX: /Users/<user>/Library/Preferences/comit/
 fn config_dir() -> Option<PathBuf> {
-    ProjectDirs::from("", "comit-network", "btsieve")
-        .map(|proj_dirs| proj_dirs.config_dir().to_path_buf())
+    ProjectDirs::from("", "", "comit").map(|proj_dirs| proj_dirs.config_dir().to_path_buf())
 }

--- a/btsieve/src/load_settings.rs
+++ b/btsieve/src/load_settings.rs
@@ -17,7 +17,7 @@ pub fn load_settings(config_file: Option<PathBuf>) -> Result<Settings, ConfigErr
             ConfigError::Message("Could not generate default configuration path".to_string())
         })?;
 
-    log::info!(
+    println!(
         "Config file was not provided - looking up config file in default location at: {:?}",
         path
     );

--- a/btsieve/src/main.rs
+++ b/btsieve/src/main.rs
@@ -8,7 +8,7 @@ use btsieve::{
     blocksource::BlockSource,
     ethereum::{self, web3_http_blocksource::Web3HttpBlockSource},
     expected_version_header,
-    load_settings::{load_settings, Opt},
+    load_settings::load_settings,
     logging, route_factory, settings, Bitcoin, Blockchain, Ethereum, InMemoryQueryRepository,
     InMemoryQueryResultRepository, QueryMatch, QueryResultRepository,
 };
@@ -27,6 +27,8 @@ use structopt::StructOpt;
 use tokio::runtime::Runtime;
 use warp::{self, filters::BoxedFilter, Filter, Reply};
 
+mod cli;
+
 #[derive(Debug, Fail)]
 enum Error {
     #[fail(display = "Could not connect to ledger: {}", ledger)]
@@ -44,9 +46,8 @@ impl From<web3::Error> for Error {
 }
 
 fn main() -> Result<(), failure::Error> {
-    let opt = Opt::from_args();
-
-    let settings = load_settings(opt)?;
+    let options = cli::Options::from_args();
+    let settings = load_settings(options.config_file)?;
     logging::set_up_logging(&settings);
 
     let mut runtime = tokio::runtime::Runtime::new()?;

--- a/btsieve/src/settings/mod.rs
+++ b/btsieve/src/settings/mod.rs
@@ -79,13 +79,10 @@ fn default_log_levels() -> LogLevels {
 
 impl Settings {
     pub fn read<D: AsRef<OsStr>>(config_file: D) -> Result<Self, ConfigError> {
-        let mut config = Config::new();
-
         let config_file = Path::new(&config_file);
 
+        let mut config = Config::new();
         config.merge(File::from(config_file))?;
-
-        // You can deserialize (and thus freeze) the entire configuration as
         config.try_into()
     }
 }

--- a/cnd/src/config/file.rs
+++ b/cnd/src/config/file.rs
@@ -197,12 +197,11 @@ impl File {
     }
 }
 
-// Linux: /home/<user>/.config/cnd/
-// Windows: C:\Users\<user>\AppData\Roaming\comit-network\cnd\config\
-// OSX: /Users/<user>/Library/Preferences/comit-network.cnd/
+// Linux: /home/<user>/.config/comit/
+// Windows: C:\Users\<user>\AppData\Roaming\comit\config\
+// OSX: /Users/<user>/Library/Preferences/comit/
 fn config_dir() -> Option<PathBuf> {
-    ProjectDirs::from("", "comit-network", "cnd")
-        .map(|proj_dirs| proj_dirs.config_dir().to_path_buf())
+    ProjectDirs::from("", "", "comit").map(|proj_dirs| proj_dirs.config_dir().to_path_buf())
 }
 
 #[cfg(test)]

--- a/cnd/src/config/file.rs
+++ b/cnd/src/config/file.rs
@@ -141,17 +141,13 @@ impl File {
     }
 
     fn default_config_path() -> Result<PathBuf, config_rs::ConfigError> {
-        // Linux: /home/<user>/.config/cnd/cnd.toml
-        // Windows: C:\Users\<user>\AppData\Roaming\comit-network\cnd\config\cnd.toml
-        // OSX: /Users/<user>/Library/Preferences/comit-network.cnd/cnd.toml
-        if let Some(proj_dirs) = ProjectDirs::from("", "comit-network", "cnd") {
-            let path = proj_dirs.config_dir();
-            return Ok(Path::join(path, "cnd.toml"));
-        }
-
-        Err(config_rs::ConfigError::Message(
-            "Could not generate configuration directory".to_string(),
-        ))
+        config_dir()
+            .map(|dir| Path::join(&dir, "cnd.toml"))
+            .ok_or_else(|| {
+                config_rs::ConfigError::Message(
+                    "Could not generate default configuration path".to_string(),
+                )
+            })
     }
 
     fn ensure_directory_exists(config_file: &PathBuf) -> Result<(), config_rs::ConfigError> {
@@ -199,6 +195,14 @@ impl File {
             ))
         })
     }
+}
+
+// Linux: /home/<user>/.config/cnd/
+// Windows: C:\Users\<user>\AppData\Roaming\comit-network\cnd\config\
+// OSX: /Users/<user>/Library/Preferences/comit-network.cnd/
+fn config_dir() -> Option<PathBuf> {
+    ProjectDirs::from("", "comit-network", "cnd")
+        .map(|proj_dirs| proj_dirs.config_dir().to_path_buf())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
For the first out-of-sprint-scope day I chose to spend some time learning the `btsieve` codebase.  This PR is a result of that time.  Refactoring is limited to the config file / settings code including command line options.

Stripped down after comments from @thomaseizinger offline.

Also fixes: #1259 (tested on Linux, needs testing on OSX please @D4nte @da-kami or @bonomat)