### PR TITLE
api_test: Fix bitcoind/parity log wait

### DIFF
--- a/api_tests/lib/log_reader.ts
+++ b/api_tests/lib/log_reader.ts
@@ -4,8 +4,13 @@ export class LogReader {
     private tail: Tail;
 
     constructor(logFile: string) {
-        const options = { fromBeginning: true, follow: true };
+        // By default tail uses `fs.watch` that watches the inode
+        // However, it looks like on Mac OS, the inode get changed at some point
+        // To counter that then we use `fs.watchFile` which is actually considered
+        // less efficient. Hence only using it on Mac.
+        const useWatchFile = process.platform === "darwin" ? true : false;
 
+        const options = { fromBeginning: true, follow: true, useWatchFile };
         this.tail = new Tail(logFile, options);
     }
 


### PR DESCRIPTION
There are issues on Mac where it waits undefinitely for the right light for both nodes despite the line being present in the file.

See https://github.com/nodejs/node/issues/5039 for more info.