### PR TITLE
Use concrete types

### DIFF
--- a/cnd/src/http_api/mod.rs
+++ b/cnd/src/http_api/mod.rs
@@ -35,7 +35,7 @@ use crate::{
             bob::BobSpawner,
             messages::{AcceptResponseBody, DeclineResponseBody, Request, ToRequest},
             state_machine::SwapStates,
-            state_store::{self, StateStore},
+            state_store::{self, InMemoryStateStore, StateStore},
             ActorState, CreateLedgerEvents, Ledger,
         },
         LedgerEventDependencies, Metadata, SwapId, SwapProtocol,
@@ -306,15 +306,15 @@ impl<'de> Deserialize<'de> for DialInformation {
 /// to another implementation. This allows us to keep the number of arguments to
 /// HTTP API controllers small and still access all the functionality we need.
 #[derive(Debug)]
-pub struct Dependencies<S, A, B, N> {
+pub struct Dependencies<A, B, N> {
     pub metadata_store: Arc<InMemoryMetadataStore>,
-    pub state_store: Arc<S>,
+    pub state_store: Arc<InMemoryStateStore>,
     pub alice_spawner: Arc<A>,
     pub bob_spawner: Arc<B>,
     pub network: Arc<N>,
 }
 
-impl<S, A, B, N> Clone for Dependencies<S, A, B, N> {
+impl<A, B, N> Clone for Dependencies<A, B, N> {
     fn clone(&self) -> Self {
         Self {
             metadata_store: Arc::clone(&self.metadata_store),
@@ -326,9 +326,8 @@ impl<S, A, B, N> Clone for Dependencies<S, A, B, N> {
     }
 }
 
-impl<S, A, B, N> MetadataStore for Dependencies<S, A, B, N>
+impl<A, B, N> MetadataStore for Dependencies<A, B, N>
 where
-    S: Send + Sync + 'static,
     A: Send + Sync + 'static,
     B: Send + Sync + 'static,
     N: Send + Sync + 'static,
@@ -346,9 +345,8 @@ where
     }
 }
 
-impl<S: StateStore, AS, B, N> StateStore for Dependencies<S, AS, B, N>
+impl<AS, B, N> StateStore for Dependencies<AS, B, N>
 where
-    S: Send + Sync + 'static,
     AS: Send + Sync + 'static,
     B: Send + Sync + 'static,
     N: Send + Sync + 'static,
@@ -366,9 +364,8 @@ where
     }
 }
 
-impl<S, A, B: BobSpawner, N> BobSpawner for Dependencies<S, A, B, N>
+impl<A, B: BobSpawner, N> BobSpawner for Dependencies<A, B, N>
 where
-    S: Send + Sync + 'static,
     A: Send + Sync + 'static,
     B: Send + Sync + 'static,
     N: Send + Sync + 'static,
@@ -384,9 +381,8 @@ where
     }
 }
 
-impl<S, A: AliceSpawner, B, N> AliceSpawner for Dependencies<S, A, B, N>
+impl<A: AliceSpawner, B, N> AliceSpawner for Dependencies<A, B, N>
 where
-    S: Send + Sync + 'static,
     A: Send + Sync + 'static,
     B: Send + Sync + 'static,
     N: Send + Sync + 'static,
@@ -404,9 +400,8 @@ where
     }
 }
 
-impl<S, A, B, N: Network> Network for Dependencies<S, A, B, N>
+impl<A, B, N: Network> Network for Dependencies<A, B, N>
 where
-    S: Send + Sync + 'static,
     A: Send + Sync + 'static,
     B: Send + Sync + 'static,
     N: Send + Sync + 'static,

--- a/cnd/src/swap_protocols/dependencies/mod.rs
+++ b/cnd/src/swap_protocols/dependencies/mod.rs
@@ -1,4 +1,7 @@
-use crate::{seed::Seed, swap_protocols::InMemoryMetadataStore};
+use crate::{
+    seed::Seed,
+    swap_protocols::{rfc003::state_store::InMemoryStateStore, InMemoryMetadataStore},
+};
 use btsieve::{bitcoin::BitcoindConnector, ethereum::Web3Connector};
 use std::sync::Arc;
 
