### PR TITLE
Remove possibility for in-memory DB

### DIFF
--- a/cnd/src/db/integration_tests.rs
+++ b/cnd/src/db/integration_tests.rs
@@ -1,5 +1,5 @@
 use crate::{
-    db::{load_swaps::LoadAcceptedSwap, Location, SaveMessage, Sqlite},
+    db::{load_swaps::LoadAcceptedSwap, SaveMessage, Sqlite},
     quickcheck::Quickcheck,
     swap_protocols::{
         ledger::{Bitcoin, Ethereum},
@@ -25,7 +25,7 @@ macro_rules! db_roundtrip_test {
                         .tempfile()?
                         .into_temp_path();
 
-                let db = Sqlite::new(Location::OnDisk(&db_path))?;
+                let db = Sqlite::new(&db_path)?;
 
                 let saved_request = Request {
                     swap_id: *swap_id,

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -3,7 +3,7 @@
 use btsieve::{bitcoin::BitcoindConnector, ethereum::Web3Connector};
 use cnd::{
     config::{self, Settings},
-    db::{Location, SaveRfc003Messages, Sqlite},
+    db::{SaveRfc003Messages, Sqlite},
     http_api::{self, route_factory},
     network::{self, Network, SendRequest},
     seed::{Seed, SwapSeed},
@@ -69,7 +69,7 @@ fn main() -> anyhow::Result<()> {
     let local_peer_id = PeerId::from(local_key_pair.clone().public());
     log::info!("Starting with peer_id: {}", local_peer_id);
 
-    let database = Sqlite::new(Location::OnDisk(&settings.database.sqlite))?;
+    let database = Sqlite::new(&settings.database.sqlite)?;
 
     let transport = libp2p::build_development_transport(local_key_pair);
     let behaviour = network::ComitNode::new(


### PR DESCRIPTION
It doesn't make much sense to have it because of the way our DB code is setup.

In-memory DBs of SQLite only live as-long as the connection is open. This means, we drop the DB just after we ran the migrations. In order to properly support in-memory DBs, we'd have to rework the way our DB code handles the connections as we would need to keep them around. In-memory DBs would only be useful for testing and we don't need them for now, hence it is not worth supporting them properly and certainly not improperly.