### PR TITLE
Remove IntoP2wpkhAddress trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ name = "backtrace-sys"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -207,7 +207,7 @@ dependencies = [
  "bitcoin_hashes 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secp256k1 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -224,7 +224,7 @@ dependencies = [
 name = "bitcoin_rpc_test_helpers"
 version = "0.1.0"
 dependencies = [
- "bitcoin_support 0.1.0",
+ "bitcoin 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoincore-rpc 0.8.0-rc1 (registry+https://github.com/rust-lang/crates.io-index)",
  "testcontainers 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -467,7 +467,7 @@ name = "bzip2-sys"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -487,7 +487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
-version = "1.0.26"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -541,7 +541,7 @@ name = "clear_on_drop"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1618,6 +1618,7 @@ dependencies = [
 name = "key_gen"
 version = "0.1.0"
 dependencies = [
+ "bitcoin 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin_support 0.1.0",
  "ethereum_support 0.1.0",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2066,7 +2067,7 @@ name = "libsqlite3-sys"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2076,7 +2077,7 @@ name = "libz-sys"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2223,7 +2224,7 @@ name = "miniz-sys"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3119,7 +3120,7 @@ name = "ring"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3296,10 +3297,11 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.12.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3309,7 +3311,7 @@ version = "0.1.0"
 dependencies = [
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secp256k1 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4646,7 +4648,7 @@ dependencies = [
 "checksum bzip2-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6584aa36f5ad4c9247f5323b0a42f37802b37a836f0ad87084d7a33961abe25f"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum c_linked_list 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
-"checksum cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "389803e36973d242e7fecb092b2de44a3d35ac62524b3b9339e51d577d668e02"
+"checksum cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "64a4b57c8f4e3a2e9ac07e0f6abc9c24b6fc9e1b54c3478cfb598f3d0023e51c"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
@@ -4922,7 +4924,7 @@ dependencies = [
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum sct 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f5adf8fbd58e1b1b52699dc8bed2630faecb6d8c7bee77d009d6bbe4af569b9"
-"checksum secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfaccd3a23619349e0878d9a241f34b1982343cdf67367058cd7d078d326b63e"
+"checksum secp256k1 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4070f3906e65249228094cf97b04a90799fba04468190bbbcfa812309cf86e32"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum send_wrapper 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0eddf2e8f50ced781f288c19f18621fa72a3779e3cb58dbf23b07469b0abeb4"

--- a/internal/bitcoin_rpc_test_helpers/Cargo.toml
+++ b/internal/bitcoin_rpc_test_helpers/Cargo.toml
@@ -5,6 +5,6 @@ authors = [ "CoBloX developers <team@coblox.tech>" ]
 edition = "2018"
 
 [dependencies]
-bitcoin_support = { path = "../bitcoin_support" }
+bitcoin = "0.19.1"
 bitcoincore-rpc = "0.8.0-rc1"
 testcontainers = "0.8"

--- a/internal/bitcoin_support/src/pubkey.rs
+++ b/internal/bitcoin_support/src/pubkey.rs
@@ -1,9 +1,5 @@
-use crate::{network::Network, Hash160};
-use bitcoin::{
-    hashes::Hash,
-    util::{address::Payload, key::PublicKey as BitcoinPublicKey},
-    Address,
-};
+use crate::Hash160;
+use bitcoin::hashes::Hash;
 use hex::{self, FromHex};
 use secp256k1_keypair::{KeyPair, PublicKey};
 use serde::{
@@ -14,34 +10,6 @@ use std::{
     convert::TryFrom,
     fmt::{self, Display},
 };
-
-pub trait IntoP2wpkhAddress {
-    fn into_p2wpkh_address(self, network: Network) -> Address;
-}
-
-impl IntoP2wpkhAddress for PublicKey {
-    fn into_p2wpkh_address(self, network: Network) -> Address {
-        Address::p2wpkh(
-            &BitcoinPublicKey {
-                compressed: true, // Only used for serialization
-                key: self,
-            },
-            network.into(),
-        )
-    }
-}
-
-impl IntoP2wpkhAddress for PubkeyHash {
-    fn into_p2wpkh_address(self, network: Network) -> Address {
-        Address {
-            payload: Payload::WitnessProgram {
-                version: bitcoin::bech32::u5::try_from_u8(0).expect("0 is a valid u5"),
-                program: self.as_ref().to_vec(),
-            },
-            network: network.into(),
-        }
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct PubkeyHash(Hash160);
@@ -182,20 +150,6 @@ mod test {
             )
             .unwrap()
         )
-    }
-
-    #[test]
-    fn generates_same_address_from_private_key_as_btc_address_generator() {
-        // https://kimbatt.github.io/btc-address-generator/
-        let private_key =
-            PrivateKey::from_str("L4nZrdzNnawCtaEcYGWuPqagQA3dJxVPgN8ARTXaMLCxiYCy89wm").unwrap();
-        let keypair: KeyPair = private_key.key.into();
-        let address = keypair.public_key().into_p2wpkh_address(Network::Mainnet);
-
-        assert_eq!(
-            address,
-            Address::from_str("bc1qmxq0cu0jktxyy2tz3je7675eca0ydcevgqlpgh").unwrap()
-        );
     }
 
     #[test]

--- a/internal/key_gen/Cargo.toml
+++ b/internal/key_gen/Cargo.toml
@@ -5,6 +5,7 @@ authors = [ "CoBloX developers <team@coblox.tech>" ]
 edition = "2018"
 
 [dependencies]
+bitcoin = "0.19.1"
 bitcoin_support  = { path = "../bitcoin_support" }
 ethereum_support = { path = "../ethereum_support" }
 hex = "0.4"

--- a/internal/key_gen/src/main.rs
+++ b/internal/key_gen/src/main.rs
@@ -2,7 +2,8 @@
 #![forbid(unsafe_code)]
 #![allow(clippy::print_stdout)]
 
-use bitcoin_support::{IntoP2wpkhAddress, Network, PrivateKey, PubkeyHash};
+use bitcoin::{Network, PrivateKey};
+use bitcoin_support::PubkeyHash;
 use ethereum_support::Address;
 use secp256k1_keypair::{KeyPair, PublicKey};
 use std::env;
@@ -20,12 +21,12 @@ fn main() {
     let public_key = keypair.public_key();
     let mainnet_private_key = PrivateKey {
         compressed: true,
-        network: Network::Mainnet.into(),
+        network: Network::Bitcoin,
         key: secret_key,
     };
     let testnet_private_key = PrivateKey {
         compressed: true,
-        network: Network::Testnet.into(),
+        network: Network::Testnet,
         key: secret_key,
     };
 
@@ -46,16 +47,34 @@ fn main() {
     let eth_address = to_ethereum_address(&public_key);
     println!("eth_address: {:?}", eth_address);
     {
-        let btc_address_mainnet = public_key.into_p2wpkh_address(Network::Mainnet);
+        let btc_address_mainnet = bitcoin::Address::p2wpkh(
+            &bitcoin::PublicKey {
+                compressed: true,
+                key: public_key,
+            },
+            Network::Bitcoin,
+        );
         println!("btc_address_p2wpkh_mainnet: {:?}", btc_address_mainnet);
     }
 
     {
-        let btc_address_testnet = public_key.into_p2wpkh_address(Network::Testnet);
+        let btc_address_testnet = bitcoin::Address::p2wpkh(
+            &bitcoin::PublicKey {
+                compressed: true,
+                key: public_key,
+            },
+            Network::Testnet,
+        );
         println!("btc_address_p2wpkh_testnet: {:?}", btc_address_testnet);
     }
     {
-        let btc_address_regtest = public_key.into_p2wpkh_address(Network::Regtest);
+        let btc_address_regtest = bitcoin::Address::p2wpkh(
+            &bitcoin::PublicKey {
+                compressed: true,
+                key: public_key,
+            },
+            Network::Regtest,
+        );
         println!("btc_address_p2wpkh_regtest: {:?}", btc_address_regtest);
     }
     println!("pubkey_hash: {:x}", PubkeyHash::from(public_key));


### PR DESCRIPTION
The functionality was only used in test code and there is no harm in inlining it because we are simply delegating to downstream functionality.