### PR TITLE
Couple of improvements to the BitcoindHttpBlockSource

### DIFF
--- a/btsieve/src/bitcoin/bitcoind_http_blocksource.rs
+++ b/btsieve/src/bitcoin/bitcoind_http_blocksource.rs
@@ -1,5 +1,5 @@
 use crate::blocksource::{self, BlockSource};
-use bitcoin_support::{deserialize, Block, Network, Transaction};
+use bitcoin_support::{consensus::Decodable, deserialize, Block, Network, Transaction};
 use futures::{Future, Stream};
 use reqwest::r#async::Client;
 use serde::Deserialize;
@@ -15,8 +15,7 @@ struct ChainInfo {
 pub enum Error {
     Reqwest(reqwest::Error),
     Hex(hex::FromHexError),
-    BlockDeserialization(bitcoin_support::consensus::encode::Error),
-    TransactionDeserialization(String),
+    Deserialization(bitcoin_support::consensus::encode::Error),
 }
 
 #[derive(Clone)]
@@ -72,11 +71,7 @@ impl BitcoindHttpBlockSource {
             .send()
             .map_err(Error::Reqwest)
             .and_then(|mut response| response.text().map_err(Error::Reqwest))
-            .and_then(move |mut response_text| {
-                response_text = response_text.as_str().trim().to_string();
-                hex::decode(response_text).map_err(Error::Hex)
-            })
-            .and_then(|bytes| deserialize(bytes.as_ref()).map_err(Error::BlockDeserialization))
+            .and_then(decode_response)
             .map(move |block| {
                 log::trace!("Got {:?}", block);
                 block
@@ -95,23 +90,8 @@ impl BitcoindHttpBlockSource {
             .send()
             .map_err(Error::Reqwest)
             .and_then(|mut response| response.text().map_err(Error::Reqwest))
-            .and_then(move |mut response_text| {
-                response_text = response_text.as_str().trim().to_string();
-                hex::decode(response_text).map_err(Error::Hex)
-            })
-            .and_then(|bytes| {
-                deserialize(bytes.as_ref()).map_err(|e| {
-                    log::error!(
-                        "Got new transaction but failed to deserialize it because {:?}",
-                        e
-                    );
-                    Error::TransactionDeserialization(format!(
-                        "Failed to deserialize the response from bitcoind into a transaction: {}",
-                        e
-                    ))
-                })
-            })
-            .inspect(move |transaction| {
+            .and_then(decode_response)
+            .map(move |transaction| {
                 log::debug!("Fetched transaction {:?}", transaction);
             })
     }
@@ -153,11 +133,10 @@ impl BlockSource for BitcoindHttpBlockSource {
                                 log::warn!(target: "bitcoin::blocksource", "hex-decode error encountered during polling: {:?}", e);
                                 Ok(None)
                             }
-                            Error::BlockDeserialization(e) => {
-                                log::warn!(target: "bitcoin::blocksource", "block-deserialization error encountered during polling: {:?}", e);
+                            Error::Deserialization(e) => {
+                                log::warn!(target: "bitcoin::blocksource", "deserialization error encountered during polling: {:?}", e);
                                 Ok(None)
                             }
-                            _ => Err(error)
                         }
                     })
                     .map_err(blocksource::Error::Source)
@@ -165,5 +144,40 @@ impl BlockSource for BitcoindHttpBlockSource {
             .filter_map(|maybe_block| maybe_block);
 
         Box::new(stream)
+    }
+}
+
+fn decode_response<T: Decodable>(response_text: String) -> Result<T, Error> {
+    let bytes = hex::decode(response_text.trim()).map_err(Error::Hex)?;
+
+    deserialize(bytes.as_slice()).map_err(Error::Deserialization)
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use spectral::prelude::*;
+
+    #[test]
+    fn can_decode_tx_from_bitcoind_http_interface() {
+        // the line break here is on purpose, as it is returned like that from bitcoind
+        let transaction = r#"02000000014135047eff77c95bce4955f630bc3e334690d31517176dbc23e9345493c48ecf000000004847304402200da78118d6970bca6f152a6ca81fa8c4dde856680eb6564edb329ce1808207c402203b3b4890dd203cc4c9361bbbeb7ebce70110d4b07f411208b2540b10373755ba01feffffff02644024180100000017a9142464790f3a3fddb132691fac9fd02549cdc09ff48700a3e1110000000017a914c40a2c4fd9dcad5e1694a41ca46d337eb59369d78765000000
+"#.to_owned();
+
+        let bytes = decode_response::<Transaction>(transaction);
+
+        assert_that(&bytes).is_ok();
+    }
+
+    #[test]
+    fn can_decode_block_from_bitcoind_http_interface() {
+        // the line break here is on purpose, as it is returned like that from bitcoind
+        let transaction = r#"00000020837603de6069115e22e7fbf063c2a6e3bc3b3206f0b7e08d6ab6c168c2e50d4a9b48676dedc93d05f677778c1d83df28fd38d377548340052823616837666fb8be1b795dffff7f200000000001020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0401650101ffffffff0200f2052a0100000023210205980e76eee77386241a3a7a5af65e910fb7be411b98e609f7c0d97c50ab8ebeac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000
+"#.to_owned();
+
+        let bytes = decode_response::<Block>(transaction);
+
+        assert_that(&bytes).is_ok();
     }
 }

--- a/btsieve/src/bitcoin/bitcoind_http_blocksource.rs
+++ b/btsieve/src/bitcoin/bitcoind_http_blocksource.rs
@@ -69,8 +69,8 @@ impl BitcoindHttpBlockSource {
         self.client
             .get(raw_block_by_hash_url.as_str())
             .send()
+            .and_then(|mut response| response.text())
             .map_err(Error::Reqwest)
-            .and_then(|mut response| response.text().map_err(Error::Reqwest))
             .and_then(decode_response)
             .map(move |block| {
                 log::trace!("Got {:?}", block);
@@ -88,8 +88,8 @@ impl BitcoindHttpBlockSource {
         self.client
             .get(raw_transaction_by_hash_url.as_str())
             .send()
+            .and_then(|mut response| response.text())
             .map_err(Error::Reqwest)
-            .and_then(|mut response| response.text().map_err(Error::Reqwest))
             .and_then(decode_response)
             .map(move |transaction| {
                 log::debug!("Fetched transaction {:?}", transaction);

--- a/btsieve/src/bitcoin/bitcoind_http_blocksource.rs
+++ b/btsieve/src/bitcoin/bitcoind_http_blocksource.rs
@@ -72,9 +72,8 @@ impl BitcoindHttpBlockSource {
             .and_then(|mut response| response.text())
             .map_err(Error::Reqwest)
             .and_then(decode_response)
-            .map(move |block| {
-                log::trace!("Got {:?}", block);
-                block
+            .inspect(|block| {
+                log::trace!("Fetched block: {:?}", block);
             })
     }
 
@@ -91,8 +90,8 @@ impl BitcoindHttpBlockSource {
             .and_then(|mut response| response.text())
             .map_err(Error::Reqwest)
             .and_then(decode_response)
-            .map(move |transaction| {
-                log::debug!("Fetched transaction {:?}", transaction);
+            .inspect(|transaction| {
+                log::debug!("Fetched transaction: {:?}", transaction);
             })
     }
 }


### PR DESCRIPTION
While reviewing #1371, I noticed a couple of things that could be optimized.
Here is my attempt in doing so! :)

My main motivation was the implementation of the `remove_trailing_newline` function because it can actually we be replaced with `.trim()` since newlines are whitespaces characters. However, that led to it no longer being tested or at least the tests were no longer useful. Hence I got example responses from bitcoind and extracted the whole response decoding into a function again which makes to test (because the test actually fails if we don't include the `trim`).

I am opening this PR directly against #1371, however, feel free to merge #1371 first and then re-target this to master! Whatever you prefer :)

The PR contains three commits, each explaining why I am suggesting certain changes.