### PR TITLE
ethereum: Test pattern matches using mainnet block

### DIFF
--- a/cnd/tests/ethereum_pattern.rs
+++ b/cnd/tests/ethereum_pattern.rs
@@ -43,11 +43,9 @@ fn pattern_matches_block(pattern: TransactionPattern) -> bool {
     false
 }
 
-// `matches()` method is a filter which returns `true` if things match 
-// and `false` otherwise.
-// In order to _really_ test that the we
-// successfully match we first do a negative test then do an identical positive
-// test.
+// `matches()` method is a filter which returns `true` if things match and
+// `false` otherwise.  In order to _really_ test that the we successfully match
+// we first do a negative test then do an identical positive test.
 
 #[test]
 fn matches_transaction_from_address() {

--- a/cnd/tests/ethereum_pattern.rs
+++ b/cnd/tests/ethereum_pattern.rs
@@ -46,7 +46,7 @@ fn pattern_matches_block(pattern: TransactionPattern) -> bool {
 // `matches()` method is a filter which returns `true` if things match 
 // and `false` otherwise.
 // specifically do _not_ match.  In order to _really_ test that the we
-// succesfully match we first do a negative test then do an identical positive
+// successfully match we first do a negative test then do an identical positive
 // test.
 
 #[test]

--- a/cnd/tests/ethereum_pattern.rs
+++ b/cnd/tests/ethereum_pattern.rs
@@ -43,7 +43,8 @@ fn pattern_matches_block(pattern: TransactionPattern) -> bool {
     false
 }
 
-// `matches()` method is a filter i.e., it returns true unless things
+// `matches()` method is a filter which returns `true` if things match 
+// and `false` otherwise.
 // specifically do _not_ match.  In order to _really_ test that the we
 // succesfully match we first do a negative test then do an identical positive
 // test.

--- a/cnd/tests/ethereum_pattern.rs
+++ b/cnd/tests/ethereum_pattern.rs
@@ -48,7 +48,7 @@ fn pattern_matches_block(pattern: TransactionPattern) -> bool {
 // we first do a negative test then do an identical positive test.
 
 #[test]
-fn matches_transaction_from_address() {
+fn invalid_from_address_does_not_match_transaction_pattern() {
     let invalid_from_address = Address::from_str("fffffa1fba5b4804863131145bc27256d3abffff")
         .expect("failed to construct from_address");
 
@@ -59,7 +59,10 @@ fn matches_transaction_from_address() {
 
     let result = pattern_matches_block(pattern);
     assert_that!(&result).is_false();
+}
 
+#[test]
+fn valid_from_address_does_match_transaction_pattern() {
     let valid_from_address = Address::from_str("fb303a1fba5b4804863131145bc27256d3ab6692")
         .expect("failed to construct from_address");
 
@@ -73,7 +76,7 @@ fn matches_transaction_from_address() {
 }
 
 #[test]
-fn matches_transaction_to_address() {
+fn invalid_to_address_does_not_match_transaction_pattern() {
     let invalid_to_address = Address::from_str("fffffe335b2786520f4c5d706c76c9ee69d0ffff")
         .expect("failed to construct to_address");
 
@@ -84,7 +87,10 @@ fn matches_transaction_to_address() {
 
     let result = pattern_matches_block(pattern);
     assert_that!(&result).is_false();
+}
 
+#[test]
+fn valid_to_address_does_match_transaction_pattern() {
     let valid_to_address = Address::from_str("c5549e335b2786520f4c5d706c76c9ee69d0a028")
         .expect("failed to construct to_address");
 
@@ -98,7 +104,7 @@ fn matches_transaction_to_address() {
 }
 
 #[test]
-fn matches_transaction_data() {
+fn invalid_transaction_data_does_not_match_transaction_pattern() {
     let invalid_transaction_data = "ffff9cbb000000000000000000000000d50fb7d948426633ec126aeea140ce4dd09796820000000000000000000000000000000000000000000000000000000ba43bffff";
     let invalid_transaction_data =
         hex::decode(invalid_transaction_data).expect("failed to decode hex data");
@@ -111,7 +117,10 @@ fn matches_transaction_data() {
 
     let result = pattern_matches_block(pattern);
     assert_that!(&result).is_false();
+}
 
+#[test]
+fn valid_transaction_data_does_match_transaction_pattern() {
     let valid_transaction_data = "a9059cbb000000000000000000000000d50fb7d948426633ec126aeea140ce4dd09796820000000000000000000000000000000000000000000000000000000ba43b7400";
     let valid_transaction_data =
         hex::decode(valid_transaction_data).expect("failed to decode hex data");
@@ -127,7 +136,7 @@ fn matches_transaction_data() {
 }
 
 #[test]
-fn matches_transaction_data_length() {
+fn invalid_transaction_data_length_does_not_match_transaction_pattern() {
     let invalid_transaction_data_length = 999_999;
 
     let pattern = TransactionPattern {
@@ -137,7 +146,10 @@ fn matches_transaction_data_length() {
 
     let result = pattern_matches_block(pattern);
     assert_that!(&result).is_false();
+}
 
+#[test]
+fn valid_transaction_data_length_does_match_transaction_pattern() {
     let valid_transaction_data = "a9059cbb000000000000000000000000d50fb7d948426633ec126aeea140ce4dd09796820000000000000000000000000000000000000000000000000000000ba43b7400";
     let valid_transaction_data =
         hex::decode(valid_transaction_data).expect("failed to decode hex data");

--- a/cnd/tests/ethereum_pattern.rs
+++ b/cnd/tests/ethereum_pattern.rs
@@ -2,9 +2,10 @@ pub mod ethereum_helper;
 
 use cnd::{
     btsieve::ethereum::{Event, Topic, TransactionPattern},
-    ethereum::{Block, Transaction, TransactionReceipt},
+    ethereum::{Address, Block, Bytes, Transaction, TransactionReceipt},
 };
 use spectral::prelude::*;
+use std::str::FromStr;
 
 #[test]
 fn cannot_skip_block_containing_transaction_with_event() {
@@ -29,4 +30,126 @@ fn cannot_skip_block_containing_transaction_with_event() {
     };
 
     assert_that!(pattern.needs_receipts(&block)).is_false();
+}
+
+fn pattern_matches_block(pattern: TransactionPattern) -> bool {
+    let block: Block<Transaction> = include_json_test_data!("./test_data/ethereum/block.json");
+
+    for transaction in block.transactions.into_iter() {
+        if pattern.matches(&transaction, None) {
+            return true;
+        }
+    }
+    false
+}
+
+// `matches()` method is a filter i.e., it returns true unless things
+// specifically do _not_ match.  In order to _really_ test that the we
+// succesfully match we first do a negative test then do an identical positive
+// test.
+
+#[test]
+fn matches_transaction_from_address() {
+    let invalid_from_address = Address::from_str("fffffa1fba5b4804863131145bc27256d3abffff")
+        .expect("failed to construct from_address");
+
+    let pattern = TransactionPattern {
+        from_address: Some(invalid_from_address),
+        ..TransactionPattern::default()
+    };
+
+    let result = pattern_matches_block(pattern);
+    assert_that!(&result).is_false();
+
+    let valid_from_address = Address::from_str("fb303a1fba5b4804863131145bc27256d3ab6692")
+        .expect("failed to construct from_address");
+
+    let pattern = TransactionPattern {
+        from_address: Some(valid_from_address),
+        ..TransactionPattern::default()
+    };
+
+    let result = pattern_matches_block(pattern);
+    assert_that!(&result).is_true();
+}
+
+#[test]
+fn matches_transaction_to_address() {
+    let invalid_to_address = Address::from_str("fffffe335b2786520f4c5d706c76c9ee69d0ffff")
+        .expect("failed to construct to_address");
+
+    let pattern = TransactionPattern {
+        to_address: Some(invalid_to_address),
+        ..TransactionPattern::default()
+    };
+
+    let result = pattern_matches_block(pattern);
+    assert_that!(&result).is_false();
+
+    let valid_to_address = Address::from_str("c5549e335b2786520f4c5d706c76c9ee69d0a028")
+        .expect("failed to construct to_address");
+
+    let pattern = TransactionPattern {
+        to_address: Some(valid_to_address),
+        ..TransactionPattern::default()
+    };
+
+    let result = pattern_matches_block(pattern);
+    assert_that!(&result).is_true();
+}
+
+#[test]
+fn matches_transaction_data() {
+    let invalid_transaction_data = "ffff9cbb000000000000000000000000d50fb7d948426633ec126aeea140ce4dd09796820000000000000000000000000000000000000000000000000000000ba43bffff";
+    let invalid_transaction_data =
+        hex::decode(invalid_transaction_data).expect("failed to decode hex data");
+    let invalid_transaction_data = Bytes::from(invalid_transaction_data);
+
+    let pattern = TransactionPattern {
+        transaction_data: Some(invalid_transaction_data),
+        ..TransactionPattern::default()
+    };
+
+    let result = pattern_matches_block(pattern);
+    assert_that!(&result).is_false();
+
+    let valid_transaction_data = "a9059cbb000000000000000000000000d50fb7d948426633ec126aeea140ce4dd09796820000000000000000000000000000000000000000000000000000000ba43b7400";
+    let valid_transaction_data =
+        hex::decode(valid_transaction_data).expect("failed to decode hex data");
+    let valid_transaction_data = Bytes::from(valid_transaction_data);
+
+    let pattern = TransactionPattern {
+        transaction_data: Some(valid_transaction_data),
+        ..TransactionPattern::default()
+    };
+
+    let result = pattern_matches_block(pattern);
+    assert_that!(&result).is_true();
+}
+
+#[test]
+fn matches_transaction_data_length() {
+    let invalid_transaction_data_length = 999999;
+
+    let pattern = TransactionPattern {
+        transaction_data_length: Some(invalid_transaction_data_length),
+        ..TransactionPattern::default()
+    };
+
+    let result = pattern_matches_block(pattern);
+    assert_that!(&result).is_false();
+
+    let valid_transaction_data = "a9059cbb000000000000000000000000d50fb7d948426633ec126aeea140ce4dd09796820000000000000000000000000000000000000000000000000000000ba43b7400";
+    let valid_transaction_data =
+        hex::decode(valid_transaction_data).expect("failed to decode hex data");
+
+    let invalid_transaction_data_length = valid_transaction_data.len();
+
+    let pattern = TransactionPattern {
+        transaction_data_length: Some(invalid_transaction_data_length),
+        ..TransactionPattern::default()
+    };
+
+    let result = pattern_matches_block(pattern);
+    assert_that!(&result).is_true();
 }

--- a/cnd/tests/ethereum_pattern.rs
+++ b/cnd/tests/ethereum_pattern.rs
@@ -45,7 +45,7 @@ fn pattern_matches_block(pattern: TransactionPattern) -> bool {
 
 // `matches()` method is a filter which returns `true` if things match 
 // and `false` otherwise.
-// specifically do _not_ match.  In order to _really_ test that the we
+// In order to _really_ test that the we
 // successfully match we first do a negative test then do an identical positive
 // test.
 

--- a/cnd/tests/ethereum_pattern.rs
+++ b/cnd/tests/ethereum_pattern.rs
@@ -129,7 +129,7 @@ fn matches_transaction_data() {
 
 #[test]
 fn matches_transaction_data_length() {
-    let invalid_transaction_data_length = 999999;
+    let invalid_transaction_data_length = 999_999;
 
     let pattern = TransactionPattern {
         transaction_data_length: Some(invalid_transaction_data_length),


### PR DESCRIPTION
Currently we are testing the matching logic for ethereum transactions using
handcrafted data.  We could have more faith in the tests if we used real data.
We have an ethereum block extracted from mainnet.  Use this block to do testing
on the matching logic for ethereum transactions.

Resolves: #1459