### PR TITLE
Remove duplicate SwapCommunication

### DIFF
--- a/cnd/src/http_api/routes/rfc003/swap_state.rs
+++ b/cnd/src/http_api/routes/rfc003/swap_state.rs
@@ -3,7 +3,7 @@ use crate::{
     http_api::{Http, SwapStatus},
     swap_protocols::{
         asset::Asset,
-        rfc003::{self, alice, bob, Ledger, SecretHash},
+        rfc003::{self, Ledger, SecretHash},
     },
     timestamp::Timestamp,
 };
@@ -55,53 +55,13 @@ pub enum SwapCommunicationState {
     Declined,
 }
 
-impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> From<alice::SwapCommunication<AL, BL, AA, BA>>
+impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> From<rfc003::SwapCommunication<AL, BL, AA, BA>>
     for SwapCommunication<AL::Identity, BL::Identity>
 {
-    fn from(communication: alice::SwapCommunication<AL, BL, AA, BA>) -> Self {
-        use self::alice::SwapCommunication::*;
+    fn from(communication: rfc003::SwapCommunication<AL, BL, AA, BA>) -> Self {
+        use rfc003::SwapCommunication::*;
         match communication {
             Proposed { request } => Self {
-                status: SwapCommunicationState::Sent,
-                alpha_expiry: request.alpha_expiry,
-                beta_expiry: request.beta_expiry,
-                alpha_redeem_identity: None,
-                beta_redeem_identity: Http(request.beta_ledger_redeem_identity),
-                alpha_refund_identity: Http(request.alpha_ledger_refund_identity),
-                beta_refund_identity: None,
-                secret_hash: request.secret_hash,
-            },
-            Accepted { request, response } => Self {
-                status: SwapCommunicationState::Accepted,
-                alpha_expiry: request.alpha_expiry,
-                beta_expiry: request.beta_expiry,
-                alpha_redeem_identity: Some(Http(response.alpha_ledger_redeem_identity)),
-                beta_redeem_identity: Http(request.beta_ledger_redeem_identity),
-                alpha_refund_identity: Http(request.alpha_ledger_refund_identity),
-                beta_refund_identity: Some(Http(response.beta_ledger_refund_identity)),
-                secret_hash: request.secret_hash,
-            },
-            Declined { request, .. } => Self {
-                status: SwapCommunicationState::Declined,
-                alpha_expiry: request.alpha_expiry,
-                beta_expiry: request.beta_expiry,
-                alpha_redeem_identity: None,
-                beta_redeem_identity: Http(request.beta_ledger_redeem_identity),
-                alpha_refund_identity: Http(request.alpha_ledger_refund_identity),
-                beta_refund_identity: None,
-                secret_hash: request.secret_hash,
-            },
-        }
-    }
-}
-
-impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> From<bob::SwapCommunication<AL, BL, AA, BA>>
-    for SwapCommunication<AL::Identity, BL::Identity>
-{
-    fn from(communication: bob::SwapCommunication<AL, BL, AA, BA>) -> Self {
-        use self::bob::SwapCommunication::*;
-        match communication {
-            Proposed { request, .. } => Self {
                 status: SwapCommunicationState::Sent,
                 alpha_expiry: request.alpha_expiry,
                 beta_expiry: request.beta_expiry,

--- a/cnd/src/swap_protocols/rfc003/alice/actions/erc20.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/actions/erc20.rs
@@ -6,9 +6,9 @@ use crate::{
         ledger::Ethereum,
         rfc003::{
             actions::{erc20, Accept, Action, Decline, FundAction, RedeemAction, RefundAction},
-            alice::{self, SwapCommunication},
+            alice,
             state_machine::HtlcParams,
-            Ledger, LedgerState,
+            Ledger, LedgerState, SwapCommunication,
         },
     },
 };

--- a/cnd/src/swap_protocols/rfc003/alice/actions/generic_impl.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/actions/generic_impl.rs
@@ -3,9 +3,9 @@ use crate::swap_protocols::{
     asset::Asset,
     rfc003::{
         actions::{Accept, Action, Decline, FundAction, RedeemAction, RefundAction},
-        alice::{self, SwapCommunication},
+        alice,
         state_machine::HtlcParams,
-        Ledger, LedgerState,
+        Ledger, LedgerState, SwapCommunication,
     },
 };
 use std::convert::Infallible;

--- a/cnd/src/swap_protocols/rfc003/alice/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/mod.rs
@@ -6,7 +6,7 @@ use crate::swap_protocols::{
     asset::Asset,
     rfc003::{
         self, ledger::Ledger, ledger_state::LedgerState, messages, secret_source::SecretSource,
-        ActorState, Secret,
+        ActorState, Secret, SwapCommunication,
     },
 };
 use derivative::Derivative;
@@ -21,21 +21,6 @@ pub struct State<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
     #[derivative(Debug = "ignore", PartialEq = "ignore")]
     pub secret_source: Arc<dyn SecretSource>,
     pub error: Option<rfc003::Error>,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum SwapCommunication<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
-    Proposed {
-        request: messages::Request<AL, BL, AA, BA>,
-    },
-    Accepted {
-        request: messages::Request<AL, BL, AA, BA>,
-        response: messages::Accept<AL, BL>,
-    },
-    Declined {
-        request: messages::Request<AL, BL, AA, BA>,
-        response: messages::Decline,
-    },
 }
 
 impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {

--- a/cnd/src/swap_protocols/rfc003/bob/actions/erc20.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/actions/erc20.rs
@@ -6,9 +6,9 @@ use crate::{
         ledger::Ethereum,
         rfc003::{
             actions::{erc20, Accept, Action, Decline, FundAction, RedeemAction, RefundAction},
-            bob::{self, SwapCommunication},
+            bob,
             state_machine::HtlcParams,
-            Ledger, LedgerState,
+            Ledger, LedgerState, SwapCommunication,
         },
     },
 };

--- a/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
@@ -3,9 +3,9 @@ use crate::swap_protocols::{
     asset::Asset,
     rfc003::{
         actions::{Accept, Action, Decline, FundAction, RedeemAction, RefundAction},
-        bob::{self, SwapCommunication},
+        bob,
         state_machine::HtlcParams,
-        Ledger, LedgerState,
+        Ledger, LedgerState, SwapCommunication,
     },
 };
 use std::convert::Infallible;

--- a/cnd/src/swap_protocols/rfc003/bob/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/mod.rs
@@ -4,7 +4,7 @@ use crate::swap_protocols::{
     asset::Asset,
     rfc003::{
         self, ledger::Ledger, ledger_state::LedgerState, messages::Request,
-        secret_source::SecretSource, Accept, ActorState, Decline, Secret,
+        secret_source::SecretSource, Accept, ActorState, Decline, Secret, SwapCommunication,
     },
 };
 use derivative::Derivative;
@@ -25,22 +25,6 @@ pub struct State<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
     pub secret_source: Arc<dyn SecretSource>,
     pub secret: Option<Secret>,
     pub error: Option<rfc003::Error>,
-}
-
-#[derive(Clone, Derivative)]
-#[derivative(Debug)]
-pub enum SwapCommunication<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
-    Proposed {
-        request: Request<AL, BL, AA, BA>,
-    },
-    Accepted {
-        request: Request<AL, BL, AA, BA>,
-        response: Accept<AL, BL>,
-    },
-    Declined {
-        request: Request<AL, BL, AA, BA>,
-        response: Decline,
-    },
 }
 
 impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {

--- a/cnd/src/swap_protocols/rfc003/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/mod.rs
@@ -28,6 +28,9 @@ pub use self::{
 };
 
 pub use self::messages::{Accept, Decline, Request};
+
+use crate::swap_protocols::asset::Asset;
+
 /// Swap request response as received from peer node acting as Bob.
 pub type Response<AL, BL> = Result<Accept<AL, BL>, Decline>;
 
@@ -41,4 +44,19 @@ pub enum Error {
     IncorrectFunding,
     #[error("internal error: {0}")]
     Internal(String),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum SwapCommunication<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
+    Proposed {
+        request: Request<AL, BL, AA, BA>,
+    },
+    Accepted {
+        request: Request<AL, BL, AA, BA>,
+        response: Accept<AL, BL>,
+    },
+    Declined {
+        request: Request<AL, BL, AA, BA>,
+        response: Decline,
+    },
 }


### PR DESCRIPTION
Currently the Bob and Alice SwapCommunication enums are identical, we
can merge them into a single definition.

Resolves #1680.