### PR TITLE
Automatically stage rust files after they have been formatted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ECHO = echo
 TOOLCHAIN = $(shell cat rust-toolchain)
 CARGO = $(RUSTUP) run --install $(TOOLCHAIN) cargo --color always
 
-NIGHTLY_TOOLCHAIN = nightly-2019-07-31
+NIGHTLY_TOOLCHAIN = nightly-2020-01-15
 CARGO_NIGHTLY = $(RUSTUP) run --install $(NIGHTLY_TOOLCHAIN) cargo --color always
 
 GIT_HOOKS_PATH = ".githooks"
@@ -102,7 +102,7 @@ STAGED_TYPESCRIPT_FILES = $(filter %.ts %.json %.yml,$(STAGED_FILES))
 
 format: install_rustfmt install_tomlfmt
 ifneq (,$(STAGED_RUST_FILES))
-	$(CARGO_NIGHTLY) fmt
+	$(CARGO_NIGHTLY) fmt -- --files-with-diff | xargs -I{} git add {}
 endif
 ifneq (,$(STAGED_TOML_FILES))
 	$(CARGO) tomlfmt -p Cargo.toml

--- a/cnd/src/swap_protocols/rfc003/create_swap.rs
+++ b/cnd/src/swap_protocols/rfc003/create_swap.rs
@@ -42,14 +42,12 @@ pub async fn create_swap<D, A: ActorState>(
     // construct a generator that watches alpha and beta ledger concurrently
     let mut generator = Gen::new({
         let dependencies = dependencies.clone();
-        |co| {
-            async move {
-                future::try_join(
-                    watch_alpha_ledger(&dependencies, &co, swap.alpha_htlc_params()),
-                    watch_beta_ledger(&dependencies, &co, swap.beta_htlc_params()),
-                )
-                .await
-            }
+        |co| async move {
+            future::try_join(
+                watch_alpha_ledger(&dependencies, &co, swap.alpha_htlc_params()),
+                watch_beta_ledger(&dependencies, &co, swap.beta_htlc_params()),
+            )
+            .await
         }
     });
 


### PR DESCRIPTION
Our makefile only formats files that are staged. Formatting them
unstages them and hence, they need to be restaged again before they
can be committed.
A recent version of rustfmt added the option `--files-with-diff`
which outputs the files that were affected by the formatting.
We can use that information to automatically restage those files
and hence save a manual step for the developer. A usual workflow
would now be:

- write code
- stage the files ready for a commit
- make format
- commit