### PR TITLE
Remove explicit hyper dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,6 @@ dependencies = [
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-serde 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-api-problem 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-comit 0.1.0",

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -31,11 +31,10 @@ futures-core = { version = "=0.3.0-alpha.19", features = ["alloc", "compat", "as
 hex = "0.4"
 hex-serde = "0.1.0"
 http-api-problem = "0.13"
-hyper = "0.12"
 lazy_static = "1"
 libp2p = { version = "0.13" }
-libp2p-core = { version = "0.13" }
 libp2p-comit = { path = "../libp2p-comit" }
+libp2p-core = { version = "0.13" }
 libsqlite3-sys = { version = ">=0.8.0, <0.13.0", features = ["bundled"] }
 log = { version = "0.4", features = ["serde"] }
 maplit = "1"

--- a/cnd/src/http_api/routes/rfc003/mod.rs
+++ b/cnd/src/http_api/routes/rfc003/mod.rs
@@ -22,8 +22,10 @@ use crate::{
 };
 use futures::Future;
 use futures_core::future::{FutureExt, TryFutureExt};
-use hyper::header;
-use warp::{http, Rejection, Reply};
+use warp::{
+    http::{self, header},
+    Rejection, Reply,
+};
 
 pub use self::swap_state::{LedgerState, SwapCommunication, SwapCommunicationState, SwapState};
 use crate::{db::Saver, http_api::problem};


### PR DESCRIPTION
We depend on hyper implicitely through warp. Removing the explicit dependency avoids problems with dependabot wanting to update it even though the dependency needs to be kept in sync with the transitive one.