### PR TITLE
Fix missing serde feature dependency

### DIFF
--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -11,7 +11,7 @@ async-std = { version = "1", features = ["unstable"] }
 async-trait = "0.1"
 bigdecimal = "0.1.0"
 binary_macros = "0.6"
-bitcoin = "0.19.1"
+bitcoin = { version = "0.19.1", features = ["use-serde"] }
 blockchain_contracts = "0.1"
 byteorder = "1.3"
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
For some reason, this did not fail on a regular `cargo build --release`,
but did cause trait bound errors on running `cargo install`.

Resolves #1740 