### PR TITLE
Run dependabot daily

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,7 +2,7 @@ version: 1
 update_configs:
   - package_manager: "rust:cargo"
     directory: "/"
-    update_schedule: "weekly"
+    update_schedule: "daily"
     default_labels:
       - "dependencies"
     allowed_updates:
@@ -23,7 +23,7 @@ update_configs:
           dependency_name: "libsqlite3-sys"
   - package_manager: "javascript"
     directory: "/api_tests"
-    update_schedule: "weekly"
+    update_schedule: "daily"
     default_labels:
       - "dependencies"
     allowed_updates:


### PR DESCRIPTION
I propose to run dependabot daily instead of weekly.

With the configuration of mergify (#1531) and bors, there should be no issue in terms of blocking the CI (it also runs at midnight, none should be working around that time). There is also always the hardlimit on how many PRs are open.

cc @bonomat I remember you having objections against this in the past. I would be keen to try of how much of a burden it actually is. Can always switch it back if it really annoys us / takes up too much time.