### PR TITLE
Add timestamps to cnd

### DIFF
--- a/cnd/src/http_api/routes/rfc003/swap_state.rs
+++ b/cnd/src/http_api/routes/rfc003/swap_state.rs
@@ -60,7 +60,7 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> From<alice::SwapCommunication
     fn from(communication: alice::SwapCommunication<AL, BL, AA, BA>) -> Self {
         use self::alice::SwapCommunication::*;
         match communication {
-            Proposed { request } => Self {
+            Proposed { request, .. } => Self {
                 status: SwapCommunicationState::Sent,
                 alpha_expiry: request.alpha_expiry,
                 beta_expiry: request.beta_expiry,
@@ -70,7 +70,9 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> From<alice::SwapCommunication
                 beta_refund_identity: None,
                 secret_hash: request.secret_hash,
             },
-            Accepted { request, response } => Self {
+            Accepted {
+                request, response, ..
+            } => Self {
                 status: SwapCommunicationState::Accepted,
                 alpha_expiry: request.alpha_expiry,
                 beta_expiry: request.beta_expiry,
@@ -110,7 +112,9 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> From<bob::SwapCommunication<A
                 beta_refund_identity: None,
                 secret_hash: request.secret_hash,
             },
-            Accepted { request, response } => Self {
+            Accepted {
+                request, response, ..
+            } => Self {
                 status: SwapCommunicationState::Accepted,
                 alpha_expiry: request.alpha_expiry,
                 beta_expiry: request.beta_expiry,

--- a/cnd/src/lib.rs
+++ b/cnd/src/lib.rs
@@ -27,6 +27,7 @@ pub mod network;
 pub mod seed;
 pub mod std_ext;
 pub mod swap_protocols;
+pub mod timestamp;
 
 use directories::ProjectDirs;
 use std::path::PathBuf;

--- a/cnd/src/swap_protocols/rfc003/alice/actions/erc20.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/actions/erc20.rs
@@ -29,10 +29,11 @@ where
     >;
 
     fn actions(&self) -> Vec<Self::ActionKind> {
-        let (request, response) = match self.swap_communication {
+        let (request, response, ..) = match self.swap_communication {
             SwapCommunication::Accepted {
                 ref request,
                 ref response,
+                ..
             } => (request, response),
             _ => return vec![],
         };
@@ -92,6 +93,7 @@ where
             SwapCommunication::Accepted {
                 ref request,
                 ref response,
+                ..
             } => (request, response),
             _ => return vec![],
         };

--- a/cnd/src/swap_protocols/rfc003/alice/actions/generic_impl.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/actions/generic_impl.rs
@@ -35,6 +35,7 @@ where
             SwapCommunication::Accepted {
                 ref request,
                 ref response,
+                ..
             } => (request, response),
             _ => return vec![],
         };

--- a/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
@@ -12,6 +12,7 @@ use crate::{
             state_machine::HtlcParams,
         },
     },
+    timestamp,
 };
 use bitcoin_support::{Amount, FindOutput, OutPoint};
 use futures::{
@@ -45,6 +46,7 @@ impl HtlcEvents<Bitcoin, Amount> for Arc<dyn QueryBitcoin + Send + Sync> {
                         vout,
                     },
                     transaction: tx,
+                    when: timestamp::now(),
                 })
             });
 
@@ -61,6 +63,7 @@ impl HtlcEvents<Bitcoin, Amount> for Arc<dyn QueryBitcoin + Send + Sync> {
         Box::new(future::ok(Funded {
             transaction: tx.clone(),
             asset,
+            when: timestamp::now(),
         }))
     }
 
@@ -113,6 +116,7 @@ impl HtlcEvents<Bitcoin, Amount> for Arc<dyn QueryBitcoin + Send + Sync> {
                         Ok(Redeemed {
                             transaction,
                             secret,
+                            when: timestamp::now(),
                         })
                     })
             })

--- a/cnd/src/swap_protocols/rfc003/bob/actions/erc20.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/actions/erc20.rs
@@ -44,6 +44,7 @@ where
             SwapCommunication::Accepted {
                 ref request,
                 ref response,
+                ..
             } => (request, response),
             _ => return vec![],
         };
@@ -119,6 +120,7 @@ where
             SwapCommunication::Accepted {
                 ref request,
                 ref response,
+                ..
             } => (request, response),
             _ => return vec![],
         };

--- a/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
@@ -46,6 +46,7 @@ where
             SwapCommunication::Accepted {
                 ref request,
                 ref response,
+                ..
             } => (request, response),
             _ => return vec![],
         };

--- a/cnd/src/swap_protocols/rfc003/ethereum/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/ethereum/htlc_events.rs
@@ -13,6 +13,7 @@ use crate::{
             Secret,
         },
     },
