### PR TITLE
Add two types `RootSeed` and `SwapSeed`

### DIFF
--- a/cnd/src/http_api/route_factory.rs
+++ b/cnd/src/http_api/route_factory.rs
@@ -4,7 +4,7 @@ use crate::{
     ethereum::{Erc20Token, EtherQuantity},
     http_api,
     network::Network,
-    seed::SwapSeed,
+    seed::DeriveSwapSeed,
     swap_protocols::{
         self,
         ledger::{Bitcoin, Ethereum},
@@ -32,7 +32,7 @@ pub fn create<
         + StateStore
         + Executor
         + Network
-        + SwapSeed
+        + DeriveSwapSeed
         + DetermineTypes
         + Retrieve
         + HtlcEvents<Bitcoin, Amount>

--- a/cnd/src/http_api/routes/rfc003/handlers/action.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/action.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     libp2p_comit_ext::ToHeader,
     network::Network,
-    seed::SwapSeed,
+    seed::DeriveSwapSeed,
     swap_protocols::{
         self,
         actions::Actions,
@@ -38,7 +38,7 @@ use warp::http;
 pub async fn handle_action<
     D: StateStore
         + Network
-        + SwapSeed
+        + DeriveSwapSeed
         + Saver
         + DetermineTypes
         + HtlcEvents<Bitcoin, Amount>
@@ -78,7 +78,7 @@ pub async fn handle_action<
                     })?;
 
                 let accept_message =
-                    body.into_accept_message(swap_id, &SwapSeed::swap_seed(&dependencies, swap_id));
+                    body.into_accept_message(swap_id, &dependencies.derive_swap_seed(swap_id));
 
                 Save::save(&dependencies, accept_message).await?;
 
@@ -124,7 +124,7 @@ pub async fn handle_action<
                 })?;
 
                 let swap_request = state.request();
-                let seed = dependencies.swap_seed(swap_id);
+                let seed = dependencies.derive_swap_seed(swap_id);
                 let state = State::declined(swap_request, decline_message, seed);
                 StateStore::insert(&dependencies, swap_id, state);
 

