### PR TITLE
Clean up Network code

### DIFF
--- a/api_tests/harness.ts
+++ b/api_tests/harness.ts
@@ -118,7 +118,17 @@ async function runTests(testFiles: string[]) {
                 .run((failures: number) => res(failures));
         });
 
+        if (global.verbose) {
+            console.log(`Running test ${testFile}`);
+        }
+
         const failures = await runTests;
+
+        if (global.verbose) {
+            console.log(
+                `Test ${testFile} ${failures ? "failed" : "succeeded"}`
+            );
+        }
 
         if (failures) {
             if (commander.dumpLogs || process.env.CARGO_MAKE_CI === "TRUE") {

--- a/api_tests/lib/cnd_runner.ts
+++ b/api_tests/lib/cnd_runner.ts
@@ -68,6 +68,10 @@ export class CndRunner {
         for (const { name, process } of startedNodes) {
             this.runningNodes[name] = process;
         }
+
+        if (global.verbose) {
+            console.log("All nodes successfully started");
+        }
     }
 
     public stopCnds() {

--- a/api_tests/lib_sdk/cnd_instance.ts
+++ b/api_tests/lib_sdk/cnd_instance.ts
@@ -32,6 +32,10 @@ export class CndInstance {
             ? process.env.CND_BIN
             : this.projectRoot + "/target/debug/cnd";
 
+        if (global.verbose) {
+            console.log(`[${this.actorConfig.name}] using binary ${bin}`);
+        }
+
         this.configFile = this.actorConfig.generateCndConfigFile(
             this.ledgerConfig
         );
@@ -55,6 +59,12 @@ export class CndInstance {
                 ), // stderr
             ],
         });
+
+        if (global.verbose) {
+            console.log(
+                `[${this.actorConfig.name}] process spawned with PID ${this.process.pid}`
+            );
+        }
 
         this.process.on("exit", (code: number, signal: number) => {
             if (global.verbose) {

--- a/cnd/src/http_api/route_factory.rs
+++ b/cnd/src/http_api/route_factory.rs
@@ -1,10 +1,9 @@
 use crate::{
     config::settings::AllowedOrigins,
     http_api,
-    network::Network,
+    network::LocalPeerId,
     swap_protocols::{self, Facade, SwapId},
 };
-use libp2p::PeerId;
 use warp::{self, filters::BoxedFilter, Filter, Reply};
 
 pub const RFC003: &str = "rfc003";
@@ -17,11 +16,11 @@ pub fn new_action_link(id: &SwapId, action: &str) -> String {
     format!("{}/{}", swap_path(*id), action)
 }
 
-pub fn create<S: Network>(
-    peer_id: PeerId,
-    dependencies: Facade<S>,
+pub fn create(
+    dependencies: Facade,
     allowed_origins: &AllowedOrigins,
 ) -> BoxedFilter<(impl Reply,)> {
+    let peer_id = dependencies.local_peer_id();
     let swaps = warp::path(http_api::PATH);
     let rfc003 = swaps.and(warp::path(RFC003));
     let peer_id = warp::any().map(move || peer_id.clone());

--- a/cnd/src/http_api/routes/index/handlers/get_swaps.rs
+++ b/cnd/src/http_api/routes/index/handlers/get_swaps.rs
@@ -4,10 +4,7 @@ use crate::{
     swap_protocols::Facade,
 };
 
-pub async fn handle_get_swaps<S>(dependencies: Facade<S>) -> anyhow::Result<siren::Entity>
-where
-    S: Send + Sync + 'static,
-{
+pub async fn handle_get_swaps(dependencies: Facade) -> anyhow::Result<siren::Entity> {
     let mut entity = siren::Entity::default().with_class_member("swaps");
 
     for swap in Retrieve::all(&dependencies).await?.into_iter() {

--- a/cnd/src/http_api/routes/rfc003/handlers/action.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/action.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     init_swap::init_accepted_swap,
     libp2p_comit_ext::ToHeader,
-    network::Network,
+    network::PendingRequestFor,
     seed::DeriveSwapSeed,
     swap_protocols::{
         actions::Actions,
@@ -30,17 +30,14 @@ use std::fmt::Debug;
 use warp::http;
 
 #[allow(clippy::unit_arg, clippy::let_unit_value, clippy::cognitive_complexity)]
-pub async fn handle_action<S: Network>(
+pub async fn handle_action(
     method: http::Method,
     swap_id: SwapId,
     action_kind: ActionKind,
     body: serde_json::Value,
     query_params: ActionExecutionParameters,
-    dependencies: Facade<S>,
-) -> anyhow::Result<ActionResponseBody>
-where
-    S: Send + Sync + 'static,
-{
+    dependencies: Facade,
+) -> anyhow::Result<ActionResponseBody> {
     let types = dependencies.determine_types(&swap_id).await?;
 
     with_swap_types!(types, {
@@ -59,8 +56,10 @@ where
                 let body = serde_json::from_value::<AcceptBody>(body)
                     .context("failed to deserialize accept body")?;
 
-                let channel =
-                    Network::pending_request_for(&dependencies, swap_id).with_context(|| {
+                let channel = dependencies
+                    .pending_request_for(swap_id)
+                    .await
+                    .with_context(|| {
                         format!("unable to find response channel for swap {}", swap_id)
                     })?;
 
@@ -85,8 +84,10 @@ where
             Action::Decline(_) => {
                 let body = serde_json::from_value::<DeclineBody>(body)?;
 
-                let channel =
-                    Network::pending_request_for(&dependencies, swap_id).with_context(|| {
+                let channel = dependencies
+                    .pending_request_for(swap_id)
+                    .await
+                    .with_context(|| {
                         format!("unable to find response channel for swap {}", swap_id)
                     })?;
 

--- a/cnd/src/http_api/routes/rfc003/handlers/get_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/get_swap.rs
@@ -4,13 +4,7 @@ use crate::{
     swap_protocols::{Facade, SwapId},
 };
 
-pub async fn handle_get_swap<S>(
-    dependencies: Facade<S>,
-    id: SwapId,
-) -> anyhow::Result<siren::Entity>
-where
-    S: Send + Sync + 'static,
-{
+pub async fn handle_get_swap(dependencies: Facade, id: SwapId) -> anyhow::Result<siren::Entity> {
     let swap = Retrieve::get(&dependencies, &id).await?;
     let types = dependencies.determine_types(&id).await?;
 

--- a/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
@@ -3,7 +3,7 @@ use crate::{
     ethereum,
     http_api::{HttpAsset, HttpLedger},
     init_swap::init_accepted_swap,
-    network::{DialInformation, Network},
+    network::{DialInformation, SendRequest},
     seed::DeriveSwapSeed,
     swap_protocols::{
         asset::Asset,
@@ -17,12 +17,12 @@ use crate::{
     timestamp::Timestamp,
 };
 use anyhow::Context;
-use futures_core::{compat::Future01CompatExt, future::TryFutureExt};
+use futures_core::future::TryFutureExt;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-pub async fn handle_post_swap<S: Network>(
-    dependencies: Facade<S>,
+pub async fn handle_post_swap(
+    dependencies: Facade,
     body: serde_json::Value,
 ) -> anyhow::Result<SwapCreated> {
     let id = SwapId::default();
@@ -185,20 +185,19 @@ pub struct UnsupportedSwap {
     beta_ledger: HttpLedger,
 }
 
-async fn initiate_request<S, AL, BL, AA, BA>(
-    dependencies: Facade<S>,
+async fn initiate_request<AL, BL, AA, BA>(
+    dependencies: Facade,
     id: SwapId,
     peer: DialInformation,
     swap_request: rfc003::Request<AL, BL, AA, BA>,
 ) -> anyhow::Result<()>
 where
-    S: Network + Send + Sync + 'static,
     Sqlite: Save<Request<AL, BL, AA, BA>> + Save<Accept<AL, BL>> + Save<Swap> + Save<Decline>,
     AL: Ledger,
     BL: Ledger,
     AA: Asset,
     BA: Asset,
-    Facade<S>: HtlcEvents<AL, AA> + HtlcEvents<BL, BA>,
+    Facade: HtlcEvents<AL, AA> + HtlcEvents<BL, BA>,
 {
     let counterparty = peer.peer_id.clone();
     let seed = dependencies.derive_swap_seed(id);
@@ -213,7 +212,6 @@ where
         async move {
             let response = dependencies
                 .send_request(peer.clone(), swap_request.clone())
-                .compat()
                 .await
                 .with_context(|| format!("Failed to send swap request to {}", peer.clone()))?;
 

--- a/cnd/src/http_api/routes/rfc003/mod.rs
+++ b/cnd/src/http_api/routes/rfc003/mod.rs
@@ -12,7 +12,6 @@ use crate::{
             rfc003::handlers::{handle_action, handle_get_swap, handle_post_swap},
         },
     },
-    network::Network,
     swap_protocols::{rfc003::actions::ActionKind, Facade, SwapId},
 };
 use futures::Future;
@@ -26,13 +25,10 @@ pub use self::swap_state::{LedgerState, SwapCommunication, SwapCommunicationStat
 use crate::http_api::problem;
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn post_swap<S: Network>(
-    dependencies: Facade<S>,
+pub fn post_swap(
+    dependencies: Facade,
     body: serde_json::Value,
-) -> impl Future<Item = impl Reply, Error = Rejection>
-where
-    S: Send + Sync + 'static,
-{
+) -> impl Future<Item = impl Reply, Error = Rejection> {
     handle_post_swap(dependencies, body)
         .boxed()
         .compat()
@@ -47,13 +43,10 @@ where
 }
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn get_swap<S>(
-    dependencies: Facade<S>,
+pub fn get_swap(
+    dependencies: Facade,
     id: SwapId,
-) -> impl Future<Item = impl Reply, Error = Rejection>
-where
-    S: Send + Sync + 'static,
-{
+) -> impl Future<Item = impl Reply, Error = Rejection> {
     handle_get_swap(dependencies, id)
         .boxed()
         .compat()
@@ -63,17 +56,14 @@ where
 }
 
 #[allow(clippy::needless_pass_by_value)]
-pub fn action<S: Network>(
+pub fn action(
     method: http::Method,
     id: SwapId,
     action_kind: ActionKind,
     query_params: ActionExecutionParameters,
-    dependencies: Facade<S>,
+    dependencies: Facade,
     body: serde_json::Value,
-) -> impl Future<Item = impl Reply, Error = Rejection>
-where
-    S: Send + Sync + 'static,
-{
+) -> impl Future<Item = impl Reply, Error = Rejection> {
     handle_action(method, id, action_kind, body, query_params, dependencies)
         .boxed()
         .compat()

--- a/cnd/src/network/mod.rs
+++ b/cnd/src/network/mod.rs
@@ -1,7 +1,10 @@
 pub mod transport;
 
+pub use transport::ComitTransport;
+
 use crate::{
     btsieve::{bitcoin::BitcoindConnector, ethereum::Web3Connector},
+    config::Settings,
     db::{Save, Saver, Sqlite, Swap},
     libp2p_comit_ext::{FromHeader, ToHeader},
     seed::{DeriveSwapSeed, RootSeed},
@@ -16,20 +19,31 @@ use crate::{
         HashFunction, LedgerKind, Role, SwapId, SwapProtocol,
     },
 };
+use async_trait::async_trait;
 use futures::{
     future::Future,
+    stream::Stream,
     sync::oneshot::{self, Sender},
 };
-use futures_core::{FutureExt, TryFutureExt};
+use futures_core::{compat::Future01CompatExt, FutureExt, TryFutureExt};
 use libp2p::{
-    core::muxing::{StreamMuxer, SubstreamRef},
+    core::muxing::SubstreamRef,
+    identity::{self, ed25519},
     mdns::{Mdns, MdnsEvent},
-    swarm::NetworkBehaviourEventProcess,
-    Multiaddr, NetworkBehaviour, PeerId, Swarm, Transport,
+    swarm::{
+        protocols_handler::DummyProtocolsHandler, ExpandedSwarm, IntoProtocolsHandlerSelect,
+        NetworkBehaviourEventProcess,
+    },
+    Multiaddr, NetworkBehaviour, PeerId,
 };
 use libp2p_comit::{
-    frame::{self, OutboundRequest, Response, ValidatedInboundRequest},
+    frame::{self, CodecError, OutboundRequest, Response, ValidatedInboundRequest},
+    handler::{ComitHandler, ProtocolInEvent, ProtocolOutEvent},
     BehaviourOutEvent, Comit, PendingInboundRequest,
+};
+use libp2p_core::{
+    either::{EitherError, EitherOutput},
+    muxing::StreamMuxerBox,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -37,7 +51,86 @@ use std::{
     io,
     sync::{Arc, Mutex},
 };
-use tokio_compat::runtime::TaskExecutor;
+use tokio_compat::runtime::{Runtime, TaskExecutor};
+
+#[derive(Clone, derivative::Derivative)]
+#[derivative(Debug)]
+#[allow(clippy::type_complexity)]
+pub struct Swarm {
+    #[derivative(Debug = "ignore")]
+    swarm: Arc<
+        Mutex<
+            ExpandedSwarm<
+                ComitTransport,
+                ComitNode<SubstreamRef<Arc<StreamMuxerBox>>>,
+                EitherOutput<ProtocolInEvent, void::Void>,
+                EitherOutput<ProtocolOutEvent, void::Void>,
+                IntoProtocolsHandlerSelect<
+                    ComitHandler<SubstreamRef<Arc<StreamMuxerBox>>>,
+                    DummyProtocolsHandler<SubstreamRef<Arc<StreamMuxerBox>>>,
+                >,
+                EitherError<CodecError, void::Void>,
+            >,
+        >,
+    >,
+    local_peer_id: PeerId,
+}
+
+impl Swarm {
+    pub fn new(
+        settings: &Settings,
+        seed: RootSeed,
+        runtime: &mut Runtime,
+        bitcoin_connector: &BitcoindConnector,
+        ethereum_connector: &Web3Connector,
+        state_store: &Arc<InMemoryStateStore>,
+        database: &Sqlite,
+    ) -> anyhow::Result<Self> {
+        let local_key_pair = derive_key_pair(&seed);
+        let local_peer_id = PeerId::from(local_key_pair.clone().public());
+        log::info!("Starting with peer_id: {}", local_peer_id);
+
+        let transport = transport::build_comit_transport(local_key_pair);
+        let behaviour = ComitNode::new(
+            bitcoin_connector.clone(),
+            ethereum_connector.clone(),
+            Arc::clone(&state_store),
+            seed,
+            database.clone(),
+            runtime.executor(),
+        )?;
+        let mut swarm = libp2p::Swarm::new(transport, behaviour, local_peer_id.clone());
+
+        for addr in settings.network.listen.clone() {
+            libp2p::Swarm::listen_on(&mut swarm, addr)
+                .expect("Could not listen on specified address");
+        }
+
+        let swarm = Arc::new(Mutex::new(swarm));
+
+        let swarm_worker = futures::stream::poll_fn({
+            let swarm = swarm.clone();
+            move || swarm.lock().unwrap().poll()
+        })
+        .for_each(|_| Ok(()))
+        .map_err(|e| {
+            log::error!("failed with {:?}", e);
+        });
+
+        runtime.spawn(swarm_worker);
+
+        Ok(Self {
+            swarm,
+            local_peer_id,
+        })
+    }
+}
+
+fn derive_key_pair(seed: &RootSeed) -> identity::Keypair {
+    let bytes = seed.sha256_with_seed(&[b"NODE_ID"]);
+    let key = ed25519::SecretKey::from_bytes(bytes).expect("we always pass 32 bytes");
+    identity::Keypair::Ed25519(key.into())
+}
 
 #[derive(NetworkBehaviour)]
 #[allow(missing_debug_implementations)]
@@ -335,136 +428,158 @@ where
     Ok(())
 }
 
-/// Defines all the operations the Comit Node can perform in regards to the
-/// Comit network.
-///
-/// Ideally, this trait would not be necessary and we would instead have one
-/// trait per function. Unfortunately, an instance of `Swarm` is very hard to
-/// name (see the complex traits bound below). To avoid this kind of code 4
-/// times, we bundle all these methods up into one trait.
-pub trait Network: Send + Sync + 'static {
-    fn comit_peers(&self) -> Box<dyn Iterator<Item = (PeerId, Vec<Multiaddr>)> + Send + 'static>;
-    fn listen_addresses(&self) -> Vec<Multiaddr>;
-    fn pending_request_for(&self, swap: SwapId) -> Option<oneshot::Sender<Response>>;
-    fn send_request<AL: rfc003::Ledger, BL: rfc003::Ledger, AA: Asset, BA: Asset>(
-        &self,
-        peer_identity: DialInformation,
-        request: rfc003::Request<AL, BL, AA, BA>,
-    ) -> Box<dyn Future<Item = rfc003::Response<AL, BL>, Error = RequestError> + Send>;
+/// Get the `PeerId` of this node.
+pub trait LocalPeerId {
+    fn local_peer_id(&self) -> PeerId;
 }
 
-impl<
-        TTransport: Transport + Send + Sync + 'static,
-        TMuxer: StreamMuxer + Send + Sync + 'static,
-    > Network for Mutex<Swarm<TTransport, ComitNode<SubstreamRef<Arc<TMuxer>>>>>
-where
-    <TMuxer as StreamMuxer>::OutboundSubstream: Send + 'static,
-    <TMuxer as StreamMuxer>::Substream: Send + Sync + 'static,
-    <TTransport as Transport>::Dial: Send,
-    <TTransport as Transport>::Error: Send,
-    <TTransport as Transport>::Listener: Send,
-    <TTransport as Transport>::ListenerUpgrade: Send,
-    TTransport: Transport<Output = (PeerId, TMuxer)> + Clone,
-{
-    fn comit_peers(&self) -> Box<dyn Iterator<Item = (PeerId, Vec<Multiaddr>)> + Send + 'static> {
-        let mut swarm = self.lock().unwrap();
+impl LocalPeerId for Swarm {
+    fn local_peer_id(&self) -> PeerId {
+        self.local_peer_id.clone()
+    }
+}
 
+/// Get `PeerId`s of connected nodes.
+#[async_trait]
+pub trait ComitPeers {
+    async fn comit_peers(
+        &self,
+    ) -> Box<dyn Iterator<Item = (PeerId, Vec<Multiaddr>)> + Send + 'static>;
+}
+
+#[async_trait]
+impl ComitPeers for Swarm {
+    async fn comit_peers(
+        &self,
+    ) -> Box<dyn Iterator<Item = (PeerId, Vec<Multiaddr>)> + Send + 'static> {
+        let mut swarm = self.swarm.lock().unwrap();
         Box::new(swarm.comit.connected_peers())
     }
+}
 
-    fn listen_addresses(&self) -> Vec<Multiaddr> {
-        let swarm = self.lock().unwrap();
+/// IP addresses local node is listening on.
+#[async_trait]
+pub trait ListenAddresses {
+    async fn listen_addresses(&self) -> Vec<Multiaddr>;
+}
 
-        Swarm::listeners(&swarm)
-            .chain(Swarm::external_addresses(&swarm))
+#[async_trait]
+impl ListenAddresses for Swarm {
+    async fn listen_addresses(&self) -> Vec<Multiaddr> {
+        let swarm = self.swarm.lock().unwrap();
+
+        libp2p::Swarm::listeners(&swarm)
+            .chain(libp2p::Swarm::external_addresses(&swarm))
             .cloned()
             .collect()
     }
+}
 
-    fn pending_request_for(&self, swap: SwapId) -> Option<Sender<Response>> {
-        let swarm = self.lock().unwrap();
+/// Get pending network requests for swap.
+#[async_trait]
+pub trait PendingRequestFor {
+    async fn pending_request_for(&self, swap: SwapId) -> Option<oneshot::Sender<Response>>;
+}
+
+#[async_trait]
+impl PendingRequestFor for Swarm {
+    async fn pending_request_for(&self, swap: SwapId) -> Option<Sender<Response>> {
+        let swarm = self.swarm.lock().unwrap();
         let mut response_channels = swarm.response_channels.lock().unwrap();
-
         response_channels.remove(&swap)
     }
+}
 
-    fn send_request<AL: rfc003::Ledger, BL: rfc003::Ledger, AA: Asset, BA: Asset>(
+/// Send swap request to connected peer.
+#[async_trait]
+pub trait SendRequest {
+    async fn send_request<AL: rfc003::Ledger, BL: rfc003::Ledger, AA: Asset, BA: Asset>(
+        &self,
+        peer_identity: DialInformation,
+        request: rfc003::Request<AL, BL, AA, BA>,
+    ) -> Result<rfc003::Response<AL, BL>, RequestError>;
+}
+
+#[async_trait]
+impl SendRequest for Swarm {
+    async fn send_request<AL: rfc003::Ledger, BL: rfc003::Ledger, AA: Asset, BA: Asset>(
         &self,
         dial_information: DialInformation,
         request: rfc003::Request<AL, BL, AA, BA>,
-    ) -> Box<dyn Future<Item = rfc003::Response<AL, BL>, Error = RequestError> + Send> {
+    ) -> Result<rfc003::Response<AL, BL>, RequestError> {
         let id = request.swap_id;
         let request = build_outbound_request(request)
             .expect("constructing a frame::OutoingRequest should never fail!");
 
-        let response = {
-            let mut swarm = self.lock().unwrap();
+        let result = {
+            let mut guard = self.swarm.lock().unwrap();
+            let swarm = &mut *guard;
+
             log::debug!(
                 "Making swap request to {}: {:?}",
                 dial_information.clone(),
                 request
             );
 
-            swarm.send_request(dial_information.clone(), request)
-        };
+            swarm
+                .send_request(dial_information.clone(), request)
+                .compat()
+        }
+        .await;
 
-        let response =
-            response.then(move |result| match result {
-                Ok(mut response) => {
-                    let decision = response
-                        .take_header("decision")
-                        .map(Decision::from_header)
-                        .map_or(Ok(None), |x| x.map(Some))
-                        .map_err(|e| {
-                            log::error!(
-                                "Could not deserialize header in response {:?}: {}",
-                                response,
-                                e,
-                            );
-                            RequestError::InvalidResponse
-                        })?;
+        match result {
+            Ok(mut response) => {
+                let decision = response
+                    .take_header("decision")
+                    .map(Decision::from_header)
+                    .map_or(Ok(None), |x| x.map(Some))
+                    .map_err(|e| {
+                        log::error!(
+                            "Could not deserialize header in response {:?}: {}",
+                            response,
+                            e,
+                        );
+                        RequestError::InvalidResponse
+                    })?;
 
-                    match decision {
-                        Some(Decision::Accepted) => {
-                            match serde_json::from_value::<
-                                rfc003::messages::AcceptResponseBody<AL, BL>,
-                            >(response.body().clone())
-                            {
-                                Ok(body) => Ok(Ok(rfc003::Accept {
-                                    swap_id: id,
-                                    beta_ledger_refund_identity: body.beta_ledger_refund_identity,
-                                    alpha_ledger_redeem_identity: body.alpha_ledger_redeem_identity,
-                                })),
-                                Err(_e) => Err(RequestError::InvalidResponse),
-                            }
+                match decision {
+                    Some(Decision::Accepted) => {
+                        match serde_json::from_value::<rfc003::messages::AcceptResponseBody<AL, BL>>(
+                            response.body().clone(),
+                        ) {
+                            Ok(body) => Ok(Ok(rfc003::Accept {
+                                swap_id: id,
+                                beta_ledger_refund_identity: body.beta_ledger_refund_identity,
+                                alpha_ledger_redeem_identity: body.alpha_ledger_redeem_identity,
+                            })),
+                            Err(_e) => Err(RequestError::InvalidResponse),
                         }
-
-                        Some(Decision::Declined) => {
-                            match serde_json::from_value::<rfc003::messages::DeclineResponseBody>(
-                                response.body().clone(),
-                            ) {
-                                Ok(body) => Ok(Err(rfc003::Decline {
-                                    swap_id: id,
-                                    reason: body.reason,
-                                })),
-                                Err(_e) => Err(RequestError::InvalidResponse),
-                            }
-                        }
-
-                        None => Err(RequestError::InvalidResponse),
                     }
-                }
-                Err(e) => {
-                    log::error!(
-                        "Unable to request over connection {:?}:{:?}",
-                        dial_information,
-                        e
-                    );
-                    Err(RequestError::Connection)
-                }
-            });
 
-        Box::new(response)
+                    Some(Decision::Declined) => {
+                        match serde_json::from_value::<rfc003::messages::DeclineResponseBody>(
+                            response.body().clone(),
+                        ) {
+                            Ok(body) => Ok(Err(rfc003::Decline {
+                                swap_id: id,
+                                reason: body.reason,
+                            })),
+                            Err(_e) => Err(RequestError::InvalidResponse),
+                        }
+                    }
+
+                    None => Err(RequestError::InvalidResponse),
+                }
+            }
+            Err(e) => {
+                log::error!(
+                    "Unable to request over connection {:?}:{:?}",
+                    dial_information,
+                    e
+                );
+                Err(RequestError::Connection)
+            }
+        }
     }
 }
 

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -33,7 +33,7 @@ use std::sync::Arc;
 /// This is a facade that implements all the required traits and forwards them
 /// to another implementation. This allows us to keep the number of arguments to
 /// HTTP API controllers small and still access all the functionality we need.
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Debug)]
 pub struct Facade {
     pub bitcoin_connector: BitcoindConnector,
     pub ethereum_connector: Web3Connector,
@@ -41,19 +41,6 @@ pub struct Facade {
     pub seed: RootSeed,
     pub swarm: Swarm,
     pub db: Sqlite,
-}
-
-impl Clone for Facade {
-    fn clone(&self) -> Self {
-        Self {
-            bitcoin_connector: self.bitcoin_connector.clone(),
-            ethereum_connector: self.ethereum_connector.clone(),
-            state_store: Arc::clone(&self.state_store),
-            seed: self.seed,
-            swarm: self.swarm.clone(),
-            db: self.db.clone(),
-        }
-    }
 }
 
 impl StateStore for Facade {

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -4,7 +4,10 @@ use crate::{
         AcceptedSwap, DetermineTypes, LoadAcceptedSwap, Retrieve, Save, Saver, Sqlite, Swap,
         SwapTypes,
     },
-    network::{DialInformation, Network, RequestError},
+    network::{
+        ComitPeers, DialInformation, ListenAddresses, LocalPeerId, PendingRequestFor, RequestError,
+        SendRequest, Swarm,
+    },
     seed::{DeriveSwapSeed, RootSeed, SwapSeed},
     swap_protocols::{
         asset::Asset,
@@ -21,9 +24,9 @@ use crate::{
 };
 use async_trait::async_trait;
 use bitcoin::Amount;
-use futures::{sync::oneshot::Sender, Future};
+use futures::sync::oneshot::Sender;
 use futures_core::future::Either;
-use libp2p::PeerId;
+use libp2p::{Multiaddr, PeerId};
 use libp2p_comit::frame::Response;
 use std::sync::Arc;
 
@@ -31,32 +34,29 @@ use std::sync::Arc;
 /// to another implementation. This allows us to keep the number of arguments to
 /// HTTP API controllers small and still access all the functionality we need.
 #[allow(missing_debug_implementations)]
-pub struct Facade<S> {
+pub struct Facade {
     pub bitcoin_connector: BitcoindConnector,
     pub ethereum_connector: Web3Connector,
     pub state_store: Arc<InMemoryStateStore>,
     pub seed: RootSeed,
-    pub swarm: Arc<S>, // S is the libp2p Swarm within a mutex.
+    pub swarm: Swarm,
     pub db: Sqlite,
 }
 
-impl<S> Clone for Facade<S> {
+impl Clone for Facade {
     fn clone(&self) -> Self {
         Self {
             bitcoin_connector: self.bitcoin_connector.clone(),
             ethereum_connector: self.ethereum_connector.clone(),
             state_store: Arc::clone(&self.state_store),
             seed: self.seed,
-            swarm: Arc::clone(&self.swarm),
+            swarm: self.swarm.clone(),
             db: self.db.clone(),
         }
     }
 }
 
-impl<S> StateStore for Facade<S>
-where
-    S: Send + Sync + 'static,
-{
+impl StateStore for Facade {
     fn insert<A: ActorState>(&self, key: SwapId, value: A) {
         self.state_store.insert(key, value)
     }
@@ -70,48 +70,54 @@ where
     }
 }
 
-impl<S: Network> Network for Facade<S>
-where
-    S: Send + Sync + 'static,
-{
-    fn comit_peers(
-        &self,
-    ) -> Box<dyn Iterator<Item = (PeerId, Vec<libp2p::Multiaddr>)> + Send + 'static> {
-        self.swarm.comit_peers()
-    }
-
-    fn listen_addresses(&self) -> Vec<libp2p::Multiaddr> {
-        self.swarm.listen_addresses()
-    }
-
-    fn pending_request_for(&self, swap: SwapId) -> Option<Sender<Response>> {
-        self.swarm.pending_request_for(swap)
-    }
-
-    fn send_request<AL: rfc003::Ledger, BL: rfc003::Ledger, AA: Asset, BA: Asset>(
-        &self,
-        peer_identity: DialInformation,
-        request: rfc003::Request<AL, BL, AA, BA>,
-    ) -> Box<dyn Future<Item = rfc003::Response<AL, BL>, Error = RequestError> + Send + 'static>
-    {
-        self.swarm.send_request(peer_identity, request)
+impl LocalPeerId for Facade {
+    fn local_peer_id(&self) -> PeerId {
+        self.swarm.local_peer_id()
     }
 }
 
-impl<S> DeriveSwapSeed for Facade<S>
-where
-    S: Send + Sync + 'static,
-{
+#[async_trait]
+impl ComitPeers for Facade {
+    async fn comit_peers(
+        &self,
+    ) -> Box<dyn Iterator<Item = (PeerId, Vec<Multiaddr>)> + Send + 'static> {
+        self.swarm.comit_peers().await
+    }
+}
+
+#[async_trait]
+impl ListenAddresses for Facade {
+    async fn listen_addresses(&self) -> Vec<Multiaddr> {
+        self.swarm.listen_addresses().await
+    }
+}
+
+#[async_trait]
+impl PendingRequestFor for Facade {
+    async fn pending_request_for(&self, swap: SwapId) -> Option<Sender<Response>> {
+        self.swarm.pending_request_for(swap).await
+    }
+}
+
+#[async_trait]
+impl SendRequest for Facade {
+    async fn send_request<AL: rfc003::Ledger, BL: rfc003::Ledger, AA: Asset, BA: Asset>(
+        &self,
+        peer_identity: DialInformation,
+        request: rfc003::Request<AL, BL, AA, BA>,
+    ) -> Result<rfc003::Response<AL, BL>, RequestError> {
+        self.swarm.send_request(peer_identity, request).await
+    }
+}
+
+impl DeriveSwapSeed for Facade {
     fn derive_swap_seed(&self, id: SwapId) -> SwapSeed {
         self.seed.derive_swap_seed(id)
     }
 }
 
 #[async_trait]
-impl<S> Retrieve for Facade<S>
-where
-    S: Send + Sync + 'static,
-{
+impl Retrieve for Facade {
     async fn get(&self, key: &SwapId) -> anyhow::Result<Swap> {
         self.db.get(key).await
     }
@@ -122,9 +128,8 @@ where
 }
 
 #[async_trait]
-impl<S, AL, BL, AA, BA> LoadAcceptedSwap<AL, BL, AA, BA> for Facade<S>
+impl<AL, BL, AA, BA> LoadAcceptedSwap<AL, BL, AA, BA> for Facade
 where
-    S: Send + Sync + 'static,
     AL: Ledger + Send + 'static,
     BL: Ledger + Send + 'static,
     AA: Asset + Send + 'static,
@@ -140,22 +145,18 @@ where
 }
 
 #[async_trait]
-impl<S> DetermineTypes for Facade<S>
-where
-    S: Send + Sync + 'static,
-{
+impl DetermineTypes for Facade {
     async fn determine_types(&self, key: &SwapId) -> anyhow::Result<SwapTypes> {
         self.db.determine_types(key).await
     }
 }
 
 #[async_trait]
-impl<S> Saver for Facade<S> where S: Send + Sync + 'static {}
+impl Saver for Facade {}
 
 #[async_trait]
-impl<S, T> Save<T> for Facade<S>
+impl<T> Save<T> for Facade
 where
-    S: Send + Sync + 'static,
     T: Send + 'static,
     Sqlite: Save<T>,
 {
@@ -165,10 +166,7 @@ where
 }
 
 #[async_trait::async_trait]
-impl<S> HtlcEvents<Bitcoin, Amount> for Facade<S>
-where
-    S: Send + Sync + 'static,
-{
+impl HtlcEvents<Bitcoin, Amount> for Facade {
     async fn htlc_deployed(
         &self,
         htlc_params: HtlcParams<Bitcoin, Amount>,
@@ -199,9 +197,8 @@ where
 }
 
 #[async_trait::async_trait]
-impl<A, S> HtlcEvents<Ethereum, A> for Facade<S>
+impl<A> HtlcEvents<Ethereum, A> for Facade
 where
-    S: Send + Sync + 'static,
     A: Asset + Send + Sync + 'static,
     Web3Connector: HtlcEvents<Ethereum, A>,
 {

--- a/libp2p-comit/src/lib.rs
+++ b/libp2p-comit/src/lib.rs
@@ -4,7 +4,7 @@
 #[macro_use]
 pub mod frame;
 mod behaviour;
-mod handler;
+pub mod handler;
 mod protocol;
 mod substream;
 #[cfg(test)]


### PR DESCRIPTION
Currently `main.rs` contains a bunch of networking code.  The root cause of much of this is due to libp2p types.  If we wrap the libp2p swarm in a struct then we can do a lot of cleaning up.

With this applied there is no more libp2p code in `main.rs` :)

Resolves: #1776