### PR TITLE
Remove preflight

### DIFF
--- a/cnd/src/http_api/route_factory.rs
+++ b/cnd/src/http_api/route_factory.rs
@@ -22,7 +22,6 @@ pub fn new_action_link(id: &SwapId, action: &str) -> String {
 }
 
 pub fn create<D: Clone + MetadataStore + StateStore + Network + SendRequest + Spawn + SwapSeed>(
-    origin_auth: String,
     peer_id: PeerId,
     dependencies: D,
 ) -> BoxedFilter<(impl Reply,)> {
@@ -76,15 +75,7 @@ pub fn create<D: Clone + MetadataStore + StateStore + Network + SendRequest + Sp
         .and(dependencies.clone())
         .and_then(http_api::routes::index::get_info);
 
-    let preflight_cors_route = warp::options().map(warp::reply);
-
-    let cors = warp::cors()
-        .allow_origin(origin_auth.as_str())
-        .allow_methods(vec!["GET", "POST"])
-        .allow_headers(vec!["content-type"]);
-
-    preflight_cors_route
-        .or(rfc003_get_swap)
+    rfc003_get_swap
         .or(rfc003_post_swap)
         .or(rfc003_action)
         .or(get_swaps)
@@ -92,6 +83,5 @@ pub fn create<D: Clone + MetadataStore + StateStore + Network + SendRequest + Sp
         .or(get_info)
         .recover(http_api::unpack_problem)
         .with(warp::log("http"))
-        .with(cors)
         .boxed()
 }

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -129,7 +129,7 @@ fn spawn_warp_instance<
     runtime: &mut tokio::runtime::Runtime,
     dependencies: D,
 ) {
-    let routes = route_factory::create(auth_origin(), peer_id, dependencies);
+    let routes = route_factory::create(peer_id, dependencies);
 
     let listen_addr = SocketAddr::new(settings.http_api.address, settings.http_api.port);
 
@@ -138,10 +138,4 @@ fn spawn_warp_instance<
     let server = warp::serve(routes).bind(listen_addr);
 
     runtime.spawn(server);
-}
-
-fn auth_origin() -> String {
-    let auth_origin = "http://localhost:3000".to_string();
-    log::trace!("Auth origin enabled on: {}", auth_origin);
-    auth_origin
 }


### PR DESCRIPTION
We are no longer embedding comit-i, hence there is no need (for now), to specify these cors headers for the arbitrary origin of localhost:3000.