### PR TITLE
Remove secret key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,7 @@ dependencies = [
 name = "cnd"
 version = "0.3.0"
 dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "binary_macros 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoincore-rpc 0.8.0-rc1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,6 @@ dependencies = [
 name = "cnd"
 version = "0.3.0"
 dependencies = [
- "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "binary_macros 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoincore-rpc 0.8.0-rc1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,7 @@ dependencies = [
 name = "cnd"
 version = "0.3.0"
 dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "binary_macros 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoincore-rpc 0.8.0-rc1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -526,6 +527,7 @@ dependencies = [
  "memsocket 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pem 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2597,6 +2599,17 @@ dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pem"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4818,6 +4831,7 @@ dependencies = [
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum parking_lot_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb88cb1cb3790baa6776844f968fea3be44956cf184fa1be5a03341f5491278c"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
+"checksum pem 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39eb474073dfddbf7156515344266245d91ce698ddbf15e0498cef22b836f45a"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"

--- a/api_tests/lib/cnd_runner.ts
+++ b/api_tests/lib/cnd_runner.ts
@@ -45,12 +45,12 @@ export class CndRunner {
                 "config.toml"
             );
 
-            const pemObject = new PEMObject("SECRET SEED", cndconfig.seed);
+            const pemObject = new PEMObject("SEED", cndconfig.seed);
             const seedFile = await tempWrite(pemObject.encoded, "seed.pem");
 
             const process = spawn(
                 this.bin,
-                ["--config", configFile, "--secret-seed-file", seedFile],
+                ["--config", configFile, "--seed-file", seedFile],
                 {
                     cwd: this.projectRoot,
                     stdio: [

--- a/api_tests/lib/cnd_runner.ts
+++ b/api_tests/lib/cnd_runner.ts
@@ -1,6 +1,7 @@
 import { JsonMap, stringify } from "@iarna/toml";
 import { ChildProcess, spawn } from "child_process";
 import * as fs from "fs";
+import { PEMObject } from "pem-ts";
 import tempWrite from "temp-write";
 import { BtsieveConfigFile, CND_CONFIGS } from "./config";
 import { sleep } from "./util";
@@ -44,14 +45,21 @@ export class CndRunner {
                 "config.toml"
             );
 
-            const process = spawn(this.bin, ["--config", configFile], {
-                cwd: this.projectRoot,
-                stdio: [
-                    "ignore", // stdin
-                    fs.openSync(this.logDir + "/cnd-" + name + ".log", "w"), // stdout
-                    fs.openSync(this.logDir + "/cnd-" + name + ".log", "w"), // stderr
-                ],
-            });
+            const pemObject = new PEMObject("SECRET SEED", cndconfig.seed);
+            const seedFile = await tempWrite(pemObject.encoded, "seed.pem");
+
+            const process = spawn(
+                this.bin,
+                ["--config", configFile, "--secret-seed-file", seedFile],
+                {
+                    cwd: this.projectRoot,
+                    stdio: [
+                        "ignore", // stdin
+                        fs.openSync(this.logDir + "/cnd-" + name + ".log", "w"), // stdout
+                        fs.openSync(this.logDir + "/cnd-" + name + ".log", "w"), // stderr
+                    ],
+                }
+            );
 
             process.on("exit", (code: number, signal: number) => {
                 console.log(

--- a/api_tests/lib/config.ts
+++ b/api_tests/lib/config.ts
@@ -27,7 +27,7 @@ export interface BtsieveConfigFile {
 export class E2ETestActorConfig {
     public readonly httpApiPort: number;
     public readonly comitPort: number;
-    public readonly seed: string;
+    public readonly seed: Uint8Array;
     public readonly webGuiPort?: number;
 
     constructor(
@@ -38,7 +38,7 @@ export class E2ETestActorConfig {
     ) {
         this.httpApiPort = httpApiPort;
         this.comitPort = comitPort;
-        this.seed = seed;
+        this.seed = new Uint8Array(Buffer.from(seed, "hex"));
         this.webGuiPort = webGuiPort;
     }
 

--- a/api_tests/lib/config.ts
+++ b/api_tests/lib/config.ts
@@ -4,7 +4,6 @@ import { EthereumNodeConfig } from "./ethereum";
 import { LedgerConfig } from "./ledger_runner";
 
 export interface CndConfigFile {
-    comit: { secret_seed: string };
     http_api: { address: string; port: number };
     database?: { sqlite: string };
     web_gui?: { address: string; port: number };
@@ -48,9 +47,6 @@ export class E2ETestActorConfig {
     ): CndConfigFile {
         const dbPath = tempfile(".sqlite");
         return {
-            comit: {
-                secret_seed: this.seed,
-            },
             http_api: {
                 address: "0.0.0.0",
                 port: this.httpApiPort,

--- a/api_tests/package.json
+++ b/api_tests/package.json
@@ -49,6 +49,7 @@
         "chai-string": "^1.5.0",
         "chai-subset": "^1.6.0",
         "json-schema-to-typescript": "^7.1.0",
+        "pem-ts": "^2.0.0",
         "prettier": "^1.15.2",
         "rimraf": "^3.0.0",
         "temp-write": "^4.0.0",

--- a/api_tests/yarn.lock
+++ b/api_tests/yarn.lock
@@ -275,6 +275,11 @@ base-x@^3.0.2:
   dependencies:
     safe-buffer "^5.0.1"
 
+base64-js@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
+  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
@@ -1777,6 +1782,13 @@ pathval@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
   integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
+
+pem-ts@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pem-ts/-/pem-ts-2.0.0.tgz#bb2c58f52528047283ef25f5941ede223e5c2c54"
+  integrity sha512-yS2U3SFf/+MIOh7BANBDUwvFYcpVlHuUKbHcBZxsoPHDfX/cdq61nQ2sNNifeWxCjPhtbh3zZBDSECsQE20j8Q==
+  dependencies:
+    base64-js "^1.3.1"
 
 performance-now@^2.1.0:
   version "2.1.0"

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 description = "Reference implementation of a COMIT network daemon."
 
 [dependencies]
-base64 = "0.10"
 binary_macros = "0.6"
 bitcoin = "0.19.1"
 blockchain_contracts = "0.1"

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 description = "Reference implementation of a COMIT network daemon."
 
 [dependencies]
+base64 = "0.10"
 binary_macros = "0.6"
 bitcoin = "0.19.1"
 blockchain_contracts = "0.1"
@@ -38,6 +39,7 @@ log = { version = "0.4", features = ["serde"] }
 maplit = "1"
 mime = "0.3"
 mime_guess = "2.0"
+pem = "0.6"
 rand = "0.7"
 reqwest = { version = "0.9", default-features = false }
 rlp = "0.4"

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -59,6 +59,7 @@ void = "1.0.2"
 warp = { version = "0.1", default-features = false }
 
 [dev-dependencies]
+base64 = "0.10"
 bitcoincore-rpc = "0.8.0-rc1"
 maplit = "1"
 matches = "0.1.8"

--- a/cnd/src/cli.rs
+++ b/cnd/src/cli.rs
@@ -8,6 +8,6 @@ pub struct Options {
     pub config_file: Option<PathBuf>,
 
     /// Path to secret seed file.
-    #[structopt(long = "secret-seed-file", parse(from_os_str))]
+    #[structopt(short = "s", long = "secret-seed-file", parse(from_os_str))]
     pub secret_seed_file: Option<PathBuf>,
 }

--- a/cnd/src/cli.rs
+++ b/cnd/src/cli.rs
@@ -3,7 +3,11 @@ use std::path::PathBuf;
 #[derive(structopt::StructOpt, Debug)]
 #[structopt(name = "COMIT network daemon")]
 pub struct Options {
-    /// Path to configuration file
+    /// Path to configuration file.
     #[structopt(short = "c", long = "config", parse(from_os_str))]
     pub config_file: Option<PathBuf>,
+
+    /// Path to secret seed file.
+    #[structopt(long = "secret-seed-file", parse(from_os_str))]
+    pub secret_seed_file: Option<PathBuf>,
 }

--- a/cnd/src/cli.rs
+++ b/cnd/src/cli.rs
@@ -8,6 +8,6 @@ pub struct Options {
     pub config_file: Option<PathBuf>,
 
     /// Path to secret seed file.
-    #[structopt(short = "s", long = "secret-seed-file", parse(from_os_str))]
-    pub secret_seed_file: Option<PathBuf>,
+    #[structopt(short = "s", long = "seed-file", parse(from_os_str))]
+    pub seed_file: Option<PathBuf>,
 }

--- a/cnd/src/config/file.rs
+++ b/cnd/src/config/file.rs
@@ -112,7 +112,7 @@ impl File {
                 "No configuration file found, creating default at {}",
                 PrintablePath(&path)
             );
-            Self::default(rand).write_to(&path)
+            Self::default().write_to(&path)
         }
     }
 
@@ -190,6 +190,7 @@ impl File {
 mod tests {
     use super::*;
     use log::LevelFilter;
+    use reqwest::Url;
     use spectral::prelude::*;
     use tempfile::NamedTempFile;
 

--- a/cnd/src/config/file.rs
+++ b/cnd/src/config/file.rs
@@ -19,7 +19,6 @@ use std::{
 /// for filling in default values for absent configuration options.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct File {
-    pub comit: Option<Comit>,
     pub network: Network,
     pub http_api: HttpSocket,
     pub database: Option<Database>,
@@ -36,7 +35,6 @@ impl File {
             .expect("cnd listen address could not be parsed");
 
         File {
-            comit: None,
             network: Network {
                 listen: vec![comit_listen],
             },
@@ -60,11 +58,6 @@ impl File {
 pub struct Logging {
     pub level: Option<LevelFilter>,
     pub structured: Option<bool>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-pub struct Comit {
-    pub secret_seed_file: PathBuf,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]

--- a/cnd/src/config/settings.rs
+++ b/cnd/src/config/settings.rs
@@ -11,7 +11,7 @@ use reqwest::Url;
 /// are created from a given `Config`.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Settings {
-    pub comit: Comit,
+    pub comit: Option<Comit>,
     pub network: Network,
     pub http_api: HttpSocket,
     pub database: Option<Database>,
@@ -78,7 +78,6 @@ mod tests {
 
     use super::*;
     use crate::config::file;
-    use rand::rngs::OsRng;
     use spectral::prelude::*;
 
     #[test]
@@ -88,7 +87,7 @@ mod tests {
                 level: None,
                 structured: None,
             }),
-            ..File::default(OsRng)
+            ..File::default()
         };
 
         let settings = Settings::from_config_file_and_defaults(config_file);
@@ -105,7 +104,7 @@ mod tests {
                 level: None,
                 structured: Some(true),
             }),
-            ..File::default(OsRng)
+            ..File::default()
         };
 
         let settings = Settings::from_config_file_and_defaults(config_file);
@@ -119,7 +118,7 @@ mod tests {
     fn logging_section_defaults_to_debug_and_false() {
         let config_file = File {
             logging: None,
-            ..File::default(OsRng)
+            ..File::default()
         };
 
         let settings = Settings::from_config_file_and_defaults(config_file);

--- a/cnd/src/config/settings.rs
+++ b/cnd/src/config/settings.rs
@@ -1,4 +1,4 @@
-use super::file::{Comit, Database, File, HttpSocket, Network};
+use super::file::{Database, File, HttpSocket, Network};
 use crate::config::file::{Bitcoin, Ethereum};
 use log::LevelFilter;
 use reqwest::Url;
@@ -11,7 +11,6 @@ use reqwest::Url;
 /// are created from a given `Config`.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Settings {
-    pub comit: Option<Comit>,
     pub network: Network,
     pub http_api: HttpSocket,
     pub database: Option<Database>,
@@ -32,7 +31,6 @@ pub struct Logging {
 impl Settings {
     pub fn from_config_file_and_defaults(config_file: File) -> Self {
         let File {
-            comit,
             network,
             http_api,
             database,
@@ -43,7 +41,6 @@ impl Settings {
         } = config_file;
 
         Self {
-            comit,
             network,
             http_api,
             database,

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), failure::Error> {
     let base_log_level = settings.logging.level;
     logging::initialize(base_log_level, settings.logging.structured)?;
 
-    let seed = match options.secret_seed_file {
+    let seed = match options.seed_file {
         Some(file) => Seed::from_file(file)?,
         None => Seed::from_default_file_or_generate(OsRng)?,
     };
@@ -126,8 +126,8 @@ fn main() -> Result<(), failure::Error> {
     Ok(())
 }
 
-fn derive_key_pair(secret_seed: &Seed) -> identity::Keypair {
-    let bytes = secret_seed.sha256_with_seed(&[b"NODE_ID"]);
+fn derive_key_pair(seed: &Seed) -> identity::Keypair {
+    let bytes = seed.sha256_with_seed(&[b"NODE_ID"]);
     let key = ed25519::SecretKey::from_bytes(bytes).expect("we always pass 32 bytes");
     identity::Keypair::Ed25519(key.into())
 }

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -45,14 +45,7 @@ fn main() -> Result<(), failure::Error> {
     let base_log_level = settings.logging.level;
     logging::initialize(base_log_level, settings.logging.structured)?;
 
-    let seed_file = match options.secret_seed_file {
-        Some(file) => Some(file),
-        None => match settings.comit.clone() {
-            Some(comit) => Some(comit.secret_seed_file),
-            None => None,
-        },
-    };
-    let seed = match seed_file {
+    let seed = match options.secret_seed_file {
         Some(file) => Seed::from_file(file)?,
         None => Seed::from_default_file_or_generate(OsRng)?,
     };

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -39,11 +39,23 @@ fn main() -> Result<(), failure::Error> {
     let config_file = options
         .config_file
         .map(config::File::read)
-        .unwrap_or_else(|| config::File::read_or_create_default(OsRng))?;
+        .unwrap_or_else(config::File::read_or_create_default)?;
     let settings = Settings::from_config_file_and_defaults(config_file);
 
     let base_log_level = settings.logging.level;
     logging::initialize(base_log_level, settings.logging.structured)?;
+
+    let seed_file = match options.secret_seed_file {
+        Some(file) => Some(file),
+        None => match settings.comit.clone() {
+            Some(comit) => Some(comit.secret_seed_file),
+            None => None,
+        },
+    };
+    let seed = match seed_file {
+        Some(file) => Seed::from_file(file)?,
+        None => Seed::from_default_file_or_generate(OsRng)?,
+    };
 
     let mut runtime = tokio::runtime::Runtime::new()?;
 
@@ -67,10 +79,10 @@ fn main() -> Result<(), failure::Error> {
         ledger_events: ledger_events.clone(),
         metadata_store: Arc::clone(&metadata_store),
         state_store: Arc::clone(&state_store),
-        seed: settings.comit.secret_seed,
+        seed,
     };
 
-    let local_key_pair = derive_key_pair(&settings.comit.secret_seed);
+    let local_key_pair = derive_key_pair(&seed);
     let local_peer_id = PeerId::from(local_key_pair.clone().public());
     log::info!("Starting with peer_id: {}", local_peer_id);
 
@@ -92,7 +104,7 @@ fn main() -> Result<(), failure::Error> {
         ledger_events: ledger_events.clone(),
         metadata_store: Arc::clone(&metadata_store),
         state_store: Arc::clone(&state_store),
-        seed: settings.comit.secret_seed,
+        seed,
         client: Arc::clone(&swarm),
     };
 

--- a/cnd/src/seed.rs
+++ b/cnd/src/seed.rs
@@ -132,9 +132,7 @@ fn ensure_directory_exists(file: PathBuf) -> Result<(), Error> {
 fn default_seed_path() -> Result<PathBuf, Error> {
     crate::data_dir()
         .map(|dir| Path::join(&dir, "secret_seed.pem"))
-        .ok_or_else(|| {
-            panic!("TODO: error handling");
-        })
+        .ok_or(Error::NoDefaultPath)
 }
 
 pub enum Error {
@@ -142,6 +140,7 @@ pub enum Error {
     PemParse(pem::PemError),
     IncorrectLength(usize),
     Rand(rand::Error),
+    NoDefaultPath,
 }
 
 impl std::error::Error for Error {}
@@ -162,6 +161,7 @@ impl fmt::Debug for Error {
                 write!(f, "expected 32 bytes of base64 encode, got {} bytes", x)
             }
             Error::Rand(e) => write!(f, "random number error: {:?}", e),
+            Error::NoDefaultPath => write!(f, "failed to generate default path"),
         }
     }
 }

--- a/cnd/src/seed.rs
+++ b/cnd/src/seed.rs
@@ -234,17 +234,20 @@ mod tests {
         assert_eq!(debug, "Seed([*****])".to_string());
     }
 
-    // 32 bytes base64 encoded.
-    const PEM: &str = "-----BEGIN SEED-----
+    #[test]
+    fn seed_from_pem_works() {
+        let payload: &str = "syl9wSYaruvgxg9P5Q1qkZaq5YkM6GvXkxe+VYrL/XM=";
+
+        // 32 bytes base64 encoded.
+        let pem_string: &str = "-----BEGIN SEED-----
 syl9wSYaruvgxg9P5Q1qkZaq5YkM6GvXkxe+VYrL/XM=
 -----END SEED-----
 ";
 
-    #[test]
-    fn seed_from_pem_works() {
-        let want = base64::decode("syl9wSYaruvgxg9P5Q1qkZaq5YkM6GvXkxe+VYrL/XM=").unwrap();
-        let pem = pem::parse(PEM).unwrap();
+        let want = base64::decode(payload).unwrap();
+        let pem = pem::parse(pem_string).unwrap();
         let got = Seed::from_pem(pem).unwrap();
+
         assert_eq!(got.0, *want);
     }
 

--- a/cnd/src/seed.rs
+++ b/cnd/src/seed.rs
@@ -62,7 +62,7 @@ impl Seed {
         Seed::from_pem(pem)
     }
 
-    pub fn from_pem(pem: pem::Pem) -> Result<Seed, Error> {
+    fn from_pem(pem: pem::Pem) -> Result<Seed, Error> {
         if pem.contents.len() != SEED_LENGTH {
             Err(Error::IncorrectLength(pem.contents.len()))
         } else {

--- a/cnd/src/seed.rs
+++ b/cnd/src/seed.rs
@@ -81,11 +81,17 @@ impl Seed {
         let path = default_seed_path()?;
 
         if path.exists() {
-            return Self::from_file(path);
+            return Self::from_file(&path);
         }
 
         let random_seed = Seed::new_random(rand)?;
-        random_seed.write_to(path)?;
+        random_seed.write_to(path.clone())?;
+
+        log::info!(
+            "No seed file found, creating default at {}",
+            PrintablePath(&path)
+        );
+
         Ok(random_seed)
     }
 
@@ -105,11 +111,6 @@ impl Seed {
 
         let mut file = File::create(path.clone())?;
         file.write_all(pem_string.as_bytes())?;
-
-        log::info!(
-            "No seed file found, creating default at {}",
-            PrintablePath(&path)
-        );
 
         Ok(())
     }

--- a/cnd/src/seed.rs
+++ b/cnd/src/seed.rs
@@ -252,14 +252,21 @@ syl9wSYaruvgxg9P5Q1qkZaq5YkM6GvXkxe+VYrL/XM=
     }
 
     #[test]
-    #[should_panic]
     fn seed_from_pem_fails_for_short_seed() {
         let short = "-----BEGIN SEED-----
-6516513
+VnZUNFZ4dlY=
 -----END SEED-----
 ";
         let pem = pem::parse(short).unwrap();
-        let _seed = Seed::from_pem(pem).unwrap();
+        match Seed::from_pem(pem) {
+            Ok(_) => panic!("should fail for short payload"),
+            Err(e) => {
+                match e {
+                    Error::IncorrectLength(_) => {} // pass
+                    _ => panic!("should fail with IncorrectLength error"),
+                }
+            }
+        }
     }
 
     #[test]
@@ -271,7 +278,15 @@ mbKANv2qKGmNVg1qtquj6Hx1pFPelpqOfE2JaJJAMEg1FlFhNRNlFlE=
 -----END SEED-----
 ";
         let pem = pem::parse(long).unwrap();
-        let _seed = Seed::from_pem(pem).unwrap();
+        match Seed::from_pem(pem) {
+            Ok(_) => panic!("should fail for short payload"),
+            Err(e) => {
+                match e {
+                    Error::IncorrectLength(_) => {} // pass
+                    _ => panic!("should fail with IncorrectLength error"),
+                }
+            }
+        }
     }
 
     #[test]

--- a/cnd/src/seed.rs
+++ b/cnd/src/seed.rs
@@ -241,12 +241,6 @@ syl9wSYaruvgxg9P5Q1qkZaq5YkM6GvXkxe+VYrL/XM=
 ";
 
     #[test]
-    fn pem_library_works_as_expected() {
-        let pem = pem::parse(PEM).unwrap();
-        assert_eq!(pem.tag, "SEED");
-    }
-
-    #[test]
     fn seed_from_pem_works() {
         let want = base64::decode("syl9wSYaruvgxg9P5Q1qkZaq5YkM6GvXkxe+VYrL/XM=").unwrap();
         let pem = pem::parse(PEM).unwrap();

--- a/cnd/src/seed.rs
+++ b/cnd/src/seed.rs
@@ -91,12 +91,11 @@ impl Seed {
 
     fn write_to(&self, seed_file: PathBuf) -> Result<(), Error> {
         ensure_directory_exists(seed_file.clone())?;
-        self.write_to_file(seed_file)?;
+        self._write_to(seed_file)?;
         Ok(())
     }
 
-    // Use write_to() to ensure directory tree exists before writing to file.
-    fn write_to_file(&self, path: PathBuf) -> Result<(), Error> {
+    fn _write_to(&self, path: PathBuf) -> Result<(), Error> {
         let pem = Pem {
             tag: String::from("SECRET SEED"),
             contents: self.0.to_vec(),
@@ -283,7 +282,7 @@ mbKANv2qKGmNVg1qtquj6Hx1pFPelpqOfE2JaJJAMEg1FlFhNRNlFlE=
         let path = tmpfile.path().to_path_buf();
 
         let seed = Seed::new_random(OsRng).unwrap();
-        seed.write_to_file(path.clone())
+        seed._write_to(path.clone())
             .expect("Write seed to temp file");
 
         let rinsed = Seed::from_file(path).expect("Read from temp file");

--- a/cnd/src/seed.rs
+++ b/cnd/src/seed.rs
@@ -137,11 +137,9 @@ fn default_seed_path() -> Result<PathBuf, Error> {
 
 pub enum Error {
     Io(io::Error),
-    PemFileParse,
     PemParse(pem::PemError),
     IncorrectLength(usize),
     Rand(rand::Error),
-    Decode(base64::DecodeError),
 }
 
 impl std::error::Error for Error {}
@@ -157,20 +155,12 @@ impl fmt::Debug for Error {
         write!(f, "secret seed: ")?;
         match self {
             Error::Io(e) => write!(f, "io error: {:?}", e),
-            Error::PemFileParse => write!(f, "pem format incorrect"),
             Error::PemParse(e) => write!(f, "pem format incorrect: {:?}", e),
             Error::IncorrectLength(x) => {
                 write!(f, "expected 32 bytes of base64 encode, got {} bytes", x)
             }
             Error::Rand(e) => write!(f, "random number error: {:?}", e),
-            Error::Decode(e) => write!(f, "base64 parse error: {:?}", e),
         }
-    }
-}
-
-impl From<base64::DecodeError> for Error {
-    fn from(e: base64::DecodeError) -> Error {
-        Error::Decode(e)
     }
 }
 


### PR DESCRIPTION
Remove secret key from the config file and put it in a pem file in the same default data directory used for the config file.  Add a config file option to specify the location and a command line option also.

WIP because e2e tests are failing.  Can someone please review the config file option choices made in this patch and the patch to `api_tests/lib/config.ts`.  I'm uncertain if I've updated the e2e test lib incorrectly or if he PR has bugs.

Thanks

Fixes: #948 