### PR TITLE
Bitcoin: Refactor `matching_transactions()`

### DIFF
--- a/cnd/src/btsieve/bitcoin/mod.rs
+++ b/cnd/src/btsieve/bitcoin/mod.rs
@@ -53,10 +53,33 @@ where
         + Clone,
     E: Debug + Send + 'static,
 {
-    let mut oldest_block: Option<bitcoin::Block> = None;
+    // Verify that we can successfully connect to the blockchain connector and check
+    // if the transaction is in the latest block.
+    let latest_block = match blockchain_connector.latest_block().compat().await {
+        Ok(block) => block,
+        Err(e) => {
+            log::error!("Failed to connect to the blockchain_connector: {:?}", e,);
+            return Err(());
+        }
+    };
+    if let Some(transaction) = check_block_against_pattern(&latest_block.clone(), &pattern) {
+        return Ok(transaction.clone());
+    };
+
+    // We didn't find the transaction, now we need to do two things; keep polling
+    // for latest block so that we see transactions in new blocks and also go
+    // back up the blockchain until 'reference_timestamp' i.e., look back in the
+    // past.
 
     let mut prev_blockhashes: HashSet<sha256d::Hash> = HashSet::new();
     let mut missing_block_futures: Vec<_> = Vec::new();
+
+    let mut oldest_block: Option<bitcoin::Block> = Some(latest_block.clone());
+    prev_blockhashes.insert(latest_block.bitcoin_hash());
+
+    let prev_blockhash = latest_block.header.prev_blockhash;
+    let future = blockchain_connector.block_by_hash(prev_blockhash).compat();
+    missing_block_futures.push((future, prev_blockhash));
 
     loop {
         // Delay so that we don't overload the CPU in the event that
@@ -94,6 +117,8 @@ where
         }
         missing_block_futures = new_missing_block_futures;
 
+        // Look back into the past (upto timestamp) for one block.
+
         if let (Some(block), Some(reference_timestamp)) =
             (oldest_block.as_ref(), reference_timestamp)
         {
@@ -118,31 +143,23 @@ where
             }
         }
 
-        let latest_block = match blockchain_connector.latest_block().compat().await {
-            Ok(block) => block,
-            Err(e) => {
-                log::warn!("Could not get latest block: {:?}", e,);
-                continue;
+        // Check if a new block has been mined.
+
+        if let Ok(latest_block) = blockchain_connector.latest_block().compat().await {
+            // If we can insert then we have not seen this block.
+            if prev_blockhashes.insert(latest_block.bitcoin_hash()) {
+                if let Some(transaction) = check_block_against_pattern(&latest_block, &pattern) {
+                    return Ok(transaction.clone());
+                };
+
+                // In case we missed a block somehow, check this blocks parent.
+                if !prev_blockhashes.contains(&latest_block.header.prev_blockhash) {
+                    let prev_blockhash = latest_block.header.prev_blockhash;
+                    let future = blockchain_connector.block_by_hash(prev_blockhash).compat();
+
+                    missing_block_futures.push((future, prev_blockhash));
+                }
             }
-        };
-        oldest_block.get_or_insert(latest_block.clone());
-
-        // If we can't insert then we have seen this block
-        if !prev_blockhashes.insert(latest_block.bitcoin_hash()) {
-            continue;
-        }
-
-        if let Some(transaction) = check_block_against_pattern(&latest_block, &pattern) {
-            return Ok(transaction.clone());
-        };
-
-        if prev_blockhashes.len() > 1
-            && !prev_blockhashes.contains(&latest_block.header.prev_blockhash)
-        {
-            let prev_blockhash = latest_block.header.prev_blockhash;
-            let future = blockchain_connector.block_by_hash(prev_blockhash).compat();
-
-            missing_block_futures.push((future, prev_blockhash));
         }
     }
 }


### PR DESCRIPTION
Function is quite complex, refactoring it into separate functions is not really a viable option because of the complexity of the types involved.  There are however a few small things we can do to reduce the cognitive load required when reading this function.

- Add verbose comments since the logic is complex.
- Refactor so that we get the initial 'latest_block' at the top of the
  function, this makes the following loop easier to read.
- Refactor the final section so we do not depend on `continue`, this
  aids maintainability as well as assisting understanding the logic.

Due to some github noobity I am unable to re-open the [original PR](https://github.com/comit-network/comit-rs/pull/1763) that was this work.

The ethereum connector refactor of `matching_transacitions` can be found [here](https://github.com/comit-network/comit-rs/pull/1796).