### PR TITLE
Increase e2e test timeout

### DIFF
--- a/api_tests/e2e/rfc003/btc_eth/happy.ts
+++ b/api_tests/e2e/rfc003/btc_eth/happy.ts
@@ -3,7 +3,7 @@ import { createActors } from "../../../lib_sdk/create_actors";
 
 setTimeout(function() {
     describe("happy path", function() {
-        this.timeout(30000);
+        this.timeout(60000);
         it("bitcoin ether", async function() {
             const { alice, bob } = await createActors(
                 "e2e-rfc003-btc-eth-happy.log"


### PR DESCRIPTION
The 30 second timeout has caused problems on CI. 

It looks like transactions on the Bitcoin regtest node sometimes take a long time to be included in a block.

Fixes #1613. Reopen if it keeps happening.