### PR TITLE
Remove seed from e2e tests

### DIFF
--- a/api_tests/lib/config.ts
+++ b/api_tests/lib/config.ts
@@ -14,18 +14,15 @@ export interface HttpApi {
 }
 
 export class E2ETestActorConfig {
-    public readonly seed: Uint8Array;
     public readonly data: string;
 
     constructor(
         public readonly httpApiPort: number,
         public readonly comitPort: number,
-        seed: string,
         public readonly name: string
     ) {
         this.httpApiPort = httpApiPort;
         this.comitPort = comitPort;
-        this.seed = new Uint8Array(Buffer.from(seed, "hex"));
 
         const tmpobj = tmp.dirSync();
         tmpobj.removeCallback(); // Manual cleanup
@@ -66,24 +63,9 @@ interface BitcoinConnector {
     network: string;
 }
 
-export const ALICE_CONFIG = new E2ETestActorConfig(
-    8000,
-    9938,
-    "f87165e305b0f7c4824d3806434f9d0909610a25641ab8773cf92a48c9d77670",
-    "alice"
-);
-export const BOB_CONFIG = new E2ETestActorConfig(
-    8010,
-    9939,
-    "1a1707bb54e5fb4deddd19f07adcb4f1e022ca7879e3c8348da8d4fa496ae8e2",
-    "bob"
-);
-export const CHARLIE_CONFIG = new E2ETestActorConfig(
-    8020,
-    8021,
-    "6b49ec1df23d124a16d6a12bd34476579e6e80cdcb97a5438cb76ac5c423c937",
-    "charlie"
-);
+export const ALICE_CONFIG = new E2ETestActorConfig(8000, 9938, "alice");
+export const BOB_CONFIG = new E2ETestActorConfig(8010, 9939, "bob");
+export const CHARLIE_CONFIG = new E2ETestActorConfig(8020, 8021, "charlie");
 
 function createLedgerConnectors(ledgerConfig: LedgerConfig): LedgerConnectors {
     const config: LedgerConnectors = {};

--- a/api_tests/lib_sdk/actors/actor.ts
+++ b/api_tests/lib_sdk/actors/actor.ts
@@ -1,6 +1,5 @@
 import { expect } from "chai";
 import { Cnd, ComitClient, Swap } from "comit-sdk";
-import { randomBytes } from "crypto";
 import { BigNumber, BigNumberish, parseEther } from "ethers/utils";
 import getPort from "get-port";
 import { Logger } from "log4js";
@@ -27,12 +26,9 @@ export class Actor {
         projectRoot: string,
         logRoot: string
     ) {
-        const seed = randomBytes(32).toString("hex");
-
         const actorConfig = new E2ETestActorConfig(
             await getPort(),
             await getPort(),
-            seed,
             name
         );
 


### PR DESCRIPTION
With the recent change to move to a data directory, we no longer use this seed. It seems like we never needed it because the tests also pass without explicitely controlling the seed.