### PR TITLE
Implement Copy on as many types as possible

### DIFF
--- a/cnd/src/btsieve/ethereum/transaction_pattern.rs
+++ b/cnd/src/btsieve/ethereum/transaction_pattern.rs
@@ -123,7 +123,7 @@ fn events_exist_in_receipt(events: &[Event], receipt: &TransactionReceipt) -> bo
     })
 }
 
-#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
 pub struct Topic(pub H256);
 
 /// Event  work similar as web3 filters:

--- a/cnd/src/config/file.rs
+++ b/cnd/src/config/file.rs
@@ -39,7 +39,7 @@ impl File {
     }
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct Logging {
     pub level: Option<LevelFilter>,
     pub structured: Option<bool>,
@@ -64,13 +64,13 @@ pub enum AllowedOrigins {
     Some(Vec<String>),
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum All {
     All,
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum None {
     None,

--- a/cnd/src/config/mod.rs
+++ b/cnd/src/config/mod.rs
@@ -18,7 +18,7 @@ pub struct Network {
     pub listen: Vec<Multiaddr>,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Socket {
     pub address: IpAddr,
     pub port: u16,

--- a/cnd/src/config/settings.rs
+++ b/cnd/src/config/settings.rs
@@ -92,7 +92,7 @@ pub enum AllowedOrigins {
     Some(Vec<String>),
 }
 
-#[derive(Clone, Debug, PartialEq, derivative::Derivative)]
+#[derive(Clone, Copy, Debug, PartialEq, derivative::Derivative)]
 #[derivative(Default)]
 pub struct Logging {
     #[derivative(Default(value = "LevelFilter::Debug"))]

--- a/cnd/src/db/mod.rs
+++ b/cnd/src/db/mod.rs
@@ -123,7 +123,7 @@ struct QueryableSwapRole {
     pub role: Text<Role>,
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
 pub enum Error {
     #[error("swap not found")]
     SwapNotFound,

--- a/cnd/src/http_api/mod.rs
+++ b/cnd/src/http_api/mod.rs
@@ -236,7 +236,7 @@ impl<'de> Deserialize<'de> for DialInformation {
 /// `beta_ledger`.
 ///
 /// Note: This enum makes use of serde's "try_from" and "into" feature: https://serde.rs/container-attrs.html#from
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(try_from = "HttpLedgerParams")]
 #[serde(into = "HttpLedgerParams")]
 pub enum HttpLedger {
@@ -248,7 +248,7 @@ pub enum HttpLedger {
 /// `beta_asset`.
 ///
 /// Note: This enum makes use of serde's "try_from" and "try_into" feature: https://serde.rs/container-attrs.html#from
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(try_from = "HttpAssetParams")]
 #[serde(into = "HttpAssetParams")]
 pub enum HttpAsset {
@@ -276,7 +276,7 @@ pub struct BitcoinLedgerParams {
     network: Http<bitcoin::Network>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
 pub struct EthereumLedgerParams {
     chain_id: Option<ChainId>,
     network: Option<ethereum_network::Network>,
@@ -302,12 +302,12 @@ pub struct BitcoinAssetParams {
     quantity: Http<bitcoin::Amount>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
 pub struct EtherAssetParams {
     quantity: ethereum::EtherQuantity,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Erc20AssetParams {
     quantity: ethereum::Erc20Quantity,
     token_contract: ethereum::Address,
@@ -349,7 +349,7 @@ impl From<ledger::Bitcoin> for BitcoinLedgerParams {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
 #[error("The Ethereum ledger requires either a network or a chain-id parameter.")]
 pub struct InvalidEthereumLedgerParams;
 

--- a/cnd/src/http_api/problem.rs
+++ b/cnd/src/http_api/problem.rs
@@ -10,21 +10,21 @@ use warp::{
     Rejection, Reply,
 };
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
 #[error("Missing GET parameters for a {} action type. Expected: {:?}", action, parameters.iter().map(|parameter| parameter.name).collect::<Vec<&str>>())]
 pub struct MissingQueryParameters {
     pub action: &'static str,
     pub parameters: &'static [MissingQueryParameter],
 }
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, Clone, Copy, serde::Serialize)]
 pub struct MissingQueryParameter {
     pub name: &'static str,
     pub data_type: &'static str,
     pub description: &'static str,
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
 #[error("unexpected GET parameters {parameters:?} for a {action} action type, expected: none")]
 pub struct UnexpectedQueryParameters {
     pub action: &'static str,

--- a/cnd/src/http_api/routes/rfc003/decline.rs
+++ b/cnd/src/http_api/routes/rfc003/decline.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize)]
 pub struct DeclineBody {
     pub reason: Option<HttpApiSwapDeclineReason>,
 }
@@ -29,7 +29,7 @@ pub fn to_swap_decline_reason(
     })
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
 pub enum HttpApiSwapDeclineReason {
     UnsatisfactoryRate,
 }

--- a/cnd/src/http_api/routes/rfc003/handlers/action.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/action.rs
@@ -113,9 +113,9 @@ pub async fn handle_action<
                     reason: to_swap_decline_reason(body.reason),
                 };
 
-                Save::save(&dependencies, decline_message.clone()).await?;
+                Save::save(&dependencies, decline_message).await?;
 
-                let response = rfc003_decline_response(decline_message.clone());
+                let response = rfc003_decline_response(decline_message);
                 channel.send(response).map_err(|_| {
                     anyhow::anyhow!(
                         "failed to send response through channel for swap {}",
@@ -125,7 +125,7 @@ pub async fn handle_action<
 
                 let swap_request = state.request();
                 let seed = dependencies.swap_seed(swap_id);
-                let state = State::declined(swap_request, decline_message.clone(), seed);
+                let state = State::declined(swap_request, decline_message, seed);
                 StateStore::insert(&dependencies, swap_id, state);
 
                 Ok(ActionResponseBody::None)
@@ -145,7 +145,7 @@ pub struct InvalidActionInvocation {
     method: http::Method,
 }
 
-#[derive(Debug, thiserror::Error, PartialEq)]
+#[derive(Debug, Clone, Copy, thiserror::Error, PartialEq)]
 #[error("action {action_kind} is invalid for this swap")]
 pub struct InvalidAction {
     action_kind: ActionKind,

--- a/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
@@ -194,7 +194,7 @@ where
 
 /// An error type for describing that a particular combination of assets and
 /// ledgers is not supported.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
 #[error("swapping {alpha_asset:?} for {beta_asset:?} from {alpha_ledger:?} to {beta_ledger:?} is not supported")]
 pub struct UnsupportedSwap {
     alpha_asset: HttpAsset,
@@ -256,9 +256,9 @@ where
                 }
                 Err(decline) => {
                     log::info!("Swap declined: {:?}", decline);
-                    let state = State::declined(swap_request.clone(), decline.clone(), seed);
+                    let state = State::declined(swap_request.clone(), decline, seed);
                     StateStore::insert(&dependencies, id, state.clone());
-                    Save::save(&dependencies, decline.clone()).await?;
+                    Save::save(&dependencies, decline).await?;
                 }
             };
             Ok(())
@@ -270,7 +270,7 @@ where
     Ok(())
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Clone, Copy, Debug)]
 pub struct SwapCreated {
     pub id: SwapId,
 }
@@ -317,26 +317,26 @@ trait IntoIdentities<AL: Ledger, BL: Ledger> {
     ) -> anyhow::Result<Identities<AL, BL>>;
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
 #[error("{kind} identity was not expected")]
 pub struct UnexpectedIdentity {
     kind: IdentityKind,
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
 #[error("{kind} identity was missing")]
 pub struct MissingIdentity {
     kind: IdentityKind,
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
 #[error("{kind} was not a valid ethereum address")]
 pub struct InvalidEthereumAddress {
     kind: IdentityKind,
     source: <ethereum::Address as FromStr>::Err,
 }
 
-#[derive(strum_macros::Display, Debug)]
+#[derive(strum_macros::Display, Debug, Clone, Copy)]
 #[strum(serialize_all = "snake_case")]
 pub enum IdentityKind {
     AlphaLedgerRefundIdentity,

--- a/cnd/src/http_api/swap_resource.rs
+++ b/cnd/src/http_api/swap_resource.rs
@@ -33,7 +33,7 @@ pub struct SwapResource<S> {
     pub state: Option<S>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize)]
 pub struct SwapParameters {
     alpha_ledger: HttpLedger,
     beta_ledger: HttpLedger,
@@ -41,7 +41,7 @@ pub struct SwapParameters {
     beta_asset: HttpAsset,
 }
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SwapStatus {
     InProgress,

--- a/cnd/src/lib.rs
+++ b/cnd/src/lib.rs
@@ -1,4 +1,9 @@
-#![warn(unused_extern_crates, missing_debug_implementations, rust_2018_idioms)]
+#![warn(
+    unused_extern_crates,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    rust_2018_idioms
+)]
 #![forbid(unsafe_code)]
 
 // Cannot do `#[strum_discriminants(derive(strum_macros::EnumString))]` at the

--- a/cnd/src/network/mod.rs
+++ b/cnd/src/network/mod.rs
@@ -76,7 +76,7 @@ impl Display for DialInformation {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
 pub enum RequestError {
     #[error("peer node had an internal error while processing the request")]
     InternalError,
@@ -88,7 +88,7 @@ pub enum RequestError {
     Connection,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
 pub struct Reason {
     pub value: SwapDeclineReason,
 }

--- a/cnd/src/swap_protocols/asset.rs
+++ b/cnd/src/swap_protocols/asset.rs
@@ -28,7 +28,7 @@ impl Asset for EtherQuantity {}
 
 impl Asset for Erc20Token {}
 
-#[derive(Clone, Derivative, PartialEq)]
+#[derive(Clone, Copy, Derivative, PartialEq)]
 #[derivative(Debug = "transparent")]
 pub enum AssetKind {
     Bitcoin(Amount),

--- a/cnd/src/swap_protocols/ledger/mod.rs
+++ b/cnd/src/swap_protocols/ledger/mod.rs
@@ -31,7 +31,7 @@ pub trait Ledger:
         + 'static;
 }
 
-#[derive(Clone, Derivative, PartialEq)]
+#[derive(Clone, Copy, Derivative, PartialEq)]
 #[derivative(Debug = "transparent")]
 pub enum LedgerKind {
     Bitcoin(Bitcoin),

--- a/cnd/src/swap_protocols/mod.rs
+++ b/cnd/src/swap_protocols/mod.rs
@@ -33,7 +33,7 @@ pub enum HashFunction {
     Sha256,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum SwapProtocol {
     Rfc003(HashFunction),
 }

--- a/cnd/src/swap_protocols/rfc003/messages.rs
+++ b/cnd/src/swap_protocols/rfc003/messages.rs
@@ -42,7 +42,7 @@ pub struct Accept<AL: Ledger, BL: Ledger> {
 ///
 /// This does _not_ represent the actual network message, that is why it also
 /// does not implement Serialize.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Decline {
     pub swap_id: SwapId,
     pub reason: Option<SwapDeclineReason>,
@@ -72,13 +72,13 @@ pub struct AcceptResponseBody<AL: Ledger, BL: Ledger> {
 }
 
 /// Body of the rfc003 decline message
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeclineResponseBody {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<SwapDeclineReason>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum SwapDeclineReason {
     UnsatisfactoryRate,

--- a/cnd/src/swap_protocols/rfc003/secret.rs
+++ b/cnd/src/swap_protocols/rfc003/secret.rs
@@ -5,7 +5,7 @@ use std::{
     str::FromStr,
 };
 
-#[derive(PartialEq, Debug, thiserror::Error)]
+#[derive(PartialEq, Clone, Copy, Debug, thiserror::Error)]
 pub enum FromErr {
     #[error("invalid length, expected: {expected:?}, got: {got:?}")]
     InvalidLength { expected: usize, got: usize },

--- a/cnd/src/swap_protocols/rfc003/state_store.rs
+++ b/cnd/src/swap_protocols/rfc003/state_store.rs
@@ -14,7 +14,7 @@ use crate::swap_protocols::{
 use either::Either;
 use std::{any::Any, collections::HashMap, sync::Mutex};
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
 pub enum Error {
     #[error("invalid type")]
     InvalidType,


### PR DESCRIPTION
If types can be copy, they should according to the docs:
https://doc.rust-lang.org/std/marker/trait.Copy.html#when-should-my-type-be-copy.

Implementing Copy on as many types as possible allows us to remove `.clone()` in some circumstances.