### PR TITLE
Use NaiveDateTime for Predates trait

### DIFF
--- a/cnd/src/btsieve/bitcoin/mod.rs
+++ b/cnd/src/btsieve/bitcoin/mod.rs
@@ -86,7 +86,7 @@ where
         // Look back into the past (upto timestamp) for one block.
 
         if let Some(block) = oldest_block.as_ref() {
-            if !block.predates(start_of_swap.timestamp()) {
+            if !block.predates(start_of_swap) {
                 match blockchain_connector
                     .block_by_hash(block.header.prev_blockhash)
                     .compat()
@@ -174,9 +174,11 @@ pub fn decode_response<T: Decodable>(response_text: String) -> Result<T, Error> 
 }
 
 impl Predates for bitcoin::Block {
-    fn predates(&self, timestamp: i64) -> bool {
+    fn predates(&self, timestamp: NaiveDateTime) -> bool {
+        let unix_timestamp = timestamp.timestamp();
         let block_time = self.header.time as i64;
-        block_time < timestamp
+
+        block_time < unix_timestamp
     }
 }
 

--- a/cnd/src/btsieve/ethereum/mod.rs
+++ b/cnd/src/btsieve/ethereum/mod.rs
@@ -89,9 +89,8 @@ where
 
     // Look back in time until we get a block that predates start_of_swap.
     let parent_hash = block.parent_hash;
-    let start = start_of_swap.timestamp() as i64;
     walk_back_until(
-        predates_start_of_swap(start),
+        predates_start_of_swap(start_of_swap),
         connector.clone(),
         co,
         parent_hash,
@@ -115,7 +114,7 @@ where
         let parent_hash = block.parent_hash;
         if !seen_blocks.contains(&parent_hash) {
             walk_back_until(
-                seen_block_or_predates_start_of_swap(seen_blocks.clone(), start),
+                seen_block_or_predates_start_of_swap(seen_blocks.clone(), start_of_swap),
                 connector.clone(),
                 co,
                 parent_hash,
@@ -163,7 +162,7 @@ where
 
 /// Constructs a predicate that returns `true` if the given block predates the
 /// start_of_swap timestamp.
-fn predates_start_of_swap(start_of_swap: i64) -> impl Fn(&Block) -> anyhow::Result<bool> {
+fn predates_start_of_swap(start_of_swap: NaiveDateTime) -> impl Fn(&Block) -> anyhow::Result<bool> {
     move |block| Ok(block.predates(start_of_swap))
 }
 
@@ -171,7 +170,7 @@ fn predates_start_of_swap(start_of_swap: i64) -> impl Fn(&Block) -> anyhow::Resu
 /// or the block predates the start_of_swap timestamp.
 fn seen_block_or_predates_start_of_swap(
     seen_blocks: HashSet<Hash>,
-    start_of_swap: i64,
+    start_of_swap: NaiveDateTime,
 ) -> impl Fn(&Block) -> anyhow::Result<bool> {
     move |block: &Block| {
         let have_seen_block = seen_blocks.contains(
@@ -267,7 +266,9 @@ where
 }
 
 impl Predates for Block {
-    fn predates(&self, timestamp: i64) -> bool {
-        self.timestamp < U256::from(timestamp)
+    fn predates(&self, timestamp: NaiveDateTime) -> bool {
+        let unix_timestamp = timestamp.timestamp();
+
+        self.timestamp < U256::from(unix_timestamp)
     }
 }

--- a/cnd/src/btsieve/mod.rs
+++ b/cnd/src/btsieve/mod.rs
@@ -4,6 +4,7 @@
 pub mod bitcoin;
 pub mod ethereum;
 
+use chrono::NaiveDateTime;
 use futures::Future;
 
 pub trait LatestBlock: Send + Sync + 'static {
@@ -37,5 +38,5 @@ pub trait ReceiptByHash: Send + Sync + 'static {
 
 /// Checks if a given block predates a certain timestamp.
 pub trait Predates {
-    fn predates(&self, timestamp: i64) -> bool;
+    fn predates(&self, timestamp: NaiveDateTime) -> bool;
 }

--- a/cnd/src/swap_protocols/rfc003/create_swap.rs
+++ b/cnd/src/swap_protocols/rfc003/create_swap.rs
@@ -45,14 +45,12 @@ pub async fn create_swap<D, A: ActorState>(
     // construct a generator that watches alpha and beta ledger concurrently
     let mut generator = Gen::new({
         let dependencies = dependencies.clone();
-        |co| {
-            async move {
-                future::try_join(
-                    watch_alpha_ledger(&dependencies, &co, swap.alpha_htlc_params(), at),
-                    watch_beta_ledger(&dependencies, &co, swap.beta_htlc_params(), at),
-                )
-                .await
-            }
+        |co| async move {
+            future::try_join(
+                watch_alpha_ledger(&dependencies, &co, swap.alpha_htlc_params(), at),
+                watch_beta_ledger(&dependencies, &co, swap.beta_htlc_params(), at),
+            )
+            .await
         }
     });
 


### PR DESCRIPTION
This allows for a more ergonomic usage because it avoids conversion at the callsite.