### PR TITLE
Remove compiler warnings

### DIFF
--- a/cnd/src/btsieve/ethereum/transaction_pattern.rs
+++ b/cnd/src/btsieve/ethereum/transaction_pattern.rs
@@ -138,7 +138,7 @@ pub struct Topic(pub H256);
 /// E.g. this `Event` would match this `Log`:
 /// ```rust, ignore
 /// Event {
-/// address: 0xe46FB33e4DB653De84cB0E0E8b810A6c4cD39d59,
+/// address: "0xe46FB33e4DB653De84cB0E0E8b810A6c4cD39d59",
 /// data: None,
 /// topics: [
 /// None,
@@ -148,13 +148,13 @@ pub struct Topic(pub H256);
 /// ```
 /// ```rust, ignore
 /// Log:
-/// [ { address: '0xe46FB33e4DB653De84cB0E0E8b810A6c4cD39d59',
-/// data: '0x123',
+/// [ { address: "0xe46FB33e4DB653De84cB0E0E8b810A6c4cD39d59",
+/// data: "0x123",
 /// ..
 /// topics:
-/// [ '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
-/// '0x000000000000000000000000e46fb33e4db653de84cb0e0e8b810a6c4cd39d59',
-/// '0x000000000000000000000000d51ecee7414c4445534f74208538683702cbb3e4' ],
+/// [ "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+/// "0x000000000000000000000000e46fb33e4db653de84cb0e0e8b810a6c4cd39d59",
+/// "0x000000000000000000000000d51ecee7414c4445534f74208538683702cbb3e4" ],
 /// },
 /// .. ] //Other data omitted
 /// }


### PR DESCRIPTION
saw these warning in our CI and removed them: 


```
error: character literal may only contain one codepoint
 --> <doctest>:2:14
  |
2 | [ { address: '0xe46FB33e4DB653De84cB0E0E8b810A6c4cD39d59',
  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
help: if you meant to write a `str` literal, use double quotes
  |
2 | [ { address: "0xe46FB33e4DB653De84cB0E0E8b810A6c4cD39d59",
  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: character literal may only contain one codepoint
 --> <doctest>:3:7
  |
3 | data: '0x123',
  |       ^^^^^^^
  |
help: if you meant to write a `str` literal, use double quotes
  |
3 | data: "0x123",
  |       ^^^^^^^

error: character literal may only contain one codepoint
 --> <doctest>:6:3
  |
6 | [ '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
help: if you meant to write a `str` literal, use double quotes
  |
6 | [ "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: character literal may only contain one codepoint
 --> <doctest>:7:1
  |
7 | '0x000000000000000000000000e46fb33e4db653de84cb0e0e8b810a6c4cd39d59',
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
help: if you meant to write a `str` literal, use double quotes
  |
7 | "0x000000000000000000000000e46fb33e4db653de84cb0e0e8b810a6c4cd39d59",
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: character literal may only contain one codepoint
 --> <doctest>:8:1
  |
8 | '0x000000000000000000000000d51ecee7414c4445534f74208538683702cbb3e4' ],
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
help: if you meant to write a `str` literal, use double quotes
  |
8 | "0x000000000000000000000000d51ecee7414c4445534f74208538683702cbb3e4" ],
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: character literal may only contain one codepoint
 --> <doctest>:2:14
  |
2 | [ { address: '0xe46FB33e4DB653De84cB0E0E8b810A6c4cD39d59',
  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
help: if you meant to write a `str` literal, use double quotes
  |
2 | [ { address: "0xe46FB33e4DB653De84cB0E0E8b810A6c4cD39d59",
  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: character literal may only contain one codepoint
 --> <doctest>:3:7
  |
3 | data: '0x123',
  |       ^^^^^^^
  |
help: if you meant to write a `str` literal, use double quotes
  |
3 | data: "0x123",
  |       ^^^^^^^

error: character literal may only contain one codepoint
 --> <doctest>:6:3
  |
6 | [ '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
help: if you meant to write a `str` literal, use double quotes
  |
6 | [ "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: character literal may only contain one codepoint
 --> <doctest>:7:1
  |
7 | '0x000000000000000000000000e46fb33e4db653de84cb0e0e8b810a6c4cd39d59',
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
help: if you meant to write a `str` literal, use double quotes
  |
7 | "0x000000000000000000000000e46fb33e4db653de84cb0e0e8b810a6c4cd39d59",
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: character literal may only contain one codepoint
 --> <doctest>:8:1
  |
8 | '0x000000000000000000000000d51ecee7414c4445534f74208538683702cbb3e4' ],
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
help: if you meant to write a `str` literal, use double quotes
  |
8 | "0x000000000000000000000000d51ecee7414c4445534f74208538683702cbb3e4" ],
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: character literal may only contain one codepoint
 --> <rustdoc-highlighting>:2:14
  |
2 | [ { address: '0xe46FB33e4DB653De84cB0E0E8b810A6c4cD39d59',
  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
help: if you meant to write a `str` literal, use double quotes
  |
2 | [ { address: "0xe46FB33e4DB653De84cB0E0E8b810A6c4cD39d59",
  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: character literal may only contain one codepoint
 --> <rustdoc-highlighting>:3:7
  |
3 | data: '0x123',
  |       ^^^^^^^
  |
help: if you meant to write a `str` literal, use double quotes
  |
3 | data: "0x123",
  |       ^^^^^^^

error: character literal may only contain one codepoint
 --> <rustdoc-highlighting>:6:3
  |
6 | [ '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
help: if you meant to write a `str` literal, use double quotes
  |
6 | [ "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: character literal may only contain one codepoint
 --> <rustdoc-highlighting>:7:1
  |
7 | '0x000000000000000000000000e46fb33e4db653de84cb0e0e8b810a6c4cd39d59',
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
help: if you meant to write a `str` literal, use double quotes
  |
7 | "0x000000000000000000000000e46fb33e4db653de84cb0e0e8b810a6c4cd39d59",
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: character literal may only contain one codepoint
 --> <rustdoc-highlighting>:8:1
  |
8 | '0x000000000000000000000000d51ecee7414c4445534f74208538683702cbb3e4' ],
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
help: if you meant to write a `str` literal, use double quotes
  |
8 | "0x000000000000000000000000d51ecee7414c4445534f74208538683702cbb3e4" ],
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```