### PR TITLE
Remove Circle CI docker layer caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,6 @@ jobs:
     working_directory: ~/comit
     machine:
       image: ubuntu-1604:201903-01
-      docker_layer_caching: true
     environment:
       RUST_TEST_THREADS: "8"
     steps:
@@ -47,7 +46,6 @@ jobs:
     working_directory: ~/comit
     machine:
       image: ubuntu-1604:201903-01
-      docker_layer_caching: true
     environment:
       RUST_TEST_THREADS: "8"
     steps:
@@ -79,7 +77,6 @@ jobs:
     working_directory: ~/comit
     machine:
       image: ubuntu-1604:201903-01
-      docker_layer_caching: true
     environment:
       RUST_TEST_THREADS: "8"
     steps:


### PR DESCRIPTION
It looks like our trial is finished.
Docker layer caching is not available in the free plan:
```
Blocked due to free-plan-docker-layer-caching-unavailable
```
See https://circleci.com/gh/comit-network/comit-rs/2167?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link.