### PR TITLE
Remove unnecessary adaptor

### DIFF
--- a/cnd/src/http_api/problem.rs
+++ b/cnd/src/http_api/problem.rs
@@ -14,7 +14,6 @@ pub struct MissingQueryParameter {
     pub description: &'static str,
 }
 
-
 pub fn state_store() -> HttpApiProblem {
     log::error!("State store didn't have state in it despite having the metadata");
     HttpApiProblem::with_title_and_type_from_status(StatusCode::INTERNAL_SERVER_ERROR)
@@ -127,9 +126,7 @@ pub fn unpack_problem(rejection: Rejection) -> Result<impl Reply, Rejection> {
     if let Some(err) = rejection.find_cause::<HttpApiProblem>() {
         log::debug!(target: "http-api", "HTTP request got rejected, returning HttpApiProblem response: {:?}", err);
 
-        let code = err
-            .status
-            .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        let code = err.status.unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
         let json = warp::reply::json(err);
         return Ok(warp::reply::with_status(json, code));
     }

--- a/cnd/src/http_api/routes/mod.rs
+++ b/cnd/src/http_api/routes/mod.rs
@@ -1,4 +1,3 @@
-use crate::http_api::HttpApiProblemStdError;
 use http_api_problem::HttpApiProblem;
 use warp::Rejection;
 
@@ -7,5 +6,5 @@ pub mod peers;
 pub mod rfc003;
 
 pub fn into_rejection(problem: HttpApiProblem) -> Rejection {
-    warp::reject::custom(HttpApiProblemStdError::from(problem))
+    warp::reject::custom(problem)
 }


### PR DESCRIPTION
Removes the custom adaptor struct for HttpApiProblem that is no longer needed.

Closes #1437 