### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2019-10-02
 ### Changed
 - Embed btsieve as a library inside cnd: From now on, you'll only need to run cnd to use COMIT.
 
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move config files to standard location based on platform (OSX, Windows, Linux).
 - Align implementation with RFC-002 to use the decision header instead of status codes.
 
-[Unreleased]: https://github.com/comit-network/comit-rs/compare/0.2.1...HEAD
+[Unreleased]: https://github.com/comit-network/comit-rs/compare/0.3.0...HEAD
+[0.3.0]: https://github.com/comit-network/comit-rs/compare/0.2.1...0.3.0
 [0.2.1]: https://github.com/comit-network/comit-rs/compare/0.2.0...0.2.1
 [0.2.0]: https://github.com/comit-network/comit-rs/compare/b2dd02a7f93dc82f5cc9fd4b6eaaf54de1459ff6...40116c3e8a9f57a213661917b8cc057e1db60755
 [0.1.0]: https://github.com/comit-network/comit-rs/compare/1625533e04119e8496b14d5e18786f150b4fce4d...b2dd02a7f93dc82f5cc9fd4b6eaaf54de1459ff6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "cnd"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "binary_macros 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin_rpc_test_helpers 0.1.0",

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["CoBloX developers <team@coblox.tech>"]
 name = "cnd"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2018"
 description = "Reference implementation of a COMIT network daemon."
 


### PR DESCRIPTION
## [0.3.0] - 2019-10-02
### Changed
- Embed btsieve as a library inside cnd: From now on, you'll only need to run cnd to use COMIT.

Resolves #1474.