### PR TITLE
Rewrite one test using property-based testing principles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1_keypair 0.1.0",
@@ -1046,6 +1047,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2820,6 +2833,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quickcheck"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quickcheck"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2939,6 +2963,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4918,6 +4950,7 @@ dependencies = [
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
 "checksum enum-display-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53f76eb63c4bfc6fce5000f106254701b741fc9a65ee08445fde0ff39e583f1c"
+"checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum ethabi 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ebdeeea85a6d217b9fcc862906d7e283c047e04114165c433756baf5dce00a6c"
@@ -5089,6 +5122,7 @@ dependencies = [
 "checksum publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5afecba86dcf1e4fd610246f89899d1924fe12e1e89f555eb7c7f710f3c5ad1d"
 "checksum quick-error 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5fb6ccf8db7bbcb9c2eae558db5ab4f3da1c2a87e4e597ed394726bc8ea6ca1d"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
+"checksum quickcheck 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4537d3e4edf73a15dd059b75bed1c292d17d3ea7517f583cebe716794fcf816"
 "checksum quickcheck 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5ca504a2fdaa08d3517f442fbbba91ac24d1ec4c51ea68688a038765e3b2662"
 "checksum quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7dfc1c4a1e048f5cc7d36a4c4118dfcf31d217c79f4b9a61bad65d68185752c"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
@@ -5101,6 +5135,7 @@ dependencies = [
 "checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
+"checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 "checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 "checksum rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "615e683324e75af5d43d8f7a39ffe3ee4a9dc42c5c701167a71dc59c3a493aca"

--- a/btsieve/Cargo.toml
+++ b/btsieve/Cargo.toml
@@ -40,6 +40,7 @@ zmq-rs = "0.1"
 env_logger = "0.6"
 hex = "0.3"
 lazy_static = "1.3.0"
+quickcheck = "0.7"
 secp256k1_keypair = { path = "../internal/secp256k1_keypair" }
 spectral = "0.6"
 tc_web3_client = { path = "../internal/tc_web3_client" }

--- a/btsieve/src/ethereum/queries/mod.rs
+++ b/btsieve/src/ethereum/queries/mod.rs
@@ -1,4 +1,6 @@
 pub mod event;
+#[cfg(test)]
+pub mod quickcheck;
 pub mod transaction;
 
 pub use self::{event::EventQuery, transaction::TransactionQuery};

--- a/btsieve/src/ethereum/queries/quickcheck.rs
+++ b/btsieve/src/ethereum/queries/quickcheck.rs
@@ -1,0 +1,93 @@
+use crate::web3::types::{Bytes, Transaction, H160, H256, U128, U256};
+use ::quickcheck::Arbitrary;
+
+#[derive(Clone, Debug)]
+pub struct Quickcheck<I>(pub I);
+
+impl From<Quickcheck<U128>> for U128 {
+    fn from(source: Quickcheck<U128>) -> Self {
+        source.0
+    }
+}
+
+impl Arbitrary for Quickcheck<U128> {
+    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        let mut inner = [0u8; 16];
+        g.fill_bytes(&mut inner);
+
+        Quickcheck(U128::from(&inner))
+    }
+}
+
+impl From<Quickcheck<U256>> for U256 {
+    fn from(source: Quickcheck<U256>) -> Self {
+        source.0
+    }
+}
+
+impl Arbitrary for Quickcheck<U256> {
+    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        let mut inner = [0u8; 32];
+        g.fill_bytes(&mut inner);
+
+        Quickcheck(U256::from(&inner))
+    }
+}
+
+impl From<Quickcheck<H160>> for H160 {
+    fn from(source: Quickcheck<H160>) -> Self {
+        source.0
+    }
+}
+
+impl Arbitrary for Quickcheck<H160> {
+    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        let mut inner = [0u8; 20];
+        g.fill_bytes(&mut inner);
+
+        Quickcheck(H160::from(&inner))
+    }
+}
+
+impl From<Quickcheck<H256>> for H256 {
+    fn from(source: Quickcheck<H256>) -> Self {
+        source.0
+    }
+}
+
+impl Arbitrary for Quickcheck<H256> {
+    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        let mut inner = [0u8; 32];
+        g.fill_bytes(&mut inner);
+
+        Quickcheck(H256::from(&inner))
+    }
+}
+
+impl From<Quickcheck<Transaction>> for Transaction {
+    fn from(source: Quickcheck<Transaction>) -> Self {
+        source.0
+    }
+}
+
+impl Arbitrary for Quickcheck<Transaction> {
+    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        Quickcheck(Transaction {
+            hash: <Quickcheck<H256> as Arbitrary>::arbitrary(g).into(),
+            nonce: <Quickcheck<U256> as Arbitrary>::arbitrary(g).into(),
+            block_hash: Option::arbitrary(g)
+                .map(|quickcheck_h256: Quickcheck<H256>| H256::from(quickcheck_h256)),
+            block_number: Option::arbitrary(g)
+                .map(|quickcheck_u256: Quickcheck<U256>| U256::from(quickcheck_u256)),
+            transaction_index: Option::arbitrary(g)
+                .map(|quickcheck_u128: Quickcheck<U128>| U128::from(quickcheck_u128)),
+            from: <Quickcheck<H160> as Arbitrary>::arbitrary(g).into(),
+            to: Option::arbitrary(g)
+                .map(|quickcheck_h160: Quickcheck<H160>| H160::from(quickcheck_h160)),
+            value: <Quickcheck<U256> as Arbitrary>::arbitrary(g).into(),
+            gas_price: <Quickcheck<U256> as Arbitrary>::arbitrary(g).into(),
+            gas: <Quickcheck<U256> as Arbitrary>::arbitrary(g).into(),
+            input: Bytes(Arbitrary::arbitrary(g)),
+        })
+    }
+}

