### PR TITLE
Remove testcontainers dev dependency from cnd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,7 +642,6 @@ dependencies = [
  "tc_bitcoincore_client 0.1.0",
  "tc_web3_client 0.1.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "testcontainers 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,8 +639,6 @@ dependencies = [
  "structopt 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tc_bitcoincore_client 0.1.0",
- "tc_web3_client 0.1.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -67,7 +67,5 @@ quickcheck_macros = "0.8.0"
 regex = "1.3.1"
 serde_urlencoded = "0.6"
 spectral = "0.6"
-tc_bitcoincore_client = { path = "../internal/tc_bitcoincore_client" }
-tc_web3_client = { path = "../internal/tc_web3_client" }
 tempfile = "3.1.0"
 tiny-keccak = "1.5"

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -70,5 +70,4 @@ spectral = "0.6"
 tc_bitcoincore_client = { path = "../internal/tc_bitcoincore_client" }
 tc_web3_client = { path = "../internal/tc_web3_client" }
 tempfile = "3.1.0"
-testcontainers = "0.7"
 tiny-keccak = "1.5"


### PR DESCRIPTION
`testcontainers` is an unused dev dependency in cnd.