### PR TITLE
Fix problem if no network connection is present

### DIFF
--- a/api_tests/dry/sanity.ts
+++ b/api_tests/dry/sanity.ts
@@ -101,7 +101,7 @@ setTimeout(async function() {
             expect(res).to.have.status(200);
             expect(res.body.listen_addresses).to.be.an("array");
             // At least 2 ipv4 addresses, lookup and external interface
-            expect(res.body.listen_addresses.length).to.be.greaterThan(2);
+            expect(res.body.listen_addresses.length).to.be.greaterThan(1);
         });
     });
 


### PR DESCRIPTION
I had no network connection enabled and this test failed as my known network addresses were only 2: 

```
[ '/ip4/127.0.0.1/tcp/9939',
  '/ip6/::1/tcp/9939']
```