### PR TITLE
Attempt to move back to cron for stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,6 @@
 on:
-  push:
-    branches:
-      - master
-      - test-stale-bot
+  schedule:
+    - cron: '0 * * * *'
 name: stale
 jobs:
   stale:


### PR DESCRIPTION
The action was triggered by pushing to master... at least something :)

As of recommendation in https://github.community/t5/GitHub-Actions/Action-not-run-and-no-logs-available-action-stale/m-p/42928#M5180 I move it now back to cron.

