### PR TITLE
Define enums for `AssetKind` and `LedgerKind`

### DIFF
--- a/cnd/src/http_api/with_swap_types.rs
+++ b/cnd/src/http_api/with_swap_types.rs
@@ -24,10 +24,8 @@ macro_rules! _match_role {
 macro_rules! with_swap_types {
     ($metadata:expr, $fn:tt) => {{
         use crate::swap_protocols::{
-            asset::AssetKind,
             ledger::{Bitcoin, Ethereum},
-            metadata_store::Metadata,
-            LedgerKind,
+            metadata_store::{AssetKind, LedgerKind, Metadata},
         };
         use bitcoin_support::BitcoinQuantity;
         use ethereum_support::{Erc20Token, EtherQuantity};
@@ -35,10 +33,10 @@ macro_rules! with_swap_types {
 
         match metadata {
             Metadata {
-                alpha_ledger: LedgerKind::Bitcoin(_),
-                beta_ledger: LedgerKind::Ethereum(_),
-                alpha_asset: AssetKind::Bitcoin(_),
-                beta_asset: AssetKind::Ether(_),
+                alpha_ledger: LedgerKind::Bitcoin,
+                beta_ledger: LedgerKind::Ethereum,
+                alpha_asset: AssetKind::Bitcoin,
+                beta_asset: AssetKind::Ether,
                 role,
                 ..
             } => {
@@ -56,10 +54,10 @@ macro_rules! with_swap_types {
                 _match_role!(role, $fn)
             }
             Metadata {
-                alpha_ledger: LedgerKind::Bitcoin(_),
-                beta_ledger: LedgerKind::Ethereum(_),
-                alpha_asset: AssetKind::Bitcoin(_),
-                beta_asset: AssetKind::Erc20(_),
+                alpha_ledger: LedgerKind::Bitcoin,
+                beta_ledger: LedgerKind::Ethereum,
+                alpha_asset: AssetKind::Bitcoin,
+                beta_asset: AssetKind::Erc20,
                 role,
                 ..
             } => {
@@ -77,10 +75,10 @@ macro_rules! with_swap_types {
                 _match_role!(role, $fn)
             }
             Metadata {
-                alpha_ledger: LedgerKind::Ethereum(_),
-                beta_ledger: LedgerKind::Bitcoin(_),
-                alpha_asset: AssetKind::Ether(_),
-                beta_asset: AssetKind::Bitcoin(_),
+                alpha_ledger: LedgerKind::Ethereum,
+                beta_ledger: LedgerKind::Bitcoin,
+                alpha_asset: AssetKind::Ether,
+                beta_asset: AssetKind::Bitcoin,
                 role,
                 ..
             } => {
@@ -98,10 +96,10 @@ macro_rules! with_swap_types {
                 _match_role!(role, $fn)
             }
             Metadata {
-                alpha_ledger: LedgerKind::Ethereum(_),
-                beta_ledger: LedgerKind::Bitcoin(_),
-                alpha_asset: AssetKind::Erc20(_),
-                beta_asset: AssetKind::Bitcoin(_),
+                alpha_ledger: LedgerKind::Ethereum,
+                beta_ledger: LedgerKind::Bitcoin,
+                alpha_asset: AssetKind::Erc20,
+                beta_asset: AssetKind::Bitcoin,
                 role,
                 ..
             } => {

--- a/cnd/src/swap_protocols/metadata_store.rs
+++ b/cnd/src/swap_protocols/metadata_store.rs
@@ -1,4 +1,4 @@
-use crate::swap_protocols::{asset::AssetKind, rfc003::Ledger, swap_id::SwapId, LedgerKind};
+use crate::swap_protocols::{asset, ledger, swap_id::SwapId};
 use failure::Fail;
 use libp2p::PeerId;
 use std::{
@@ -12,6 +12,40 @@ use std::{
 pub enum RoleKind {
     Alice,
     Bob,
+}
+
+#[derive(Debug, Clone)]
+pub enum LedgerKind {
+    Bitcoin,
+    Ethereum,
+}
+
+impl From<ledger::LedgerKind> for LedgerKind {
+    fn from(ledger: ledger::LedgerKind) -> LedgerKind {
+        match ledger {
+            ledger::LedgerKind::Bitcoin(_) => LedgerKind::Bitcoin,
+            ledger::LedgerKind::Ethereum(_) => LedgerKind::Ethereum,
+            _ => unimplemented!(""), // FIXME: How to handle the unknown variant?
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum AssetKind {
+    Bitcoin,
+    Ether,
+    Erc20,
+}
+
+impl From<asset::AssetKind> for AssetKind {
+    fn from(asset: asset::AssetKind) -> AssetKind {
+        match asset {
+            asset::AssetKind::Bitcoin(_) => AssetKind::Bitcoin,
+            asset::AssetKind::Ether(_) => AssetKind::Ether,
+            asset::AssetKind::Erc20(_) => AssetKind::Erc20,
+            _ => unimplemented!(""), // FIXME: How to handle the unknown variant?
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/cnd/src/swap_protocols/metadata_store.rs
+++ b/cnd/src/swap_protocols/metadata_store.rs
@@ -25,7 +25,9 @@ impl From<ledger::LedgerKind> for LedgerKind {
         match ledger {
             ledger::LedgerKind::Bitcoin(_) => LedgerKind::Bitcoin,
             ledger::LedgerKind::Ethereum(_) => LedgerKind::Ethereum,
-            _ => unimplemented!(""), // FIXME: How to handle the unknown variant?
+            // In order to remove this ledger::LedgerKind::Unknown should be removed.
+            // Doing so requires handling unknown ledger during deserialization.
+            _ => unreachable!(),
         }
     }
 }
@@ -43,7 +45,9 @@ impl From<asset::AssetKind> for AssetKind {
             asset::AssetKind::Bitcoin(_) => AssetKind::Bitcoin,
             asset::AssetKind::Ether(_) => AssetKind::Ether,
             asset::AssetKind::Erc20(_) => AssetKind::Erc20,
-            _ => unimplemented!(""), // FIXME: How to handle the unknown variant?
+            // In order to remove this ledger::AssetKind::Unknown should be removed.
+            // Doing so requires handling unknown asset during deserialization.
+            _ => unreachable!(),
         }
     }
 }

--- a/cnd/src/swap_protocols/metadata_store.rs
+++ b/cnd/src/swap_protocols/metadata_store.rs
@@ -16,13 +16,13 @@ pub enum RoleKind {
 
 #[derive(Clone, Debug)]
 pub struct Metadata {
+    pub swap_id: SwapId,
     pub alpha_ledger: LedgerKind,
     pub beta_ledger: LedgerKind,
     pub alpha_asset: AssetKind,
     pub beta_asset: AssetKind,
     pub role: RoleKind,
     pub counterparty: PeerId,
-    pub swap_id: SwapId,
 }
 
 #[derive(Debug, Fail)]

--- a/cnd/src/swap_protocols/metadata_store.rs
+++ b/cnd/src/swap_protocols/metadata_store.rs
@@ -1,4 +1,4 @@
-use crate::swap_protocols::{asset::AssetKind, swap_id::SwapId, LedgerKind};
+use crate::swap_protocols::{asset::AssetKind, rfc003::Ledger, swap_id::SwapId, LedgerKind};
 use failure::Fail;
 use libp2p::PeerId;
 use std::{
@@ -23,6 +23,28 @@ pub struct Metadata {
     pub beta_asset: AssetKind,
     pub role: RoleKind,
     pub counterparty: PeerId,
+}
+
+impl Metadata {
+    pub fn new(
+        swap_id: SwapId,
+        al: ledger::LedgerKind,
+        bl: ledger::LedgerKind,
+        aa: asset::AssetKind,
+        ba: asset::AssetKind,
+        role: RoleKind,
+        counterparty: PeerId,
+    ) -> Metadata {
+        Metadata {
+            swap_id,
+            alpha_ledger: al.into(),
+            beta_ledger: bl.into(),
+            alpha_asset: aa.into(),
+            beta_asset: ba.into(),
+            role,
+            counterparty,
+        }
+    }
 }
 
 #[derive(Debug, Fail)]

--- a/cnd/src/swap_protocols/rfc003/alice/spawner.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/spawner.rs
@@ -63,16 +63,18 @@ impl<T: MetadataStore<SwapId>, S: StateStore, C: Client> AliceSpawner
         let swap_request = partial_swap_request.to_request(swap_seed.as_ref());
         let alice = alice::State::new(swap_request.clone(), swap_seed);
 
+        let metadata = Metadata::new(
+            id,
+            swap_request.alpha_ledger.into(),
+            swap_request.beta_ledger.into(),
+            swap_request.alpha_asset.into(),
+            swap_request.beta_asset.into(),
+            RoleKind::Alice,
+            bob_dial_info.peer_id.to_owned(),
+        );
+
         self.metadata_store
-            .insert(id, Metadata {
-                swap_id: id,
-                alpha_ledger: swap_request.alpha_ledger.into(),
-                beta_ledger: swap_request.beta_ledger.into(),
-                alpha_asset: swap_request.alpha_asset.into(),
-                beta_asset: swap_request.beta_asset.into(),
-                role: RoleKind::Alice,
-                counterparty: bob_dial_info.peer_id.to_owned(),
-            })
+            .insert(id, metadata)
             .map_err(Error::Metadata)?;
 
         let (sender, receiver) = mpsc::unbounded();

--- a/cnd/src/swap_protocols/rfc003/alice/spawner.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/spawner.rs
@@ -65,13 +65,13 @@ impl<T: MetadataStore<SwapId>, S: StateStore, C: Client> AliceSpawner
 
         self.metadata_store
             .insert(id, Metadata {
+                swap_id: id,
                 alpha_ledger: swap_request.alpha_ledger.into(),
                 beta_ledger: swap_request.beta_ledger.into(),
                 alpha_asset: swap_request.alpha_asset.into(),
                 beta_asset: swap_request.beta_asset.into(),
                 role: RoleKind::Alice,
                 counterparty: bob_dial_info.peer_id.to_owned(),
-                swap_id: id,
             })
             .map_err(Error::Metadata)?;
 

--- a/cnd/src/swap_protocols/rfc003/bob/spawner.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/spawner.rs
@@ -66,13 +66,13 @@ impl<T: MetadataStore<SwapId>, S: StateStore> BobSpawner
 
         self.metadata_store
             .insert(id, Metadata {
+                swap_id: id,
                 alpha_ledger: swap_request.alpha_ledger.into(),
                 beta_ledger: swap_request.beta_ledger.into(),
                 alpha_asset: swap_request.alpha_asset.into(),
                 beta_asset: swap_request.beta_asset.into(),
                 role: RoleKind::Bob,
                 counterparty,
-                swap_id: id,
             })
             .map_err(Error::Metadata)?;
 

--- a/cnd/src/swap_protocols/rfc003/bob/spawner.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/spawner.rs
@@ -64,16 +64,18 @@ impl<T: MetadataStore<SwapId>, S: StateStore> BobSpawner
             .response_future()
             .expect("This is always Some when Bob is created");
 
+        let metadata = Metadata::new(
+            id,
+            swap_request.alpha_ledger.into(),
+            swap_request.beta_ledger.into(),
+            swap_request.alpha_asset.into(),
+            swap_request.beta_asset.into(),
+            RoleKind::Bob,
+            counterparty,
+        );
+
         self.metadata_store
-            .insert(id, Metadata {
-                swap_id: id,
-                alpha_ledger: swap_request.alpha_ledger.into(),
-                beta_ledger: swap_request.beta_ledger.into(),
-                alpha_asset: swap_request.alpha_asset.into(),
-                beta_asset: swap_request.beta_asset.into(),
-                role: RoleKind::Bob,
-                counterparty,
-            })
+            .insert(id, metadata)
             .map_err(Error::Metadata)?;
 
         let (sender, receiver) = mpsc::unbounded();


### PR DESCRIPTION
Currently we use `AssetKind` and `LedgerKind` from the ledger module within the `Metadata` structure.  These are defined as enums with associated invariant data.  `MetadataStore` however ignores the additional invariant data. 

This was found to be problematic for writing/reading to and from a `MetadataStore` SQL backed database.

This PR adds a `LedgerKind` and `AssetKind` enum within the `metadata_store` module.  We implement the `From` trait to convert from `ledger::LedgerKind` and `ledger::AssetKind` respectively.

Fixes: #1301 