### PR TITLE
Merge `Save` and `SaveMessage` traits

### DIFF
--- a/cnd/src/db/integration_tests.rs
+++ b/cnd/src/db/integration_tests.rs
@@ -2,7 +2,7 @@ use crate::{
     db::{
         load_swaps::LoadAcceptedSwap,
         swap_types::{DetermineTypes, SwapTypes},
-        AssetKind, LedgerKind, Retrieve, Save, SaveMessage, Sqlite, Swap,
+        AssetKind, LedgerKind, Retrieve, Save, Sqlite, Swap,
     },
     quickcheck::Quickcheck,
     swap_protocols::{
@@ -50,8 +50,8 @@ macro_rules! db_roundtrip_test {
                     let (loaded_swap, loaded_request, loaded_accept, loaded_swap_types) =
                     async_std::task::block_on::<_, Result<_, anyhow::Error>>(async {
                         db.save(saved_swap.clone()).await?;
-                        db.save_message(saved_request.clone()).await?;
-                        db.save_message(saved_accept.clone()).await?;
+                        db.save(saved_request.clone()).await?;
+                        db.save(saved_accept.clone()).await?;
 
                         let loaded_swap = Retrieve::get(&db, &swap_id).await?;
                         let (loaded_request, loaded_accept) = db.load_accepted_swap(swap_id).await?;

--- a/cnd/src/db/mod.rs
+++ b/cnd/src/db/mod.rs
@@ -3,7 +3,7 @@ mod custom_sql_types;
 mod integration_tests;
 mod load_swaps;
 mod new_types;
-mod save_message;
+mod save;
 mod schema;
 #[cfg(test)]
 mod serialization_format_stability_tests;
@@ -14,8 +14,8 @@ pub mod with_swap_types;
 embed_migrations!("./migrations");
 
 pub use self::{
-    load_swaps::*,
-    save_message::{SaveMessage, SaveRfc003Messages},
+    load_swaps::{AcceptedSwap, LoadAcceptedSwap},
+    save::*,
     swap::*,
     swap_types::*,
 };

--- a/cnd/src/http_api/dependencies.rs
+++ b/cnd/src/http_api/dependencies.rs
@@ -1,7 +1,5 @@
 use crate::{
-    db::{
-        DetermineTypes, Retrieve, Save, SaveMessage, SaveRfc003Messages, Sqlite, Swap, SwapTypes,
-    },
+    db::{DetermineTypes, Retrieve, Save, Saver, Sqlite, Swap, SwapTypes},
     network::{DialInformation, Network, RequestError, SendRequest},
     seed::{Seed, SwapSeed},
     swap_protocols::{
@@ -132,16 +130,6 @@ where
 }
 
 #[async_trait]
-impl<S> Save for Dependencies<S>
-where
-    S: Send + Sync + 'static,
-{
-    async fn save(&self, swap: Swap) -> anyhow::Result<()> {
-        self.db.save(swap).await
-    }
-}
-
-#[async_trait]
 impl<S> Retrieve for Dependencies<S>
 where
     S: Send + Sync + 'static,
@@ -166,16 +154,16 @@ where
 }
 
 #[async_trait]
-impl<S> SaveRfc003Messages for Dependencies<S> where S: Send + Sync + 'static {}
+impl<S> Saver for Dependencies<S> where S: Send + Sync + 'static {}
 
 #[async_trait]
-impl<S, M> SaveMessage<M> for Dependencies<S>
+impl<S, T> Save<T> for Dependencies<S>
 where
     S: Send + Sync + 'static,
-    M: Send + 'static,
-    Sqlite: SaveMessage<M>,
+    T: Send + 'static,
+    Sqlite: Save<T>,
 {
-    async fn save_message(&self, message: M) -> anyhow::Result<()> {
-        self.db.save_message(message).await
+    async fn save(&self, data: T) -> anyhow::Result<()> {
+        self.db.save(data).await
     }
 }

--- a/cnd/src/http_api/route_factory.rs
+++ b/cnd/src/http_api/route_factory.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::settings::AllowedOrigins,
-    db::{DetermineTypes, Retrieve, Save, SaveRfc003Messages},
+    db::{DetermineTypes, Retrieve, Saver},
     http_api,
     network::{Network, SendRequest},
     seed::SwapSeed,
@@ -31,9 +31,8 @@ pub fn create<
         + Spawn
         + SwapSeed
         + DetermineTypes
-        + Save
         + Retrieve
-        + SaveRfc003Messages,
+        + Saver,
 >(
     peer_id: PeerId,
     dependencies: D,

--- a/cnd/src/http_api/routes/rfc003/handlers/action.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/action.rs
@@ -1,5 +1,5 @@
 use crate::{
-    db::{DetermineTypes, SaveMessage, SaveRfc003Messages},
+    db::{DetermineTypes, Save, Saver},
     http_api::{
         action::{
             ActionExecutionParameters, ActionResponseBody, IntoResponsePayload, ListRequiredFields,
@@ -31,9 +31,7 @@ use libp2p_comit::frame::Response;
 use std::fmt::Debug;
 
 #[allow(clippy::unit_arg, clippy::let_unit_value, clippy::cognitive_complexity)]
-pub async fn handle_action<
-    D: StateStore + Network + Spawn + SwapSeed + SaveRfc003Messages + DetermineTypes,
->(
+pub async fn handle_action<D: StateStore + Network + Spawn + SwapSeed + Saver + DetermineTypes>(
     method: http::Method,
     swap_id: SwapId,
     action_kind: ActionKind,
@@ -67,7 +65,7 @@ pub async fn handle_action<
                 let accept_message =
                     body.into_accept_message(swap_id, &SwapSeed::swap_seed(&dependencies, swap_id));
 
-                SaveMessage::save_message(&dependencies, accept_message)
+                Save::save(&dependencies, accept_message)
                     .await
                     .map_err(problem::internal_error)?;
 
@@ -100,7 +98,7 @@ pub async fn handle_action<
                     reason: to_swap_decline_reason(body.reason),
                 };
 
-                SaveMessage::save_message(&dependencies, decline_message.clone())
+                Save::save(&dependencies, decline_message.clone())
                     .await
                     .map_err(problem::internal_error)?;
 

--- a/cnd/src/http_api/routes/rfc003/mod.rs
+++ b/cnd/src/http_api/routes/rfc003/mod.rs
@@ -4,7 +4,7 @@ mod handlers;
 mod swap_state;
 
 use crate::{
-    db::{DetermineTypes, Retrieve, Save},
+    db::{DetermineTypes, Retrieve, Save, Swap},
     http_api::{
         action::ActionExecutionParameters,
         route_factory::swap_path,
@@ -28,12 +28,10 @@ use hyper::header;
 use warp::{Rejection, Reply};
 
 pub use self::swap_state::{LedgerState, SwapCommunication, SwapCommunicationState, SwapState};
-use crate::db::SaveRfc003Messages;
+use crate::db::Saver;
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn post_swap<
-    D: Clone + StateStore + Save + SendRequest + Spawn + SwapSeed + SaveRfc003Messages,
->(
+pub fn post_swap<D: Clone + StateStore + Save<Swap> + SendRequest + Spawn + SwapSeed + Saver>(
     dependencies: D,
     request_body_kind: SwapRequestBodyKind,
 ) -> impl Future<Item = impl Reply, Error = Rejection> {
@@ -62,9 +60,7 @@ pub fn get_swap<D: DetermineTypes + Retrieve + StateStore>(
 }
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn action<
-    D: DetermineTypes + Retrieve + StateStore + Network + Spawn + SwapSeed + SaveRfc003Messages,
->(
+pub fn action<D: DetermineTypes + Retrieve + StateStore + Network + Spawn + SwapSeed + Saver>(
     method: http::Method,
     id: SwapId,
     action_kind: ActionKind,

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -5,7 +5,7 @@ use anyhow::Context;
 use btsieve::{bitcoin::BitcoindConnector, ethereum::Web3Connector};
 use cnd::{
     config::{self, Settings},
-    db::{DetermineTypes, Retrieve, Save, SaveRfc003Messages, Sqlite},
+    db::{DetermineTypes, Retrieve, Saver, Sqlite},
     http_api::{self, route_factory},
     load_swaps,
     network::{self, Network, SendRequest},
@@ -146,9 +146,8 @@ fn spawn_warp_instance<
         + Spawn
         + SwapSeed
         + DetermineTypes
-        + Save
         + Retrieve
-        + SaveRfc003Messages,
+        + Saver,
 >(
     settings: &Settings,
     peer_id: PeerId,


### PR DESCRIPTION
Now that we have all the database saving implemented it is clear that the `Save` trait (used for saving what was swap metadata) is a a specific case of the generic `SaveMessage<M>` if 'message' was the more general 'anything'.

Merge the two traits together and remove reference to 'messages'.
 
Fixes: #1678 