### PR TITLE
1586 stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Write all diagnostics and log messages to stderr.
+
 ## [0.5.0] - 2019-12-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 - Write all diagnostics and log messages to stderr.
 
 ## [0.5.0] - 2019-12-06

--- a/cnd/src/logging/initialize.rs
+++ b/cnd/src/logging/initialize.rs
@@ -7,7 +7,7 @@ pub fn initialize(
     structured: bool,
 ) -> Result<(), log::SetLoggerError> {
     #![allow(clippy::print_stdout)] // We cannot use `log` before we have the config file
-    println!("Initializing logging with base level {}", base_log_level);
+    eprintln!("Initializing logging with base level {}", base_log_level);
 
     let (max_level, log) = create_logger(base_log_level, structured, stderr());
 

--- a/cnd/src/logging/initialize.rs
+++ b/cnd/src/logging/initialize.rs
@@ -1,6 +1,6 @@
 use fern::{Dispatch, FormatCallback};
 use log::{LevelFilter, Record};
-use std::{fmt::Arguments, io::stdout};
+use std::{fmt::Arguments, io::stderr};
 
 pub fn initialize(
     base_log_level: LevelFilter,
@@ -9,7 +9,7 @@ pub fn initialize(
     #![allow(clippy::print_stdout)] // We cannot use `log` before we have the config file
     println!("Initializing logging with base level {}", base_log_level);
 
-    let (max_level, log) = create_logger(base_log_level, structured, stdout());
+    let (max_level, log) = create_logger(base_log_level, structured, stderr());
 
     log::set_boxed_logger(log)?;
     log::set_max_level(max_level);

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -159,7 +159,7 @@ fn spawn_warp_instance<
 fn read_config(options: &Options) -> anyhow::Result<config::File> {
     // if the user specifies a config path, use it
     if let Some(path) = &options.config_file {
-        println!("Using config file {}", path.display());
+        eprintln!("Using config file {}", path.display());
 
         return config::File::read(&path)
             .with_context(|| format!("failed to read config file {}", path.display()));
@@ -172,7 +172,7 @@ fn read_config(options: &Options) -> anyhow::Result<config::File> {
         return Ok(config::File::default());
     }
 
-    println!(
+    eprintln!(
         "Using config file at default path: {}",
         default_path.display()
     );


### PR DESCRIPTION
Print all diagnostics and log messages to stderr instead of stdout.  With this applied the only output that goes to stdout is the output from `cnd --dump-config`.

Verify with: `target/debug/cnd 2> /tmp/cnd.stderr`.

Resolves: #1586 