### PR TITLE
Make btsieve matching code clearer

### DIFF
--- a/btsieve/src/lib.rs
+++ b/btsieve/src/lib.rs
@@ -10,12 +10,12 @@ pub mod quickcheck;
 
 use tokio::prelude::{Future, Stream};
 
-pub trait MatchingTransactions<Q>: Send + Sync + 'static {
+pub trait MatchingTransactions<P>: Send + Sync + 'static {
     type Transaction;
 
     fn matching_transactions(
         &self,
-        query: Q,
+        pattern: P,
     ) -> Box<dyn Stream<Item = Self::Transaction, Error = ()> + Send>;
 }
 

--- a/btsieve/tests/bitcoin.rs
+++ b/btsieve/tests/bitcoin.rs
@@ -1,7 +1,7 @@
 use bitcoin_support::{Amount, Network};
 use bitcoincore_rpc::RpcApi;
 use btsieve::{
-    bitcoin::{BitcoindConnector, TransactionQuery},
+    bitcoin::{BitcoindConnector, TransactionPattern},
     MatchingTransactions,
 };
 use images::coblox_bitcoincore::BitcoinCore;
@@ -18,12 +18,12 @@ use tokio::{
 };
 
 /// A very basic e2e test that verifies that we glued all our code together
-/// correctly for bitcoin queries
+/// correctly for bitcoin transaction pattern matching.
 ///
 /// We send money to an address and check if the transaction that we filter out
-/// is the same one as the one that was returned when we sent the money
+/// is the same one as the one that was returned when we sent the money.
 #[test]
