### PR TITLE
Add a custom version string

### DIFF
--- a/cnd/build.rs
+++ b/cnd/build.rs
@@ -1,0 +1,11 @@
+use std::process::Command;
+fn main() {
+    let output = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .expect("failed to get commit hash for tip of branch");
+
+    let git_hash = String::from_utf8(output.stdout).expect("failed to convert hash");
+
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+}

--- a/cnd/build.rs
+++ b/cnd/build.rs
@@ -1,11 +1,13 @@
 use std::process::Command;
 fn main() {
-    let output = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
-        .output()
-        .expect("failed to get commit hash for tip of branch");
+    let unknown = String::from("************");
 
-    let git_hash = String::from_utf8(output.stdout).expect("failed to convert hash");
+    let output = Command::new("git").args(&["rev-parse", "HEAD"]).output();
+
+    let git_hash = match output {
+        Ok(output) => String::from_utf8(output.stdout).unwrap_or(unknown),
+        Err(_) => unknown,
+    };
 
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 }

--- a/cnd/src/cli.rs
+++ b/cnd/src/cli.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 #[derive(structopt::StructOpt, Debug)]
-#[structopt(name = "COMIT network daemon")]
 pub struct Options {
     /// Path to configuration file
     #[structopt(short = "c", long = "config", parse(from_os_str))]
@@ -10,4 +9,8 @@ pub struct Options {
     /// Dump the current configuration and exit
     #[structopt(long = "dump-config")]
     pub dump_config: bool,
+
+    /// Display the current version
+    #[structopt(short = "V", long = "version")]
+    pub version: bool,
 }

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -36,6 +36,11 @@ mod logging;
 fn main() -> anyhow::Result<()> {
     let options = cli::Options::from_args();
 
+    if options.version {
+        version();
+        process::exit(0);
+    }
+
     let settings = read_config(&options).and_then(Settings::from_config_file_and_defaults)?;
 
     if options.dump_config {
@@ -113,6 +118,17 @@ fn main() -> anyhow::Result<()> {
     // Block the current thread.
     ::std::thread::park();
     Ok(())
+}
+
+#[allow(clippy::print_stdout)] // We cannot use `log` before we have the config file
+fn version() {
+    const NAME: &'static str = "COMIT network daemon";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const COMMIT: &'static str = env!("GIT_HASH");
+    const LENGTH: usize = 12; // Abbreviate the hash, 12 digits is plenty.
+    let short = &COMMIT[..LENGTH];
+
+    println!("{} {} ({})", NAME, VERSION, short);
 }
 
 fn derive_key_pair(seed: &Seed) -> identity::Keypair {

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -122,13 +122,13 @@ fn main() -> anyhow::Result<()> {
 
 #[allow(clippy::print_stdout)] // We cannot use `log` before we have the config file
 fn version() {
-    const NAME: &'static str = "COMIT network daemon";
-    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
-    const COMMIT: &'static str = env!("GIT_HASH");
-    const LENGTH: usize = 12; // Abbreviate the hash, 12 digits is plenty.
-    let short = &COMMIT[..LENGTH];
+    let name: &'static str = "COMIT network daemon";
+    let version: &'static str = env!("CARGO_PKG_VERSION");
+    let commit: &'static str = env!("GIT_HASH");
+    let length: usize = 12; // Abbreviate the hash, 12 digits is plenty.
+    let short = &commit[..length];
 
-    println!("{} {} ({})", NAME, VERSION, short);
+    println!("{} {} ({})", name, version, short);
 }
 
 fn derive_key_pair(seed: &Seed) -> identity::Keypair {


### PR DESCRIPTION
Add a custom version string to the cnd executable.  With this applied version option form is unchanged.  Output includes first 12 characters of the latest commit hash.
```
$ cnd --version
COMIT network daemon 0.5.0 (8e5181c4bab3)
```

Resolves: #1417