### PR TITLE
Allow for an eager `bors r+`

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,2 @@
 status = ["ci/circleci: debug-build-test"]
-pr_status = [
-    "ci/circleci: debug-build-test",
-    "license/cla"
-]
+pr_status = ["license/cla"]


### PR DESCRIPTION
Currently, one has to wait for a successful build before the PR can be handled to bors. However, sometimes we now upfront a build will succeed (textfile only changes for example). Hence, we can immediately delegate to bors without waiting for the build.