### PR TITLE
Move clippy lints to lib.rs and main.rs files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,17 +72,7 @@ build:
 	$(CARGO) build --all --all-targets $(BUILD_ARGS)
 
 clippy: install_clippy
-	$(CARGO) clippy \
-	    --all-targets \
-	    -- \
-	    -W clippy::cast_possible_truncation \
-	    -W clippy::cast_sign_loss \
-	    -W clippy::fallible_impl_from \
-	    -W clippy::cast_precision_loss \
-	    -W clippy::cast_possible_wrap \
-	    -W clippy::print_stdout \
-	    -W clippy::dbg_macro \
-	    -D warnings
+	$(CARGO) clippy --all-targets -- -D warnings
 
 test:
 	$(CARGO) test --all

--- a/cnd/src/lib.rs
+++ b/cnd/src/lib.rs
@@ -2,7 +2,14 @@
     unused_extern_crates,
     missing_debug_implementations,
     missing_copy_implementations,
-    rust_2018_idioms
+    rust_2018_idioms,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::fallible_impl_from,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_wrap,
+    clippy::print_stdout,
+    clippy::dbg_macro
 )]
 #![forbid(unsafe_code)]
 

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -1,4 +1,16 @@
-#![warn(unused_extern_crates, missing_debug_implementations, rust_2018_idioms)]
+#![warn(
+    unused_extern_crates,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    rust_2018_idioms,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::fallible_impl_from,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_wrap,
+    clippy::print_stdout,
+    clippy::dbg_macro
+)]
 #![forbid(unsafe_code)]
 use crate::cli::Options;
 use anyhow::Context;

--- a/libp2p-comit/src/frame/codec.rs
+++ b/libp2p-comit/src/frame/codec.rs
@@ -11,7 +11,7 @@ pub enum CodecError {
     IO(#[from] io::Error),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct JsonFrameCodec;
 
 impl Default for JsonFrameCodec {

--- a/libp2p-comit/src/lib.rs
+++ b/libp2p-comit/src/lib.rs
@@ -1,4 +1,16 @@
-#![warn(unused_extern_crates, missing_debug_implementations, rust_2018_idioms)]
+#![warn(
+    unused_extern_crates,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    rust_2018_idioms,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::fallible_impl_from,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_wrap,
+    clippy::print_stdout,
+    clippy::dbg_macro
+)]
 #![forbid(unsafe_code)]
 
 #[macro_use]
@@ -35,7 +47,7 @@ pub struct Frame {
     pub payload: JsonValue,
 }
 
-#[derive(Deserialize, Serialize, PartialEq, Debug)]
+#[derive(Deserialize, Serialize, PartialEq, Debug, Clone, Copy)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum FrameType {
     Request,


### PR DESCRIPTION
This aids integration with IDEs that allow to run clippy directly. Doing so makes it easier to navigate through the warnings provided by clippy which otherwise would need to be gone through manually on the commandline.

I thought I've done this at some point already but maybe that was a different repo :D