### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,7 @@ See [#626](https://github.com/comit-network/comit-rs/issues/626) for tracking.
 
 ## Setup build environment
 
-1. Install `rustup`: `curl https://sh.rustup.rs -sSf | sh`
-2. Install libzmq:
-   - Ubuntu/Debian: `apt install libzmq3-dev`
-   - Mac ([Homebrew](https://brew.sh/)) `brew install zeromq`
-3. Install OpenSSL:
-   - Ubuntu/Debian: `apt install libssl-dev pkg-config`
+All you need is ~love~ rust: `curl https://sh.rustup.rs -sSf | sh` 
 
 ## Build & Run
 


### PR DESCRIPTION
With PR #1376, we no longer need to have openssl installed for development since it is compiled automatically.

This PR also removes the installation instruction for zmq, which is actually only done in #1371. However, otherwise the joke would have not worked.