### PR TITLE
Yield blocks for Ethereum matching_transaction using a generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "genawaiter"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "generic-array"

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -24,7 +24,7 @@ ethbloom = "0.6.4"
 fern = { version = "0.5", features = ["colored"] }
 futures = { version = "0.1" }
 futures-core = { version = "0.3", features = ["alloc", "compat", "async-await"], package = "futures" }
-genawaiter = { version = "0.2" }
+genawaiter = { version = "0.2", features = ["futures03"] }
 hex = "0.4"
 hex-serde = "0.1.0"
 http-api-problem = "0.13"

--- a/cnd/src/btsieve/ethereum/mod.rs
+++ b/cnd/src/btsieve/ethereum/mod.rs
@@ -9,9 +9,13 @@ use crate::{
     btsieve::{BlockByHash, LatestBlock, ReceiptByHash},
     ethereum::{Transaction, TransactionAndReceipt, TransactionReceipt, H256, U256},
 };
-use futures_core::{compat::Future01CompatExt, future::join};
+use anyhow;
+use futures_core::compat::Future01CompatExt;
+use genawaiter::{
+    sync::{Co, Gen},
+    GeneratorState,
+};
 use std::{collections::HashSet, fmt::Debug};
-use tokio::sync::mpsc::{self, Receiver, Sender};
 
 type Hash = H256;
 type Block = crate::ethereum::Block<Transaction>;
@@ -26,321 +30,198 @@ where
         + BlockByHash<Block = Option<Block>, BlockHash = Hash, Error = E>
         + ReceiptByHash<Receipt = Option<TransactionReceipt>, TransactionHash = Hash, Error = E>
         + Clone,
-    E: Debug + Send + 'static,
+    E: std::error::Error + Debug + Send + 'static + Sync,
 {
-    let (block_queue, next_block) = mpsc::channel(1);
-    let (find_parent_queue, next_find_parent) = mpsc::channel(5);
-    let (look_in_the_past_queue, next_look_in_the_past) = mpsc::channel(5);
+    let mut block_generator = Gen::new({
+        let connector = connector.clone();
+        |co| async move { yield_blocks(connector, &co, reference_timestamp).await }
+    });
 
-    tokio::task::spawn(process_latest_blocks(
-        connector.clone(),
-        block_queue.clone(),
-        find_parent_queue.clone(),
-        look_in_the_past_queue.clone(),
-    ));
-
-    let (fetch_block_by_hash_queue, next_hash) = mpsc::channel(5);
-
-    tokio::task::spawn(process_blocks_by_hash(
-        connector.clone(),
-        block_queue.clone(),
-        find_parent_queue.clone(),
-        (fetch_block_by_hash_queue.clone(), next_hash),
-    ));
-
-    tokio::task::spawn(process_next_find_parent(
-        connector.clone(),
-        next_find_parent,
-        fetch_block_by_hash_queue.clone(),
-    ));
-
-    tokio::task::spawn(process_next_look_in_the_past(
-        connector.clone(),
-        block_queue.clone(),
-        (look_in_the_past_queue.clone(), next_look_in_the_past),
-        reference_timestamp,
-    ));
-
-    let (matching_transaction_queue, mut matching_transaction) = mpsc::channel(1);
-
-    tokio::task::spawn(process_next_block(
-        connector.clone(),
-        next_block,
-        matching_transaction_queue,
-        pattern,
-    ));
-
-    Ok(matching_transaction
-        .recv()
-        .await
-        .expect("sender cannot be dropped"))
+    loop {
+        match block_generator.async_resume().await {
+            GeneratorState::Yielded(block) => {
+                if let Some(transaction_and_receipt) =
+                    check_block_against_pattern(connector.clone(), block, pattern.clone()).await?
+                {
+                    return Ok(transaction_and_receipt);
+                } else {
+                    continue;
+                }
+            }
+            GeneratorState::Complete(Err(e)) => return Err(e),
+            GeneratorState::Complete(Ok(infallible)) => match infallible {},
+        }
+    }
 }
 
