### PR TITLE
Use SIGKILL instead of SIGINT to kill parity node

### DIFF
--- a/api_tests/lib/parity_instance.ts
+++ b/api_tests/lib/parity_instance.ts
@@ -53,6 +53,6 @@ export class ParityInstance implements LedgerInstance {
     }
 
     public stop() {
-        this.process.kill("SIGINT");
+        this.process.kill("SIGKILL");
     }
 }

--- a/api_tests/lib/parity_instance.ts
+++ b/api_tests/lib/parity_instance.ts
@@ -4,6 +4,7 @@ import tmp from "tmp";
 import { promisify } from "util";
 import { LedgerInstance } from "./ledger_runner";
 import { LogReader } from "./log_reader";
+import { sleep } from "./util";
 
 const openAsync = promisify(fs.open);
 
@@ -52,7 +53,9 @@ export class ParityInstance implements LedgerInstance {
         return this;
     }
 
-    public stop() {
+    public async stop() {
+        this.process.kill("SIGTERM");
+        await sleep(3000);
         this.process.kill("SIGKILL");
     }
 }


### PR DESCRIPTION
I had problems with multiple parity instances being alive on my Mac.
This solves the problem, should not affect Linux.

I tested this by running single tests, i.e. `yarn run test e2e/rfc003/btc_eth/happy.ts` in `api_tests` folder and with `SIGINT` and `SIGTERM` the instance is almost never killed properly on my machine.