### PR TITLE
http_api: Use Facade as arg instead of trait bounds

### DIFF
--- a/cnd/src/http_api/routes/index/handlers/get_swaps.rs
+++ b/cnd/src/http_api/routes/index/handlers/get_swaps.rs
@@ -1,12 +1,13 @@
 use crate::{
     db::{DetermineTypes, Retrieve},
     http_api::swap_resource::{build_rfc003_siren_entity, IncludeState},
-    swap_protocols::rfc003::state_store::StateStore,
+    swap_protocols::Facade,
 };
 
-pub async fn handle_get_swaps<D: DetermineTypes + Retrieve + StateStore>(
-    dependencies: D,
-) -> anyhow::Result<siren::Entity> {
+pub async fn handle_get_swaps<S>(dependencies: Facade<S>) -> anyhow::Result<siren::Entity>
+where
+    S: Send + Sync + 'static,
+{
     let mut entity = siren::Entity::default().with_class_member("swaps");
 
     for swap in Retrieve::all(&dependencies).await?.into_iter() {

--- a/cnd/src/http_api/routes/peers/mod.rs
+++ b/cnd/src/http_api/routes/peers/mod.rs
@@ -1,4 +1,4 @@
-use crate::{http_api::Http, network::Network};
+use crate::{http_api::Http, network::Network, swap_protocols::Facade};
 use libp2p::{Multiaddr, PeerId};
 use serde::Serialize;
 use warp::{Rejection, Reply};
@@ -15,7 +15,10 @@ pub struct Peer {
 }
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn get_peers<D: Network>(dependencies: D) -> Result<impl Reply, Rejection> {
+pub fn get_peers<S: Network>(dependencies: Facade<S>) -> Result<impl Reply, Rejection>
+where
+    S: Send + Sync + 'static,
+{
     let peers = Network::comit_peers(&dependencies)
         .map(|(peer, addresses)| Peer {
             id: Http(peer),

--- a/cnd/src/http_api/routes/rfc003/handlers/get_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/get_swap.rs
@@ -1,13 +1,16 @@
 use crate::{
     db::{DetermineTypes, Retrieve},
     http_api::swap_resource::{build_rfc003_siren_entity, IncludeState},
-    swap_protocols::{rfc003::state_store::StateStore, SwapId},
+    swap_protocols::{Facade, SwapId},
 };
 
-pub async fn handle_get_swap<D: Retrieve + StateStore + DetermineTypes>(
-    dependencies: D,
+pub async fn handle_get_swap<S>(
+    dependencies: Facade<S>,
     id: SwapId,
-) -> anyhow::Result<siren::Entity> {
+) -> anyhow::Result<siren::Entity>
+where
+    S: Send + Sync + 'static,
+{
     let swap = Retrieve::get(&dependencies, &id).await?;
     let types = dependencies.determine_types(&id).await?;
 

--- a/cnd/src/http_api/routes/rfc003/mod.rs
+++ b/cnd/src/http_api/routes/rfc003/mod.rs
@@ -4,8 +4,6 @@ pub mod handlers;
 mod swap_state;
 
 use crate::{
-    db::{DetermineTypes, Retrieve, Save, Swap},
-    ethereum::{Erc20Token, EtherQuantity},
     http_api::{
         action::ActionExecutionParameters,
         route_factory::swap_path,
@@ -15,14 +13,8 @@ use crate::{
         },
     },
     network::Network,
-    seed::DeriveSwapSeed,
-    swap_protocols::{
-        ledger::{Bitcoin, Ethereum},
-        rfc003::{actions::ActionKind, events::HtlcEvents, state_store::StateStore},
-        SwapId,
-    },
+    swap_protocols::{rfc003::actions::ActionKind, Facade, SwapId},
 };
-use bitcoin::Amount;
 use futures::Future;
 use futures_core::future::{FutureExt, TryFutureExt};
 use warp::{
@@ -31,25 +23,16 @@ use warp::{
 };
 
 pub use self::swap_state::{LedgerState, SwapCommunication, SwapCommunicationState, SwapState};
-use crate::{db::Saver, http_api::problem};
-use tokio::executor::Executor;
+use crate::http_api::problem;
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn post_swap<
-    D: Clone
-        + Network
-        + StateStore
-        + Executor
-        + Save<Swap>
-        + DeriveSwapSeed
-        + Saver
-        + HtlcEvents<Bitcoin, Amount>
-        + HtlcEvents<Ethereum, EtherQuantity>
-        + HtlcEvents<Ethereum, Erc20Token>,
->(
-    dependencies: D,
+pub fn post_swap<S: Network>(
+    dependencies: Facade<S>,
     body: serde_json::Value,
-) -> impl Future<Item = impl Reply, Error = Rejection> {
+) -> impl Future<Item = impl Reply, Error = Rejection>
+where
+    S: Send + Sync + 'static,
+{
     handle_post_swap(dependencies, body)
         .boxed()
         .compat()
@@ -64,10 +47,13 @@ pub fn post_swap<
 }
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn get_swap<D: DetermineTypes + Retrieve + StateStore>(
-    dependencies: D,
+pub fn get_swap<S>(
+    dependencies: Facade<S>,
     id: SwapId,
-) -> impl Future<Item = impl Reply, Error = Rejection> {
+) -> impl Future<Item = impl Reply, Error = Rejection>
+where
+    S: Send + Sync + 'static,
+{
     handle_get_swap(dependencies, id)
         .boxed()
         .compat()
@@ -77,26 +63,17 @@ pub fn get_swap<D: DetermineTypes + Retrieve + StateStore>(
 }
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn action<
-    D: DetermineTypes
-        + Retrieve
-        + StateStore
-        + Executor
-        + Clone
-        + Network
-        + DeriveSwapSeed
-        + Saver
-        + HtlcEvents<Bitcoin, Amount>
-        + HtlcEvents<Ethereum, EtherQuantity>
-        + HtlcEvents<Ethereum, Erc20Token>,
->(
+pub fn action<S: Network>(
     method: http::Method,
     id: SwapId,
     action_kind: ActionKind,
     query_params: ActionExecutionParameters,
-    dependencies: D,
+    dependencies: Facade<S>,
     body: serde_json::Value,
-) -> impl Future<Item = impl Reply, Error = Rejection> {
+) -> impl Future<Item = impl Reply, Error = Rejection>
+where
+    S: Send + Sync + 'static,
+{
     handle_action(method, id, action_kind, body, query_params, dependencies)
         .boxed()
         .compat()


### PR DESCRIPTION
Currently we pass the dependencies throughout the http_api module using trait bounds.  This is super verbose.  Also since we now this is only ever going to be an actual instance of the `Facade` and we are not trying to limit the callers usage of the facade it adds no real benefit using trait bounds.