### PR TITLE
Use Facade instead of trait bounds

### DIFF
--- a/cnd/src/load_swaps.rs
+++ b/cnd/src/load_swaps.rs
@@ -1,57 +1,27 @@
 #![allow(clippy::type_repetition_in_bounds)]
 use crate::{
-    asset,
     db::{DetermineTypes, LoadAcceptedSwap, Retrieve},
     init_swap::init_accepted_swap,
-    seed::DeriveSwapSeed,
-    swap_protocols::{
-        ledger::{self, Ethereum},
-        rfc003::{events::HtlcEvents, state_store::StateStore},
-    },
+    swap_protocols::Facade,
 };
 
 #[allow(clippy::cognitive_complexity)]
-pub async fn load_swaps_from_database<D>(dependencies: D) -> anyhow::Result<()>
-where
-    D: StateStore
-        + Clone
-        + DeriveSwapSeed
-        + Retrieve
-        + DetermineTypes
-        + HtlcEvents<ledger::bitcoin::Regtest, asset::Bitcoin>
-        + HtlcEvents<ledger::bitcoin::Testnet, asset::Bitcoin>
-        + HtlcEvents<ledger::bitcoin::Mainnet, asset::Bitcoin>
-        + HtlcEvents<Ethereum, asset::Ether>
-        + HtlcEvents<Ethereum, asset::Erc20>
-        + LoadAcceptedSwap<ledger::bitcoin::Regtest, Ethereum, asset::Bitcoin, asset::Ether>
-        + LoadAcceptedSwap<ledger::bitcoin::Testnet, Ethereum, asset::Bitcoin, asset::Ether>
-        + LoadAcceptedSwap<ledger::bitcoin::Mainnet, Ethereum, asset::Bitcoin, asset::Ether>
-        + LoadAcceptedSwap<Ethereum, ledger::bitcoin::Regtest, asset::Ether, asset::Bitcoin>
-        + LoadAcceptedSwap<Ethereum, ledger::bitcoin::Testnet, asset::Ether, asset::Bitcoin>
-        + LoadAcceptedSwap<Ethereum, ledger::bitcoin::Mainnet, asset::Ether, asset::Bitcoin>
-        + LoadAcceptedSwap<ledger::bitcoin::Regtest, Ethereum, asset::Bitcoin, asset::Erc20>
-        + LoadAcceptedSwap<ledger::bitcoin::Testnet, Ethereum, asset::Bitcoin, asset::Erc20>
-        + LoadAcceptedSwap<ledger::bitcoin::Mainnet, Ethereum, asset::Bitcoin, asset::Erc20>
-        + LoadAcceptedSwap<Ethereum, ledger::bitcoin::Regtest, asset::Erc20, asset::Bitcoin>
-        + LoadAcceptedSwap<Ethereum, ledger::bitcoin::Testnet, asset::Erc20, asset::Bitcoin>
-        + LoadAcceptedSwap<Ethereum, ledger::bitcoin::Mainnet, asset::Erc20, asset::Bitcoin>,
-{
+pub async fn load_swaps_from_database(facade: Facade) -> anyhow::Result<()> {
     tracing::debug!("loading swaps from database ...");
 
-    for swap in Retrieve::all(&dependencies).await?.iter() {
+    for swap in Retrieve::all(&facade).await?.iter() {
         let swap_id = swap.swap_id;
         tracing::debug!("got swap from database: {}", swap_id);
 
-        let types = DetermineTypes::determine_types(&dependencies, &swap_id).await?;
+        let types = DetermineTypes::determine_types(&facade, &swap_id).await?;
 
         with_swap_types!(types, {
             let accepted =
-                LoadAcceptedSwap::<AL, BL, AA, BA>::load_accepted_swap(&dependencies, &swap_id)
-                    .await;
+                LoadAcceptedSwap::<AL, BL, AA, BA>::load_accepted_swap(&facade, &swap_id).await;
 
             match accepted {
                 Ok(accepted) => {
-                    init_accepted_swap(&dependencies, accepted, types.role)?;
+                    init_accepted_swap(&facade, accepted, types.role)?;
                 }
                 Err(e) => tracing::error!("failed to load swap: {}, continuing ...", e),
             };


### PR DESCRIPTION
The function load_swaps_from_database is an application concern. It can know about the Facade.