-/// Repeatedly fetches the latest block from the Ethereum blockchain connector.
-/// For the first (and first only) block; sends the block to the
-/// `look_in_the_past_queue` channel. On fetch of each unique block; sends block
-/// to the `block_queue` and `find_parent_queue` channels.
-async fn process_latest_blocks<C, E>(
+async fn yield_blocks<C, E>(
     mut connector: C,
-    mut block_queue: Sender<Block>,
-    mut find_parent_queue: Sender<(Hash, Hash)>,
-    mut look_in_the_past_queue: Sender<Hash>,
-) where
+    co: &Co<Block>,
+    reference_timestamp: Option<u32>,
+) -> anyhow::Result<std::convert::Infallible>
+where
     C: LatestBlock<Block = Option<Block>, Error = E>
         + BlockByHash<Block = Option<Block>, BlockHash = Hash, Error = E>
         + ReceiptByHash<Receipt = Option<TransactionReceipt>, TransactionHash = Hash, Error = E>
         + Clone,
-    E: Debug + Send + 'static,
+    E: std::error::Error + Debug + Send + Sync + 'static,
 {
-    let mut sent_blockhashes: HashSet<H256> = HashSet::new();
+    let mut seen_blockhashes: HashSet<Hash> = HashSet::new();
 
     loop {
+        // The duration of this timeout could/should depend on the network
         tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
 
-        match connector.latest_block().compat().await {
-            Ok(Some(block)) if block.hash.is_some() => {
-                let blockhash = block.hash.expect("cannot fail");
+        let block = connector
+            .latest_block()
+            .compat()
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Connector returned nullable latest block"))?;
 
-                if !sent_blockhashes.contains(&blockhash) {
-                    sent_blockhashes.insert(blockhash);
+        let blockhash = block
+            .hash
+            .ok_or_else(|| anyhow::anyhow!("Connector returned latest block with nullable hash"))?;
+        seen_blockhashes.insert(blockhash);
 
-                    let _ = join(
-                        block_queue.send(block.clone()),
-                        find_parent_queue.send((blockhash, block.parent_hash)),
-                    )
-                    .await;
+        if let Some(timestamp) = reference_timestamp {
+            if seen_blockhashes.len() == 1 && block.timestamp > U256::from(timestamp) {
+                yield_blocks_until_timestamp(connector.clone(), co, blockhash, timestamp).await?;
+            }
+        }
 
-                    if sent_blockhashes.len() == 1 {
-                        let _ = look_in_the_past_queue.send(block.parent_hash).await;
-                    };
-                }
-            }
-            Ok(Some(_)) => {
-                log::warn!("Ignoring block without blockhash");
-            }
-            Ok(None) => {
-                log::warn!("Could not get latest block");
-            }
-            Err(e) => {
-                log::warn!("Could not get latest block: {:?}", e);
-            }
-        };
+        let parent_hash = block.parent_hash;
+        if !seen_blockhashes.contains(&parent_hash) && seen_blockhashes.len() > 1 {
+            yield_missed_blocks(
+                connector.clone(),
+                co,
+                parent_hash,
+                seen_blockhashes.clone(),
+                reference_timestamp.unwrap_or(0),
+            )
+            .await?;
+        }
+
+        co.yield_(block).await;
     }
 }
 
-/// Processes block hashes from the `next_hash` receiver, fetches blocks from
-/// the blockchain connector by block hash and enqueues the block on the
-/// `block_queue`. Enqueues the block hash and parent block hash on the
-/// `find_parent_queue`.
-async fn process_blocks_by_hash<C, E>(
+async fn yield_blocks_until_timestamp<C, E>(
     connector: C,
-    mut block_queue: Sender<Block>,
-    mut find_parent_queue: Sender<(Hash, Hash)>,
-    next_block_channel: (Sender<Hash>, Receiver<Hash>),
-) where
+    co: &Co<Block>,
+    starting_blockhash: Hash,
+    timestamp: u32,
+) -> anyhow::Result<()>
+where
     C: LatestBlock<Block = Option<Block>, Error = E>
         + BlockByHash<Block = Option<Block>, BlockHash = Hash, Error = E>
         + ReceiptByHash<Receipt = Option<TransactionReceipt>, TransactionHash = Hash, Error = E>
         + Clone,