--- a/btsieve/src/ethereum/queries/quickcheck.rs
+++ b/btsieve/src/ethereum/queries/quickcheck.rs
@@ -75,15 +75,12 @@ impl Arbitrary for Quickcheck<Transaction> {
         Quickcheck(Transaction {
             hash: <Quickcheck<H256> as Arbitrary>::arbitrary(g).into(),
             nonce: <Quickcheck<U256> as Arbitrary>::arbitrary(g).into(),
-            block_hash: Option::arbitrary(g)
-                .map(|quickcheck_h256: Quickcheck<H256>| H256::from(quickcheck_h256)),
-            block_number: Option::arbitrary(g)
-                .map(|quickcheck_u256: Quickcheck<U256>| U256::from(quickcheck_u256)),
-            transaction_index: Option::arbitrary(g)
-                .map(|quickcheck_u128: Quickcheck<U128>| U128::from(quickcheck_u128)),
+            block_hash: <Option<Quickcheck<H256>> as Arbitrary>::arbitrary(g).map(H256::from),
+            block_number: <Option<Quickcheck<U256>> as Arbitrary>::arbitrary(g).map(U256::from),
+            transaction_index: <Option<Quickcheck<U128>> as Arbitrary>::arbitrary(g)
+                .map(U128::from),
             from: <Quickcheck<H160> as Arbitrary>::arbitrary(g).into(),
-            to: Option::arbitrary(g)
-                .map(|quickcheck_h160: Quickcheck<H160>| H160::from(quickcheck_h160)),
+            to: <Option<Quickcheck<H160>> as Arbitrary>::arbitrary(g).map(H160::from),
             value: <Quickcheck<U256> as Arbitrary>::arbitrary(g).into(),
             gas_price: <Quickcheck<U256> as Arbitrary>::arbitrary(g).into(),
             gas: <Quickcheck<U256> as Arbitrary>::arbitrary(g).into(),

--- a/btsieve/src/ethereum/queries/transaction.rs
+++ b/btsieve/src/ethereum/queries/transaction.rs
@@ -141,7 +141,7 @@ mod tests {
             query.matches(&transaction)
         }
 
-        quickcheck::quickcheck(prop as fn(Quickcheck<H160>, Quickcheck<Transaction>) -> bool)
+        quickcheck::quickcheck(prop as fn(Quickcheck<Address>, Quickcheck<Transaction>) -> bool)
     }
 
     #[test]


### PR DESCRIPTION
This PR just introduces an approach to property-based testing for the codebase. It is tied to a library choice, in this case [quickcheck](https://github.com/BurntSushi/quickcheck).

It introduces a tests-only `Quickcheck<T>` struct which can wrap around any type `T` for which we want to implement a trait (`quickcheck::Arbitrary`) that allows us to generate random values. This is done to circumvent [Rust orphan rules](https://github.com/Ixrec/rust-orphan-rules), which prevent us from implementing foreign traits on foreign types.

It only modifies one test, but if we like the idea we can extend it to more tests within btsieve.