@@ -8,15 +11,15 @@ pub mod alice {
     use super::*;
 
     #[allow(missing_debug_implementations)]
-    pub struct ProtocolDependencies<S, C> {
+    pub struct ProtocolDependencies<C> {
         pub ledger_events: LedgerEventDependencies,
         pub metadata_store: Arc<InMemoryMetadataStore>,
-        pub state_store: Arc<S>,
+        pub state_store: Arc<InMemoryStateStore>,
         pub seed: Seed,
         pub client: Arc<C>,
     }
 
-    impl<S, C> Clone for ProtocolDependencies<S, C> {
+    impl<C> Clone for ProtocolDependencies<C> {
         fn clone(&self) -> Self {
             Self {
                 ledger_events: self.ledger_events.clone(),
@@ -33,14 +36,14 @@ pub mod bob {
     use super::*;
 
     #[allow(missing_debug_implementations)]
-    pub struct ProtocolDependencies<S> {
+    pub struct ProtocolDependencies {
         pub ledger_events: LedgerEventDependencies,
         pub metadata_store: Arc<InMemoryMetadataStore>,
-        pub state_store: Arc<S>,
+        pub state_store: Arc<InMemoryStateStore>,
         pub seed: Seed,
     }
 
-    impl<S> Clone for ProtocolDependencies<S> {
+    impl Clone for ProtocolDependencies {
         fn clone(&self) -> Self {
             Self {
                 ledger_events: self.ledger_events.clone(),

--- a/cnd/src/swap_protocols/dependencies/mod.rs
+++ b/cnd/src/swap_protocols/dependencies/mod.rs
@@ -1,4 +1,4 @@
-use crate::seed::Seed;
+use crate::{seed::Seed, swap_protocols::InMemoryMetadataStore};
 use btsieve::{bitcoin::BitcoindConnector, ethereum::Web3Connector};
 use std::sync::Arc;
 
@@ -8,15 +8,15 @@ pub mod alice {
     use super::*;
 
     #[allow(missing_debug_implementations)]
-    pub struct ProtocolDependencies<T, S, C> {
+    pub struct ProtocolDependencies<S, C> {
         pub ledger_events: LedgerEventDependencies,
-        pub metadata_store: Arc<T>,
+        pub metadata_store: Arc<InMemoryMetadataStore>,
         pub state_store: Arc<S>,
         pub seed: Seed,
         pub client: Arc<C>,
     }
 
-    impl<T, S, C> Clone for ProtocolDependencies<T, S, C> {
+    impl<S, C> Clone for ProtocolDependencies<S, C> {
         fn clone(&self) -> Self {
             Self {
                 ledger_events: self.ledger_events.clone(),
@@ -33,14 +33,14 @@ pub mod bob {
     use super::*;
 
     #[allow(missing_debug_implementations)]
-    pub struct ProtocolDependencies<T, S> {
+    pub struct ProtocolDependencies<S> {
         pub ledger_events: LedgerEventDependencies,
-        pub metadata_store: Arc<T>,
+        pub metadata_store: Arc<InMemoryMetadataStore>,
         pub state_store: Arc<S>,
         pub seed: Seed,
     }
 
-    impl<T, S> Clone for ProtocolDependencies<T, S> {
+    impl<S> Clone for ProtocolDependencies<S> {
         fn clone(&self) -> Self {
             Self {
                 ledger_events: self.ledger_events.clone(),

--- a/cnd/src/swap_protocols/mod.rs
+++ b/cnd/src/swap_protocols/mod.rs
@@ -10,7 +10,7 @@ mod timestamp;
 pub use self::{
     dependencies::{alice, bob, LedgerEventDependencies},
     ledger::{Ledger, LedgerKind},
-    metadata_store::{Metadata, MetadataStore, Role},
+    metadata_store::{InMemoryMetadataStore, Metadata, MetadataStore, Role},
     swap_id::*,
     timestamp::Timestamp,
 };

--- a/cnd/src/swap_protocols/rfc003/alice/spawner.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/spawner.rs
@@ -51,9 +51,7 @@ pub trait AliceSpawner: Send + Sync + 'static {
         LedgerEventDependencies: CreateLedgerEvents<AL, AA> + CreateLedgerEvents<BL, BA>;
 }
 
-impl<T: MetadataStore, S: StateStore, C: Client> AliceSpawner
-    for swap_protocols::alice::ProtocolDependencies<T, S, C>
-{
+impl<S: StateStore, C: Client> AliceSpawner for swap_protocols::alice::ProtocolDependencies<S, C> {
     fn spawn<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset>(
         &self,
         id: SwapId,

--- a/cnd/src/swap_protocols/rfc003/alice/spawner.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/spawner.rs
@@ -51,7 +51,7 @@ pub trait AliceSpawner: Send + Sync + 'static {
         LedgerEventDependencies: CreateLedgerEvents<AL, AA> + CreateLedgerEvents<BL, BA>;
 }
 
-impl<S: StateStore, C: Client> AliceSpawner for swap_protocols::alice::ProtocolDependencies<S, C> {
+impl<C: Client> AliceSpawner for swap_protocols::alice::ProtocolDependencies<C> {
     fn spawn<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset>(
         &self,
         id: SwapId,

--- a/cnd/src/swap_protocols/rfc003/bob/insert_state.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/insert_state.rs
@@ -31,9 +31,7 @@ pub trait InsertState: Send + Sync + 'static {
     ) -> Result<(), Error>;
 }
 
-impl<T: MetadataStore, S: StateStore> InsertState
-    for dependencies::bob::ProtocolDependencies<T, S>
-{
+impl<S: StateStore> InsertState for dependencies::bob::ProtocolDependencies<S> {
     #[allow(clippy::type_complexity)]
     fn insert_state<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset>(
         &self,

--- a/cnd/src/swap_protocols/rfc003/bob/insert_state.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/insert_state.rs
@@ -31,7 +31,7 @@ pub trait InsertState: Send + Sync + 'static {
     ) -> Result<(), Error>;
 }
 
-impl<S: StateStore> InsertState for dependencies::bob::ProtocolDependencies<S> {
+impl InsertState for dependencies::bob::ProtocolDependencies {
     #[allow(clippy::type_complexity)]
     fn insert_state<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset>(
         &self,

--- a/cnd/src/swap_protocols/rfc003/bob/spawner.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/spawner.rs
@@ -30,7 +30,7 @@ pub trait BobSpawner: Send + Sync + 'static {
         LedgerEventDependencies: CreateLedgerEvents<AL, AA> + CreateLedgerEvents<BL, BA>;
 }
 
-impl<S: StateStore> BobSpawner for dependencies::bob::ProtocolDependencies<S> {
+impl BobSpawner for dependencies::bob::ProtocolDependencies {
     #[allow(clippy::type_complexity)]
     fn spawn<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset>(
         &self,

--- a/cnd/src/swap_protocols/rfc003/bob/spawner.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/spawner.rs
@@ -1,7 +1,6 @@
 use crate::swap_protocols::{
     asset::Asset,
     dependencies::{self, LedgerEventDependencies},
-    metadata_store::MetadataStore,
     rfc003::{
         self,
         bob::{self, State, SwapCommunication},
@@ -31,7 +30,7 @@ pub trait BobSpawner: Send + Sync + 'static {
         LedgerEventDependencies: CreateLedgerEvents<AL, AA> + CreateLedgerEvents<BL, BA>;
 }
 
-impl<T: MetadataStore, S: StateStore> BobSpawner for dependencies::bob::ProtocolDependencies<T, S> {
+impl<S: StateStore> BobSpawner for dependencies::bob::ProtocolDependencies<S> {
     #[allow(clippy::type_complexity)]
     fn spawn<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset>(
         &self,

--- a/cnd/src/swap_protocols/rfc003/state_store.rs
+++ b/cnd/src/swap_protocols/rfc003/state_store.rs
@@ -12,7 +12,7 @@ use crate::swap_protocols::{
     swap_id::SwapId,
 };
 use either::Either;
-use std::{any::Any, collections::HashMap, hash::Hash, sync::Mutex};
+use std::{any::Any, collections::HashMap, sync::Mutex};
 
 #[derive(Debug)]
 pub enum Error {
@@ -26,11 +26,11 @@ pub trait StateStore: Send + Sync + 'static {
 }
 
 #[derive(Default, Debug)]
-pub struct InMemoryStateStore<K: Hash + Eq> {
-    states: Mutex<HashMap<K, Box<dyn Any + Send + Sync>>>,
+pub struct InMemoryStateStore {
+    states: Mutex<HashMap<SwapId, Box<dyn Any + Send + Sync>>>,
 }
 
-impl StateStore for InMemoryStateStore<SwapId> {
+impl StateStore for InMemoryStateStore {
     fn insert<A: ActorState>(&self, key: SwapId, value: A) {
         let mut states = self.states.lock().unwrap();
         states.insert(key, Box::new(value));


### PR DESCRIPTION
Use of generics for traits that have only a single implementation adds complexity.

Remove usage of `K` and use `SwapId`.

Remove usage of the `MetadataStore` and `StateStore` traits and use the structs that satisfy these traits, `InMemoryMetadataStore` and `InMemoryStateStore` respectively.