### PR TITLE
Simplify error handling in http routes

### DIFF
--- a/cnd/src/http_api/problem.rs
+++ b/cnd/src/http_api/problem.rs
@@ -1,149 +1,118 @@
 use crate::{
     db,
-    swap_protocols::rfc003::{self, actions::ActionKind, state_store},
+    http_api::routes::rfc003::handlers::{
+        post_swap::{MalformedRequest, UnsupportedSwap},
+        InvalidAction, InvalidActionInvocation,
+    },
 };
 use http::StatusCode;
 use http_api_problem::HttpApiProblem;
-use libp2p_comit::frame::Response;
-use serde::Serialize;
 use warp::{Rejection, Reply};
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, thiserror::Error)]
+#[error("Missing GET parameters for a {} action type. Expected: {:?}", action, parameters.iter().map(|parameter| parameter.name).collect::<Vec<&str>>())]
+pub struct MissingQueryParameters {
+    pub action: &'static str,
+    pub parameters: &'static [MissingQueryParameter],
+}
+
+#[derive(Debug, serde::Serialize)]
 pub struct MissingQueryParameter {
     pub name: &'static str,
     pub data_type: &'static str,
     pub description: &'static str,
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error("unexpected GET parameters {parameters:?} for a {action} action type, expected: none")]
+pub struct UnexpectedQueryParameters {
+    pub action: &'static str,
+    pub parameters: &'static [&'static str],
+}
+
 pub fn from_anyhow(e: anyhow::Error) -> HttpApiProblem {
+    let e = match e.downcast::<HttpApiProblem>() {
+        Ok(problem) => return problem,
+        Err(e) => e,
+    };
+
     if let Some(db::Error::SwapNotFound) = e.downcast_ref::<db::Error>() {
-        return swap_not_found();
+        return HttpApiProblem::new("Swap not found.").set_status(StatusCode::NOT_FOUND);
     }
 
-    internal_error(e)
-}
+    if let Some(e) = e.downcast_ref::<UnexpectedQueryParameters>() {
+        log::error!("{}", e);
 
-pub fn internal_error(e: anyhow::Error) -> HttpApiProblem {
+        let mut problem = HttpApiProblem::new("Unexpected query parameter(s).")
+            .set_status(StatusCode::BAD_REQUEST)
+            .set_detail("This action does not take any query parameters.");
+
+        problem
+            .set_value("unexpected_parameters", &e.parameters)
+            .expect("parameters will never fail to serialize");
+
+        return problem;
+    }
+
+    if let Some(e) = e.downcast_ref::<MissingQueryParameters>() {
+        log::error!("{}", e);
+
+        let mut problem = HttpApiProblem::new("Missing query parameter(s).")
+            .set_status(StatusCode::BAD_REQUEST)
+            .set_detail("This action requires additional query parameters.");
+
+        problem
+            .set_value("missing_parameters", &e.parameters)
+            .expect("parameters will never fail to serialize");
+
+        return problem;
+    }
+
+    if e.is::<serde_json::Error>() {
+        log::error!("deserialization error: {:?}", e);
+
+        return HttpApiProblem::new("Invalid body.")
+            .set_status(StatusCode::BAD_REQUEST)
+            .set_detail("Failed to deserialize given body.");
+    }
+
+    if e.is::<InvalidActionInvocation>() {
+        log::warn!("{:?}", e);
+
+        return HttpApiProblem::new("Invalid action invocation")
+            .set_status(http::StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    if e.is::<InvalidAction>() {
+        log::warn!("{:?}", e);
+
+        return HttpApiProblem::new("Invalid action.")
+            .set_status(StatusCode::CONFLICT)
+            .set_detail("Cannot perform requested action for this swap.");
+    }
+
+    if e.is::<UnsupportedSwap>() {
+        log::warn!("{:?}", e);
+
+        return HttpApiProblem::new("Swap not supported.")
+            .set_status(StatusCode::BAD_REQUEST)
+            .set_detail("The requested combination of ledgers and assets is not supported.");
+    }
+
+    if e.is::<MalformedRequest>() {
+        log::warn!("{:?}", e);
+
+        return HttpApiProblem::with_title_and_type_from_status(StatusCode::BAD_REQUEST)
+            .set_detail("The request body was malformed.");
+    }
+
     log::error!("internal error occurred: {:?}", e);
+
     HttpApiProblem::with_title_and_type_from_status(StatusCode::INTERNAL_SERVER_ERROR)
-}
-
-pub fn missing_channel() -> HttpApiProblem {
-    log::error!("Channel for swap was not found in hash map");
-    HttpApiProblem::with_title_and_type_from_status(StatusCode::INTERNAL_SERVER_ERROR)
-}
-
-pub fn send_over_channel(_e: Response) -> HttpApiProblem {
-    log::error!("Sending response over channel failed");
-    HttpApiProblem::with_title_and_type_from_status(StatusCode::INTERNAL_SERVER_ERROR)
-}
-
-pub fn state_store() -> HttpApiProblem {
-    log::error!("State store didn't have state in it despite swap being in database");
-    HttpApiProblem::with_title_and_type_from_status(StatusCode::INTERNAL_SERVER_ERROR)
-}
-
-pub fn swap_not_found() -> HttpApiProblem {
-    HttpApiProblem::new("Swap not found.").set_status(StatusCode::NOT_FOUND)
-}
-
-pub fn unsupported() -> HttpApiProblem {
-    HttpApiProblem::new("Swap not supported.")
-        .set_status(StatusCode::BAD_REQUEST)
-        .set_detail("The requested combination of ledgers and assets is not supported.")
-}
-
-pub fn deserialize(e: serde_json::Error) -> HttpApiProblem {
-    log::error!("Failed to deserialize body: {:?}", e);
-    HttpApiProblem::new("Invalid body.")
-        .set_status(StatusCode::BAD_REQUEST)
-        .set_detail("Failed to deserialize given body.")
-}
-
-pub fn serialize(e: serde_json::Error) -> HttpApiProblem {
-    log::error!("Failed to serialize body: {:?}", e);
-    HttpApiProblem::with_title_and_type_from_status(StatusCode::INTERNAL_SERVER_ERROR)
-}
-
-pub fn not_yet_implemented(feature: &str) -> HttpApiProblem {
-    log::error!("{} not yet implemented", feature);
-    HttpApiProblem::new("Feature not yet implemented.")
-        .set_status(StatusCode::INTERNAL_SERVER_ERROR)
-        .set_detail(format!("{} is not yet implemented! Sorry :(", feature))
-}
-
-pub fn action_already_done(action: ActionKind) -> HttpApiProblem {
-    log::error!("{} action has already been done", action);
-    HttpApiProblem::new("Action already done.").set_status(StatusCode::GONE)
-}
-
-pub fn invalid_action(action: ActionKind) -> HttpApiProblem {
-    log::error!("{} action is invalid for this swap", action);
-    HttpApiProblem::new("Invalid action.")
-        .set_status(StatusCode::CONFLICT)
-        .set_detail("Cannot perform requested action for this swap.")
-}
-
-pub fn unexpected_query_parameters(action: &str, parameters: Vec<String>) -> HttpApiProblem {
-    log::error!(
-        "Unexpected GET parameters {:?} for a {} action type. Expected: none",
-        parameters,
-        action
-    );
-    let mut problem = HttpApiProblem::new("Unexpected query parameter(s).")
-        .set_status(StatusCode::BAD_REQUEST)
-        .set_detail("This action does not take any query parameters.");
-
-    problem
-        .set_value("unexpected_parameters", &parameters)
-        .expect("parameters will never fail to serialize");
-
-    problem
-}
-
-pub fn missing_query_parameters(
-    action: &str,
-    parameters: Vec<&MissingQueryParameter>,
-) -> HttpApiProblem {
-    log::error!(
-        "Missing GET parameters for a {} action type. Expected: {:?}",
-        action,
-        parameters
-            .iter()
-            .map(|parameter| parameter.name)
-            .collect::<Vec<&str>>()
-    );
-
-    let mut problem = HttpApiProblem::new("Missing query parameter(s).")
-        .set_status(StatusCode::BAD_REQUEST)
-        .set_detail("This action requires additional query parameters.");
-
-    problem
-        .set_value("missing_parameters", &parameters)
-        .expect("parameters will never fail to serialize");
-
-    problem
-}
-
-impl From<state_store::Error> for HttpApiProblem {
-    fn from(e: state_store::Error) -> Self {
-        log::error!("Storage layer failure: {:?}", e);
-        HttpApiProblem::with_title_and_type_from_status(StatusCode::INTERNAL_SERVER_ERROR)
-    }
-}
-
-impl From<rfc003::state_machine::Error> for HttpApiProblem {
-    fn from(e: rfc003::state_machine::Error) -> Self {
-        log::error!("Protocol execution error: {:?}", e);
-        HttpApiProblem::with_title_and_type_from_status(StatusCode::INTERNAL_SERVER_ERROR)
-            .set_title("Protocol execution error.")
-    }
 }
 
 pub fn unpack_problem(rejection: Rejection) -> Result<impl Reply, Rejection> {
     if let Some(problem) = rejection.find_cause::<HttpApiProblem>() {
-        log::debug!(target: "http-api", "HTTP request got rejected, returning HttpApiProblem response: {:?}", problem);
-
         let code = problem.status.unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
         let reply = warp::reply::json(problem);

--- a/cnd/src/http_api/routes/index/handlers/get_swaps.rs
+++ b/cnd/src/http_api/routes/index/handlers/get_swaps.rs
@@ -1,27 +1,16 @@
 use crate::{
     db::{DetermineTypes, Retrieve},
-    http_api::{
-        problem,
-        swap_resource::{build_rfc003_siren_entity, IncludeState},
-    },
+    http_api::swap_resource::{build_rfc003_siren_entity, IncludeState},
     swap_protocols::rfc003::state_store::StateStore,
 };
-use http_api_problem::HttpApiProblem;
 
 pub async fn handle_get_swaps<D: DetermineTypes + Retrieve + StateStore>(
     dependencies: D,
-) -> Result<siren::Entity, HttpApiProblem> {
+) -> anyhow::Result<siren::Entity> {
     let mut entity = siren::Entity::default().with_class_member("swaps");
 
-    for swap in Retrieve::all(&dependencies)
-        .await
-        .map_err(problem::internal_error)?
-        .into_iter()
-    {
-        let types = dependencies
-            .determine_types(&swap.swap_id)
-            .await
-            .map_err(problem::internal_error)?;
+    for swap in Retrieve::all(&dependencies).await?.into_iter() {
+        let types = dependencies.determine_types(&swap.swap_id).await?;
 
         let sub_entity = build_rfc003_siren_entity(&dependencies, swap, types, IncludeState::No)?;
         entity.push_sub_entity(siren::SubEntity::from_entity(sub_entity, &["item"]));

--- a/cnd/src/http_api/routes/index/mod.rs
+++ b/cnd/src/http_api/routes/index/mod.rs
@@ -3,7 +3,7 @@ mod handlers;
 use self::handlers::handle_get_swaps;
 use crate::{
     db::{DetermineTypes, Retrieve},
-    http_api::{routes::into_rejection, Http},
+    http_api::{problem, routes::into_rejection, Http},
     network::Network,
     swap_protocols::rfc003::state_store::StateStore,
 };
@@ -43,5 +43,6 @@ pub fn get_swaps<D: DetermineTypes + Retrieve + StateStore>(
                 "application/vnd.siren+json",
             ))
         })
+        .map_err(problem::from_anyhow)
         .map_err(into_rejection)
 }

--- a/cnd/src/http_api/routes/rfc003/handlers/get_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/get_swap.rs
@@ -1,25 +1,15 @@
 use crate::{
     db::{DetermineTypes, Retrieve},
-    http_api::{
-        problem,
-        swap_resource::{build_rfc003_siren_entity, IncludeState},
-    },
+    http_api::swap_resource::{build_rfc003_siren_entity, IncludeState},
     swap_protocols::{rfc003::state_store::StateStore, SwapId},
 };
-use http_api_problem::HttpApiProblem;
 
 pub async fn handle_get_swap<D: Retrieve + StateStore + DetermineTypes>(
     dependencies: D,
     id: SwapId,
-) -> Result<siren::Entity, HttpApiProblem> {
-    let swap = Retrieve::get(&dependencies, &id)
-        .await
-        .map_err(problem::from_anyhow)?;
-
-    let types = dependencies
-        .determine_types(&id)
-        .await
-        .map_err(problem::from_anyhow)?;
+) -> anyhow::Result<siren::Entity> {
+    let swap = Retrieve::get(&dependencies, &id).await?;
+    let types = dependencies.determine_types(&id).await?;
 
     build_rfc003_siren_entity(&dependencies, swap, types, IncludeState::Yes)
 }

--- a/cnd/src/http_api/routes/rfc003/handlers/mod.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/mod.rs
@@ -3,7 +3,7 @@ mod get_swap;
 pub mod post_swap;
 
 pub use self::{
-    action::handle_action,
+    action::{handle_action, InvalidAction, InvalidActionInvocation},
     get_swap::handle_get_swap,
     post_swap::{handle_post_swap, SwapRequestBodyKind},
 };

--- a/cnd/src/http_api/swap_resource.rs
+++ b/cnd/src/http_api/swap_resource.rs
@@ -3,7 +3,6 @@ use crate::{
     db::{Swap, SwapTypes},
     http_api::{
         action::ToSirenAction,
-        problem,
         route_factory::swap_path,
         routes::rfc003::{LedgerState, SwapCommunication, SwapState},
         Http,
@@ -81,13 +80,13 @@ pub fn build_rfc003_siren_entity<S: StateStore>(
     swap: Swap,
     types: SwapTypes,
     include_state: IncludeState,
-) -> Result<siren::Entity, HttpApiProblem> {
+) -> anyhow::Result<siren::Entity> {
     let id = swap.swap_id;
 
     with_swap_types!(types, {
         let state = state_store
             .get::<ROLE>(&id)?
-            .ok_or_else(problem::state_store)?;
+            .ok_or_else(|| anyhow::anyhow!("state store did not contain an entry for {}", id))?;
 
         let communication = SwapCommunication::from(state.swap_communication.clone());
         let alpha_ledger = LedgerState::from(state.alpha_ledger_state.clone());

--- a/cnd/src/lib.rs
+++ b/cnd/src/lib.rs
@@ -28,6 +28,8 @@ pub mod network;
 #[cfg(test)]
 pub mod quickcheck;
 pub mod seed;
+#[cfg(test)]
+pub mod spectral_ext;
 pub mod swap_protocols;
 
 use anyhow::Context;

--- a/cnd/src/spectral_ext.rs
+++ b/cnd/src/spectral_ext.rs
@@ -1,0 +1,36 @@
+use spectral::{result::ResultAssertions, AssertionFailure, Spec};
+use std::fmt::{Debug, Display};
+
+pub trait AnyhowResultAssertions<'s, T> {
+    fn is_inner_err<E>(&'s mut self) -> Spec<'s, E>
+    where
+        T: Debug,
+        E: Display + Debug + Send + Sync + 'static;
+}
+
+impl<'s, T> AnyhowResultAssertions<'s, T> for Spec<'s, anyhow::Result<T>> {
+    fn is_inner_err<E>(&'s mut self) -> Spec<'s, E>
+    where
+        T: Debug,
+        E: Display + Debug + Send + Sync + 'static,
+    {
+        let e = self.is_err().subject;
+
+        match e.downcast_ref() {
+            Some(inner) => Spec {
+                subject: inner,
+                subject_name: self.subject_name,
+                location: self.location.clone(),
+                description: self.description,
+            },
+            None => {
+                AssertionFailure::from_spec(self)
+                    .with_expected("error that can be downcasted".to_string())
+                    .with_actual("error could not be downcasted".to_string())
+                    .fail();
+
+                unreachable!();
+            }
+        }
+    }
+}


### PR DESCRIPTION
By making better use of anyhow and thiserror, we can question-mark
away many of the errors. We still have control of the error returned to the user through the custom recover function of warp.

Fixes #1683.