### PR TITLE
Allow release build to be done on branches with `release` prefix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ workflows:
       - release-build-test:
           filters: # runs for "release/" branches and all tags.
             branches:
-              only: /^release\/.*$/
+              only: /^release.*$/
             tags:
               only: /.*/
       - publish-github-release:


### PR DESCRIPTION
Instead of `release/` so that when doing something specific to the
release build, the branch can be named `release-foo-bar` and run the
release build instead of being named `release/foo-bar`.