### PR TITLE
Make http_api and network optional in config file

### DIFF
--- a/cnd/src/config/file.rs
+++ b/cnd/src/config/file.rs
@@ -21,8 +21,8 @@ use std::{
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct File {
     pub comit: Comit,
-    pub network: Network,
-    pub http_api: HttpSocket,
+    pub network: Option<Network>,
+    pub http_api: Option<HttpSocket>,
     pub database: Option<Database>,
     pub web_gui: Option<HttpSocket>,
     pub logging: Option<Logging>,
@@ -32,20 +32,12 @@ pub struct File {
 
 impl File {
     pub fn default<R: Rng>(rand: R) -> Self {
-        let comit_listen = "/ip4/0.0.0.0/tcp/9939"
-            .parse()
-            .expect("cnd listen address could not be parsed");
         let seed = Seed::new_random(rand).expect("Could not generate random seed");
 
         File {
             comit: Comit { secret_seed: seed },
-            network: Network {
-                listen: vec![comit_listen],
-            },
-            http_api: HttpSocket {
-                address: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                port: 8000,
-            },
+            network: None,
+            http_api: None,
             database: None,
             web_gui: Some(HttpSocket {
                 address: IpAddr::V4(Ipv4Addr::UNSPECIFIED),

--- a/cnd/src/config/settings.rs
+++ b/cnd/src/config/settings.rs
@@ -2,6 +2,7 @@ use super::file::{Comit, Database, File, HttpSocket, Network};
 use crate::config::file::{Bitcoin, Ethereum};
 use log::LevelFilter;
 use reqwest::Url;
+use std::net::{IpAddr, Ipv4Addr};
 
 /// This structs represents the settings as they are used through out the code.
 ///
@@ -41,7 +42,22 @@ impl Settings {
             bitcoin,
             ethereum,
         } = config_file;
-
+        let http_api = match http_api {
+            None => HttpSocket {
+                address: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                port: 8000,
+            },
+            Some(val) => val,
+        };
+        let comit_listen = "/ip4/0.0.0.0/tcp/9939"
+            .parse()
+            .expect("cnd listen address could not be parsed");
+        let network = match network {
+            None => Network {
+                listen: vec![comit_listen],
+            },
+            Some(val) => val,
+        };
         Self {
             comit,
             network,


### PR DESCRIPTION
Fixes #1448.

Tested:
- With no config file, starting `cnd` produces a default file without `network` and `http_api`, but `Settings` takes the default
- With a config file specifying `network` and `http_api`, `Settings` uses the value from the config file