+    timestamp,
 };
 use ethereum_support::{
     web3::types::Address, CalculateContractAddress, Erc20Token, EtherQuantity, Transaction,
@@ -50,6 +51,7 @@ impl HtlcEvents<Ethereum, EtherQuantity> for Arc<dyn QueryEthereum + Send + Sync
             .map(|tx| Deployed {
                 location: calcualte_contract_address_from_deployment_transaction(&tx),
                 transaction: tx,
+                when: timestamp::now(),
             });
 
         Box::new(deployed_future)
@@ -63,6 +65,7 @@ impl HtlcEvents<Ethereum, EtherQuantity> for Arc<dyn QueryEthereum + Send + Sync
         Box::new(future::ok(Funded {
             transaction: deploy_transaction.transaction.clone(),
             asset: EtherQuantity::from_wei(deploy_transaction.transaction.value),
+            when: timestamp::now(),
         }))
     }
 
@@ -136,6 +139,7 @@ fn htlc_redeemed_or_refunded<A: Asset>(
                     Ok(Redeemed {
                             transaction,
                             secret,
+                        when: timestamp::now(),
                     })
                 })
             })
@@ -176,6 +180,7 @@ mod erc20 {
                 .map(|tx| Deployed {
                     location: calcualte_contract_address_from_deployment_transaction(&tx),
                     transaction: tx,
+                    when: timestamp::now(),
                 });
 
             Box::new(deployed_future)
@@ -216,7 +221,7 @@ mod erc20 {
                             let quantity = Erc20Quantity(U256::from_big_endian(log.data.0.as_ref()));
                             let asset = Erc20Token::new(log.address, quantity);
 
-                            Funded { transaction, asset }
+                            Funded { transaction, asset, when: timestamp::now(), }
                         })
                     },
                 );

--- a/cnd/src/swap_protocols/rfc003/events/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/events/mod.rs
@@ -6,15 +6,18 @@ mod ledger_event_futures;
 
 pub use self::ledger_event_futures::*;
 
-use crate::swap_protocols::{
-    asset::Asset,
-    rfc003::{
-        self,
-        ledger::Ledger,
-        messages::{AcceptResponseBody, DeclineResponseBody},
-        state_machine::HtlcParams,
-        Secret,
+use crate::{
+    swap_protocols::{
+        asset::Asset,
+        rfc003::{
+            self,
+            ledger::Ledger,
+            messages::{AcceptResponseBody, DeclineResponseBody},
+            state_machine::HtlcParams,
+            Secret,
+        },
     },
+    timestamp::{self, Timestamp},
 };
 use serde::{Deserialize, Serialize};
 use tokio::{self, prelude::future::Either};
@@ -28,28 +31,35 @@ pub type ResponseFuture<AL, BL> = Future<Result<AcceptResponseBody<AL, BL>, Decl
 pub struct Funded<L: Ledger, A: Asset> {
     pub transaction: L::Transaction,
     pub asset: A,
+    pub when: Timestamp,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Redeemed<L: Ledger> {
     pub transaction: L::Transaction,
     pub secret: Secret,
+    pub when: Timestamp,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Deployed<L: Ledger> {
     pub transaction: L::Transaction,
     pub location: L::HtlcLocation,
+    pub when: Timestamp,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Refunded<L: Ledger> {
     pub transaction: L::Transaction,
+    pub when: Timestamp,
 }
 
 impl<L: Ledger> Refunded<L> {
     pub fn new(transaction: L::Transaction) -> Self {
-        Self { transaction }
+        Self {
+            transaction,
+            when: timestamp::now(),
+        }
     }
 }
 

--- a/cnd/src/timestamp.rs
+++ b/cnd/src/timestamp.rs
@@ -1,6 +1,7 @@
+use serde::{Deserialize, Serialize};
 use std::time::SystemTime;
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
 pub struct Timestamp(SystemTime);
 
 pub fn now() -> Timestamp {

--- a/cnd/src/timestamp.rs
+++ b/cnd/src/timestamp.rs
@@ -1,0 +1,18 @@
+use std::time::SystemTime;
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct Timestamp(SystemTime);
+
+pub fn now() -> Timestamp {
+    Timestamp(SystemTime::now())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_create_timestamp() {
+        let _ts = now();
+    }
+}


### PR DESCRIPTION
We are working on the assumption that COMIT protocol events should have an associated timestamp.

This PR adds timestamps for COMIT message events and also for ledger events.  As described in the issue ledger events are only added as cnd perceives the event.  Please see the issue below for more information on scope of this Pr (including the fact that this PR does _not_ expose the timestamps to cnd clients).

This PR is quite tightly scoped, new issues have been created for the next steps.

Resolves: #1252 