### PR TITLE
Remove task executor from ComitNode

### DIFF
--- a/cnd/src/libp2p_comit_ext.rs
+++ b/cnd/src/libp2p_comit_ext.rs
@@ -20,7 +20,7 @@ macro_rules! header {
                 reason: Some(SwapDeclineReason::MissingMandatoryHeader),
             };
 
-            return Err(Box::new(futures::future::ok(Response::empty().with_header(
+            return Err(Response::empty().with_header(
                 "decision",
                 Decision::Declined
                     .to_header()
@@ -28,7 +28,7 @@ macro_rules! header {
             )
             .with_body(serde_json::to_value(decline_body).expect(
                 "decline body should always serialize into serde_json::Value",
-            )))));
+            )));
         })
     };
 }
@@ -44,7 +44,7 @@ macro_rules! body {
                     reason: Some(SwapDeclineReason::BadJsonField),
                 };
 
-                return Err(Box::new(futures::future::ok(Response::empty().with_header(
+                return Err(Response::empty().with_header(
                     "decision",
                     Decision::Declined
                         .to_header()
@@ -52,7 +52,7 @@ macro_rules! body {
                 )
                 .with_body(serde_json::to_value(decline_body).expect(
                     "decline body should always serialize into serde_json::Value",
-                )))));
+                )));
             }
         }
     };
@@ -70,7 +70,7 @@ macro_rules! header_internal {
                     reason: Some(SwapDeclineReason::BadJsonField),
                 };
 
-                return Err(Box::new(futures::future::ok(Response::empty().with_header(
+                return Err(Response::empty().with_header(
                     "decision",
                     Decision::Declined
                         .to_header()
@@ -78,7 +78,7 @@ macro_rules! header_internal {
                 )
                 .with_body(serde_json::to_value(decline_body).expect(
                     "decline body should always serialize into serde_json::Value",
-                )))));
+                )));
 
             },
             None => $none,

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -80,7 +80,7 @@ fn main() -> Result<(), failure::Error> {
     log::info!("Starting with peer_id: {}", local_peer_id);
 
     let transport = libp2p::build_development_transport(local_key_pair);
-    let behaviour = network::ComitNode::new(bob_protocol_dependencies.clone(), runtime.executor())?;
+    let behaviour = network::ComitNode::new(bob_protocol_dependencies.clone())?;
 
     let mut swarm = Swarm::new(transport, behaviour, local_peer_id.clone());
 


### PR DESCRIPTION
Recent work saved the channel (future) for an incoming swap request instead of
spawning the future.  At that time we still had a future for the error path.  It
was not noticed that this error path future was only there because of the now
removed spawning.  We can remove this error path future also, this means the
task executor is no longer needed in the ComitNode.