### PR TITLE
Test transaction queries

### DIFF
--- a/btsieve/src/ethereum/queries/transaction.rs
+++ b/btsieve/src/ethereum/queries/transaction.rs
@@ -166,6 +166,8 @@ mod tests {
 
     #[test]
     fn given_query_transaction_data_transaction_matches() {
+        let to_address = "0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".parse().unwrap();
+
         let query_data = TransactionQuery {
             from_address: None,
             to_address: None,
@@ -184,14 +186,14 @@ mod tests {
 
         let refund_query = TransactionQuery {
             from_address: None,
-            to_address: Some("0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".parse().unwrap()),
+            to_address: Some(to_address),
             is_contract_creation: Some(false),
             transaction_data: Some(Bytes::from(vec![])),
             transaction_data_length: None,
         };
 
         let transaction = Transaction {
-            to: Some("0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".parse().unwrap()),
+            to: Some(to_address),
             input: Bytes::from(vec![1, 2, 3, 4, 5]),
             ..Transaction::default()
         };

--- a/btsieve/src/ethereum/queries/transaction.rs
+++ b/btsieve/src/ethereum/queries/transaction.rs
@@ -168,7 +168,7 @@ mod tests {
     fn given_query_transaction_data_transaction_matches() {
         let to_address = "0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".parse().unwrap();
 
-        let query_data = TransactionQuery {
+        let query = TransactionQuery {
             from_address: None,
             to_address: None,
             is_contract_creation: None,
@@ -176,7 +176,21 @@ mod tests {
             transaction_data_length: None,
         };
 
-        let query_data_length = TransactionQuery {
+        let transaction = Transaction {
+            to: Some(to_address),
+            input: Bytes::from(vec![1, 2, 3, 4, 5]),
+            ..Transaction::default()
+        };
+
+        let result = query.matches(&transaction);
+        assert_that(&result).is_true();
+    }
+
+    #[test]
+    fn given_query_transaction_data_length_transaction_matches() {
+        let to_address = "0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".parse().unwrap();
+
+        let query = TransactionQuery {
             from_address: None,
             to_address: None,
             is_contract_creation: None,
@@ -184,7 +198,21 @@ mod tests {
             transaction_data_length: Some(5),
         };
 
-        let refund_query = TransactionQuery {
+        let transaction = Transaction {
+            to: Some(to_address),
+            input: Bytes::from(vec![1, 2, 3, 4, 5]),
+            ..Transaction::default()
+        };
+
+        let result = query.matches(&transaction);
+        assert_that(&result).is_true();
+    }
+
+    #[test]
+    fn given_empty_query_transaction_data_does_not_match() {
+        let to_address = "0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".parse().unwrap();
+
+        let query = TransactionQuery {
             from_address: None,
             to_address: Some(to_address),
             is_contract_creation: Some(false),
@@ -198,13 +226,7 @@ mod tests {
             ..Transaction::default()
         };
 
-        let result = query_data.matches(&transaction);
-        assert_that(&result).is_true();
-
-        let result = query_data_length.matches(&transaction);
-        assert_that(&result).is_true();
-
-        let result = refund_query.matches(&transaction);
+        let result = query.matches(&transaction);
         assert_that(&result).is_false();
     }
 }

--- a/btsieve/src/ethereum/queries/transaction.rs
+++ b/btsieve/src/ethereum/queries/transaction.rs
@@ -229,4 +229,110 @@ mod tests {
         let result = query.matches(&transaction);
         assert_that(&result).is_false();
     }
+
+    // given_query_transaction_data_transaction_matches() above, goes with the
+    // following two tests to cover all combinations of `is_contract_creation`.
+
+    #[test]
+    fn given_transaction_data_with_negative_contract_does_not_match() {
+        let query = TransactionQuery {
+            from_address: None,
+            to_address: None,
+            is_contract_creation: Some(false),
+            transaction_data: Some(Bytes::from(vec![1, 2, 3, 4, 5])),
+            transaction_data_length: None,
+        };
+
+        let transaction = Transaction {
+            input: Bytes::from(vec![1, 2, 3, 4, 5]),
+            ..Transaction::default()
+        };
+
+        let result = query.matches(&transaction);
+        assert_that(&result).is_false();
+    }
+
+    #[test]
+    fn given_transaction_data_with_positive_contract_creation_matches() {
+        let query = TransactionQuery {
+            from_address: None,
+            to_address: None,
+            is_contract_creation: Some(true),
+            transaction_data: Some(Bytes::from(vec![1, 2, 3, 4, 5])),
+            transaction_data_length: None,
+        };
+
+        let transaction = Transaction {
+            input: Bytes::from(vec![1, 2, 3, 4, 5]),
+            ..Transaction::default()
+        };
+
+        let result = query.matches(&transaction);
+        assert_that(&result).is_true();
+    }
+
+    #[test]
+    fn given_transaction_data_with_negative_contract_and_to_address_matches() {
+        let to_address = "0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".parse().unwrap();
+
+        let query = TransactionQuery {
+            from_address: None,
+            to_address: Some(to_address),
+            is_contract_creation: Some(false),
+            transaction_data: Some(Bytes::from(vec![1, 2, 3, 4, 5])),
+            transaction_data_length: None,
+        };
+
+        let transaction = Transaction {
+            to: Some(to_address),
+            input: Bytes::from(vec![1, 2, 3, 4, 5]),
+            ..Transaction::default()
+        };
+
+        let result = query.matches(&transaction);
+        assert_that(&result).is_true();
+    }
+
+    #[test]
+    fn given_transaction_data_with_negative_contract_and_no_to_address_does_not_match() {
+        let to_address = "0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".parse().unwrap();
+
+        let query = TransactionQuery {
+            from_address: None,
+            to_address: Some(to_address),
+            is_contract_creation: Some(false),
+            transaction_data: Some(Bytes::from(vec![1, 2, 3, 4, 5])),
+            transaction_data_length: None,
+        };
+
+        let transaction = Transaction {
+            input: Bytes::from(vec![1, 2, 3, 4, 5]),
+            ..Transaction::default()
+        };
+
+        let result = query.matches(&transaction);
+        assert_that(&result).is_false();
+    }
+
+    #[test]
+    fn given_transaction_data_with_positive_contract_and_to_address_does_not_match() {
+        let to_address = "0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".parse().unwrap();
+
+        let query = TransactionQuery {
+            from_address: None,
+            to_address: Some(to_address),
+            is_contract_creation: Some(true),
+            transaction_data: Some(Bytes::from(vec![1, 2, 3, 4, 5])),
+            transaction_data_length: None,
+        };
+
+        let transaction = Transaction {
+            to: Some(to_address),
+            input: Bytes::from(vec![1, 2, 3, 4, 5]),
+            ..Transaction::default()
+        };
+
+        let result = query.matches(&transaction);
+        assert_that(&result).is_false();
+    }
 }


### PR DESCRIPTION
For some time now I have been postulating that, when designing struct objects, the use of Option types with an optional type that has a nil value makes the code hard to reason about.  I have argued this point at length with other members of the team (@thomaseizinger and @luckysori) but have thus far been unconvincing.

In an effort to lay out in code why I believe this practice is a bad idea this patch set attempts to test the logic when matching transaction queries.  The struct member used as an example is `is_contract_creation: Option<bool>`.  The argument against my position is that `None` and `Some(false)` have a different semantic meaning, I am not disputing this, my claim is that this different meaning is _not_ apparent from reading the code and reasoning about the code that uses this struct member is difficult.  This patch adds tests that more thoroughly test the logic that we have.  All tests pass - I do not know if, logically, they should pass or fail.

If  you have the patience to humour me, please review the tests in the last commit of this PR and see if they are valid tests that we want.  If they are valid, all well and good - the code is hard to reason about (for me), nothing lost nothing gained.  If they are _not_ valid tests then the difficulty in reasoning about the code has opened us up to bugs either present or future.

Thanks for you patience.

One side note; I may lack the domain knowledge to understand what `is_contract_creation` is and how it would be used.  This domain knowledge may make the semantic difference more obvious.