### PR TITLE
Migrate init_accepted_swap to tokio 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,6 @@ dependencies = [
  "tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-compat 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -54,7 +54,6 @@ thiserror = "1"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 tokio = { version = "0.2", features = ["rt-core", "time", "macros", "sync"] }
 tokio-compat = "0.1"
-tokio-executor01 = { version = "0.1", package = "tokio-executor" }
 toml = "0.5"
 url = { version = "2", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/cnd/src/http_api/routes/rfc003/handlers/action.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/action.rs
@@ -8,11 +8,11 @@ use crate::{
         route_factory::new_action_link,
         routes::rfc003::decline::{to_swap_decline_reason, DeclineBody},
     },
+    init_swap::init_accepted_swap,
     libp2p_comit_ext::ToHeader,
     network::Network,
     seed::DeriveSwapSeed,
     swap_protocols::{
-        self,
         actions::Actions,
         rfc003::{
             self,
@@ -78,12 +78,7 @@ where
                 })?;
 
                 let swap_request = state.request();
-                swap_protocols::init_accepted_swap(
-                    &dependencies,
-                    swap_request,
-                    accept_message,
-                    types.role,
-                )?;
+                init_accepted_swap(&dependencies, swap_request, accept_message, types.role)?;
 
                 Ok(ActionResponseBody::None)
             }

--- a/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
@@ -2,10 +2,10 @@ use crate::{
     db::{Save, Sqlite, Swap},
     ethereum,
     http_api::{HttpAsset, HttpLedger},
+    init_swap::init_accepted_swap,
     network::{DialInformation, Network},
     seed::DeriveSwapSeed,
     swap_protocols::{
-        self,
         asset::Asset,
         ledger,
         rfc003::{
@@ -221,12 +221,7 @@ where
                 Ok(accept) => {
                     Save::save(&dependencies, accept).await?;
 
-                    swap_protocols::init_accepted_swap(
-                        &dependencies,
-                        swap_request,
-                        accept,
-                        Role::Alice,
-                    )?;
+                    init_accepted_swap(&dependencies, swap_request, accept, Role::Alice)?;
                 }
                 Err(decline) => {
                     log::info!("Swap declined: {:?}", decline);

--- a/cnd/src/init_swap.rs
+++ b/cnd/src/init_swap.rs
@@ -9,8 +9,6 @@ use crate::{
         Role,
     },
 };
-use futures_core::{FutureExt, TryFutureExt};
-use tokio_executor01::Executor;
 
 #[allow(clippy::cognitive_complexity)]
 pub fn init_accepted_swap<D, AL: Ledger, BL: Ledger, AA: Asset, BA: Asset>(
@@ -20,7 +18,7 @@ pub fn init_accepted_swap<D, AL: Ledger, BL: Ledger, AA: Asset, BA: Asset>(
     role: Role,
 ) -> anyhow::Result<()>
 where
-    D: StateStore + Clone + DeriveSwapSeed + Executor + HtlcEvents<AL, AA> + HtlcEvents<BL, BA>,
+    D: StateStore + Clone + DeriveSwapSeed + HtlcEvents<AL, AA> + HtlcEvents<BL, BA>,
 {
     let id = request.swap_id;
     let seed = dependencies.derive_swap_seed(id);
@@ -30,26 +28,21 @@ where
             let state = alice::State::accepted(request.clone(), accept, seed);
             StateStore::insert(dependencies, id, state);
 
-            let swap_execution = create_swap::<D, alice::State<AL, BL, AA, BA>>(
+            tokio::task::spawn(create_swap::<D, alice::State<AL, BL, AA, BA>>(
                 dependencies.clone(),
                 request,
                 accept,
-            );
-
-            dependencies
-                .clone()
-                .spawn(Box::new(swap_execution.unit_error().boxed().compat()))?;
+            ));
         }
         Role::Bob => {
             let state = bob::State::accepted(request.clone(), accept, seed);
             StateStore::insert(dependencies, id, state);
 
-            let swap_execution =
-                create_swap::<D, bob::State<AL, BL, AA, BA>>(dependencies.clone(), request, accept);
-
-            dependencies
-                .clone()
-                .spawn(Box::new(swap_execution.unit_error().boxed().compat()))?;
+            tokio::task::spawn(create_swap::<D, bob::State<AL, BL, AA, BA>>(
+                dependencies.clone(),
+                request,
+                accept,
+            ));
         }
     };
 

--- a/cnd/src/lib.rs
+++ b/cnd/src/lib.rs
@@ -28,6 +28,7 @@ pub mod comit_api;
 pub mod config;
 pub mod ethereum;
 pub mod http_api;
+pub mod init_swap;
 pub mod load_swaps;
 pub mod logging;
 pub mod network;

--- a/cnd/src/load_swaps.rs
+++ b/cnd/src/load_swaps.rs
@@ -2,21 +2,19 @@
 use crate::{
     db::{DetermineTypes, LoadAcceptedSwap, Retrieve},
     ethereum::{Erc20Token, EtherQuantity},
+    init_swap::init_accepted_swap,
     seed::DeriveSwapSeed,
     swap_protocols::{
-        self,
         ledger::{Bitcoin, Ethereum},
         rfc003::{events::HtlcEvents, state_store::StateStore},
     },
 };
 use bitcoin::Amount;
-use tokio_executor01::Executor;
 
 #[allow(clippy::cognitive_complexity)]
 pub async fn load_swaps_from_database<D>(dependencies: D) -> anyhow::Result<()>
 where
     D: StateStore
-        + Executor
         + Clone
         + DeriveSwapSeed
         + Retrieve
@@ -44,7 +42,7 @@ where
 
             match accepted {
                 Ok((request, accept, _at)) => {
-                    swap_protocols::init_accepted_swap(&dependencies, request, accept, types.role)?;
+                    init_accepted_swap(&dependencies, request, accept, types.role)?;
                 }
                 Err(e) => log::error!("failed to load swap: {}, continuing ...", e),
             };

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -93,7 +93,6 @@ fn main() -> anyhow::Result<()> {
         seed,
         swarm: Arc::clone(&swarm),
         db: database,
-        task_executor: runtime.executor(),
     };
 
     runtime.block_on(

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -26,8 +26,6 @@ use futures_core::future::Either;
 use libp2p::PeerId;
 use libp2p_comit::frame::Response;
 use std::sync::Arc;
-use tokio_compat::runtime::TaskExecutor;
-use tokio_executor01::Executor;
 
 /// This is a facade that implements all the required traits and forwards them
 /// to another implementation. This allows us to keep the number of arguments to
@@ -40,7 +38,6 @@ pub struct Facade<S> {
     pub seed: RootSeed,
     pub swarm: Arc<S>, // S is the libp2p Swarm within a mutex.
     pub db: Sqlite,
-    pub task_executor: TaskExecutor,
 }
 
 impl<S> Clone for Facade<S> {
@@ -52,7 +49,6 @@ impl<S> Clone for Facade<S> {
             seed: self.seed,
             swarm: Arc::clone(&self.swarm),
             db: self.db.clone(),
-            task_executor: self.task_executor.clone(),
         }
     }
 }
@@ -235,17 +231,5 @@ where
         self.ethereum_connector
             .htlc_redeemed_or_refunded(htlc_params, htlc_deployment, htlc_funding)
             .await
-    }
-}
-
-impl<S> Executor for Facade<S>
-where
-    S: Send + Sync + 'static,
-{
-    fn spawn(
-        &mut self,
-        future: Box<dyn Future<Item = (), Error = ()> + Send>,
-    ) -> Result<(), tokio_executor01::SpawnError> {
-        Executor::spawn(&mut self.task_executor, future)
     }
 }

--- a/cnd/src/swap_protocols/mod.rs
+++ b/cnd/src/swap_protocols/mod.rs
@@ -1,14 +1,12 @@
 pub mod actions;
 pub mod asset;
 mod facade;
-mod init_swap;
 pub mod ledger;
 pub mod rfc003;
 mod swap_id;
 
 pub use self::{
     facade::*,
-    init_swap::*,
     ledger::{Ledger, LedgerKind},
     swap_id::*,
 };


### PR DESCRIPTION
Tokio 0.2 no longer provides an `Executor` trait. Instead, we use the `tokio::task::spawn` method to spawn an async task in the background.
This is not as explicit as calling `.spawn()` on dependencies, but as long as we only do this from application code (read cnd) and not from potential library code, this should be fine.