### PR TITLE
Terminate cnd in new e2e format

### DIFF
--- a/api_tests/e2e/rfc003/btc_eth/cnd_can_be_restarted.ts
+++ b/api_tests/e2e/rfc003/btc_eth/cnd_can_be_restarted.ts
@@ -1,13 +1,29 @@
+import { Actor } from "../../../lib_sdk/actors/actor";
 import { createActors } from "../../../lib_sdk/create_actors";
 
 setTimeout(function() {
+    let alice: Actor;
+    let bob: Actor;
+
+    beforeEach(async function() {
+        this.timeout(20000);
+        const actors = await createActors("cnd_can_be_restarted.log");
+        alice = actors.alice;
+        bob = actors.bob;
+    });
+
+    afterEach(() => {
+        if (alice) {
+            alice.stop();
+        }
+        if (bob) {
+            bob.stop();
+        }
+    });
+
     describe("cnd can be restarted", function() {
         this.timeout(60000);
         it("after the swap was accepted", async function() {
-            const { alice, bob } = await createActors(
-                "cnd_can_be_restarted.log"
-            );
-
             await alice.sendRequest();
             await bob.accept();
 

--- a/api_tests/e2e/rfc003/btc_eth/happy.ts
+++ b/api_tests/e2e/rfc003/btc_eth/happy.ts
@@ -1,14 +1,30 @@
+import { Actor } from "../../../lib_sdk/actors/actor";
 import { AssetKind } from "../../../lib_sdk/asset";
 import { createActors } from "../../../lib_sdk/create_actors";
 
 setTimeout(function() {
+    let alice: Actor;
+    let bob: Actor;
+
+    beforeEach(async function() {
+        this.timeout(20000);
+        const actors = await createActors("e2e-rfc003-btc-eth-happy.log");
+        alice = actors.alice;
+        bob = actors.bob;
+    });
+
+    afterEach(() => {
+        if (alice) {
+            alice.stop();
+        }
+        if (bob) {
+            bob.stop();
+        }
+    });
+
     describe("happy path", function() {
         this.timeout(60000);
         it("bitcoin ether", async function() {
-            const { alice, bob } = await createActors(
-                "e2e-rfc003-btc-eth-happy.log"
-            );
-
             await alice.sendRequest(AssetKind.Bitcoin, AssetKind.Ether);
             await bob.accept();
             await alice.fund();

--- a/api_tests/lib_sdk/actors/actor.ts
+++ b/api_tests/lib_sdk/actors/actor.ts
@@ -244,6 +244,10 @@ export class Actor {
         await this.cndInstance.start();
     }
 
+    public stop() {
+        this.cndInstance.stop();
+    }
+
     private async additionalIdentities(
         alphaAsset: AssetKind,
         betaAsset: AssetKind


### PR DESCRIPTION
In the new e2e format the cnd nodes are not terminated leaving us with unwanted running processes. Even worse, since we do not stop btsieve queries, these cnd nodes keep firing requests to the blockchain nodes. 

Note: 
This does not work as the test framework does not honor the final block, i.e. if the test times out, finally is not executed.

```javascript
         it("after the swap was accepted", async function() {
            const { alice, bob } = await createActors(
                "cnd_can_be_restarted.log"
            );
            try {
                await do_the_limbo_dance();
            } finally {
                if (alice) {
                    alice.stop();
                }
                if (bob) {
                    bob.stop();
                }
            }
        }
```
