### PR TITLE
Simplify the data-flow when accepting & declining swap requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,7 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-serde 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -23,7 +23,8 @@ enum-display-derive = "0.1"
 ethereum_support = { path = "../internal/ethereum_support" }
 failure = "0.1"
 fern = { version = "0.5", features = ["colored"] }
-futures = "0.1"
+futures = { version = "0.1" }
+futures-core = { version = "=0.3.0-alpha.19", features = ["alloc", "compat", "async-await"], package = "futures-preview" }
 hex = "0.4"
 hex-serde = "0.1.0"
 http = "0.1"

--- a/cnd/src/http_api/mod.rs
+++ b/cnd/src/http_api/mod.rs
@@ -24,20 +24,33 @@ use crate::{
         asset::{FromHttpAsset, HttpAsset},
         ledger::{FromHttpLedger, HttpLedger},
     },
-    network::DialInformation,
+    network::{DialInformation, Network},
     swap_protocols::{
+        asset::Asset,
         ledger::{Bitcoin, Ethereum},
-        SwapId, SwapProtocol,
+        metadata_store,
+        rfc003::{
+            alice::{self, AliceSpawner},
+            bob::BobSpawner,
+            messages::{AcceptResponseBody, DeclineResponseBody, Request, ToRequest},
+            state_machine::SwapStates,
+            state_store::{self, StateStore},
+            ActorState, CreateLedgerEvents, Ledger,
+        },
+        LedgerEventDependencies, Metadata, MetadataStore, SwapId, SwapProtocol,
     },
 };
 use bitcoin_support::{amount::Denomination, Amount as BitcoinAmount};
 use ethereum_support::{Erc20Token, EtherQuantity};
+use futures::sync::oneshot::Sender;
 use libp2p::PeerId;
+use libp2p_comit::frame::Response;
 use serde::{
     de::{self, MapAccess},
     ser::SerializeStruct,
     Deserialize, Deserializer, Serialize, Serializer,
 };
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct Http<I>(pub I);
@@ -229,6 +242,139 @@ impl<'de> Deserialize<'de> for DialInformation {
         }
 
         deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// A struct for capturing dependencies that are needed within the HTTP API
+/// controllers.
+///
+/// This is a facade that implements all the required traits and simplify
+/// forwards them to another implementation. This allows us to keep the number
+/// arguments to HTTP API controllers small and still access all the
+/// functionality we need.
+#[derive(Debug)]
+pub struct Dependencies<M, S, A, B, N> {
+    pub metadata_store: Arc<M>,
+    pub state_store: Arc<S>,
+    pub alice_spawner: Arc<A>,
+    pub bob_spawner: Arc<B>,
+    pub network: Arc<N>,
+}
+
+impl<M, S, A, B, N> Clone for Dependencies<M, S, A, B, N> {
+    fn clone(&self) -> Self {
+        Self {
+            metadata_store: Arc::clone(&self.metadata_store),
+            state_store: Arc::clone(&self.state_store),
+            alice_spawner: Arc::clone(&self.alice_spawner),
+            bob_spawner: Arc::clone(&self.bob_spawner),
+            network: Arc::clone(&self.network),
+        }
+    }
+}
+
+impl<M: MetadataStore, S, A, B, N> MetadataStore for Dependencies<M, S, A, B, N>
+where
+    M: Send + Sync + 'static,
+    S: Send + Sync + 'static,
+    A: Send + Sync + 'static,
+    B: Send + Sync + 'static,
+    N: Send + Sync + 'static,
+{
+    fn get(&self, key: SwapId) -> Result<Option<Metadata>, metadata_store::Error> {
+        self.metadata_store.get(key)
+    }
+
+    fn insert(&self, metadata: Metadata) -> Result<(), metadata_store::Error> {
+        self.metadata_store.insert(metadata)
+    }
+
+    fn all(&self) -> Result<Vec<Metadata>, metadata_store::Error> {
+        self.metadata_store.all()
+    }
+}
+
+impl<M, S: StateStore, AS, B, N> StateStore for Dependencies<M, S, AS, B, N>
+where
+    M: Send + Sync + 'static,
+    S: Send + Sync + 'static,
+    AS: Send + Sync + 'static,
+    B: Send + Sync + 'static,
+    N: Send + Sync + 'static,
+{
+    fn insert<A: ActorState>(&self, key: SwapId, value: A) {
+        self.state_store.insert(key, value)
+    }
+
+    fn get<A: ActorState>(&self, key: &SwapId) -> Result<Option<A>, state_store::Error> {
+        self.state_store.get(key)
+    }
+
+    fn update<A: ActorState>(&self, key: &SwapId, update: SwapStates<A::AL, A::BL, A::AA, A::BA>) {
+        self.state_store.update::<A>(key, update)
+    }
+}
+
+impl<M, S, A, B: BobSpawner, N> BobSpawner for Dependencies<M, S, A, B, N>
+where
+    M: Send + Sync + 'static,
+    S: Send + Sync + 'static,
+    A: Send + Sync + 'static,
+    B: Send + Sync + 'static,
+    N: Send + Sync + 'static,
+{
+    fn spawn<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset>(
+        &self,
+        swap_request: Request<AL, BL, AA, BA>,
+        response: Result<AcceptResponseBody<AL, BL>, DeclineResponseBody>,
+    ) where
+        LedgerEventDependencies: CreateLedgerEvents<AL, AA> + CreateLedgerEvents<BL, BA>,
+    {
+        self.bob_spawner.spawn(swap_request, response)
+    }
+}
+
+impl<M, S, A: AliceSpawner, B, N> AliceSpawner for Dependencies<M, S, A, B, N>
+where
+    M: Send + Sync + 'static,
+    S: Send + Sync + 'static,
+    A: Send + Sync + 'static,
+    B: Send + Sync + 'static,
+    N: Send + Sync + 'static,
+{
+    fn spawn<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset>(
+        &self,
+        id: SwapId,
+        bob_dial_info: DialInformation,
+        swap_request: Box<dyn ToRequest<AL, BL, AA, BA>>,
+    ) -> Result<(), alice::Error>
+    where
+        LedgerEventDependencies: CreateLedgerEvents<AL, AA> + CreateLedgerEvents<BL, BA>,
+    {
+        self.alice_spawner.spawn(id, bob_dial_info, swap_request)
+    }
+}
+
+impl<M, S, A, B, N: Network> Network for Dependencies<M, S, A, B, N>
+where
+    M: Send + Sync + 'static,
+    S: Send + Sync + 'static,
+    A: Send + Sync + 'static,
+    B: Send + Sync + 'static,
+    N: Send + Sync + 'static,
+{
+    fn comit_peers(
+        &self,
+    ) -> Box<dyn Iterator<Item = (PeerId, Vec<libp2p::Multiaddr>)> + Send + 'static> {
+        self.network.comit_peers()
+    }
+
+    fn listen_addresses(&self) -> Vec<libp2p::Multiaddr> {
+        self.network.listen_addresses()
+    }
+
+    fn pending_request_for(&self, swap: SwapId) -> Option<Sender<Response>> {
+        self.network.pending_request_for(swap)
     }
 }
 

