### PR TITLE
Better wallet assertions

### DIFF
--- a/api_tests/lib/setup_chai.ts
+++ b/api_tests/lib/setup_chai.ts
@@ -1,12 +1,14 @@
 // A helper file to configure chai with all the plugins we need
 // This is to reduce noise in our actual test files
 
+import chaiBn = require("bn-chai");
 import { tv4, use } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import chaiEach = require("chai-each");
 import chaiHttp = require("chai-http");
 import chaiJsonSchema = require("chai-json-schema");
 import chaiSubset = require("chai-subset");
+import { BigNumber } from "ethers/utils";
 import * as sirenJsonSchema from "../siren.schema.json";
 
 use(chaiAsPromised);
@@ -14,5 +16,6 @@ use(chaiHttp);
 use(chaiSubset);
 use(chaiEach);
 use(chaiJsonSchema);
+use(chaiBn(BigNumber));
 
 tv4.addSchema("http://sirenspec.org/schema", sirenJsonSchema);

--- a/api_tests/lib_sdk/actors/actor.ts
+++ b/api_tests/lib_sdk/actors/actor.ts
@@ -204,6 +204,16 @@ export class Actor {
     }
 
     public async assertSwapped() {
+        this.logger.debug("Checking if cnd reports status 'SWAPPED'");
+
+        while (true) {
+            await sleep(200);
+            const entity = await this.swap.fetchDetails();
+            if (entity.properties.status === "SWAPPED") {
+                break;
+            }
+        }
+
         for (const [
             assetKind,
             expectedBalanceChange,
@@ -222,15 +232,10 @@ export class Actor {
             ).add(expectedBalanceChange);
             const maximumFee = wallet.MaximumFee;
 
-            await expect(
-                wallet
-                    .getBalance()
-                    .then(balance =>
-                        new BigNumber(balance).gte(
-                            expectedBalance.sub(maximumFee)
-                        )
-                    )
-            ).to.eventually.be.true;
+            const balanceInclFees = expectedBalance.sub(maximumFee);
+            const currentWalletBalance = await wallet.getBalance();
+
+            expect(currentWalletBalance).to.be.gte.BN(balanceInclFees);
         }
     }
 

--- a/api_tests/package.json
+++ b/api_tests/package.json
@@ -35,6 +35,7 @@
         "bignumber.js": "^9.0.0",
         "bitcoin-core": "^3.0.0",
         "bitcoinjs-lib": "^5.1.6",
+        "bn-chai": "^1.0.1",
         "chai": "^4.2.0",
         "chai-as-promised": "^7.1.1",
         "chai-each": "^0.0.1",

--- a/api_tests/tslint.json
+++ b/api_tests/tslint.json
@@ -13,6 +13,7 @@
         "no-shadowed-variable": false,
         "object-literal-sort-keys": false,
         "no-reference": false,
+        "no-namespace": false,
         "only-arrow-functions": false,
         "file-name-casing": [true, "snake-case"]
     },

--- a/api_tests/types/bn-chai/index.d.ts
+++ b/api_tests/types/bn-chai/index.d.ts
@@ -1,0 +1,11 @@
+declare module "bn-chai" {
+    function bnChaiFn(ctor: any): Chai.ChaiPlugin;
+
+    export = bnChaiFn;
+}
+
+declare namespace Chai {
+    interface NumberComparer {
+        BN(value: any): void;
+    }
+}

--- a/api_tests/yarn.lock
+++ b/api_tests/yarn.lock
@@ -590,6 +590,11 @@ bmutex@~0.1.6:
   dependencies:
     bsert "~0.0.10"
 
+bn-chai@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bn-chai/-/bn-chai-1.0.1.tgz#5d6e9654162602a527b08a1546e60cfb44213725"
+  integrity sha512-7rJXt21DwYiLLpvzLaACixBBoUGkRV1iuFD3wElEhw8Ji9IiY/QsJRtvW+c7ChRgEOyLQkGaSGFUUqBKm21SNA==
+
 bn.js@^4.11.8, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"


### PR DESCRIPTION
This improves the assertions in two ways:

1. Before we check the wallet balances, we wait until cnd reports the swap as 'SWAPPED'.
2. We use `bn-chai` to compare the balances to improve the error message. In case of failure, we now get:

![image](https://user-images.githubusercontent.com/5486389/70546710-102ea180-1b70-11ea-9785-64546a011523.png)

Fixes #1719. (Hopefully)