-    E: Debug + Send + 'static,
+    E: std::error::Error + Debug + Send + Sync + 'static,
 {
-    let (mut fetch_block_by_hash_queue, mut next_hash) = next_block_channel;
-    let mut sent_blockhashes: HashSet<H256> = HashSet::new();
+    let mut blockhash = starting_blockhash;
 
     loop {
-        match next_hash.recv().await {
-            Some(blockhash) => {
-                match connector.block_by_hash(blockhash).compat().await {
-                    Ok(Some(block)) => {
-                        if !sent_blockhashes.contains(&blockhash) {
-                            sent_blockhashes.insert(blockhash);
+        let block = connector
+            .block_by_hash(blockhash)
+            .compat()
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Could not fetch block with hash {}", blockhash))?;
 
-                            let _ = join(
-                                block_queue.send(block.clone()),
-                                find_parent_queue.send((blockhash, block.parent_hash)),
-                            )
-                            .await;
-                        }
-                    }
-                    Ok(None) => {
-                        log::warn!("Block with hash {} does not exist", blockhash);
-                    }
-                    Err(e) => {
-                        log::warn!("Could not get block with hash {}: {:?}", blockhash, e);
+        co.yield_(block.clone()).await;
 
-                        let _ = fetch_block_by_hash_queue.send(blockhash).await;
-                    }
-                };
-            }
-            None => unreachable!("sender cannot be dropped"),
+        if block.timestamp <= U256::from(timestamp) {
+            return Ok(());
+        } else {
+            blockhash = block.parent_hash
         }
     }
 }
 
-/// Processes `next_find_parent` queue by adding parent_blockhash to the
-/// `fetch_block_by_hash` if it has not already been seen.
-async fn process_next_find_parent<C, E>(
-    _connector: C,
-    mut next_find_parent: Receiver<(Hash, Hash)>,
-    mut fetch_block_by_hash_queue: Sender<Hash>,
-) where
+async fn yield_missed_blocks<C, E>(
+    connector: C,
+    co: &Co<Block>,
+    starting_blockhash: Hash,
+    seen_blockhashes: HashSet<Hash>,
+    timestamp: u32,
+) -> anyhow::Result<()>
+where
     C: LatestBlock<Block = Option<Block>, Error = E>
         + BlockByHash<Block = Option<Block>, BlockHash = Hash, Error = E>
         + ReceiptByHash<Receipt = Option<TransactionReceipt>, TransactionHash = Hash, Error = E>
         + Clone,
-    E: Debug + Send + 'static,
+    E: std::error::Error + Debug + Send + Sync + 'static,
 {
-    let mut prev_blockhashes: HashSet<H256> = HashSet::new();
+    let mut blockhash = starting_blockhash;
 
     loop {
-        match next_find_parent.recv().await {
-            Some((blockhash, parent_blockhash)) => {
-                prev_blockhashes.insert(blockhash);
+        let block = connector
+            .block_by_hash(blockhash)
+            .compat()
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Could not fetch block with hash {}", blockhash))?;
 
-                if !prev_blockhashes.contains(&parent_blockhash) && prev_blockhashes.len() > 1 {
-                    let _ = fetch_block_by_hash_queue.send(parent_blockhash).await;
-                }
-            }
-            None => unreachable!("senders cannot be dropped"),
+        co.yield_(block.clone()).await;
+
+        if seen_blockhashes.contains(
+            &block
+                .hash
+                .ok_or_else(|| anyhow::anyhow!("Block with nullable hash"))?,
+        ) || U256::from(timestamp) >= block.timestamp
+        {
+            return Ok(());
+        } else {
+            blockhash = block.parent_hash
         }
     }
 }
 
-/// Process hashes from the `next_look_in_the_past` receiver. Gets the block
-/// for this hash from the blockchain connector, if the block is _not_ yet
-/// further back in time than `reference_timestamp` then enqueues block on the
-/// `block_queue` and the block hash of parent to the `look_in_the_past_queue`.
-async fn process_next_look_in_the_past<C, E>(
+async fn check_block_against_pattern<C, E>(
     connector: C,
-    mut block_queue: Sender<Block>,
-    look_in_the_past_channel: (Sender<Hash>, Receiver<Hash>),
-    reference_timestamp: Option<u32>,
-) where
-    C: LatestBlock<Block = Option<Block>, Error = E>
-        + BlockByHash<Block = Option<Block>, BlockHash = Hash, Error = E>
-        + ReceiptByHash<Receipt = Option<TransactionReceipt>, TransactionHash = Hash, Error = E>
-        + Clone,
-    E: Debug + Send + 'static,
-{
-    let reference_timestamp = reference_timestamp.map(U256::from);
-    let (mut look_in_the_past_queue, mut next_look_in_the_past) = look_in_the_past_channel;
-
-    loop {
-        match next_look_in_the_past.recv().await {
-            Some(parent_blockhash) => {
-                match connector.block_by_hash(parent_blockhash).compat().await {
-                    Ok(Some(block)) => {
-                        let younger_than_reference_timestamp = reference_timestamp
-                            .map(|reference_timestamp| reference_timestamp <= block.timestamp)
-                            .unwrap_or(false);
-                        if younger_than_reference_timestamp {
-                            let _ = join(
-                                block_queue.send(block.clone()),
-                                look_in_the_past_queue.send(block.parent_hash),
-                            )
-                            .await;
-                        }
-                    }
-                    Ok(None) => {
-                        log::warn!("Block with hash {} does not exist", parent_blockhash);
-                    }
-                    Err(e) => {
-                        log::warn!(
-                            "Could not get block with hash {}: {:?}",
-                            parent_blockhash,
-                            e
-                        );
-                        // Delay here otherwise the error code path can go into a hot loop.
-                        tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
-                        let _ = look_in_the_past_queue.send(parent_blockhash).await;
-                    }
-                }
-            }
-            None => unreachable!("senders cannot be dropped"),
-        }
-    }
-}
-
-/// This is the actual processing of the blocks. Gets receipts if needed,
-/// matches transactions in the block using `pattern` and enqueues 'transaction
-/// and receipt' onto the `matching_transaction_queue` if a matching transaction
-/// is found.
-async fn process_next_block<C, E>(
-    connector: C,
-    mut next_block: Receiver<Block>,
-    mut matching_transaction_queue: Sender<TransactionAndReceipt>,
+    block: Block,
     pattern: TransactionPattern,
-) where
+) -> anyhow::Result<Option<TransactionAndReceipt>>
+where
     C: LatestBlock<Block = Option<Block>, Error = E>
         + BlockByHash<Block = Option<Block>, BlockHash = Hash, Error = E>
         + ReceiptByHash<Receipt = Option<TransactionReceipt>, TransactionHash = Hash, Error = E>
         + Clone,
-    E: Debug + Send + 'static,
+    E: std::error::Error + Debug + Send + Sync + 'static,
 {
-    loop {
-        match next_block.recv().await {
-            Some(block) => {
-                let needs_receipt = pattern.needs_receipts(&block);
+    let needs_receipt = pattern.needs_receipts(&block);
 
-                for transaction in block.transactions.into_iter() {
-                    if needs_receipt {
-                        let result = connector.receipt_by_hash(transaction.hash).compat().await;
+    for transaction in block.transactions.into_iter() {
+        if needs_receipt {
+            let hash = transaction.hash;
+            let receipt = connector
+                .receipt_by_hash(hash)
+                .compat()
+                .await?
+                .ok_or_else(|| {
+                    anyhow::anyhow!("Could not get transaction receipt for transaction {}", hash)
+                })?;
 
-                        let receipt = match result {
-                            Ok(Some(receipt)) => receipt,
-                            Ok(None) => {
-                                log::warn!("Could not get transaction receipt");
-                                continue;
-                            }
-                            Err(e) => {
-                                log::warn!(
-                                    "Could not retrieve transaction receipt for {}: {:?}",
-                                    transaction.hash,
-                                    e
-                                );
-                                continue;
-                            }
-                        };
-
-                        if pattern.matches(&transaction, Some(&receipt)) {
-                            let _ = matching_transaction_queue
-                                .send(TransactionAndReceipt {
-                                    transaction,
-                                    receipt,
-                                })
-                                .await;
-                        }
-                    } else if pattern.matches(&transaction, None) {
-                        let result = connector.receipt_by_hash(transaction.hash).compat().await;
-
-                        let receipt = match result {
-                            Ok(Some(receipt)) => receipt,
-                            Ok(None) => {
-                                log::warn!(
-                                    "Could not get transaction receipt for matching transaction"
-                                );
-                                continue;
-                            }
-                            Err(e) => {
-                                log::warn!(
-                                    "Could not retrieve transaction receipt for matching transaction {}: {:?}",
-                                    transaction.hash,
-                                    e
-                                );
-                                continue;
-                            }
-                        };
-
-                        let _ = matching_transaction_queue
-                            .send(TransactionAndReceipt {
-                                transaction,
-                                receipt,
-                            })
-                            .await;
-                    }
-                }
+            if pattern.matches(&transaction, Some(&receipt)) {
+                return Ok(Some(TransactionAndReceipt {
+                    transaction,
+                    receipt,
+                }));
             }
-            None => unreachable!("senders cannot be dropped"),
+        } else if pattern.matches(&transaction, None) {
+            let hash = transaction.hash;
+            let receipt = connector
+                .receipt_by_hash(hash)
+                .compat()
+                .await?
+                .ok_or_else(|| {
+                    anyhow::anyhow!("Could not get transaction receipt for transaction {}", hash)
+                })?;
+
+            return Ok(Some(TransactionAndReceipt {
+                transaction,
+                receipt,
+            }));
         }
     }
+
+    Ok(None)
 }

--- a/cnd/tests/ethereum_missing_blocks.rs
+++ b/cnd/tests/ethereum_missing_blocks.rs
@@ -2,7 +2,7 @@ pub mod ethereum_helper;
 
 use cnd::{
     btsieve::ethereum::{matching_transaction, TransactionPattern},
-    ethereum::{Transaction, TransactionAndReceipt, TransactionReceipt},
+    ethereum::{Block, Transaction, TransactionAndReceipt, TransactionReceipt},
 };
 use ethereum_helper::EthereumConnectorMock;
 
@@ -36,6 +36,9 @@ async fn find_transaction_in_missing_block() {
         ],
         vec![(transaction.hash, receipt.clone())],
     );
+    let block1: Block<Transaction> = include_json_test_data!(
+        "./test_data/ethereum/find_transaction_in_missing_block/block1.json"
+    );
 
     let pattern = TransactionPattern {
         from_address: None,
@@ -45,9 +48,10 @@ async fn find_transaction_in_missing_block() {
         transaction_data_length: None,
         events: None,
     };
-    let expected_transaction_and_receipt = matching_transaction(connector, pattern, None)
-        .await
-        .unwrap();
+    let expected_transaction_and_receipt =
+        matching_transaction(connector, pattern, Some(block1.timestamp.as_u32()))
+            .await
+            .unwrap();
 
     assert_eq!(expected_transaction_and_receipt, TransactionAndReceipt {
         transaction,
@@ -91,6 +95,9 @@ async fn find_transaction_in_missing_block_with_big_gap() {
         ],
         vec![(transaction.hash, receipt.clone())],
     );
+    let block1: Block<Transaction> = include_json_test_data!(
+        "./test_data/ethereum/find_transaction_in_missing_block/block1.json"
+    );
 
     let pattern = TransactionPattern {
         from_address: None,
@@ -100,9 +107,10 @@ async fn find_transaction_in_missing_block_with_big_gap() {
         transaction_data_length: None,
         events: None,
     };
-    let expected_transaction_and_receipt = matching_transaction(connector, pattern, None)
-        .await
-        .unwrap();
+    let expected_transaction_and_receipt =
+        matching_transaction(connector, pattern, Some(block1.timestamp.as_u32()))
+            .await
+            .unwrap();
 
     assert_eq!(expected_transaction_and_receipt, TransactionAndReceipt {
         transaction,


### PR DESCRIPTION
- Stop spawning tasks using `tokio`'s executor in `matching_transaction`.
- Simplify the code and make the yielding of blocks more specific to our needs.

There is no need to fetch new and old blocks concurrently. Given that fetching old blocks by hash is fast (since they're all available) that work can always be done on demand, halting the fetching of new blocks in the meantime.

---
Fixes #1780.

Added @tcharding to reviewers so that he can eventually tell me whether he thinks this is a step forward in terms of clarity.