--- a/cnd/src/http_api/mod.rs
+++ b/cnd/src/http_api/mod.rs
@@ -248,10 +248,9 @@ impl<'de> Deserialize<'de> for DialInformation {
 /// A struct for capturing dependencies that are needed within the HTTP API
 /// controllers.
 ///
-/// This is a facade that implements all the required traits and simplify
-/// forwards them to another implementation. This allows us to keep the number
-/// arguments to HTTP API controllers small and still access all the
-/// functionality we need.
+/// This is a facade that implements all the required traits and forwards them
+/// to another implementation. This allows us to keep the number of arguments to
+/// HTTP API controllers small and still access all the functionality we need.
 #[derive(Debug)]
 pub struct Dependencies<M, S, A, B, N> {
     pub metadata_store: Arc<M>,

--- a/cnd/src/http_api/problem.rs
+++ b/cnd/src/http_api/problem.rs
@@ -18,6 +18,7 @@ pub fn state_store() -> HttpApiProblem {
     log::error!("State store didn't have state in it despite having the metadata");
     HttpApiProblem::with_title_and_type_from_status(StatusCode::INTERNAL_SERVER_ERROR)
 }
+
 pub fn swap_not_found() -> HttpApiProblem {
     HttpApiProblem::new("Swap not found.").set_status(StatusCode::NOT_FOUND)
 }

--- a/cnd/src/http_api/problem.rs
+++ b/cnd/src/http_api/problem.rs
@@ -4,6 +4,7 @@ use crate::swap_protocols::{
 };
 use http::StatusCode;
 use http_api_problem::HttpApiProblem;
+use libp2p_comit::frame::Response;
 use serde::Serialize;
 use warp::{Rejection, Reply};
 
@@ -12,6 +13,16 @@ pub struct MissingQueryParameter {
     pub name: &'static str,
     pub data_type: &'static str,
     pub description: &'static str,
+}
+
+pub fn missing_channel() -> HttpApiProblem {
+    log::error!("Channel for swap was not found in hash map");
+    HttpApiProblem::with_title_and_type_from_status(StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+pub fn send_over_channel(_e: Response) -> HttpApiProblem {
+    log::error!("Sending response over channel failed");
+    HttpApiProblem::with_title_and_type_from_status(StatusCode::INTERNAL_SERVER_ERROR)
 }
 
 pub fn state_store() -> HttpApiProblem {

--- a/cnd/src/http_api/route_factory.rs
+++ b/cnd/src/http_api/route_factory.rs
@@ -1,16 +1,13 @@
 use crate::{
-    comit_client::Client,
     http_api,
-    network::SwarmInfo,
-    swap_protocols::{self, rfc003::state_store, MetadataStore, SwapId},
+    network::Network,
+    swap_protocols::{
+        self,
+        rfc003::{alice::AliceSpawner, bob::BobSpawner, state_store::StateStore},
+        MetadataStore, SwapId,
+    },
 };
-use futures::sync::oneshot;
 use libp2p::PeerId;
-use libp2p_comit::frame::Response;
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
 use warp::{self, filters::BoxedFilter, Filter, Reply};
 
 pub const RFC003: &str = "rfc003";
@@ -23,38 +20,27 @@ pub fn new_action_link(id: &SwapId, action: &str) -> String {
     format!("{}/{}", swap_path(*id), action)
 }
 
-pub fn create<T: MetadataStore, S: state_store::StateStore, C: Client, SI: SwarmInfo>(
-    metadata_store: Arc<T>,
-    state_store: Arc<S>,
-    alice_protocol_dependencies: swap_protocols::alice::ProtocolDependencies<T, S, C>,
-    bob_protocol_dependencies: swap_protocols::bob::ProtocolDependencies<T, S>,
+pub fn create<D: MetadataStore + StateStore + AliceSpawner + BobSpawner + Network + Clone>(
     origin_auth: String,
-    swarm_info: Arc<SI>,
     peer_id: PeerId,
-    response_channels: Arc<Mutex<HashMap<SwapId, oneshot::Sender<Response>>>>,
+    dependencies: D,
 ) -> BoxedFilter<(impl Reply,)> {
     let swaps = warp::path(http_api::PATH);
     let rfc003 = swaps.and(warp::path(RFC003));
-    let metadata_store = warp::any().map(move || Arc::clone(&metadata_store));
-    let state_store = warp::any().map(move || Arc::clone(&state_store));
-    let alice_protocol_dependencies = warp::any().map(move || alice_protocol_dependencies.clone());
-    let bob_protocol_dependencies = warp::any().map(move || bob_protocol_dependencies.clone());
-    let swarm_info = warp::any().map(move || Arc::clone(&swarm_info));
     let peer_id = warp::any().map(move || peer_id.clone());
     let empty_json_body = warp::any().map(|| serde_json::json!({}));
-    let response_channels = warp::any().map(move || Arc::clone(&response_channels));
+    let dependencies = warp::any().map(move || dependencies.clone());
 
     let rfc003_post_swap = rfc003
         .and(warp::path::end())
         .and(warp::post2())
-        .and(alice_protocol_dependencies.clone())
+        .and(dependencies.clone())
         .and(warp::body::json())
         .and_then(http_api::routes::rfc003::post_swap);
 
     let rfc003_get_swap = rfc003
         .and(warp::get2())
-        .and(metadata_store.clone())
-        .and(state_store.clone())
+        .and(dependencies.clone())
         .and(warp::path::param())
         .and(warp::path::end())
         .and_then(http_api::routes::rfc003::get_swap);
@@ -62,8 +48,7 @@ pub fn create<T: MetadataStore, S: state_store::StateStore, C: Client, SI: Swarm
     let get_swaps = swaps
         .and(warp::get2())
         .and(warp::path::end())
-        .and(metadata_store.clone())
-        .and(state_store.clone())
+        .and(dependencies.clone())
         .and_then(http_api::routes::index::get_swaps);
 
     let rfc003_action = warp::method()
@@ -74,23 +59,20 @@ pub fn create<T: MetadataStore, S: state_store::StateStore, C: Client, SI: Swarm
         >())
         .and(warp::path::end())
         .and(warp::query::<http_api::action::ActionExecutionParameters>())
-        .and(metadata_store.clone())
-        .and(state_store.clone())
-        .and(bob_protocol_dependencies.clone())
+        .and(dependencies.clone())
         .and(warp::body::json().or(empty_json_body).unify())
-        .and(response_channels)
         .and_then(http_api::routes::rfc003::action);
 
     let get_peers = warp::get2()
         .and(warp::path("peers"))
         .and(warp::path::end())
-        .and(swarm_info.clone())
+        .and(dependencies.clone())
         .and_then(http_api::routes::peers::get_peers);
 
     let get_info = warp::get2()
         .and(warp::path::end())
         .and(peer_id.clone())
-        .and(swarm_info.clone())
+        .and(dependencies.clone())
         .and_then(http_api::routes::index::get_info);
 
     let preflight_cors_route = warp::options().map(warp::reply);

--- a/cnd/src/http_api/routes/index/handlers/get_swaps.rs
+++ b/cnd/src/http_api/routes/index/handlers/get_swaps.rs
@@ -4,15 +4,14 @@ use crate::{
 };
 use http_api_problem::HttpApiProblem;
 
-pub fn handle_get_swaps<T: MetadataStore, S: StateStore>(
-    metadata_store: &T,
-    state_store: &S,
+pub fn handle_get_swaps<D: MetadataStore + StateStore>(
+    dependencies: &D,
 ) -> Result<siren::Entity, HttpApiProblem> {
     let mut entity = siren::Entity::default().with_class_member("swaps");
 
-    for metadata in metadata_store.all()?.into_iter() {
+    for metadata in MetadataStore::all(dependencies)?.into_iter() {
         let id = metadata.swap_id;
-        let sub_entity = build_rfc003_siren_entity(state_store, id, metadata, IncludeState::No)?;
+        let sub_entity = build_rfc003_siren_entity(dependencies, id, metadata, IncludeState::No)?;
         entity.push_sub_entity(siren::SubEntity::from_entity(sub_entity, &["item"]));
     }
 

--- a/cnd/src/http_api/routes/index/mod.rs
+++ b/cnd/src/http_api/routes/index/mod.rs
@@ -3,12 +3,11 @@ mod handlers;
 use self::handlers::handle_get_swaps;
 use crate::{
     http_api::{routes::into_rejection, Http},
-    network::SwarmInfo,
+    network::Network,
     swap_protocols::{rfc003::state_store::StateStore, MetadataStore},
 };
 use libp2p::{Multiaddr, PeerId};
 use serde::Serialize;
-use std::sync::Arc;
 use warp::{Rejection, Reply};
 
 #[derive(Serialize, Debug)]
@@ -18,8 +17,8 @@ pub struct InfoResource {
 }
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn get_info<SI: SwarmInfo>(id: PeerId, swarm_info: Arc<SI>) -> Result<impl Reply, Rejection> {
-    let listen_addresses: Vec<Multiaddr> = swarm_info.listen_addresses().to_vec();
+pub fn get_info<D: Network>(id: PeerId, dependencies: D) -> Result<impl Reply, Rejection> {
+    let listen_addresses: Vec<Multiaddr> = Network::listen_addresses(&dependencies).to_vec();
 
     Ok(warp::reply::json(&InfoResource {
         id: Http(id),
@@ -28,11 +27,8 @@ pub fn get_info<SI: SwarmInfo>(id: PeerId, swarm_info: Arc<SI>) -> Result<impl R
 }
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn get_swaps<T: MetadataStore, S: StateStore>(
-    metadata_store: Arc<T>,
-    state_store: Arc<S>,
-) -> Result<impl Reply, Rejection> {
-    handle_get_swaps(metadata_store.as_ref(), state_store.as_ref())
+pub fn get_swaps<D: MetadataStore + StateStore>(dependencies: D) -> Result<impl Reply, Rejection> {
+    handle_get_swaps(&dependencies)
         .map(|swaps| {
             Ok(warp::reply::with_header(
                 warp::reply::json(&swaps),

--- a/cnd/src/http_api/routes/peers/mod.rs
+++ b/cnd/src/http_api/routes/peers/mod.rs
@@ -1,7 +1,6 @@
-use crate::{http_api::Http, network::SwarmInfo};
+use crate::{http_api::Http, network::Network};
 use libp2p::{Multiaddr, PeerId};
 use serde::Serialize;
-use std::sync::Arc;
 use warp::{Rejection, Reply};
 
 #[derive(Serialize, Debug)]
@@ -16,9 +15,8 @@ pub struct Peer {
 }
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn get_peers<BP: SwarmInfo>(swarm_info: Arc<BP>) -> Result<impl Reply, Rejection> {
-    let peers = swarm_info
-        .comit_peers()
+pub fn get_peers<D: Network>(dependencies: D) -> Result<impl Reply, Rejection> {
+    let peers = Network::comit_peers(&dependencies)
         .map(|(peer, addresses)| Peer {
             id: Http(peer),
             endpoints: addresses,

--- a/cnd/src/http_api/routes/rfc003/handlers/action.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/action.rs
@@ -46,9 +46,14 @@ pub fn handle_action<T: MetadataStore, S: StateStore, B: BobSpawner>(
                 .ok_or_else(problem::state_store)?;
             log::trace!("Retrieved state for {}: {:?}", id, state);
 
-            let response_channel: oneshot::Sender<
-                Result<AcceptResponseBody<AL, BL>, DeclineResponseBody>,
-            > = unimplemented!("get this out of the HashMap inside `ComitNode`");
+            // For each request in the state store
+            // - get channel out of HashMap inside ComitNode using swap_id
+            // - call network::spawn with BobSpawner and the request
+            // - write the response to the channel
+
+            let response_channel: oneshot::Sender<Response>> = {
+                unimplemented!("make this build")
+            }
 
             state
                 .actions()

--- a/cnd/src/http_api/routes/rfc003/handlers/get_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/get_swap.rs
@@ -7,14 +7,11 @@ use crate::{
 };
 use http_api_problem::HttpApiProblem;
 
-pub fn handle_get_swap<T: MetadataStore, S: StateStore>(
-    metadata_store: &T,
-    state_store: &S,
+pub fn handle_get_swap<D: MetadataStore + StateStore>(
+    dependencies: &D,
     id: SwapId,
 ) -> Result<siren::Entity, HttpApiProblem> {
-    let metadata = metadata_store
-        .get(id)?
-        .ok_or_else(problem::swap_not_found)?;
+    let metadata = MetadataStore::get(dependencies, id)?.ok_or_else(problem::swap_not_found)?;
 
-    build_rfc003_siren_entity(state_store, id, metadata, IncludeState::Yes)
+    build_rfc003_siren_entity(dependencies, id, metadata, IncludeState::Yes)
 }

--- a/cnd/src/http_api/routes/rfc003/mod.rs
+++ b/cnd/src/http_api/routes/rfc003/mod.rs
@@ -19,24 +19,18 @@ use crate::{
         MetadataStore, SwapId,
     },
 };
-use futures::sync::oneshot;
 use hyper::header;
-use libp2p_comit::frame::Response;
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
 use warp::{Rejection, Reply};
 
 pub use self::swap_state::{LedgerState, SwapCommunication, SwapCommunicationState, SwapState};
-use crate::swap_protocols::rfc003::bob::BobSpawner;
+use crate::{network::Network, swap_protocols::rfc003::bob::BobSpawner};
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn post_swap<A: AliceSpawner>(
-    alice_spawner: A,
+pub fn post_swap<D: AliceSpawner>(
+    dependencies: D,
     request_body_kind: SwapRequestBodyKind,
 ) -> Result<impl Reply, Rejection> {
-    handle_post_swap(&alice_spawner, request_body_kind)
+    handle_post_swap(&dependencies, request_body_kind)
         .map(|swap_created| {
             let body = warp::reply::json(&swap_created);
             let response =
@@ -47,43 +41,25 @@ pub fn post_swap<A: AliceSpawner>(
 }
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn get_swap<T: MetadataStore, S: StateStore>(
-    metadata_store: Arc<T>,
-    state_store: Arc<S>,
+pub fn get_swap<D: MetadataStore + StateStore>(
+    dependencies: D,
     id: SwapId,
 ) -> Result<impl Reply, Rejection> {
-    handle_get_swap(metadata_store.as_ref(), state_store.as_ref(), id)
+    handle_get_swap(&dependencies, id)
         .map(|swap_resource| warp::reply::json(&swap_resource))
         .map_err(into_rejection)
 }
 
-// TODO: Remove two arguments here (they are in the dependencies struct)
 #[allow(clippy::needless_pass_by_value)]
-pub fn action<T: MetadataStore, S: StateStore, B: BobSpawner>(
+pub fn action<D: MetadataStore + StateStore + BobSpawner + Network>(
     method: http::Method,
     id: SwapId,
     action_kind: ActionKind,
     query_params: ActionExecutionParameters,
-    metadata_store: Arc<T>,
-    state_store: Arc<S>,
-    bob_spawner: B,
+    dependencies: D,
     body: serde_json::Value,
-    response_channels: Arc<Mutex<HashMap<SwapId, oneshot::Sender<Response>>>>,
 ) -> Result<impl Reply, Rejection> {
-    let metadata_store = metadata_store.as_ref();
-    let state_store = state_store.as_ref();
-
-    handle_action(
-        method,
-        id,
-        action_kind,
-        body,
-        query_params,
-        metadata_store,
-        state_store,
-        &bob_spawner,
-        response_channels,
-    )
-    .map(|body| warp::reply::json(&body))
-    .map_err(into_rejection)
+    handle_action(method, id, action_kind, body, query_params, dependencies)
+        .map(|body| warp::reply::json(&body))
+        .map_err(into_rejection)
 }

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -75,7 +75,7 @@ fn main() -> Result<(), failure::Error> {
     log::info!("Starting with peer_id: {}", local_peer_id);
 
     let transport = libp2p::build_development_transport(local_key_pair);
-    let behaviour = network::ComitNode::new(bob_protocol_dependencies, runtime.executor())?;
+    let behaviour = network::ComitNode::new(bob_protocol_dependencies.clone(), runtime.executor())?;
 
     let mut swarm = Swarm::new(transport, behaviour, local_peer_id.clone());
 
@@ -101,6 +101,7 @@ fn main() -> Result<(), failure::Error> {
         Arc::clone(&metadata_store),
         Arc::clone(&state_store),
         alice_protocol_dependencies,
+        bob_protocol_dependencies,
         Arc::clone(&swarm),
         local_peer_id,
         &mut runtime,
@@ -131,7 +132,8 @@ fn spawn_warp_instance<T: MetadataStore, S: StateStore, C: Client, SI: SwarmInfo
     settings: &Settings,
     metadata_store: Arc<T>,
     state_store: Arc<S>,
-    protocol_dependencies: swap_protocols::alice::ProtocolDependencies<T, S, C>,
+    alice_protocol_dependencies: swap_protocols::alice::ProtocolDependencies<T, S, C>,
+    bob_protocol_dependencies: swap_protocols::bob::ProtocolDependencies<T, S>,
     swarm_info: Arc<SI>,
     peer_id: PeerId,
     runtime: &mut tokio::runtime::Runtime,
@@ -139,7 +141,8 @@ fn spawn_warp_instance<T: MetadataStore, S: StateStore, C: Client, SI: SwarmInfo
     let routes = route_factory::create(
         metadata_store,
         state_store,
-        protocol_dependencies,
+        alice_protocol_dependencies,
+        bob_protocol_dependencies,
         auth_origin(&settings),
         swarm_info,
         peer_id,

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -367,63 +367,65 @@ where
 {
     let swap_id = swap_request.id;
 
-    match bob_spawner.spawn(counterparty, swap_request) {
-        Ok(response_future) => Box::new(response_future.then(move |result| {
-            let response = match result {
-                Ok(Ok(accept_body)) => {
-                    let body = rfc003::messages::AcceptResponseBody::<AL, BL> {
-                        beta_ledger_refund_identity: accept_body.beta_ledger_refund_identity,
-                        alpha_ledger_redeem_identity: accept_body.alpha_ledger_redeem_identity,
-                    };
-                    Response::empty()
-                        .with_header(
-                            "decision",
-                            Decision::Accepted
-                                .to_header()
-                                .expect("Decision should not fail to serialize"),
-                        )
-                        .with_body(
-                            serde_json::to_value(body)
-                                .expect("body should always serialize into serde_json::Value"),
-                        )
-                }
-                Ok(Err(decline_body)) => Response::empty()
-                    .with_header(
-                        "decision",
-                        Decision::Declined
-                            .to_header()
-                            .expect("Decision shouldn't fail to serialize"),
-                    )
-                    .with_body(
-                        serde_json::to_value(decline_body)
-                            .expect("decline body should always serialize into serde_json::Value"),
-                    ),
-                Err(_) => {
-                    log::warn!(
-                        "Failed to receive from oneshot channel for swap {}",
-                        swap_id
-                    );
-                    Response::empty().with_header(
-                        "decision",
-                        Decision::Declined
-                            .to_header()
-                            .expect("Decision should not fail to serialize"),
-                    )
-                }
-            };
-
-            Ok(response)
-        })),
-        Err(e) => {
-            log::error!("Unable to spawn Bob: {:?}", e);
-            Box::new(futures::future::ok(
-                Response::empty().with_header(
-                    "decision",
-                    Decision::Declined
-                        .to_header()
-                        .expect("Decision should not fail to serialize"),
-                ),
-            ))
-        }
-    }
+    unimplemented!("Tobin is fixing this")
+    //    match bob_spawner.spawn(swap_request) {
+    //        Ok(response_future) => Box::new(response_future.then(move |result|
+    // {            let response = match result {
+    //                Ok(Ok(accept_body)) => {
+    //                    let body = rfc003::messages::AcceptResponseBody::<AL,
+    // BL> {                        beta_ledger_refund_identity:
+    // accept_body.beta_ledger_refund_identity,
+    // alpha_ledger_redeem_identity: accept_body.alpha_ledger_redeem_identity,
+    //                    };
+    //                    Response::empty()
+    //                        .with_header(
+    //                            "decision",
+    //                            Decision::Accepted
+    //                                .to_header()
+    //                                .expect("Decision should not fail to
+    // serialize"),                        )
+    //                        .with_body(
+    //                            serde_json::to_value(body)
+    //                                .expect("body should always serialize into
+    // serde_json::Value"),                        )
+    //                }
+    //                Ok(Err(decline_body)) => Response::empty()
+    //                    .with_header(
+    //                        "decision",
+    //                        Decision::Declined
+    //                            .to_header()
+    //                            .expect("Decision shouldn't fail to
+    // serialize"),                    )
+    //                    .with_body(
+    //                        serde_json::to_value(decline_body)
+    //                            .expect("decline body should always serialize
+    // into serde_json::Value"),                    ),
+    //                Err(_) => {
+    //                    log::warn!(
+    //                        "Failed to receive from oneshot channel for swap
+    // {}",                        swap_id
+    //                    );
+    //                    Response::empty().with_header(
+    //                        "decision",
+    //                        Decision::Declined
+    //                            .to_header()
+    //                            .expect("Decision should not fail to
+    // serialize"),                    )
+    //                }
+    //            };
+    //
+    //            Ok(response)
+    //        })),
+    //        Err(e) => {
+    //            log::error!("Unable to spawn Bob: {:?}", e);
+    //            Box::new(futures::future::ok(
+    //                Response::empty().with_header(
+    //                    "decision",
+    //                    Decision::Declined
+    //                        .to_header()
+    //                        .expect("Decision should not fail to serialize"),
+    //                ),
+    //            ))
+    //        }
+    //    }
 }

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -6,9 +6,8 @@ use crate::{
             self,
             bob::{BobSpawner, InsertState},
             messages::{Decision, DeclineResponseBody, SwapDeclineReason},
-            CreateLedgerEvents,
         },
-        HashFunction, LedgerEventDependencies, LedgerKind, SwapId, SwapProtocol,
+        HashFunction, LedgerKind, SwapId, SwapProtocol,
     },
 };
 use futures::{future::Future, sync::oneshot};
@@ -377,75 +376,5 @@ fn rfc003_swap_request<AL: rfc003::Ledger, BL: rfc003::Ledger, AA: Asset, BA: As
         alpha_expiry: body.alpha_expiry,
         beta_expiry: body.beta_expiry,
         secret_hash: body.secret_hash,
-    }
-}
-
-pub fn spawn<AL: rfc003::Ledger, BL: rfc003::Ledger, AA: Asset, BA: Asset, B: BobSpawner>(
-    bob_spawner: &B,
-    swap_request: rfc003::messages::Request<AL, BL, AA, BA>,
-) -> Box<dyn Future<Item = Response, Error = Infallible> + Send + 'static>
-where
-    LedgerEventDependencies: CreateLedgerEvents<AL, AA> + CreateLedgerEvents<BL, BA>,
-{
-    let swap_id = swap_request.id;
-
-    match bob_spawner.spawn(swap_request) {
-        Ok(response_future) => Box::new(response_future.then(move |result| {
-            let response = match result {
-                Ok(Ok(accept_body)) => {
-                    let body = rfc003::messages::AcceptResponseBody::<AL, BL> {
-                        beta_ledger_refund_identity: accept_body.beta_ledger_refund_identity,
-                        alpha_ledger_redeem_identity: accept_body.alpha_ledger_redeem_identity,
-                    };
-                    Response::empty()
-                        .with_header(
-                            "decision",
-                            Decision::Accepted
-                                .to_header()
-                                .expect("Decision should not fail to serialize"),
-                        )
-                        .with_body(
-                            serde_json::to_value(body)
-                                .expect("body should always serialize into serde_json::Value"),
-                        )
-                }
-                Ok(Err(decline_body)) => Response::empty()
-                    .with_header(
-                        "decision",
-                        Decision::Declined
-                            .to_header()
-                            .expect("Decision shouldn't fail to serialize"),
-                    )
-                    .with_body(
-                        serde_json::to_value(decline_body)
-                            .expect("decline body should always serialize into serde_json::Value"),
-                    ),
-                Err(_) => {
-                    log::warn!(
-                        "Failed to receive from oneshot channel for swap {}",
-                        swap_id
-                    );
-                    Response::empty().with_header(
-                        "decision",
-                        Decision::Declined
-                            .to_header()
-                            .expect("Decision should not fail to serialize"),
-                    )
-                }
-            };
-
-            Ok(response)
-        })),
-        Err(e) => {
-            log::error!("Unable to spawn Bob: {:?}", e);
-            Box::new(futures::future::ok(
-                Response::empty().with_header(
-                    "decision",
-                    Decision::Declined
-                        .to_header()
-                        .expect("Decision should not fail to serialize"),
-                ),
-            ))
-        }
     }
 }

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -357,9 +357,8 @@ fn rfc003_swap_request<AL: rfc003::Ledger, BL: rfc003::Ledger, AA: Asset, BA: As
     }
 }
 
-fn spawn<AL: rfc003::Ledger, BL: rfc003::Ledger, AA: Asset, BA: Asset, B: BobSpawner>(
+pub fn spawn<AL: rfc003::Ledger, BL: rfc003::Ledger, AA: Asset, BA: Asset, B: BobSpawner>(
     bob_spawner: &B,
-    counterparty: PeerId,
     swap_request: rfc003::messages::Request<AL, BL, AA, BA>,
 ) -> Box<dyn Future<Item = Response, Error = Infallible> + Send + 'static>
 where
@@ -367,65 +366,63 @@ where
 {
     let swap_id = swap_request.id;
 
-    unimplemented!("Tobin is fixing this")
-    //    match bob_spawner.spawn(swap_request) {
-    //        Ok(response_future) => Box::new(response_future.then(move |result|
-    // {            let response = match result {
-    //                Ok(Ok(accept_body)) => {
-    //                    let body = rfc003::messages::AcceptResponseBody::<AL,
-    // BL> {                        beta_ledger_refund_identity:
-    // accept_body.beta_ledger_refund_identity,
-    // alpha_ledger_redeem_identity: accept_body.alpha_ledger_redeem_identity,
-    //                    };
-    //                    Response::empty()
-    //                        .with_header(
-    //                            "decision",
-    //                            Decision::Accepted
-    //                                .to_header()
-    //                                .expect("Decision should not fail to
-    // serialize"),                        )
-    //                        .with_body(
-    //                            serde_json::to_value(body)
-    //                                .expect("body should always serialize into
-    // serde_json::Value"),                        )
-    //                }
-    //                Ok(Err(decline_body)) => Response::empty()
-    //                    .with_header(
-    //                        "decision",
-    //                        Decision::Declined
-    //                            .to_header()
-    //                            .expect("Decision shouldn't fail to
-    // serialize"),                    )
-    //                    .with_body(
-    //                        serde_json::to_value(decline_body)
-    //                            .expect("decline body should always serialize
-    // into serde_json::Value"),                    ),
-    //                Err(_) => {
-    //                    log::warn!(
-    //                        "Failed to receive from oneshot channel for swap
-    // {}",                        swap_id
-    //                    );
-    //                    Response::empty().with_header(
-    //                        "decision",
-    //                        Decision::Declined
-    //                            .to_header()
-    //                            .expect("Decision should not fail to
-    // serialize"),                    )
-    //                }
-    //            };
-    //
-    //            Ok(response)
-    //        })),
-    //        Err(e) => {
-    //            log::error!("Unable to spawn Bob: {:?}", e);
-    //            Box::new(futures::future::ok(
-    //                Response::empty().with_header(
-    //                    "decision",
-    //                    Decision::Declined
-    //                        .to_header()
-    //                        .expect("Decision should not fail to serialize"),
-    //                ),
-    //            ))
-    //        }
-    //    }
+    match bob_spawner.spawn(swap_request) {
+        Ok(response_future) => Box::new(response_future.then(move |result| {
+            let response = match result {
+                Ok(Ok(accept_body)) => {
+                    let body = rfc003::messages::AcceptResponseBody::<AL, BL> {
+                        beta_ledger_refund_identity: accept_body.beta_ledger_refund_identity,
+                        alpha_ledger_redeem_identity: accept_body.alpha_ledger_redeem_identity,
+                    };
+                    Response::empty()
+                        .with_header(
+                            "decision",
+                            Decision::Accepted
+                                .to_header()
+                                .expect("Decision should not fail to serialize"),
+                        )
+                        .with_body(
+                            serde_json::to_value(body)
+                                .expect("body should always serialize into serde_json::Value"),
+                        )
+                }
+                Ok(Err(decline_body)) => Response::empty()
+                    .with_header(
+                        "decision",
+                        Decision::Declined
+                            .to_header()
+                            .expect("Decision shouldn't fail to serialize"),
+                    )
+                    .with_body(
+                        serde_json::to_value(decline_body)
+                            .expect("decline body should always serialize into serde_json::Value"),
+                    ),
+                Err(_) => {
+                    log::warn!(
+                        "Failed to receive from oneshot channel for swap {}",
+                        swap_id
+                    );
+                    Response::empty().with_header(
+                        "decision",
+                        Decision::Declined
+                            .to_header()
+                            .expect("Decision should not fail to serialize"),
+                    )
+                }
+            };
+
+            Ok(response)
+        })),
+        Err(e) => {
+            log::error!("Unable to spawn Bob: {:?}", e);
+            Box::new(futures::future::ok(
+                Response::empty().with_header(
+                    "decision",
+                    Decision::Declined
+                        .to_header()
+                        .expect("Decision should not fail to serialize"),
+                ),
+            ))
+        }
+    }
 }

--- a/cnd/src/swap_protocols/dependencies/mod.rs
+++ b/cnd/src/swap_protocols/dependencies/mod.rs
@@ -33,12 +33,22 @@ pub mod bob {
     use super::*;
 
     #[allow(missing_debug_implementations)]
-    #[derive(Clone)]
     pub struct ProtocolDependencies<T, S> {
         pub ledger_events: LedgerEventDependencies,
         pub metadata_store: Arc<T>,
         pub state_store: Arc<S>,
         pub seed: Seed,
+    }
+
+    impl<T, S> Clone for ProtocolDependencies<T, S> {
+        fn clone(&self) -> Self {
+            Self {
+                ledger_events: self.ledger_events.clone(),
+                metadata_store: Arc::clone(&self.metadata_store),
+                state_store: Arc::clone(&self.state_store),
+                seed: self.seed,
+            }
+        }
     }
 }
 

--- a/cnd/src/swap_protocols/rfc003/actions/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/mod.rs
@@ -85,7 +85,7 @@ impl<AL: Ledger, BL: Ledger> Accept<AL, BL> {
     }
 }
 
-#[derive(Clone, derivative::Derivative)]
+#[derive(Clone, derivative::Derivative, Default)]
 #[derivative(Debug)]
 pub struct Decline<AL: Ledger, BL: Ledger> {
     phantom_data: PhantomData<(AL, BL)>,

--- a/cnd/src/swap_protocols/rfc003/actions/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/mod.rs
@@ -13,8 +13,7 @@ use crate::swap_protocols::{
         Ledger, Secret,
     },
 };
-use failure::_core::marker::PhantomData;
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
 
 /// Defines the set of actions available in the RFC003 protocol
 #[derive(Debug, Clone, PartialEq, strum_macros::EnumDiscriminants)]

--- a/cnd/src/swap_protocols/rfc003/actor_state.rs
+++ b/cnd/src/swap_protocols/rfc003/actor_state.rs
@@ -1,6 +1,6 @@
 use crate::swap_protocols::{
     asset::Asset,
-    rfc003::{self, ledger_state::LedgerState, messages::*, secret::Secret, Ledger},
+    rfc003::{self, ledger_state::LedgerState, secret::Secret, Ledger},
 };
 use std::fmt::Debug;
 
@@ -10,10 +10,6 @@ pub trait ActorState: Debug + Clone + Send + Sync + 'static {
     type AA: Asset;
     type BA: Asset;
 
-    fn set_response(
-        &mut self,
-        response: Result<AcceptResponseBody<Self::AL, Self::BL>, DeclineResponseBody>,
-    );
     fn set_secret(&mut self, secret: Secret);
     fn set_error(&mut self, error: rfc003::Error);
     fn alpha_ledger_mut(&mut self) -> &mut LedgerState<Self::AL>;

--- a/cnd/src/swap_protocols/rfc003/alice/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/mod.rs
@@ -54,6 +54,7 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
             error: None,
         }
     }
+
     pub fn accepted(
         request: Request<AL, BL, AA, BA>,
         response: AcceptResponseBody<AL, BL>,

--- a/cnd/src/swap_protocols/rfc003/alice/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/mod.rs
@@ -4,22 +4,15 @@ mod spawner;
 
 pub use self::{actions::*, communication_events::*, spawner::*};
 
-use crate::{
-    comit_client,
-    network::DialInformation,
-    swap_protocols::{
-        asset::Asset,
-        rfc003::{
-            self,
-            events::LedgerEvents,
-            ledger::Ledger,
-            ledger_state::LedgerState,
-            messages::{AcceptResponseBody, DeclineResponseBody, Request},
-            save_state::SaveState,
-            secret_source::SecretSource,
-            state_machine::{Context, FutureSwapOutcome, Start, Swap},
-            ActorState, Secret,
-        },
+use crate::swap_protocols::{
+    asset::Asset,
+    rfc003::{
+        self,
+        ledger::Ledger,
+        ledger_state::LedgerState,
+        messages::{AcceptResponseBody, DeclineResponseBody, Request},
+        secret_source::SecretSource,
+        ActorState, Secret,
     },
 };
 use derivative::Derivative;
@@ -52,37 +45,41 @@ pub enum SwapCommunication<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
 }
 
 impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
-    pub fn new_state_machine<C: comit_client::Client>(
-        &self,
-        alpha_ledger_events: Box<dyn LedgerEvents<AL, AA>>,
-        beta_ledger_events: Box<dyn LedgerEvents<BL, BA>>,
-        comit_client: Arc<C>,
-        bob_dial_info: DialInformation,
-        save_state: Arc<dyn SaveState<AL, BL, AA, BA>>,
-    ) -> Box<FutureSwapOutcome<AL, BL, AA, BA>> {
-        let swap_request = self.request();
-        let start_state = Start {
-            id: swap_request.id,
-            alpha_ledger: swap_request.alpha_ledger,
-            beta_ledger: swap_request.beta_ledger,
-            alpha_asset: swap_request.alpha_asset,
-            beta_asset: swap_request.beta_asset,
-            hash_function: swap_request.hash_function,
-            alpha_ledger_refund_identity: swap_request.alpha_ledger_refund_identity,
-            beta_ledger_redeem_identity: swap_request.beta_ledger_redeem_identity,
-            alpha_expiry: swap_request.alpha_expiry,
-            beta_expiry: swap_request.beta_expiry,
-            secret_hash: swap_request.secret_hash,
-        };
+    pub fn proposed(request: Request<AL, BL, AA, BA>, secret_source: impl SecretSource) -> Self {
+        Self {
+            swap_communication: SwapCommunication::Proposed { request },
+            alpha_ledger_state: LedgerState::NotDeployed,
+            beta_ledger_state: LedgerState::NotDeployed,
+            secret_source: Arc::new(secret_source),
+            error: None,
+        }
+    }
+    pub fn accepted(
+        request: Request<AL, BL, AA, BA>,
+        response: AcceptResponseBody<AL, BL>,
+        secret_source: impl SecretSource,
+    ) -> Self {
+        Self {
+            swap_communication: SwapCommunication::Accepted { request, response },
+            alpha_ledger_state: LedgerState::NotDeployed,
+            beta_ledger_state: LedgerState::NotDeployed,
+            secret_source: Arc::new(secret_source),
+            error: None,
+        }
+    }
 
-        let context = Context {
-            alpha_ledger_events,
-            beta_ledger_events,
-            communication_events: Box::new(AliceToBob::new(comit_client, bob_dial_info)),
-            state_repo: save_state,
-        };
-
-        Box::new(Swap::start_in(start_state, context))
+    pub fn declined(
+        request: Request<AL, BL, AA, BA>,
+        response: DeclineResponseBody,
+        secret_source: impl SecretSource,
+    ) -> Self {
+        Self {
+            swap_communication: SwapCommunication::Declined { request, response },
+            alpha_ledger_state: LedgerState::NotDeployed,
+            beta_ledger_state: LedgerState::NotDeployed,
+            secret_source: Arc::new(secret_source),
+            error: None,
+        }
     }
 
     pub fn request(&self) -> Request<AL, BL, AA, BA> {
@@ -92,16 +89,6 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
             | SwapCommunication::Declined { request, .. } => request.clone(),
         }
     }
-
-    pub fn new(request: Request<AL, BL, AA, BA>, secret_source: Arc<dyn SecretSource>) -> Self {
-        Self {
-            swap_communication: SwapCommunication::Proposed { request },
-            alpha_ledger_state: LedgerState::NotDeployed,
-            beta_ledger_state: LedgerState::NotDeployed,
-            secret_source,
-            error: None,
-        }
-    }
 }
 
 impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> ActorState for State<AL, BL, AA, BA> {
@@ -109,26 +96,6 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> ActorState for State<AL, BL, 
     type BL = BL;
     type AA = AA;
     type BA = BA;
-
-    fn set_response(&mut self, response: Result<AcceptResponseBody<AL, BL>, DeclineResponseBody>) {
-        match self.swap_communication {
-            SwapCommunication::Proposed { ref request } => match response {
-                Ok(response) => {
-                    self.swap_communication = SwapCommunication::Accepted {
-                        request: request.clone(),
-                        response,
-                    }
-                }
-                Err(response) => {
-                    self.swap_communication = SwapCommunication::Declined {
-                        request: request.clone(),
-                        response,
-                    }
-                }
-            },
-            _ => log::error!("Tried to set a response after it's already set"),
-        }
-    }
 
     fn set_secret(&mut self, _secret: Secret) {
         // ignored because Alice already knows the secret

--- a/cnd/src/swap_protocols/rfc003/alice/spawner.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/spawner.rs
@@ -7,15 +7,20 @@ use crate::{
         dependencies::LedgerEventDependencies,
         metadata_store::{self, Metadata, MetadataStore, Role},
         rfc003::{
-            alice,
+            alice::{self, State, SwapCommunication},
             messages::ToRequest,
+            state_machine,
             state_store::{self, StateStore},
             CreateLedgerEvents, Ledger,
         },
         SwapId,
     },
 };
-use futures::{sync::mpsc, Future, Stream};
+use futures::{sync::mpsc, Stream};
+use futures_core::{
+    compat::Future01CompatExt,
+    future::{FutureExt, TryFutureExt},
+};
 use http_api_problem::HttpApiProblem;
 use std::sync::Arc;
 
@@ -58,10 +63,8 @@ impl<T: MetadataStore, S: StateStore, C: Client> AliceSpawner
     where
         LedgerEventDependencies: CreateLedgerEvents<AL, AA> + CreateLedgerEvents<BL, BA>,
     {
-        let swap_seed = Arc::new(self.seed.swap_seed(id));
-
-        let swap_request = partial_swap_request.to_request(id, swap_seed.as_ref());
-        let alice = alice::State::new(swap_request.clone(), swap_seed);
+        let swap_seed = self.seed.swap_seed(id);
+        let swap_request = partial_swap_request.to_request(id, &swap_seed);
 
         let metadata = Metadata::new(
             id,
@@ -80,32 +83,93 @@ impl<T: MetadataStore, S: StateStore, C: Client> AliceSpawner
         let (sender, receiver) = mpsc::unbounded();
 
         let swap_execution = {
+            let client = Arc::clone(&self.client);
             let ledger_events = self.ledger_events.clone();
-            alice.new_state_machine(
-                ledger_events.create_ledger_events(),
-                ledger_events.create_ledger_events(),
-                self.client.clone(),
-                bob_dial_info,
-                Arc::new(sender),
-            )
+            let state_store = Arc::clone(&self.state_store);
+
+            // For legacy reasons, we also store the communication in the state store
+            // This value is overwritten as soon as we have a reply from the other party
+            state_store.insert(id, State::proposed(swap_request.clone(), swap_seed));
+
+            async move {
+                let alice_state = client
+                    .send_rfc003_swap_request(bob_dial_info.clone(), swap_request.clone())
+                    .compat()
+                    .await
+                    .map_err(|e| {
+                        log::error!(
+                            "Failed to send swap request to {} because {:?}",
+                            bob_dial_info.peer_id,
+                            e
+                        );
+                    })?
+                    .map(|accept_response_body| {
+                        State::accepted(swap_request.clone(), accept_response_body, swap_seed)
+                    })
+                    .unwrap_or_else(|decline_response_body| {
+                        State::declined(swap_request.clone(), decline_response_body, swap_seed)
+                    });
+
+                state_store.insert(id, alice_state.clone());
+
+                match alice_state {
+                    State {
+                        swap_communication: SwapCommunication::Accepted { request, response },
+                        ..
+                    } => {
+                        let context = state_machine::Context {
+                            alpha_ledger_events: ledger_events.create_ledger_events(),
+                            beta_ledger_events: ledger_events.create_ledger_events(),
+                            state_repo: Arc::new(sender),
+                        };
+
+                        let result = state_machine::Swap::start_in(
+                            state_machine::Start {
+                                swap: state_machine::OngoingSwap {
+                                    alpha_ledger: request.alpha_ledger,
+                                    beta_ledger: request.beta_ledger,
+                                    alpha_asset: request.alpha_asset,
+                                    beta_asset: request.beta_asset,
+                                    hash_function: request.hash_function,
+                                    alpha_ledger_redeem_identity: response
+                                        .alpha_ledger_redeem_identity,
+                                    alpha_ledger_refund_identity: request
+                                        .alpha_ledger_refund_identity,
+                                    beta_ledger_redeem_identity: request
+                                        .beta_ledger_redeem_identity,
+                                    beta_ledger_refund_identity: response
+                                        .beta_ledger_refund_identity,
+                                    alpha_expiry: request.alpha_expiry,
+                                    beta_expiry: request.beta_expiry,
+                                    secret_hash: request.secret_hash,
+                                },
+                            },
+                            context,
+                        )
+                        .compat()
+                        .await;
+
+                        match result {
+                            Ok(outcome) => log::info!("Swap {} finished with {:?}", id, outcome),
+                            Err(e) => log::error!("Swap {} failed with {:?}", id, e),
+                        }
+                    }
+                    _ => {
+                        log::info!("Swap {} was declined", id);
+                    }
+                }
+
+                Ok(())
+            }
         };
 
         let state_store = Arc::clone(&self.state_store);
-        state_store.insert(id, alice);
         tokio::spawn(receiver.for_each(move |update| {
             state_store.update::<alice::State<AL, BL, AA, BA>>(&id, update);
             Ok(())
         }));
 
-        tokio::spawn(
-            swap_execution
-                .map(move |outcome| {
-                    log::info!("Swap {} finished with {:?}", id, outcome);
-                })
-                .map_err(move |e| {
-                    log::error!("Swap {} failed with {:?}", id, e);
-                }),
-        );
+        tokio::spawn(swap_execution.boxed().compat());
 
         Ok(())
     }

--- a/cnd/src/swap_protocols/rfc003/alice/spawner.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/spawner.rs
@@ -87,11 +87,9 @@ impl<T: MetadataStore, S: StateStore, C: Client> AliceSpawner
             let ledger_events = self.ledger_events.clone();
             let state_store = Arc::clone(&self.state_store);
 
-            // For legacy reasons, we also store the communication in the state store
-            // This value is overwritten as soon as we have a reply from the other party
-            state_store.insert(id, State::proposed(swap_request.clone(), swap_seed));
-
             async move {
+                state_store.insert(id, State::proposed(swap_request.clone(), swap_seed));
+
                 let alice_state = client
                     .send_rfc003_swap_request(bob_dial_info.clone(), swap_request.clone())
                     .compat()

--- a/cnd/src/swap_protocols/rfc003/bob/actions/erc20.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/actions/erc20.rs
@@ -30,15 +30,10 @@ where
 
     fn actions(&self) -> Vec<Self::ActionKind> {
         let (request, response) = match &self.swap_communication {
-            SwapCommunication::Proposed {
-                pending_response, ..
-            } => {
+            SwapCommunication::Proposed { .. } => {
                 return vec![
-                    Action::Accept(Accept::new(
-                        pending_response.sender.clone(),
-                        Arc::clone(&self.secret_source),
-                    )),
-                    Action::Decline(Decline::new(pending_response.sender.clone())),
+                    Action::Accept(Accept::new(Arc::clone(&self.secret_source))),
+                    Action::Decline(Decline::new()),
                 ];
             }
             SwapCommunication::Accepted {
@@ -104,15 +99,10 @@ where
 
     fn actions(&self) -> Vec<Self::ActionKind> {
         let (request, response) = match &self.swap_communication {
-            SwapCommunication::Proposed {
-                pending_response, ..
-            } => {
+            SwapCommunication::Proposed { .. } => {
                 return vec![
-                    Action::Accept(Accept::new(
-                        pending_response.sender.clone(),
-                        Arc::clone(&self.secret_source),
-                    )),
-                    Action::Decline(Decline::new(pending_response.sender.clone())),
+                    Action::Accept(Accept::new(Arc::clone(&self.secret_source))),
+                    Action::Decline(Decline::new()),
                 ];
             }
             SwapCommunication::Accepted {

--- a/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
@@ -31,15 +31,10 @@ where
 
     fn actions(&self) -> Vec<Self::ActionKind> {
         let (request, response) = match &self.swap_communication {
-            SwapCommunication::Proposed {
-                pending_response, ..
-            } => {
+            SwapCommunication::Proposed { .. } => {
                 return vec![
-                    Action::Accept(Accept::new(
-                        pending_response.sender.clone(),
-                        Arc::clone(&self.secret_source),
-                    )),
-                    Action::Decline(Decline::new(pending_response.sender.clone())),
+                    Action::Accept(Accept::new(Arc::clone(&self.secret_source))),
+                    Action::Decline(Decline::new()),
                 ];
             }
             SwapCommunication::Accepted {

--- a/cnd/src/swap_protocols/rfc003/bob/insert_state.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/insert_state.rs
@@ -41,8 +41,8 @@ impl<T: MetadataStore, S: StateStore> InsertState
         swap_request: rfc003::messages::Request<AL, BL, AA, BA>,
     ) -> Result<(), Error> {
         let id = swap_request.id;
-        let swap_seed = Arc::new(self.seed.swap_seed(id));
-        let bob = bob::State::new(swap_request.clone(), swap_seed);
+        let seed = self.seed.swap_seed(id);
+        let bob = bob::State::proposed(swap_request.clone(), seed);
 
         let metadata = Metadata::new(
             id,

--- a/cnd/src/swap_protocols/rfc003/bob/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/mod.rs
@@ -8,19 +8,15 @@ use crate::swap_protocols::{
     asset::Asset,
     rfc003::{
         self,
-        actions::{Accept, Decline},
-        events::{LedgerEvents, ResponseFuture},
         ledger::Ledger,
         ledger_state::LedgerState,
         messages::{AcceptResponseBody, DeclineResponseBody, Request},
-        save_state::SaveState,
         secret_source::SecretSource,
-        state_machine::{Context, FutureSwapOutcome, Start, Swap},
         ActorState, Secret,
     },
 };
 use derivative::Derivative;
-use futures::{future::Shared, sync::oneshot, Future};
+use futures::sync::oneshot;
 use std::sync::{Arc, Mutex};
 
 #[allow(type_alias_bounds)]
@@ -44,8 +40,6 @@ pub struct State<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
 pub enum SwapCommunication<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
     Proposed {
         request: Request<AL, BL, AA, BA>,
-        #[derivative(Debug = "ignore")]
-        pending_response: PendingResponse<AL, BL>,
     },
     Accepted {
         request: Request<AL, BL, AA, BA>,
@@ -57,86 +51,32 @@ pub enum SwapCommunication<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
     },
 }
 
-#[allow(missing_debug_implementations)]
-#[derive(Clone)]
-pub struct PendingResponse<AL: Ledger, BL: Ledger> {
-    sender: ResponseSender<AL, BL>,
-    receiver: Shared<Box<ResponseFuture<AL, BL>>>,
-}
-
-impl<AL: Ledger, BL: Ledger> PendingResponse<AL, BL> {
-    fn response_future(&self) -> Box<ResponseFuture<AL, BL>> {
-        Box::new(self.receiver.clone().then(|result| match result {
-            Ok(response) => Ok((*response).clone()),
-            Err(e) => Err((*e).clone()),
-        }))
-    }
-
-    pub fn accept_action(&self, secret_source: Arc<dyn SecretSource>) -> Accept<AL, BL> {
-        Accept::new(self.sender.clone(), secret_source)
-    }
-
-    pub fn decline_action(&self) -> Decline<AL, BL> {
-        Decline::new(self.sender.clone())
-    }
-}
-
 impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
-    #[allow(clippy::type_complexity)]
-    pub fn new_state_machine(
-        &self,
-        alpha_ledger_events: Box<dyn LedgerEvents<AL, AA>>,
-        beta_ledger_events: Box<dyn LedgerEvents<BL, BA>>,
-        save_state: Arc<dyn SaveState<AL, BL, AA, BA>>,
-    ) -> Box<FutureSwapOutcome<AL, BL, AA, BA>> {
-        let response_future = self
-            .response_future()
-            .expect("A new state machine is only created when a swap has been proposed");
-        let communication_events = Box::new(BobToAlice::new(Box::new(response_future)));
-
-        let swap_request = self.request();
-        let start_state = Start {
-            id: swap_request.id,
-            alpha_ledger: swap_request.alpha_ledger,
-            beta_ledger: swap_request.beta_ledger,
-            alpha_asset: swap_request.alpha_asset,
-            beta_asset: swap_request.beta_asset,
-            hash_function: swap_request.hash_function,
-            alpha_ledger_refund_identity: swap_request.alpha_ledger_refund_identity,
-            beta_ledger_redeem_identity: swap_request.beta_ledger_redeem_identity,
-            alpha_expiry: swap_request.alpha_expiry,
-            beta_expiry: swap_request.beta_expiry,
-            secret_hash: swap_request.secret_hash,
-        };
-
-        let context = Context {
-            alpha_ledger_events,
-            beta_ledger_events,
-            communication_events,
-            state_repo: save_state,
-        };
-
-        Box::new(Swap::start_in(start_state, context))
-    }
-
-    pub fn new(request: Request<AL, BL, AA, BA>, secret_source: Arc<dyn SecretSource>) -> Self {
-        let (sender, receiver) = oneshot::channel();
-        let sender = Arc::new(Mutex::new(Some(sender)));
-        let receiver = receiver.map_err(|_e| {
-            rfc003::Error::Internal(String::from(
-                "For now, it should be impossible for the sender to go out of scope before the receiver",
-            ))
-        });
-        let receiver = (Box::new(receiver) as Box<ResponseFuture<AL, BL>>).shared();
-
-        State {
-            swap_communication: SwapCommunication::Proposed {
-                request,
-                pending_response: PendingResponse { sender, receiver },
-            },
+    pub fn accepted(
+        request: Request<AL, BL, AA, BA>,
+        response: AcceptResponseBody<AL, BL>,
+        secret_source: impl SecretSource,
+    ) -> Self {
+        Self {
+            swap_communication: SwapCommunication::Accepted { request, response },
             alpha_ledger_state: LedgerState::NotDeployed,
             beta_ledger_state: LedgerState::NotDeployed,
-            secret_source,
+            secret_source: Arc::new(secret_source),
+            secret: None,
+            error: None,
+        }
+    }
+
+    pub fn declined(
+        request: Request<AL, BL, AA, BA>,
+        response: DeclineResponseBody,
+        secret_source: impl SecretSource,
+    ) -> Self {
+        Self {
+            swap_communication: SwapCommunication::Declined { request, response },
+            alpha_ledger_state: LedgerState::NotDeployed,
+            beta_ledger_state: LedgerState::NotDeployed,
+            secret_source: Arc::new(secret_source),
             secret: None,
             error: None,
         }
@@ -149,18 +89,6 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
             | SwapCommunication::Declined { request, .. } => request.clone(),
         }
     }
-
-    pub fn response_future(&self) -> Option<Box<ResponseFuture<AL, BL>>> {
-        match &self.swap_communication {
-            SwapCommunication::Proposed {
-                pending_response, ..
-            } => Some(Box::new(pending_response.response_future())),
-            _ => {
-                log::warn!("Swap not in proposed state: {:?}", self);
-                None
-            }
-        }
-    }
 }
 
 impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> ActorState for State<AL, BL, AA, BA> {
@@ -168,26 +96,6 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> ActorState for State<AL, BL, 
     type BL = BL;
     type AA = AA;
     type BA = BA;
-
-    fn set_response(&mut self, response: Result<AcceptResponseBody<AL, BL>, DeclineResponseBody>) {
-        match self.swap_communication {
-            SwapCommunication::Proposed { ref request, .. } => match response {
-                Ok(response) => {
-                    self.swap_communication = SwapCommunication::Accepted {
-                        request: request.clone(),
-                        response,
-                    }
-                }
-                Err(response) => {
-                    self.swap_communication = SwapCommunication::Declined {
-                        request: request.clone(),
-                        response,
-                    }
-                }
-            },
-            _ => log::error!("Tried to set a response after it's already set"),
-        }
-    }
 
     fn set_secret(&mut self, secret: Secret) {
         self.secret = Some(secret)

--- a/cnd/src/swap_protocols/rfc003/bob/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/mod.rs
@@ -53,6 +53,17 @@ pub enum SwapCommunication<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
 }
 
 impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
+    pub fn proposed(request: Request<AL, BL, AA, BA>, secret_source: impl SecretSource) -> Self {
+        Self {
+            swap_communication: SwapCommunication::Proposed { request },
+            alpha_ledger_state: LedgerState::NotDeployed,
+            beta_ledger_state: LedgerState::NotDeployed,
+            secret_source: Arc::new(secret_source),
+            secret: None,
+            error: None,
+        }
+    }
+
     pub fn accepted(
         request: Request<AL, BL, AA, BA>,
         response: AcceptResponseBody<AL, BL>,

--- a/cnd/src/swap_protocols/rfc003/bob/spawner.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/spawner.rs
@@ -1,23 +1,21 @@
 use crate::swap_protocols::{
     asset::Asset,
     dependencies::{self, LedgerEventDependencies},
-    metadata_store::{self, MetadataStore},
+    metadata_store::MetadataStore,
     rfc003::{
         self,
         bob::{self, State, SwapCommunication},
         create_ledger_events::CreateLedgerEvents,
         state_machine,
-        state_store::{self, StateStore},
+        state_store::StateStore,
         Ledger,
     },
-    MetadataStore,
 };
 use futures::{sync::mpsc, Future, Stream};
 use futures_core::{
     compat::Future01CompatExt,
     future::{FutureExt, TryFutureExt},
 };
-use http_api_problem::HttpApiProblem;
 use std::sync::Arc;
 
 pub trait BobSpawner: Send + Sync + 'static {

--- a/cnd/src/swap_protocols/rfc003/bob/spawner.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/spawner.rs
@@ -1,18 +1,22 @@
 use crate::swap_protocols::{
     asset::Asset,
     dependencies::{self, LedgerEventDependencies},
-    metadata_store::{self, Metadata, MetadataStore, Role},
+    metadata_store::{self, MetadataStore},
     rfc003::{
-        self, bob,
+        self,
+        bob::{self, State, SwapCommunication},
         create_ledger_events::CreateLedgerEvents,
-        events::ResponseFuture,
+        state_machine,
         state_store::{self, StateStore},
         Ledger,
     },
 };
 use futures::{sync::mpsc, Future, Stream};
+use futures_core::{
+    compat::Future01CompatExt,
+    future::{FutureExt, TryFutureExt},
+};
 use http_api_problem::HttpApiProblem;
-use libp2p::PeerId;
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -35,10 +39,12 @@ pub trait BobSpawner: Send + Sync + 'static {
     #[allow(clippy::type_complexity)]
     fn spawn<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset>(
         &self,
-        counterparty: PeerId,
         swap_request: rfc003::messages::Request<AL, BL, AA, BA>,
-    ) -> Result<Box<ResponseFuture<AL, BL>>, Error>
-    where
+        response: Result<
+            rfc003::messages::AcceptResponseBody<AL, BL>,
+            rfc003::messages::DeclineResponseBody,
+        >,
+    ) where
         LedgerEventDependencies: CreateLedgerEvents<AL, AA> + CreateLedgerEvents<BL, BA>;
 }
 
@@ -46,59 +52,88 @@ impl<T: MetadataStore, S: StateStore> BobSpawner for dependencies::bob::Protocol
     #[allow(clippy::type_complexity)]
     fn spawn<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset>(
         &self,
-        counterparty: PeerId,
         swap_request: rfc003::messages::Request<AL, BL, AA, BA>,
-    ) -> Result<Box<ResponseFuture<AL, BL>>, Error>
-    where
+        response: Result<
+            rfc003::messages::AcceptResponseBody<AL, BL>,
+            rfc003::messages::DeclineResponseBody,
+        >,
+    ) where
         LedgerEventDependencies: CreateLedgerEvents<AL, AA> + CreateLedgerEvents<BL, BA>,
     {
         let id = swap_request.id;
-        let swap_seed = Arc::new(self.seed.swap_seed(id));
-        let bob = bob::State::new(swap_request.clone(), swap_seed);
-
-        let response_future = bob
-            .response_future()
-            .expect("This is always Some when Bob is created");
-
-        let metadata = Metadata::new(
-            id,
-            swap_request.alpha_ledger.into(),
-            swap_request.beta_ledger.into(),
-            swap_request.alpha_asset.into(),
-            swap_request.beta_asset.into(),
-            Role::Bob,
-            counterparty,
-        );
-
-        self.metadata_store
-            .insert(metadata)
-            .map_err(Error::Metadata)?;
+        let seed = self.seed.swap_seed(id);
 
         let (sender, receiver) = mpsc::unbounded();
 
-        let state_machine_future = bob.new_state_machine(
-            self.ledger_events.create_ledger_events(),
-            self.ledger_events.create_ledger_events(),
-            Arc::new(sender),
-        );
+        let swap_execution = {
+            let ledger_events = self.ledger_events.clone();
+            let state_store = Arc::clone(&self.state_store);
+
+            async move {
+                let bob_state = match response {
+                    Ok(accepted) => State::accepted(swap_request, accepted, seed),
+                    Err(declined) => State::declined(swap_request, declined, seed),
+                };
+
+                state_store.insert(id, bob_state.clone());
+
+                match bob_state {
+                    State {
+                        swap_communication: SwapCommunication::Accepted { request, response },
+                        ..
+                    } => {
+                        let context = state_machine::Context {
+                            alpha_ledger_events: ledger_events.create_ledger_events(),
+                            beta_ledger_events: ledger_events.create_ledger_events(),
+                            state_repo: Arc::new(sender),
+                        };
+
+                        let result = state_machine::Swap::start_in(
+                            state_machine::Start {
+                                swap: state_machine::OngoingSwap {
+                                    alpha_ledger: request.alpha_ledger,
+                                    beta_ledger: request.beta_ledger,
+                                    alpha_asset: request.alpha_asset,
+                                    beta_asset: request.beta_asset,
+                                    hash_function: request.hash_function,
+                                    alpha_ledger_redeem_identity: response
+                                        .alpha_ledger_redeem_identity,
+                                    alpha_ledger_refund_identity: request
+                                        .alpha_ledger_refund_identity,
+                                    beta_ledger_redeem_identity: request
+                                        .beta_ledger_redeem_identity,
+                                    beta_ledger_refund_identity: response
+                                        .beta_ledger_refund_identity,
+                                    alpha_expiry: request.alpha_expiry,
+                                    beta_expiry: request.beta_expiry,
+                                    secret_hash: request.secret_hash,
+                                },
+                            },
+                            context,
+                        )
+                        .compat()
+                        .await;
+
+                        match result {
+                            Ok(outcome) => log::info!("Swap {} finished with {:?}", id, outcome),
+                            Err(e) => log::error!("Swap {} failed with {:?}", id, e),
+                        }
+                    }
+                    _ => {
+                        log::info!("Swap {} was declined", id);
+                    }
+                }
+
+                Ok(())
+            }
+        };
 
         let state_store = Arc::clone(&self.state_store);
-        state_store.insert(id, bob);
         tokio::spawn(receiver.for_each(move |update| {
             state_store.update::<bob::State<AL, BL, AA, BA>>(&id, update);
             Ok(())
         }));
 
-        tokio::spawn(
-            state_machine_future
-                .map(move |outcome| {
-                    log::info!("Swap {} finished with {:?}", id, outcome);
-                })
-                .map_err(move |e| {
-                    log::error!("Swap {} failed with {:?}", id, e);
-                }),
-        );
-
-        Ok(response_future)
+        tokio::spawn(swap_execution.boxed().compat());
     }
 }

--- a/cnd/src/swap_protocols/rfc003/bob/spawner.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/spawner.rs
@@ -11,7 +11,7 @@ use crate::swap_protocols::{
         Ledger,
     },
 };
-use futures::{sync::mpsc, Future, Stream};
+use futures::{sync::mpsc, Stream};
 use futures_core::{
     compat::Future01CompatExt,
     future::{FutureExt, TryFutureExt},

--- a/cnd/src/swap_protocols/rfc003/secret_source.rs
+++ b/cnd/src/swap_protocols/rfc003/secret_source.rs
@@ -1,7 +1,7 @@
 use crate::{seed::Seed, swap_protocols::rfc003::Secret};
 use bitcoin_support::bitcoin::secp256k1::SecretKey;
 
-pub trait SecretSource: Send + Sync {
+pub trait SecretSource: Send + Sync + 'static {
     fn secret(&self) -> Secret;
     fn secp256k1_redeem(&self) -> SecretKey;
     fn secp256k1_refund(&self) -> SecretKey;

--- a/cnd/src/swap_protocols/rfc003/state_machine.rs
+++ b/cnd/src/swap_protocols/rfc003/state_machine.rs
@@ -98,10 +98,6 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> OngoingSwap<AL, BL, AA, BA> {
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum SwapOutcome<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
-    //    Declined {
-    //        request: Request<AL, BL, AA, BA>,
-    //        reason: DeclineResponseBody,
-    //    },
     AlphaRefunded {
         swap: OngoingSwap<AL, BL, AA, BA>,
         alpha_deployed: Deployed<AL>,

--- a/cnd/src/swap_protocols/rfc003/state_store.rs
+++ b/cnd/src/swap_protocols/rfc003/state_store.rs
@@ -292,7 +292,7 @@ mod tests {
             beta_asset: EtherQuantity::from_eth(10.0),
             hash_function: HashFunction::Sha256,
             alpha_ledger_refund_identity: bitcoin_pub_key,
-            beta_ledger_redeem_identity: ethereum_address.clone(),
+            beta_ledger_redeem_identity: ethereum_address,
             alpha_expiry: Timestamp::from(2_000_000_000),
             beta_expiry: Timestamp::from(2_000_000_000),
             secret_hash: Secret::from(*b"hello world, you are beautiful!!").hash(),


### PR DESCRIPTION
This PR is a combination of work done by @thomaseizinger and @tcharding.  It removes the communication from the state machine and changes the way the bob spawning is done.  With this when a swap request arrives from the peer node we save the channel in a hashmap and store the swap request in the state store but do **not** spawn bob until later when the action handler gets triggered by the client withe accept/decline.  We also use async/await when spawning bob.

Resolves #1507.
Resolves #1406.
Resolves #1508.