### PR TITLE
Remove TODO in favor of dedicated ticket

### DIFF
--- a/blockchain_contracts/tests/ethereum_helper/to_ethereum_address.rs
+++ b/blockchain_contracts/tests/ethereum_helper/to_ethereum_address.rs
@@ -1,7 +1,6 @@
 use rust_bitcoin::secp256k1::PublicKey;
 use web3::types::Address;
 
-// TODO: Should/Can this be contributed back?
 pub trait ToEthereumAddress {
     fn to_ethereum_address(&self) -> Address;
 }


### PR DESCRIPTION
The reason why the TODO was added was because the code should be moved eventually. Hence I think it is better suited if we have a dedicated clean-up ticket that includes this instead of a TODO on this repository.

Here is the follow-up ticket: https://github.com/coblox/blockchain-contracts/issues/9