### PR TITLE
Statically link latest openssl lib in release binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,6 @@ jobs:
           command: |
             set -v
             cd ~/ && curl -O https://www.openssl.org/source/openssl-1.1.1c.tar.gz
-            # TODO: checksum, see https://www.openssl.org/source/openssl-fips-ecp-2.0.16.tar.gz.sha256
             tar xaf openssl-1.1.1c.tar.gz
             mkdir ~/openssl
             cd openssl-1.1.1c && ./config --prefix=$HOME/openssl -static

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,17 +56,18 @@ jobs:
       - run:
           name: "Compile openssl static libs"
           command: |
+            set -v
             cd ~/ && curl -O https://www.openssl.org/source/openssl-1.1.1c.tar.gz
             # TODO: checksum, see https://www.openssl.org/source/openssl-fips-ecp-2.0.16.tar.gz.sha256
-            tar xavf openssl-1.1.1c.tar.gz
+            tar xaf openssl-1.1.1c.tar.gz
             mkdir ~/openssl
-            cd openssl-1.1.1c && ./config --prefix ~/openssl -static
+            cd openssl-1.1.1c && ./config --prefix=$HOME/openssl -static
             make
             make install
       - run:
           name: Release build and test using cargo make
           command: |
-            export OPENSSL_DIR=~/openssl/
+            export OPENSSL_DIR=$HOME/openssl/
             export OPENSSL_STATIC=1
             export CARGO_MAKE_CARGO_BUILD_TEST_FLAGS="--all --release"
             export BTSIEVE_BIN=~/comit/target/release/btsieve

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,20 @@ jobs:
       - install_node_devlibs
       - print_current_versions
       - run:
+          name: "Compile openssl static libs"
+          command: |
+            cd ~/ && curl -O https://www.openssl.org/source/openssl-1.1.1c.tar.gz
+            # TODO: checksum, see https://www.openssl.org/source/openssl-fips-ecp-2.0.16.tar.gz.sha256
+            tar xavf openssl-1.1.1c.tar.gz
+            mkdir ~/openssl
+            cd openssl-1.1.1c && ./config --prefix ~/openssl -static
+            make
+            make install
+      - run:
           name: Release build and test using cargo make
           command: |
+            export OPENSSL_DIR=~/openssl/
+            export OPENSSL_STATIC=1
             export CARGO_MAKE_CARGO_BUILD_TEST_FLAGS="--all --release"
             export BTSIEVE_BIN=~/comit/target/release/btsieve
             export CND_BIN=~/comit/target/release/cnd


### PR DESCRIPTION
Fixes #1366

Please note openssl is the only problematic library.
ZMQ is also an issue but will be removed with #1131.
All other dynamically linked libraries are system libraries:
```
# ldd ./target/release/btsieve
    linux-vdso.so.1 =>  (0x00007fff7bfef000)
    libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007fe6cd8fd000)
    libzmq.so.5 => /usr/lib/x86_64-linux-gnu/libzmq.so.5 (0x00007fe6cd697000)
    libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fe6cd493000)
    librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fe6cd28b000)
    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fe6cd06e000)
    libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fe6cce58000)
    libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fe6cca8e000)
    /lib64/ld-linux-x86-64.so.2 (0x00007fe6ce7de000)
    libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fe6cc785000)
    libsodium.so.18 => /usr/lib/x86_64-linux-gnu/libsodium.so.18 (0x00007fe6cc527000)
    libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fe6cc1a5000)
# ldd ./target/release/cnd
    linux-vdso.so.1 =>  (0x00007ffdedffb000)
    libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f63589db000)
    libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f63587d7000)
    librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f63585cf000)
    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f63583b2000)
    libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f635819c000)
    libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f6357dd2000)
    /lib64/ld-linux-x86-64.so.2 (0x00007f635a96f000)
    libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f6357ac9000)
```

The resulting binaries have been tested on:
- Ubuntu 19.094
- Latest debian
- Latest fedora

No issue encountered (except for ZMQ).

Fixes #1366 
Supersedes #1368