### PR TITLE
Handle swap failure

### DIFF
--- a/cnd/src/http_api/mod.rs
+++ b/cnd/src/http_api/mod.rs
@@ -9,7 +9,7 @@ mod swap_resource;
 
 pub use self::{
     problem::*,
-    swap_resource::{SwapParameters, SwapResource, SwapStatus},
+    swap_resource::{OnFail, SwapParameters, SwapResource, SwapStatus},
 };
 
 pub const PATH: &str = "swaps";

--- a/cnd/src/http_api/routes/index/handlers/get_swaps.rs
+++ b/cnd/src/http_api/routes/index/handlers/get_swaps.rs
@@ -1,6 +1,6 @@
 use crate::{
     db::{DetermineTypes, Retrieve},
-    http_api::swap_resource::{build_rfc003_siren_entity, IncludeState},
+    http_api::swap_resource::{build_rfc003_siren_entity_no_err, IncludeState},
     swap_protocols::Facade,
 };
 
@@ -10,7 +10,8 @@ pub async fn handle_get_swaps(dependencies: Facade) -> anyhow::Result<siren::Ent
     for swap in Retrieve::all(&dependencies).await?.into_iter() {
         let types = dependencies.determine_types(&swap.swap_id).await?;
 
-        let sub_entity = build_rfc003_siren_entity(&dependencies, swap, types, IncludeState::No)?;
+        let sub_entity =
+            build_rfc003_siren_entity_no_err(&dependencies, swap, types, IncludeState::No)?;
         entity.push_sub_entity(siren::SubEntity::from_entity(sub_entity, &["item"]));
     }
 

--- a/cnd/src/http_api/routes/index/handlers/get_swaps.rs
+++ b/cnd/src/http_api/routes/index/handlers/get_swaps.rs
@@ -1,6 +1,6 @@
 use crate::{
     db::{DetermineTypes, Retrieve},
-    http_api::swap_resource::{build_rfc003_siren_entity_no_err, IncludeState},
+    http_api::swap_resource::{build_rfc003_siren_entity, IncludeState, OnFail},
     swap_protocols::Facade,
 };
 
@@ -10,8 +10,13 @@ pub async fn handle_get_swaps(dependencies: Facade) -> anyhow::Result<siren::Ent
     for swap in Retrieve::all(&dependencies).await?.into_iter() {
         let types = dependencies.determine_types(&swap.swap_id).await?;
 
-        let sub_entity =
-            build_rfc003_siren_entity_no_err(&dependencies, swap, types, IncludeState::No)?;
+        let sub_entity = build_rfc003_siren_entity(
+            &dependencies,
+            swap,
+            types,
+            IncludeState::No,
+            OnFail::NoAction,
+        )?;
         entity.push_sub_entity(siren::SubEntity::from_entity(sub_entity, &["item"]));
     }
 

--- a/cnd/src/http_api/routes/rfc003/handlers/get_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/get_swap.rs
@@ -1,6 +1,6 @@
 use crate::{
     db::{DetermineTypes, Retrieve},
-    http_api::swap_resource::{build_rfc003_siren_entity_err, IncludeState},
+    http_api::swap_resource::{build_rfc003_siren_entity, IncludeState, OnFail},
     swap_protocols::{Facade, SwapId},
 };
 
@@ -8,5 +8,5 @@ pub async fn handle_get_swap(dependencies: Facade, id: SwapId) -> anyhow::Result
     let swap = Retrieve::get(&dependencies, &id).await?;
     let types = dependencies.determine_types(&id).await?;
 
-    build_rfc003_siren_entity_err(&dependencies, swap, types, IncludeState::Yes)
+    build_rfc003_siren_entity(&dependencies, swap, types, IncludeState::Yes, OnFail::Error)
 }

--- a/cnd/src/http_api/routes/rfc003/handlers/get_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/get_swap.rs
@@ -1,6 +1,6 @@
 use crate::{
     db::{DetermineTypes, Retrieve},
-    http_api::swap_resource::{build_rfc003_siren_entity, IncludeState},
+    http_api::swap_resource::{build_rfc003_siren_entity_err, IncludeState},
     swap_protocols::{Facade, SwapId},
 };
 
@@ -8,5 +8,5 @@ pub async fn handle_get_swap(dependencies: Facade, id: SwapId) -> anyhow::Result
     let swap = Retrieve::get(&dependencies, &id).await?;
     let types = dependencies.determine_types(&id).await?;
 
-    build_rfc003_siren_entity(&dependencies, swap, types, IncludeState::Yes)
+    build_rfc003_siren_entity_err(&dependencies, swap, types, IncludeState::Yes)
 }

--- a/cnd/src/http_api/swap_resource.rs
+++ b/cnd/src/http_api/swap_resource.rs
@@ -108,7 +108,7 @@ pub enum IncludeState {
     No,
 }
 
