### PR TITLE
Use the process field instead of the config file check if cnd is running

### DIFF
--- a/api_tests/lib_sdk/cnd_instance.ts
+++ b/api_tests/lib_sdk/cnd_instance.ts
@@ -80,10 +80,10 @@ export class CndInstance {
 
     public stop() {
         this.process.kill("SIGINT");
-        this.configFile = null; // Please see function is_running() below before changing this.
+        this.process = null;
     }
 
     public isRunning() {
-        return !this.configFile == null;
+        return this.process != null;
     }
 }


### PR DESCRIPTION
Using the process seems more natural because the process is dead anyway after it has been killed and hence, the reference to the object is worthless.