### PR TITLE
Use custom Infallible

### DIFF
--- a/cnd/src/btsieve/ethereum/mod.rs
+++ b/cnd/src/btsieve/ethereum/mod.rs
@@ -53,6 +53,10 @@ where
     }
 }
 
+#[allow(missing_debug_implementations)]
+#[derive(Copy, Clone)]
+pub enum Infallible {}
+
 /// This function uses the `connector` to find blocks relevant to a swap.
 ///
 /// It yields those blocks as part of the process.
@@ -60,7 +64,7 @@ async fn find_relevant_blocks<C>(
     mut connector: C,
     co: &Co<Block>,
     start_of_swap: Option<u32>,
-) -> anyhow::Result<std::convert::Infallible>
+) -> anyhow::Result<Infallible>
 where
     C: LatestBlock<Block = Option<Block>>
         + BlockByHash<Block = Option<Block>, BlockHash = Hash>


### PR DESCRIPTION
`std::convert::Infallible` is meant to be used as error type (according to the docs), seeing it in the `Ok` variant of `Result` is confusing. We are using `Infallible` to make explicit that no `Ok` result is ever returned by this function.  Using the std infallible violates the principle of least surprise.  We can better achieve this behaviour by adding a custom `Infallible` type and using it.