### PR TITLE
Macrofy everything

### DIFF
--- a/cnd/src/swap_protocols/ledger/bitcoin.rs
+++ b/cnd/src/swap_protocols/ledger/bitcoin.rs
@@ -14,27 +14,17 @@ pub trait Bitcoin:
 {
 }
 
+impl Bitcoin for Mainnet {}
+impl Bitcoin for Testnet {}
+impl Bitcoin for Regtest {}
+
 pub trait Network {
     fn network() -> ::bitcoin::Network;
 }
 
-impl Bitcoin for Mainnet {}
-
-impl From<Mainnet> for LedgerKind {
-    fn from(_: Mainnet) -> Self {
-        LedgerKind::BitcoinMainnet
-    }
-}
 impl Network for Mainnet {
     fn network() -> ::bitcoin::Network {
         ::bitcoin::Network::Bitcoin
-    }
-}
-impl Bitcoin for Testnet {}
-
-impl From<Testnet> for LedgerKind {
-    fn from(_: Testnet) -> Self {
-        LedgerKind::BitcoinTestnet
     }
 }
 impl Network for Testnet {
@@ -42,15 +32,26 @@ impl Network for Testnet {
         ::bitcoin::Network::Testnet
     }
 }
-
-impl Bitcoin for Regtest {}
-impl From<Regtest> for LedgerKind {
-    fn from(_: Regtest) -> Self {
-        LedgerKind::BitcoinRegtest
-    }
-}
 impl Network for Regtest {
     fn network() -> ::bitcoin::Network {
         ::bitcoin::Network::Regtest
+    }
+}
+
+impl From<Mainnet> for LedgerKind {
+    fn from(_: Mainnet) -> Self {
+        LedgerKind::BitcoinMainnet
+    }
+}
+
+impl From<Testnet> for LedgerKind {
+    fn from(_: Testnet) -> Self {
+        LedgerKind::BitcoinTestnet
+    }
+}
+
+impl From<Regtest> for LedgerKind {
+    fn from(_: Regtest) -> Self {
+        LedgerKind::BitcoinRegtest
     }
 }

--- a/cnd/src/swap_protocols/ledger/bitcoin.rs
+++ b/cnd/src/swap_protocols/ledger/bitcoin.rs
@@ -36,20 +36,15 @@ impl_network!(Mainnet, bitcoin::Network::Bitcoin);
 impl_network!(Testnet, bitcoin::Network::Testnet);
 impl_network!(Regtest, bitcoin::Network::Regtest);
 
-impl From<Mainnet> for LedgerKind {
-    fn from(_: Mainnet) -> Self {
-        LedgerKind::BitcoinMainnet
-    }
+macro_rules! impl_from_for_ledgerkind {
+    ($ledger:ty, $ledger_kind:expr) => {
+        impl From<$ledger> for LedgerKind {
+            fn from(_: Mainnet) -> Self {
+                $ledger_kind
+            }
+        }
+    };
 }
-
-impl From<Testnet> for LedgerKind {
-    fn from(_: Testnet) -> Self {
-        LedgerKind::BitcoinTestnet
-    }
-}
-
-impl From<Regtest> for LedgerKind {
-    fn from(_: Regtest) -> Self {
-        LedgerKind::BitcoinRegtest
-    }
-}
+impl_from_for_ledgerkind!(Mainnet, LedgerKind::BitcoinMainnet);
+impl_from_for_ledgerkind!(Testnet, LedgerKind::BitcoinTestnet);
+impl_from_for_ledgerkind!(Regtest, LedgerKind::BitcoinRegtest);

--- a/cnd/src/swap_protocols/ledger/bitcoin.rs
+++ b/cnd/src/swap_protocols/ledger/bitcoin.rs
@@ -1,13 +1,14 @@
 use crate::comit_api::LedgerKind;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct Mainnet;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct Testnet;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct Regtest;
+macro_rules! declare_ledger {
+    ($ledger:ident) => {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+        pub struct $ledger;
+    };
+}
+declare_ledger!(Mainnet);
+declare_ledger!(Testnet);
+declare_ledger!(Regtest);
 
 pub trait Bitcoin:
     Sized + std::fmt::Debug + std::hash::Hash + Eq + Sync + Copy + Send + Into<LedgerKind> + 'static

--- a/cnd/src/swap_protocols/ledger/bitcoin.rs
+++ b/cnd/src/swap_protocols/ledger/bitcoin.rs
@@ -23,21 +23,18 @@ pub trait Network {
     fn network() -> bitcoin::Network;
 }
 
-impl Network for Mainnet {
-    fn network() -> bitcoin::Network {
-        bitcoin::Network::Bitcoin
-    }
+macro_rules! impl_network {
+    ($ledger:ty, $network:expr) => {
+        impl Network for $ledger {
+            fn network() -> bitcoin::Network {
+                $network
+            }
+        }
+    };
 }
-impl Network for Testnet {
-    fn network() -> bitcoin::Network {
-        bitcoin::Network::Testnet
-    }
-}
-impl Network for Regtest {
-    fn network() -> bitcoin::Network {
-        bitcoin::Network::Regtest
-    }
-}
+impl_network!(Mainnet, bitcoin::Network::Bitcoin);
+impl_network!(Testnet, bitcoin::Network::Testnet);
+impl_network!(Regtest, bitcoin::Network::Regtest);
 
 impl From<Mainnet> for LedgerKind {
     fn from(_: Mainnet) -> Self {

--- a/cnd/src/swap_protocols/ledger/bitcoin.rs
+++ b/cnd/src/swap_protocols/ledger/bitcoin.rs
@@ -19,22 +19,22 @@ impl Bitcoin for Testnet {}
 impl Bitcoin for Regtest {}
 
 pub trait Network {
-    fn network() -> ::bitcoin::Network;
+    fn network() -> bitcoin::Network;
 }
 
 impl Network for Mainnet {
-    fn network() -> ::bitcoin::Network {
-        ::bitcoin::Network::Bitcoin
+    fn network() -> bitcoin::Network {
+        bitcoin::Network::Bitcoin
     }
 }
 impl Network for Testnet {
-    fn network() -> ::bitcoin::Network {
-        ::bitcoin::Network::Testnet
+    fn network() -> bitcoin::Network {
+        bitcoin::Network::Testnet
     }
 }
 impl Network for Regtest {
-    fn network() -> ::bitcoin::Network {
-        ::bitcoin::Network::Regtest
+    fn network() -> bitcoin::Network {
+        bitcoin::Network::Regtest
     }
 }
 


### PR DESCRIPTION
Recent work added types for different ledgers i.e., `Mainnet`, `Testnet`, etc.  This has led to a lot of code duplication.  Do we want to macrofy everything?

We should, IMO, weigh the costs vs the benefits.  Some of these are:

### Pro
- Less code duplication
- Reduced maintenance burden because of point above
- Helps us increase our proficiency with macros
- Way less copy/pasta.  Much more enjoyable to work with both during writing and after when modifying

### Cons
- Harder to read
- Harder to write ... at first

Thoughts @comit-network/rust-devs?