### PR TITLE
Run generate task only before testing instead of on every install

### DIFF
--- a/api_tests/package.json
+++ b/api_tests/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "scripts": {
         "check": "tsc && prettier --check '**/*.{ts,json,yml}' && tslint --project .",
-        "postinstall": "mkdir -p ./gen && json2ts -i ./siren.schema.json -o ./gen/siren.d.ts",
+        "pretest": "mkdir -p ./gen && json2ts -i ./siren.schema.json -o ./gen/siren.d.ts",
         "test": "ts-node ./harness.ts",
         "fix": "tslint --project . --fix && prettier --write '**/*.{ts,js,json,yml}'"
     },


### PR DESCRIPTION
We run `yarn install` quite a lot with the tasks in the Makefile.
Not running this tasks shaves of some time of that.