### PR TITLE
Improve comment explaining the delay

### DIFF
--- a/btsieve/src/bitcoin/mod.rs
+++ b/btsieve/src/bitcoin/mod.rs
@@ -52,8 +52,8 @@ where
     let mut missing_block_futures: Vec<_> = Vec::new();
 
     loop {
-        // Delay so that we don't overload the machine given the assumption
-        // that latest_block and block_by_hash resolve quickly
+        // Delay so that we don't overload the CPU in the event that
+        // latest_block() and block_by_hash() resolve quickly.
         Delay::new(std::time::Instant::now().add(std::time::Duration::from_secs(1)))
             .compat()
             .await

--- a/btsieve/src/ethereum/mod.rs
+++ b/btsieve/src/ethereum/mod.rs
@@ -50,8 +50,8 @@ where
         > + Clone,
 {
     loop {
-        // Delay so that we don't overload the machine given the assumption
-        // that latest_block and block_by_hash resolve quickly
+        // Delay so that we don't overload the CPU in the event that
+        // latest_block() and block_by_hash() resolve quickly.
         Delay::new(std::time::Instant::now().add(std::time::Duration::from_secs(1)))
             .compat()
             .await


### PR DESCRIPTION
This comment has caused some confusion in the team; attempt to improve it.

- 'the machine' is ambiguous - the machine we are running on, the machine the
blockchain connector is connecting to?  Use 'the CPU' instead since
non-ambiguously refers to the CPU running the current process.

- 'given the assumption' - this is not an assumption since it does not always
  hold true, better to say 'in the event that'.