--- a/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
@@ -3,7 +3,7 @@ use crate::{
     ethereum::{self, Erc20Token, EtherQuantity},
     http_api::{HttpAsset, HttpLedger},
     network::{DialInformation, Network},
-    seed::SwapSeed,
+    seed::DeriveSwapSeed,
     swap_protocols::{
         self,
         asset::Asset,
@@ -32,7 +32,7 @@ pub async fn handle_post_swap<
         + Executor
         + StateStore
         + Save<Swap>
-        + SwapSeed
+        + DeriveSwapSeed
         + Saver
         + Network
         + Clone
@@ -44,7 +44,7 @@ pub async fn handle_post_swap<
     body: serde_json::Value,
 ) -> anyhow::Result<SwapCreated> {
     let id = SwapId::default();
-    let seed = dependencies.swap_seed(id);
+    let seed = dependencies.derive_swap_seed(id);
     let secret_hash = seed.secret().hash();
 
     let body = serde_json::from_value(body)?;
@@ -212,7 +212,7 @@ async fn initiate_request<D, AL, BL, AA, BA>(
 where
     D: StateStore
         + Executor
-        + SwapSeed
+        + DeriveSwapSeed
         + Save<Request<AL, BL, AA, BA>>
         + Save<Accept<AL, BL>>
         + Save<Swap>
@@ -227,7 +227,7 @@ where
     BA: Asset,
 {
     let counterparty = peer.peer_id.clone();
-    let seed = dependencies.swap_seed(id);
+    let seed = dependencies.derive_swap_seed(id);
 
     Save::save(&dependencies, Swap::new(id, Role::Alice, counterparty)).await?;
     Save::save(&dependencies, swap_request.clone()).await?;

--- a/cnd/src/http_api/routes/rfc003/mod.rs
+++ b/cnd/src/http_api/routes/rfc003/mod.rs
@@ -15,7 +15,7 @@ use crate::{
         },
     },
     network::Network,
-    seed::SwapSeed,
+    seed::DeriveSwapSeed,
     swap_protocols::{
         ledger::{Bitcoin, Ethereum},
         rfc003::{actions::ActionKind, events::HtlcEvents, state_store::StateStore},
@@ -41,7 +41,7 @@ pub fn post_swap<
         + StateStore
         + Executor
         + Save<Swap>
-        + SwapSeed
+        + DeriveSwapSeed
         + Saver
         + HtlcEvents<Bitcoin, Amount>
         + HtlcEvents<Ethereum, EtherQuantity>
@@ -84,7 +84,7 @@ pub fn action<
         + Executor
         + Clone
         + Network
-        + SwapSeed
+        + DeriveSwapSeed
         + Saver
         + HtlcEvents<Bitcoin, Amount>
         + HtlcEvents<Ethereum, EtherQuantity>

--- a/cnd/src/load_swaps.rs
+++ b/cnd/src/load_swaps.rs
@@ -2,7 +2,7 @@
 use crate::{
     db::{DetermineTypes, LoadAcceptedSwap, Retrieve},
     ethereum::{Erc20Token, EtherQuantity},
-    seed::SwapSeed,
+    seed::DeriveSwapSeed,
     swap_protocols::{
         self,
         ledger::{Bitcoin, Ethereum},
@@ -18,7 +18,7 @@ where
     D: StateStore
         + Executor
         + Clone
-        + SwapSeed
+        + DeriveSwapSeed
         + Retrieve
         + DetermineTypes
         + HtlcEvents<Bitcoin, Amount>

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -9,7 +9,7 @@ use cnd::{
     http_api::route_factory,
     load_swaps,
     network::{self, transport, Network},
-    seed::Seed,
+    seed::RootSeed,
     swap_protocols::{rfc003::state_store::InMemoryStateStore, Facade},
 };
 use futures::{stream, Future, Stream};
@@ -47,7 +47,7 @@ fn main() -> anyhow::Result<()> {
     let base_log_level = settings.logging.level;
     logging::initialize(base_log_level, settings.logging.structured)?;
 
-    let seed = Seed::from_dir_or_generate(&settings.data.dir, OsRng)?;
+    let seed = RootSeed::from_dir_or_generate(&settings.data.dir, OsRng)?;
 
     let mut runtime = tokio::runtime::Runtime::new()?;
 
@@ -127,7 +127,7 @@ fn version() {
     println!("{} {} ({})", name, version, short);
 }
 
-fn derive_key_pair(seed: &Seed) -> identity::Keypair {
+fn derive_key_pair(seed: &RootSeed) -> identity::Keypair {
     let bytes = seed.sha256_with_seed(&[b"NODE_ID"]);
     let key = ed25519::SecretKey::from_bytes(bytes).expect("we always pass 32 bytes");
     identity::Keypair::Ed25519(key.into())

--- a/cnd/src/network/mod.rs
+++ b/cnd/src/network/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     btsieve::{bitcoin::BitcoindConnector, ethereum::Web3Connector},
     db::{Save, Saver, Sqlite, Swap},
     libp2p_comit_ext::{FromHeader, ToHeader},
-    seed::Seed,
+    seed::{DeriveSwapSeed, RootSeed},
     swap_protocols::{
         asset::{Asset, AssetKind},
         rfc003::{
@@ -52,7 +52,7 @@ pub struct ComitNode<TSubstream> {
     #[behaviour(ignore)]
     pub state_store: Arc<InMemoryStateStore>,
     #[behaviour(ignore)]
-    pub seed: Seed,
+    pub seed: RootSeed,
     #[behaviour(ignore)]
     pub db: Sqlite,
     #[behaviour(ignore)]
@@ -98,7 +98,7 @@ impl<TSubstream> ComitNode<TSubstream> {
         bitcoin_connector: BitcoindConnector,
         ethereum_connector: Web3Connector,
         state_store: Arc<InMemoryStateStore>,
-        seed: Seed,
+        seed: RootSeed,
         db: Sqlite,
         task_executor: TaskExecutor,
     ) -> Result<Self, io::Error> {
@@ -138,7 +138,7 @@ impl<TSubstream> ComitNode<TSubstream> {
 
 async fn handle_request(
     db: Sqlite,
-    seed: Seed,
+    seed: RootSeed,
     state_store: Arc<InMemoryStateStore>,
     counterparty: PeerId,
     mut request: ValidatedInboundRequest,
@@ -315,7 +315,7 @@ async fn handle_request(
 #[allow(clippy::type_complexity)]
 async fn insert_state_for_bob<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset, DB>(
     db: DB,
-    seed: Seed,
+    seed: RootSeed,
     state_store: Arc<InMemoryStateStore>,
     counterparty: PeerId,
     swap_request: Request<AL, BL, AA, BA>,
@@ -324,7 +324,7 @@ where
     DB: Save<Request<AL, BL, AA, BA>> + Saver,
 {
     let id = swap_request.swap_id;
-    let seed = seed.swap_seed(id);
+    let seed = seed.derive_swap_seed(id);
 
     Save::save(&db, Swap::new(id, Role::Bob, counterparty)).await?;
     Save::save(&db, swap_request.clone()).await?;

--- a/cnd/src/seed.rs
+++ b/cnd/src/seed.rs
@@ -267,9 +267,9 @@ mod tests {
         let seed = RootSeed::new_random(OsRng).unwrap();
 
         let out = seed.to_string();
-        assert_eq!(out, "RootSeed([*****])".to_string());
+        assert_eq!(out, "Seed([*****])".to_string());
         let debug = format!("{:?}", seed);
-        assert_eq!(debug, "RootSeed([*****])".to_string());
+        assert_eq!(debug, "Seed([*****])".to_string());
     }
 
     #[test]

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -5,7 +5,7 @@ use crate::{
         SwapTypes,
     },
     network::{DialInformation, Network, RequestError},
-    seed::{Seed, SwapSeed},
+    seed::{DeriveSwapSeed, RootSeed, SwapSeed},
     swap_protocols::{
         asset::Asset,
         ledger::{Bitcoin, Ethereum},
@@ -38,7 +38,7 @@ pub struct Facade<S> {
     pub bitcoin_connector: BitcoindConnector,
     pub ethereum_connector: Web3Connector,
     pub state_store: Arc<InMemoryStateStore>,
-    pub seed: Seed,
+    pub seed: RootSeed,
     pub swarm: Arc<S>, // S is the libp2p Swarm within a mutex.
     pub db: Sqlite,
     pub task_executor: TaskExecutor,
@@ -103,12 +103,12 @@ where
     }
 }
 
-impl<S> SwapSeed for Facade<S>
+impl<S> DeriveSwapSeed for Facade<S>
 where
     S: Send + Sync + 'static,
 {
-    fn swap_seed(&self, id: SwapId) -> Seed {
-        self.seed.swap_seed(id)
+    fn derive_swap_seed(&self, id: SwapId) -> SwapSeed {
+        self.seed.derive_swap_seed(id)
     }
 }
 

--- a/cnd/src/swap_protocols/init_swap.rs
+++ b/cnd/src/swap_protocols/init_swap.rs
@@ -1,5 +1,5 @@
 use crate::{
-    seed::SwapSeed,
+    seed::DeriveSwapSeed,
     swap_protocols::{
         asset::Asset,
         rfc003::{
@@ -23,10 +23,10 @@ pub fn init_accepted_swap<D, AL: Ledger, BL: Ledger, AA: Asset, BA: Asset>(
     role: Role,
 ) -> anyhow::Result<()>
 where
-    D: StateStore + Clone + SwapSeed + Executor + HtlcEvents<AL, AA> + HtlcEvents<BL, BA>,
+    D: StateStore + Clone + DeriveSwapSeed + Executor + HtlcEvents<AL, AA> + HtlcEvents<BL, BA>,
 {
     let id = request.swap_id;
-    let seed = SwapSeed::swap_seed(dependencies, id);
+    let seed = dependencies.derive_swap_seed(id);
 
     match role {
         Role::Alice => {

--- a/cnd/src/swap_protocols/rfc003/secret_source.rs
+++ b/cnd/src/swap_protocols/rfc003/secret_source.rs
@@ -1,4 +1,4 @@
-use crate::{seed::Seed, swap_protocols::rfc003::Secret};
+use crate::{seed::SwapSeed, swap_protocols::rfc003::Secret};
 use bitcoin::secp256k1::SecretKey;
 
 pub trait SecretSource: Send + Sync + 'static {
@@ -7,7 +7,7 @@ pub trait SecretSource: Send + Sync + 'static {
     fn secp256k1_refund(&self) -> SecretKey;
 }
 
-impl SecretSource for Seed {
+impl SecretSource for SwapSeed {
     fn secret(&self) -> Secret {
         self.sha256_with_seed(&[b"SECRET"]).into()
     }

--- a/cnd/src/swap_protocols/rfc003/state_store.rs
+++ b/cnd/src/swap_protocols/rfc003/state_store.rs
@@ -260,7 +260,7 @@ mod tests {
     use super::*;
     use crate::{
         ethereum::{Address, EtherQuantity},
-        seed::Seed,
+        seed::{DeriveSwapSeed, RootSeed},
         swap_protocols::{
             ledger::{Bitcoin, Ethereum},
             rfc003::{alice, messages::Request, Accept, Secret},
@@ -302,8 +302,8 @@ mod tests {
         };
 
         let id = SwapId::default();
-        let seed = Seed::from(*b"hello world, you are beautiful!!");
-        let secret_source = seed.swap_seed(id);
+        let seed = RootSeed::from(*b"hello world, you are beautiful!!");
+        let secret_source = seed.derive_swap_seed(id);
         let state = alice::State::accepted(request, accept, secret_source);
 
         state_store


### PR DESCRIPTION
Currently we have a `Seed` type that is used as the root seed to derive
per swap seeds which are then used to derive identities (refund/redeem).
Using the same type for all of these seeds means the compiler cannot
give us type safety.  Since these two things are separate we can use
separate types to allow the compiler to differentiate the types and
provide safety.

Add `RootSeed` for the seed read in from the PEM file and derive a new
`SwapSeed` to use for identity derivation.

Note: I'm not totally happy with this one, open to any suggested improvements, thanks.

Done in preparation for #1682 