### PR TITLE
Use the bundled feature of libsqlite3-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-comit 0.1.0",
+ "libsqlite3-sys 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2065,6 +2066,7 @@ name = "libsqlite3-sys"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -33,6 +33,7 @@ hyper = "0.12"
 lazy_static = "1"
 libp2p = { version = "0.12" }
 libp2p-comit = { path = "../libp2p-comit" }
+libsqlite3-sys = { version = ">=0.8.0, <0.13.0", features = ["bundled"] }
 log = { version = "0.4", features = ["serde"] }
 maplit = "1"
 mime = "0.3"


### PR DESCRIPTION
This avoids a compile-time dependency on libsqlite3-dev and a runtime dependency on the shared libsqlite3 library.