### PR TITLE
Run stale bot on push to master

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,6 @@
 on:
+  schedule:
+    - cron: '0 * * * *'
   push:
     branches:
       - master

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,7 @@
 on:
-  schedule:
-    - cron: '0 * * * *'
+  push:
+    branches:
+      - master
 name: stale
 jobs:
   stale:


### PR DESCRIPTION
We want this bot to run, however, cron jobs does not seem to work at the moment. 
I've reached out to github support already, but in the meantime, let's run it on every push to master. 