-/// Build siren entity.  For failed swaps do not return any actions.
+/// Build siren entity. For failed swaps do not return any actions.
 pub fn build_rfc003_siren_entity_no_err<S: StateStore>(
     state_store: &S,
     swap: Swap,
@@ -118,7 +118,7 @@ pub fn build_rfc003_siren_entity_no_err<S: StateStore>(
     build_rfc003_siren_entity(state_store, swap, types, include_state, false)
 }
 
-/// Build siren entity.  For failed swaps return 500 error.
+/// Build siren entity. For failed swaps return 500 error.
 pub fn build_rfc003_siren_entity_err<S: StateStore>(
     state_store: &S,
     swap: Swap,

--- a/cnd/src/swap_protocols/rfc003/actor_state.rs
+++ b/cnd/src/swap_protocols/rfc003/actor_state.rs
@@ -15,4 +15,12 @@ pub trait ActorState: Debug + Clone + Send + Sync + 'static {
 
     fn alpha_ledger_mut(&mut self) -> &mut LedgerState<Self::AL, Self::AA>;
     fn beta_ledger_mut(&mut self) -> &mut LedgerState<Self::BL, Self::BA>;
+
+    /// Returns true if the current swap failed at some stage.
+    fn swap_failed(&self) -> bool;
+
+    /// An error during swap execution results in this being called.  We
+    /// specifically do not support setting this to `false` because currently a
+    /// failed swap cannot be restarted.
+    fn set_swap_failed(&mut self);
 }

--- a/cnd/src/swap_protocols/rfc003/alice/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/mod.rs
@@ -19,6 +19,7 @@ pub struct State<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
     pub beta_ledger_state: LedgerState<BL, BA>,
     #[derivative(Debug = "ignore", PartialEq = "ignore")]
     pub secret_source: SwapSeed, // Used to derive identities and also to generate the secret.
+    pub failed: bool,
 }
 
 impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
@@ -28,6 +29,7 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
             alpha_ledger_state: LedgerState::NotDeployed,
             beta_ledger_state: LedgerState::NotDeployed,
             secret_source,
+            failed: false,
         }
     }
 
@@ -41,6 +43,7 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
             alpha_ledger_state: LedgerState::NotDeployed,
             beta_ledger_state: LedgerState::NotDeployed,
             secret_source,
+            failed: false,
         }
     }
 
@@ -54,6 +57,7 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
             alpha_ledger_state: LedgerState::NotDeployed,
             beta_ledger_state: LedgerState::NotDeployed,
             secret_source,
+            failed: false,
         }
     }
 
@@ -82,5 +86,13 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> ActorState for State<AL, BL, 
 
     fn beta_ledger_mut(&mut self) -> &mut LedgerState<BL, BA> {
         &mut self.beta_ledger_state
+    }
+
+    fn swap_failed(&self) -> bool {
+        self.failed
+    }
+
+    fn set_swap_failed(&mut self) {
+        self.failed = true;
     }
 }

--- a/cnd/src/swap_protocols/rfc003/bob/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/mod.rs
@@ -23,6 +23,7 @@ pub struct State<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
     pub beta_ledger_state: LedgerState<BL, BA>,
     #[derivative(Debug = "ignore")]
     pub secret_source: Arc<dyn DeriveIdentities>,
+    pub failed: bool, // Gets set on any error during the execution of a swap.
 }
 
 impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
@@ -35,6 +36,7 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
             alpha_ledger_state: LedgerState::NotDeployed,
             beta_ledger_state: LedgerState::NotDeployed,
             secret_source: Arc::new(secret_source),
+            failed: false,
         }
     }
 
@@ -48,6 +50,7 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
             alpha_ledger_state: LedgerState::NotDeployed,
             beta_ledger_state: LedgerState::NotDeployed,
             secret_source: Arc::new(secret_source),
+            failed: false,
         }
     }
 
@@ -61,6 +64,7 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
             alpha_ledger_state: LedgerState::NotDeployed,
             beta_ledger_state: LedgerState::NotDeployed,
             secret_source: Arc::new(secret_source),
+            failed: false,
         }
     }
 
@@ -93,5 +97,13 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> ActorState for State<AL, BL, 
 
     fn beta_ledger_mut(&mut self) -> &mut LedgerState<BL, BA> {
         &mut self.beta_ledger_state
+    }
+
+    fn swap_failed(&self) -> bool {
+        self.failed
+    }
+
+    fn set_swap_failed(&mut self) {
+        self.failed = true;
     }
 }


### PR DESCRIPTION
Currently there is no indication on the `/swap/<foo>` endpoint if there
has been an error for a given swap.  This is not useful for a user.

This problem exists for `/swaps` endpoint also but needs to be handled
differently.

Do:
- For the `/swap/<foo>` endpoint return a 500 error if the swap has erred.
- For the `/swaps` endpoint return an erred swap but do not add any
  actions.

**untested**

Fixes: #1945