### PR TITLE
Shorten test sleep time

### DIFF
--- a/api_tests/harness.ts
+++ b/api_tests/harness.ts
@@ -14,6 +14,7 @@ import { HarnessGlobal } from "./lib/util";
 
 commander
     .option("--dump-logs", "Dump logs to stdout on failure")
+    .option("--verbose", "Verbose output")
     .parse(process.argv);
 
 // ************************ //
@@ -32,6 +33,10 @@ global.projectRoot = projectRoot;
 global.testRoot = testRoot;
 global.logRoot = logDir;
 global.ledgerConfigs = {};
+global.verbose = false;
+if (commander.verbose) {
+    global.verbose = true;
+}
 
 rimraf.sync(logDir);
 fs.mkdirSync(logDir);
@@ -60,7 +65,9 @@ async function runTests(testFiles: string[]) {
     }
 
     process.on("SIGINT", async () => {
-        console.log("SIGINT RECEIVED");
+        if (global.verbose) {
+            console.log("SIGINT RECEIVED");
+        }
 
         await cleanupAll();
 

--- a/api_tests/lib/actor.ts
+++ b/api_tests/lib/actor.ts
@@ -74,7 +74,7 @@ export class Actor {
         if (predicate(response.body)) {
             return response.body;
         } else {
-            await sleep(500);
+            await sleep(200);
 
             return this.pollCndUntil(location, predicate);
         }
@@ -195,7 +195,7 @@ export class Actor {
                         let escapeSequence = "";
 
                         while (diff > 0) {
-                            await sleep(1000);
+                            await sleep(200);
 
                             currentMedianBlockTime = await fetchMedianTime();
                             diff =
@@ -252,7 +252,7 @@ export class Actor {
                             min_block_timestamp
                         );
                     }
-                    await sleep(delay * 1000);
+                    await sleep(delay * 200);
                 }
 
                 return this.wallet

--- a/api_tests/lib/actor.ts
+++ b/api_tests/lib/actor.ts
@@ -156,10 +156,10 @@ export class Actor {
     }
 
     public async doLedgerAction(action: LedgerAction) {
-        // wait 1 second to make sure that both parties have created a btsieve
-        // query to watch for the action that is about to be performed. Should
-        // be removed with https://github.com/comit-network/comit-rs/issues/1289
-        await sleep(1000);
+        // wait to make sure that both parties have created a btsieve query to
+        // watch for the action that is about to be performed. Should be removed
+        // with https://github.com/comit-network/comit-rs/issues/1289
+        await sleep(200);
 
         switch (action.type) {
             case "bitcoin-send-amount-to-address": {

--- a/api_tests/lib/actor.ts
+++ b/api_tests/lib/actor.ts
@@ -8,7 +8,10 @@ import * as bitcoin from "./bitcoin";
 import { LedgerAction } from "./comit";
 import { CND_CONFIGS, E2ETestActorConfig } from "./config";
 import { seconds_until, sleep } from "./util";
+import { HarnessGlobal } from "./util";
 import { Wallet, WalletConfig } from "./wallet";
+
+declare var global: HarnessGlobal;
 
 use(chaiHttp);
 
@@ -182,10 +185,12 @@ export class Actor {
                     let diff = min_median_block_time - currentMedianBlockTime;
 
                     if (diff > 0) {
-                        console.log(
-                            `Waiting for median time to pass %d`,
-                            min_median_block_time
-                        );
+                        if (global.verbose) {
+                            console.log(
+                                `Waiting for median time to pass %d`,
+                                min_median_block_time
+                            );
+                        }
 
                         let escapeSequence = "";
 
@@ -196,10 +201,12 @@ export class Actor {
                             diff =
                                 min_median_block_time - currentMedianBlockTime;
 
-                            console.log(
-                                `${escapeSequence}Current median time:            %d`,
-                                currentMedianBlockTime
-                            );
+                            if (global.verbose) {
+                                console.log(
+                                    `${escapeSequence}Current median time:            %d`,
+                                    currentMedianBlockTime
+                                );
+                            }
                             escapeSequence = MOVE_CURSOR_UP_ONE_LINE;
                         }
                     }
@@ -238,12 +245,13 @@ export class Actor {
                     const buffer = 2;
                     const delay = seconds_until(min_block_timestamp) + buffer;
 
-                    console.log(
-                        `Waiting for %d seconds before action can be executed to reach %d.`,
-                        delay,
-                        min_block_timestamp
-                    );
-
+                    if (global.verbose) {
+                        console.log(
+                            `Waiting for %d seconds before action can be executed to reach %d.`,
+                            delay,
+                            min_block_timestamp
+                        );
+                    }
                     await sleep(delay * 1000);
                 }
 

--- a/api_tests/lib/cnd_runner.ts
+++ b/api_tests/lib/cnd_runner.ts
@@ -4,6 +4,9 @@ import { promisify } from "util";
 import { CndInstance } from "../lib_sdk/cnd_instance";
 import { CND_CONFIGS } from "./config";
 import { LedgerConfig } from "./ledger_runner";
+import { HarnessGlobal } from "./util";
+
+declare var global: HarnessGlobal;
 
 const unlinkAsync = promisify(fs.unlink);
 const existsAsync = promisify(fs.exists);
@@ -26,7 +29,9 @@ export class CndRunner {
             actor => !Object.keys(this.runningNodes).includes(actor)
         );
 
-        console.log("Starting cnd for " + actorsToBeStarted.join(", "));
+        if (global.verbose) {
+            console.log("Starting cnd for " + actorsToBeStarted.join(", "));
+        }
 
         const promises = actorsToBeStarted.map(async name => {
             const cndconfig = CND_CONFIGS[name];
@@ -69,7 +74,9 @@ export class CndRunner {
         const names = Object.keys(this.runningNodes);
 
         if (names.length > 0) {
-            console.log("Stopping cnds: " + names.join(", "));
+            if (global.verbose) {
+                console.log("Stopping cnds: " + names.join(", "));
+            }
             for (const process of Object.values(this.runningNodes)) {
                 process.stop();
             }

--- a/api_tests/lib/ledger_runner.ts
+++ b/api_tests/lib/ledger_runner.ts
@@ -3,6 +3,9 @@ import { GenericContainer, StartedTestContainer, Wait } from "testcontainers";
 import * as bitcoin from "./bitcoin";
 import { BitcoinNodeConfig } from "./bitcoin";
 import { EthereumNodeConfig } from "./ethereum";
+import { HarnessGlobal } from "./util";
+
+declare var global: HarnessGlobal;
 
 export interface LedgerConfig {
     bitcoin?: BitcoinNodeConfig;
@@ -22,8 +25,9 @@ export class LedgerRunner {
         const toBeStarted = ledgers.filter(name => !this.runningLedgers[name]);
 
         const promises = toBeStarted.map(async ledger => {
-            console.log(`Starting ledger ${ledger}`);
-
+            if (global.verbose) {
+                console.log(`Starting ledger ${ledger}`);
+            }
             switch (ledger) {
                 case "bitcoin": {
                     return {
@@ -78,8 +82,9 @@ export class LedgerRunner {
         const ledgers = Object.entries(this.runningLedgers);
 
         const promises = ledgers.map(async ([ledger, container]) => {
-            console.log(`Stopping ledger ${ledger}`);
-
+            if (global.verbose) {
+                console.log(`Stopping ledger ${ledger}`);
+            }
             clearInterval(this.blockTimers[ledger]);
             await container.stop();
             delete this.runningLedgers[ledger];

--- a/api_tests/lib/util.ts
+++ b/api_tests/lib/util.ts
@@ -31,4 +31,5 @@ export interface HarnessGlobal extends Global {
     testRoot: string;
     projectRoot: string;
     logRoot: string;
+    verbose: boolean;
 }

--- a/api_tests/lib_sdk/cnd_instance.ts
+++ b/api_tests/lib_sdk/cnd_instance.ts
@@ -65,7 +65,7 @@ export class CndInstance {
             }
         });
 
-        await sleep(1000); // allow the nodes to start up
+        await sleep(200); // allow the nodes to start up
     }
 
     public stop() {

--- a/api_tests/lib_sdk/cnd_instance.ts
+++ b/api_tests/lib_sdk/cnd_instance.ts
@@ -6,6 +6,9 @@ import { promisify } from "util";
 import { CndConfigFile, E2ETestActorConfig } from "../lib/config";
 import { LedgerConfig } from "../lib/ledger_runner";
 import { sleep } from "../lib/util";
+import { HarnessGlobal } from "../lib/util";
+
+declare var global: HarnessGlobal;
 
 const openAsync = promisify(fs.open);
 
@@ -54,10 +57,12 @@ export class CndInstance {
         });
 
         this.process.on("exit", (code: number, signal: number) => {
-            console.log(
-                `cnd ${this.actorConfig.name} exited with ${code ||
-                    "signal " + signal}`
-            );
+            if (global.verbose) {
+                console.log(
+                    `cnd ${this.actorConfig.name} exited with ${code ||
+                        "signal " + signal}`
+                );
+            }
         });
 
         await sleep(1000); // allow the nodes to start up

--- a/api_tests/lib_sdk/wallets/index.ts
+++ b/api_tests/lib_sdk/wallets/index.ts
@@ -65,7 +65,7 @@ export async function pollUntilMinted(
     if (new BigNumber(currentBalance).gte(minimumBalance)) {
         return;
     } else {
-        await sleep(500);
+        await sleep(200);
 
         return pollUntilMinted(wallet, minimumBalance);
     }


### PR DESCRIPTION
Shorten sleep times to 200 milliseconds instead of 1 second.  200 milliseconds is an eternity for a modern processor.  We do not need to wait for a second for the CPU to process things.  As for the CI infrastructure ...