### PR TITLE
Encode the capability of deriving a Secret into the type system so that only Alice can do that

### DIFF
--- a/cnd/src/http_api/routes/rfc003/accept.rs
+++ b/cnd/src/http_api/routes/rfc003/accept.rs
@@ -5,7 +5,7 @@ use crate::{
         rfc003::{
             actions::Accept,
             messages::{self, IntoAcceptMessage},
-            Ledger, SecretSource,
+            DeriveIdentities, Ledger,
         },
         SwapId,
     },
@@ -33,11 +33,11 @@ impl IntoAcceptMessage<Ethereum, Bitcoin> for OnlyRedeem<Ethereum> {
     fn into_accept_message(
         self,
         id: SwapId,
-        secret_source: &dyn SecretSource,
+        secret_source: &dyn DeriveIdentities,
     ) -> messages::Accept<Ethereum, Bitcoin> {
         let beta_ledger_refund_identity = crate::bitcoin::PublicKey::from_secret_key(
             &*crate::SECP,
-            &secret_source.secp256k1_refund(),
+            &secret_source.derive_refund_identity(),
         );
         messages::Accept {
             swap_id: id,
@@ -68,11 +68,11 @@ impl IntoAcceptMessage<Bitcoin, Ethereum> for OnlyRefund<Ethereum> {
     fn into_accept_message(
         self,
         id: SwapId,
-        secret_source: &dyn SecretSource,
+        secret_source: &dyn DeriveIdentities,
     ) -> messages::Accept<Bitcoin, Ethereum> {
         let alpha_ledger_redeem_identity = crate::bitcoin::PublicKey::from_secret_key(
             &*crate::SECP,
-            &secret_source.secp256k1_redeem(),
+            &secret_source.derive_redeem_identity(),
         );
         messages::Accept {
             swap_id: id,

--- a/cnd/src/swap_protocols/rfc003/actions/ether.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/ether.rs
@@ -6,8 +6,7 @@ use crate::{
         rfc003::{
             actions::{FundAction, RedeemAction, RefundAction},
             create_swap::HtlcParams,
-            secret_source::SecretSource,
-            Secret,
+            DeriveIdentities, Secret,
         },
     },
 };
@@ -26,7 +25,7 @@ impl RefundAction<Ethereum, EtherQuantity> for (Ethereum, EtherQuantity) {
     fn refund_action(
         htlc_params: HtlcParams<Ethereum, EtherQuantity>,
         htlc_location: EthereumAddress,
-        _secret_source: &dyn SecretSource,
+        _secret_source: &dyn DeriveIdentities,
         _fund_transaction: &Transaction,
     ) -> Self::RefundActionOutput {
         let gas_limit = EtherHtlc::tx_gas_limit();
@@ -46,7 +45,7 @@ impl RedeemAction<Ethereum, EtherQuantity> for (Ethereum, EtherQuantity) {
     fn redeem_action(
         htlc_params: HtlcParams<Ethereum, EtherQuantity>,
         htlc_location: EthereumAddress,
-        _secret_source: &dyn SecretSource,
+        _secret_source: &dyn DeriveIdentities,
         secret: Secret,
     ) -> Self::RedeemActionOutput {
         let data = Bytes::from(secret.as_raw_secret().to_vec());

--- a/cnd/src/swap_protocols/rfc003/actions/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/mod.rs
@@ -4,7 +4,7 @@ pub mod ether;
 
 use crate::swap_protocols::{
     asset::Asset,
-    rfc003::{create_swap::HtlcParams, secret_source::SecretSource, Ledger, Secret},
+    rfc003::{create_swap::HtlcParams, DeriveIdentities, Ledger, Secret},
 };
 use std::marker::PhantomData;
 
@@ -36,7 +36,7 @@ pub trait RefundAction<L: Ledger, A: Asset> {
     fn refund_action(
         htlc_params: HtlcParams<L, A>,
         htlc_location: L::HtlcLocation,
-        secret_source: &dyn SecretSource,
+        secret_source: &dyn DeriveIdentities,
         fund_transaction: &L::Transaction,
     ) -> Self::RefundActionOutput;
 }
@@ -47,7 +47,7 @@ pub trait RedeemAction<L: Ledger, A: Asset> {
     fn redeem_action(
         htlc_params: HtlcParams<L, A>,
         htlc_location: L::HtlcLocation,
-        secret_source: &dyn SecretSource,
+        secret_source: &dyn DeriveIdentities,
         secret: Secret,
     ) -> Self::RedeemActionOutput;
 }

--- a/cnd/src/swap_protocols/rfc003/alice/actions/erc20.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/actions/erc20.rs
@@ -8,7 +8,7 @@ use crate::{
             actions::{erc20, Accept, Action, Decline, FundAction, RedeemAction, RefundAction},
             alice,
             create_swap::HtlcParams,
-            Ledger, LedgerState, SwapCommunication,
+            DeriveSecret, Ledger, LedgerState, SwapCommunication,
         },
     },
 };
@@ -64,8 +64,8 @@ where
             actions.push(Action::Redeem(<(BL, BA)>::redeem_action(
                 HtlcParams::new_beta_params(request, response),
                 htlc_location.clone(),
-                &*self.secret_source,
-                self.secret_source.secret(),
+                &self.secret_source, // Derive identities with this.
+                self.secret_source.derive_secret(), // The secret used by Alice.
             )));
         }
         actions
@@ -112,7 +112,7 @@ where
             } => vec![Action::Refund(<(AL, AA)>::refund_action(
                 HtlcParams::new_alpha_params(request, response),
                 htlc_location.clone(),
-                &*self.secret_source,
+                &self.secret_source,
                 fund_transaction,
             ))],
             _ => vec![],
@@ -121,7 +121,7 @@ where
         if let Funded { htlc_location, .. } = beta_state {
             actions.push(Action::Redeem(erc20::redeem_action(
                 *htlc_location,
-                self.secret_source.secret(),
+                self.secret_source.derive_secret(),
                 request.beta_ledger.chain_id,
             )));
         }

--- a/cnd/src/swap_protocols/rfc003/alice/actions/generic_impl.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/actions/generic_impl.rs
@@ -5,7 +5,7 @@ use crate::swap_protocols::{
         actions::{Accept, Action, Decline, FundAction, RedeemAction, RefundAction},
         alice,
         create_swap::HtlcParams,
-        Ledger, LedgerState, SwapCommunication,
+        DeriveSecret, Ledger, LedgerState, SwapCommunication,
     },
 };
 use std::convert::Infallible;
@@ -52,7 +52,7 @@ where
             } => vec![Action::Refund(<(AL, AA)>::refund_action(
                 HtlcParams::new_alpha_params(request, response),
                 htlc_location.clone(),
-                &*self.secret_source,
+                &self.secret_source,
                 fund_transaction,
             ))],
             Funded {
@@ -62,7 +62,7 @@ where
             } => vec![Action::Refund(<(AL, AA)>::refund_action(
                 HtlcParams::new_alpha_params(request, response),
                 htlc_location.clone(),
-                &*self.secret_source,
+                &self.secret_source,
                 fund_transaction,
             ))],
             _ => vec![],
@@ -72,8 +72,8 @@ where
             actions.push(Action::Redeem(<(BL, BA)>::redeem_action(
                 HtlcParams::new_beta_params(request, response),
                 htlc_location.clone(),
-                &*self.secret_source,
-                self.secret_source.secret(),
+                &self.secret_source, // Derive identities with this.
+                self.secret_source.derive_secret(), // The secret used by Alice.
             )));
         }
         actions

--- a/cnd/src/swap_protocols/rfc003/bob/actions/erc20.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/actions/erc20.rs
@@ -55,8 +55,9 @@ where
                 vec![Action::Redeem(<(AL, AA)>::redeem_action(
                     HtlcParams::new_alpha_params(request, response),
                     htlc_location.clone(),
-                    &*self.secret_source,
-                    *secret,
+                    &*self.secret_source, // Derive identities with this.
+                    *secret,              /* Bob uses the secret learned from Alice's redeem
+                                           * action. */
                 ))]
             }
             (Funded { .. }, NotDeployed) => vec![Action::Deploy(erc20::deploy_action(

--- a/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
@@ -53,8 +53,9 @@ where
                 vec![Action::Redeem(<(AL, AA)>::redeem_action(
                     HtlcParams::new_alpha_params(request, response),
                     htlc_location.clone(),
-                    &*self.secret_source,
-                    *secret,
+                    &*self.secret_source, // Derive identities with this.
+                    *secret,              /* Bob uses the secret learned from Alice's redeem
+                                           * action. */
                 ))]
             }
             (Funded { .. }, NotDeployed) => vec![Action::Fund(<(BL, BA)>::fund_action(

--- a/cnd/src/swap_protocols/rfc003/bob/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/mod.rs
@@ -3,8 +3,8 @@ pub mod actions;
 use crate::swap_protocols::{
     asset::Asset,
     rfc003::{
-        self, ledger::Ledger, ledger_state::LedgerState, messages::Request,
-        secret_source::SecretSource, Accept, ActorState, Decline, SwapCommunication,
+        self, ledger::Ledger, ledger_state::LedgerState, messages::Request, Accept, ActorState,
+        Decline, DeriveIdentities, SwapCommunication,
     },
 };
 use derivative::Derivative;
@@ -22,11 +22,14 @@ pub struct State<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
     pub alpha_ledger_state: LedgerState<AL, AA>,
     pub beta_ledger_state: LedgerState<BL, BA>,
     #[derivative(Debug = "ignore")]
-    pub secret_source: Arc<dyn SecretSource>,
+    pub secret_source: Arc<dyn DeriveIdentities>,
 }
 
 impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
-    pub fn proposed(request: Request<AL, BL, AA, BA>, secret_source: impl SecretSource) -> Self {
+    pub fn proposed(
+        request: Request<AL, BL, AA, BA>,
+        secret_source: impl DeriveIdentities,
+    ) -> Self {
         Self {
             swap_communication: SwapCommunication::Proposed { request },
             alpha_ledger_state: LedgerState::NotDeployed,
@@ -38,7 +41,7 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
     pub fn accepted(
         request: Request<AL, BL, AA, BA>,
         response: Accept<AL, BL>,
-        secret_source: impl SecretSource,
+        secret_source: impl DeriveIdentities,
     ) -> Self {
         Self {
             swap_communication: SwapCommunication::Accepted { request, response },
@@ -51,7 +54,7 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
     pub fn declined(
         request: Request<AL, BL, AA, BA>,
         response: Decline,
-        secret_source: impl SecretSource,
+        secret_source: impl DeriveIdentities,
     ) -> Self {
         Self {
             swap_communication: SwapCommunication::Declined { request, response },

--- a/cnd/src/swap_protocols/rfc003/messages.rs
+++ b/cnd/src/swap_protocols/rfc003/messages.rs
@@ -1,7 +1,7 @@
 use crate::{
     swap_protocols::{
         asset::Asset,
-        rfc003::{Ledger, SecretHash, SecretSource},
+        rfc003::{DeriveIdentities, Ledger, SecretHash},
         HashFunction, SwapId,
     },
     timestamp::Timestamp,
@@ -88,12 +88,12 @@ pub enum SwapDeclineReason {
     BadJsonField,
 }
 
-pub trait ToRequest<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
-    fn to_request(&self, id: SwapId, secret_source: &dyn SecretSource) -> Request<AL, BL, AA, BA>;
-}
-
 pub trait IntoAcceptMessage<AL: Ledger, BL: Ledger> {
-    fn into_accept_message(self, id: SwapId, secret_source: &dyn SecretSource) -> Accept<AL, BL>;
+    fn into_accept_message(
+        self,
+        id: SwapId,
+        secret_source: &dyn DeriveIdentities,
+    ) -> Accept<AL, BL>;
 }
 
 #[cfg(test)]

--- a/cnd/src/swap_protocols/rfc003/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/mod.rs
@@ -15,7 +15,6 @@ pub mod actions;
 mod actor_state;
 mod ledger;
 mod secret;
-mod secret_source;
 
 pub use self::{
     actor_state::ActorState,
@@ -23,12 +22,12 @@ pub use self::{
     ledger::Ledger,
     ledger_state::{HtlcState, LedgerState},
     secret::{FromErr, Secret, SecretHash},
-    secret_source::*,
 };
 
 pub use self::messages::{Accept, Decline, Request};
 
-use crate::swap_protocols::asset::Asset;
+use crate::{seed::SwapSeed, swap_protocols::asset::Asset};
+use ::bitcoin::secp256k1::SecretKey;
 
 /// Swap request response as received from peer node acting as Bob.
 pub type Response<AL, BL> = Result<Accept<AL, BL>, Decline>;
@@ -67,5 +66,34 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> SwapCommunication<AL, BL, AA,
             SwapCommunication::Proposed { request } => request,
             SwapCommunication::Declined { request, .. } => request,
         }
+    }
+}
+
+pub trait DeriveIdentities: Send + Sync + 'static {
+    fn derive_redeem_identity(&self) -> SecretKey;
+    fn derive_refund_identity(&self) -> SecretKey;
+}
+
+/// Both Alice and Bob use their `SwapSeed` to derive identities.
+impl DeriveIdentities for SwapSeed {
+    fn derive_redeem_identity(&self) -> SecretKey {
+        SecretKey::from_slice(self.sha256_with_seed(&[b"REDEEM"]).as_ref())
+            .expect("The probability of this happening is < 1 in 2^120")
+    }
+
+    fn derive_refund_identity(&self) -> SecretKey {
+        SecretKey::from_slice(self.sha256_with_seed(&[b"REFUND"]).as_ref())
+            .expect("The probability of this happening is < 1 in 2^120")
+    }
+}
+
+pub trait DeriveSecret: Send + Sync + 'static {
+    fn derive_secret(&self) -> Secret;
+}
+
+/// Only Alice derives the secret, Bob learns the secret from Alice.
+impl DeriveSecret for SwapSeed {
+    fn derive_secret(&self) -> Secret {
+        self.sha256_with_seed(&[b"SECRET"]).into()
     }
 }

--- a/cnd/src/swap_protocols/rfc003/secret_source.rs
+++ b/cnd/src/swap_protocols/rfc003/secret_source.rs
@@ -1,24 +1,32 @@
-use crate::{seed::SwapSeed, swap_protocols::rfc003::Secret};
+use crate::{
+    seed::SwapSeed,
+    swap_protocols::rfc003::{Secret, SecretHash},
+};
 use bitcoin::secp256k1::SecretKey;
 
-pub trait SecretSource: Send + Sync + 'static {
-    fn secret(&self) -> Secret;
-    fn secp256k1_redeem(&self) -> SecretKey;
-    fn secp256k1_refund(&self) -> SecretKey;
+pub trait DeriveIdentities: Send + Sync + 'static {
+    fn derive_redeem_identity(&self) -> SecretKey;
+    fn derive_refund_identity(&self) -> SecretKey;
 }
 
-impl SecretSource for SwapSeed {
-    fn secret(&self) -> Secret {
-        self.sha256_with_seed(&[b"SECRET"]).into()
-    }
-
-    fn secp256k1_redeem(&self) -> SecretKey {
+impl DeriveIdentities for SwapSeed {
+    fn derive_redeem_identity(&self) -> SecretKey {
         SecretKey::from_slice(self.sha256_with_seed(&[b"REDEEM"]).as_ref())
             .expect("The probability of this happening is < 1 in 2^120")
     }
 
-    fn secp256k1_refund(&self) -> SecretKey {
+    fn derive_refund_identity(&self) -> SecretKey {
         SecretKey::from_slice(self.sha256_with_seed(&[b"REFUND"]).as_ref())
             .expect("The probability of this happening is < 1 in 2^120")
+    }
+}
+
+pub trait DeriveSecret: Send + Sync + 'static {
+    fn derive_secret(&self) -> Secret;
+}
+
+impl DeriveSecret for SwapSeed {
+    fn derive_secret(&self) -> Secret {
+        self.sha256_with_seed(&[b"SECRET"]).into()
     }
 }


### PR DESCRIPTION
Currently Bob can derive the secret from seed found in the state store.  This is logically incorrect.  With this applied Bob's functionality when using the `secret_source` is reduced to only deriving identities.

Resolves: #1682 

