### PR TITLE
Don't generate unnecessary blocks

### DIFF
--- a/api_tests/lib/bitcoin.ts
+++ b/api_tests/lib/bitcoin.ts
@@ -56,7 +56,9 @@ function createBitcoinRpcClient(btcConfig?: BitcoinNodeConfig) {
 }
 
 export async function generate(num: number = 1) {
-    return createBitcoinRpcClient(bitcoinConfig).generate(num);
+    const client = createBitcoinRpcClient(bitcoinConfig);
+
+    return client.generateToAddress(num, await client.getNewAddress());
 }
 
 export async function getBlockchainInfo() {
@@ -68,7 +70,12 @@ export async function ensureFunding() {
         bitcoinConfig
     ).getBlockCount();
     if (blockHeight < 101) {
-        await createBitcoinRpcClient(bitcoinConfig).generate(101 - blockHeight);
+        const client = createBitcoinRpcClient(bitcoinConfig);
+
+        await client.generateToAddress(
+            101 - blockHeight,
+            await client.getNewAddress()
+        );
     }
 }
 

--- a/api_tests/lib/ledger_runner.ts
+++ b/api_tests/lib/ledger_runner.ts
@@ -78,6 +78,7 @@ export class LedgerRunner {
                     );
                 }
                 bitcoin.init(await this.getBitcoinClientConfig());
+                await bitcoin.ensureFunding();
                 this.blockTimers.bitcoin = global.setInterval(async () => {
                     await bitcoin.generate();
                 }, 1000);

--- a/api_tests/lib_sdk/actors/actor.ts
+++ b/api_tests/lib_sdk/actors/actor.ts
@@ -389,19 +389,21 @@ export class Actor {
     public async dumpState() {
         this.logger.debug("dumping current state");
 
-        const swapDetails = await this.swap.fetchDetails();
+        if (this.swap) {
+            const swapDetails = await this.swap.fetchDetails();
 
-        this.logger.debug("swap status: %s", swapDetails.properties.status);
-        this.logger.debug("swap details: ", JSON.stringify(swapDetails));
+            this.logger.debug("swap status: %s", swapDetails.properties.status);
+            this.logger.debug("swap details: ", JSON.stringify(swapDetails));
 
-        this.logger.debug(
-            "alpha ledger wallet balance %d",
-            await this.alphaLedgerWallet().getBalance()
-        );
-        this.logger.debug(
-            "beta ledger wallet balance %d",
-            await this.betaLedgerWallet().getBalance()
-        );
+            this.logger.debug(
+                "alpha ledger wallet balance %d",
+                await this.alphaLedgerWallet().getBalance()
+            );
+            this.logger.debug(
+                "beta ledger wallet balance %d",
+                await this.betaLedgerWallet().getBalance()
+            );
+        }
     }
 
     private async waitForAlphaExpiry() {

--- a/api_tests/lib_sdk/wallets/bitcoin.ts
+++ b/api_tests/lib_sdk/wallets/bitcoin.ts
@@ -47,7 +47,14 @@ export class BitcoinWallet implements Wallet {
         const startingBalance = new BigNumber(await this.getBalance());
 
         const minimumExpectedBalance = new BigNumber(asset.quantity);
-        await this.bitcoinRpcClient.generate(101);
+
+        const blockHeight = await this.bitcoinRpcClient.getBlockCount();
+        if (blockHeight < 101) {
+            throw new Error(
+                "unable to mint bitcoin, coinbase transactions are not yet spendable"
+            );
+        }
+
         await this.bitcoinRpcClient.sendToAddress(
             await this.address(),
             toBitcoin(minimumExpectedBalance.times(2).toString()) // make sure we have at least twice as much

--- a/api_tests/types/bitcoin-core/index.d.ts
+++ b/api_tests/types/bitcoin-core/index.d.ts
@@ -30,10 +30,11 @@ declare module "bitcoin-core" {
     export default class BitcoinRpcClient {
         public constructor(args: ClientConstructorArgs);
 
-        public generate(num: number): Promise<string[]>;
         public getBlockchainInfo(): Promise<GetBlockchainInfoResponse>;
 
         public getBlockCount(): Promise<number>;
+
+        public getNewAddress(): Promise<string>;
 
         public getRawTransaction(
             txId: string,
@@ -45,6 +46,11 @@ declare module "bitcoin-core" {
             address: string,
             amount: number | string
         ): Promise<string>;
+
+        public generateToAddress(
+            nblocks: number,
+            address: string
+        ): Promise<string[]>;
 
         public sendRawTransaction(hexString: string): Promise<string>;
     }


### PR DESCRIPTION
Previously, we generated 101 blocks _for each test_ to ensure we can spend the coinbase transactiosn and hence can send money to the wallet address.

We've also been using the `generate` RPC call which will be phased out in the future. It is recommended to use `generateToAddress` instead.

We should strictly avoid generating blocks from two different sources because it seems that it creates race conditions inside bitcoin of which "generate" RPC call wins and is actually able to produce a single chain. We generate a new block every second, hence it is likely that trying to generate 101 from a 2nd source causes problems.

To solve this, we move the ensureFunding call to the beginning of the test harness and simply fail inside the wallet if for some reason the wallet is used from a context that doesn't have the first 101 blocks generated.

This should solve some flakiness in our e2e tests when the minting on bitcoin takes ages (like here https://app.circleci.com/jobs/github/comit-network/comit-rs/3567)