### PR TITLE
ON ICE: Only show refund after expiry time has passed

### DIFF
--- a/api_tests/e2e/rfc003/eth_btc/bitcoin_high_fee.ts
+++ b/api_tests/e2e/rfc003/eth_btc/bitcoin_high_fee.ts
@@ -97,16 +97,6 @@ declare var global: HarnessGlobal;
                 },
             },
         },
-        {
-            actor: bob,
-            action: {
-                kind: ActionKind.Refund,
-                test: response => {
-                    expect(response).to.have.status(400);
-                    expect(response.body.title).to.equal("Fee is too high.");
-                },
-            },
-        },
     ];
 
     describe("RFC003: Ether for Bitcoin - Redeem/Refund Bitcoin with high fee", () => {

--- a/cnd/src/swap_protocols/rfc003/alice/actions/generic_impl.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/actions/generic_impl.rs
@@ -2,6 +2,7 @@ use crate::swap_protocols::{
     actions::Actions,
     asset::Asset,
     rfc003::{
+        self,
         actions::{Accept, Action, Decline, FundAction, RedeemAction, RefundAction},
         alice::{self, SwapCommunication},
         state_machine::HtlcParams,
@@ -59,12 +60,18 @@ where
                 htlc_location,
                 fund_transaction,
                 ..
-            } => vec![Action::Refund(<(AL, AA)>::refund_action(
-                HtlcParams::new_alpha_params(request, response),
-                htlc_location.clone(),
-                &*self.secret_source,
-                fund_transaction,
-            ))],
+            } => {
+                if rfc003::alpha_expiry_has_passed(request) {
+                    vec![Action::Refund(<(AL, AA)>::refund_action(
+                        HtlcParams::new_alpha_params(request, response),
+                        htlc_location.clone(),
+                        &*self.secret_source,
+                        fund_transaction,
+                    ))]
+                } else {
+                    vec![]
+                }
+            }
             _ => vec![],
         };
 

--- a/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
@@ -2,6 +2,7 @@ use crate::swap_protocols::{
     actions::Actions,
     asset::Asset,
     rfc003::{
+        self,
         actions::{Accept, Action, Decline, FundAction, RedeemAction, RefundAction},
         bob::{self, SwapCommunication},
         state_machine::HtlcParams,
@@ -69,14 +70,15 @@ where
             ..
         } = beta_state
         {
-            actions.push(Action::Refund(<(BL, BA)>::refund_action(
-                HtlcParams::new_beta_params(request, response),
-                htlc_location.clone(),
-                &*self.secret_source,
-                fund_transaction,
-            )))
+            if rfc003::beta_expiry_has_passed(request) {
+                actions.push(Action::Refund(<(BL, BA)>::refund_action(
+                    HtlcParams::new_beta_params(request, response),
+                    htlc_location.clone(),
+                    &*self.secret_source,
+                    fund_transaction,
+                )))
+            }
         }
-
         actions
     }
 }

--- a/cnd/src/swap_protocols/rfc003/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/mod.rs
@@ -28,6 +28,9 @@ pub use self::{
 };
 
 pub use self::messages::{Accept, Decline, Request};
+
+use crate::{swap_protocols::asset::Asset, timestamp::Timestamp};
+
 /// Swap request response as received from peer node acting as Bob.
 pub type Response<AL, BL> = Result<Accept<AL, BL>, Decline>;
 
@@ -41,4 +44,16 @@ pub enum Error {
     IncorrectFunding,
     #[error("internal error: {0}")]
     Internal(String),
+}
+
+pub fn alpha_expiry_has_passed<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset>(
+    request: &Request<AL, BL, AA, BA>,
+) -> bool {
+    request.alpha_expiry < Timestamp::now()
+}
+
+pub fn beta_expiry_has_passed<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset>(
+    request: &Request<AL, BL, AA, BA>,
+) -> bool {
+    request.beta_expiry < Timestamp::now()
 }


### PR DESCRIPTION
Do not show the refund action if expiry time has not passed.  This PR _totally_ removes the refund action, there is no way to get it if the expiry time has not passed.

Draft, and on ice, because still needs testing (breaks current e2e tests also).  There is also some doubt whether we should even do this ticket - leaving to discuss with the team after Christmas. 

Resolves: #1075