-fn bitcoin_transaction_query_e2e_test() {
+fn bitcoin_transaction_pattern_e2e_test() {
     let cli = clients::Cli::default();
     let container = cli.run(BitcoinCore::default());
     let client = tc_bitcoincore_client::new(&container);
@@ -41,7 +41,7 @@ fn bitcoin_transaction_query_e2e_test() {
     client.generate(101, None).unwrap();
 
     let funding_transaction = blocksource
-        .matching_transactions(TransactionQuery {
+        .matching_transactions(TransactionPattern {
             to_address: Some(target_address.clone()),
             from_outpoint: None,
             unlock_script: None,

--- a/btsieve/tests/bitcoin_missing_blocks.rs
+++ b/btsieve/tests/bitcoin_missing_blocks.rs
@@ -1,6 +1,6 @@
 use bitcoin_support::{consensus::Decodable, deserialize, Address, BitcoinHash, Block};
 use btsieve::{
-    bitcoin::TransactionQuery, first_or_else::StreamExt, BlockByHash, LatestBlock,
+    bitcoin::TransactionPattern, first_or_else::StreamExt, BlockByHash, LatestBlock,
     MatchingTransactions,
 };
 use std::{
@@ -98,7 +98,7 @@ fn find_transaction_in_missing_block() {
     );
 
     let expected_transaction: bitcoin_support::Transaction = connector
-        .matching_transactions(TransactionQuery {
+        .matching_transactions(TransactionPattern {
             to_address: Some(
                 Address::from_str(
                     include_str!("./test_data/find_transaction_in_missing_block/address").trim(),
@@ -138,7 +138,7 @@ fn find_transaction_in_missing_block_with_big_gap() {
     );
 
     let expected_transaction: bitcoin_support::Transaction = connector
-        .matching_transactions(TransactionQuery {
+        .matching_transactions(TransactionPattern {
             to_address: Some(
                 Address::from_str(
                     include_str!(
@@ -177,7 +177,7 @@ fn find_transaction_if_blockchain_reorganisation() {
     );
 
     let expected_transaction: bitcoin_support::Transaction = connector
-        .matching_transactions(TransactionQuery {
+        .matching_transactions(TransactionPattern {
             to_address: Some(
                 Address::from_str(
                     include_str!(
@@ -219,7 +219,7 @@ fn find_transaction_if_blockchain_reorganisation_with_long_chain() {
     );
 
     let expected_transaction: bitcoin_support::Transaction = connector
-        .matching_transactions(TransactionQuery {
+        .matching_transactions(TransactionPattern {
             to_address: Some(
                 Address::from_str(
                     include_str!(

--- a/btsieve/tests/ethereum.rs
+++ b/btsieve/tests/ethereum.rs
@@ -1,5 +1,5 @@
 use btsieve::{
-    ethereum::{TransactionQuery, Web3Connector},
+    ethereum::{TransactionPattern, Web3Connector},
     MatchingTransactions,
 };
 use ethereum_support::{TransactionRequest, U256};
@@ -13,13 +13,13 @@ use tokio::{
 };
 
 /// A very basic e2e test that verifies that we glued all our code together
-/// correctly for ethereum queries
+/// correctly for ethereum transaction pattern matching.
 ///
 /// We get the default account from the node and send some money to it
 /// from the parity dev account. Afterwards we verify that the tx hash of
 /// the sent tx equals the one that we found through btsieve.
 #[test]
-fn ethereum_transaction_query_e2e_test() {
+fn ethereum_transaction_pattern_e2e_test() {
     let cli = clients::Cli::default();
     let container = cli.run(images::parity_parity::ParityEthereum::default());
 
@@ -40,7 +40,7 @@ fn ethereum_transaction_query_e2e_test() {
     let target_address = accounts[0];
 
     let funding_transaction = connector
-        .matching_transactions(TransactionQuery {
+        .matching_transactions(TransactionPattern {
             from_address: None,
             to_address: Some(target_address),
             is_contract_creation: None,

--- a/cnd/src/logging/initialize.rs
+++ b/cnd/src/logging/initialize.rs
@@ -121,7 +121,7 @@ mod tests {
         if !regex.is_match(&message) {
             panic!(
                 "Log message didn't match expected pattern!\n\n\
-                 Pattern: {}\n\
+                 TransactionPattern: {}\n\
                  Message: {}\n",
                 pattern, message
             );

--- a/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
@@ -12,7 +12,7 @@ use crate::swap_protocols::{
 };
 use bitcoin_support::{Amount, FindOutput, OutPoint};
 use btsieve::{
-    bitcoin::{BitcoindConnector, TransactionQuery},
+    bitcoin::{BitcoindConnector, TransactionPattern},
     first_or_else::StreamExt,
     MatchingTransactions,
 };
@@ -27,7 +27,7 @@ impl HtlcEvents<Bitcoin, Amount> for BitcoindConnector {
         htlc_params: HtlcParams<Bitcoin, Amount>,
     ) -> Box<DeployedFuture<Bitcoin>> {
         let future = self
-            .matching_transactions(TransactionQuery {
+            .matching_transactions(TransactionPattern {
                 to_address: Some(htlc_params.compute_address()),
                 from_outpoint: None,
                 unlock_script: None,
@@ -81,7 +81,7 @@ impl HtlcEvents<Bitcoin, Amount> for BitcoindConnector {
         _htlc_funding: &Funded<Bitcoin, Amount>,
     ) -> Box<RedeemedOrRefundedFuture<Bitcoin>> {
         let refunded_future = {
-            self.matching_transactions(TransactionQuery {
+            self.matching_transactions(TransactionPattern {
                 to_address: None,
                 from_outpoint: Some(htlc_deployment.location),
                 unlock_script: Some(vec![vec![]]),
@@ -95,7 +95,7 @@ impl HtlcEvents<Bitcoin, Amount> for BitcoindConnector {
         };
 
         let redeemed_future = {
-            self.matching_transactions(TransactionQuery {
+            self.matching_transactions(TransactionPattern {
                 to_address: None,
                 from_outpoint: Some(htlc_deployment.location),
                 unlock_script: Some(vec![vec![1u8]]),

--- a/cnd/src/swap_protocols/rfc003/ethereum/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/ethereum/htlc_events.rs
@@ -12,7 +12,7 @@ use crate::swap_protocols::{
     },
 };
 use btsieve::{
-    ethereum::{Event, Topic, TransactionQuery, Web3Connector},
+    ethereum::{Event, Topic, TransactionPattern, Web3Connector},
     first_or_else::StreamExt,
     MatchingTransactions,
 };
@@ -40,7 +40,7 @@ impl HtlcEvents<Ethereum, EtherQuantity> for Web3Connector {
         htlc_params: HtlcParams<Ethereum, EtherQuantity>,
     ) -> Box<DeployedFuture<Ethereum>> {
         let future = self
-            .matching_transactions(TransactionQuery {
+            .matching_transactions(TransactionPattern {
                 from_address: None,
                 to_address: None,
                 is_contract_creation: Some(true),
@@ -94,7 +94,7 @@ fn htlc_redeemed_or_refunded<A: Asset>(
 ) -> Box<RedeemedOrRefundedFuture<Ethereum>> {
     let refunded_future = {
         ethereum_connector
-            .matching_transactions(TransactionQuery {
+            .matching_transactions(TransactionPattern {
                 from_address: None,
                 to_address: None,
                 is_contract_creation: None,
@@ -117,7 +117,7 @@ fn htlc_redeemed_or_refunded<A: Asset>(
     };
 
     let redeemed_future = {
-        ethereum_connector.matching_transactions(TransactionQuery {
+        ethereum_connector.matching_transactions(TransactionPattern {
             from_address: None,
             to_address: None,
             is_contract_creation: None,
@@ -178,7 +178,7 @@ mod erc20 {
             htlc_params: HtlcParams<Ethereum, Erc20Token>,
         ) -> Box<DeployedFuture<Ethereum>> {
             let future = self
-                .matching_transactions(TransactionQuery {
+                .matching_transactions(TransactionPattern {
                     from_address: None,
                     to_address: None,
                     is_contract_creation: Some(true),
@@ -207,7 +207,7 @@ mod erc20 {
             htlc_deployment: &Deployed<Ethereum>,
         ) -> Box<FundedFuture<Ethereum, Erc20Token>> {
             let future = self
-                .matching_transactions(TransactionQuery {
+                .matching_transactions(TransactionPattern {
                     from_address: None,
                     to_address: None,
                     is_contract_creation: None,


### PR DESCRIPTION
Current matching logic in btsieve uses a mutable variable and logical and (`&&`) statements to mutate this variable.  This is unnecessary, also idiomatic Rust typically only uses mutable variables when needed.  We should change this code to not use mutable variables.

While we are cleaning up also do:
- Rename `TransactionQuery` to `Pattern`: since this struct holds data used to pattern match against transactions.
- Add documentation to the newly named `Pattern` struct and the pattern matching function.
- Rename the queries modules (bitcoin and ethereum) to `pattern_matching`.