### PR TITLE
Unroll Bitcoin trait

### DIFF
--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -103,15 +103,13 @@ where
 }
 
 #[async_trait::async_trait]
-impl<B: ledger::bitcoin::Bitcoin + ledger::bitcoin::Network> HtlcFunded<B, asset::Bitcoin>
-    for Facade
-{
+impl HtlcFunded<ledger::bitcoin::Mainnet, asset::Bitcoin> for Facade {
     async fn htlc_funded(
         &self,
-        htlc_params: HtlcParams<B, asset::Bitcoin>,
-        htlc_deployment: &Deployed<B>,
+        htlc_params: HtlcParams<ledger::bitcoin::Mainnet, asset::Bitcoin>,
+        htlc_deployment: &Deployed<ledger::bitcoin::Mainnet>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Funded<B, asset::Bitcoin>> {
+    ) -> anyhow::Result<Funded<ledger::bitcoin::Mainnet, asset::Bitcoin>> {
         self.bitcoin_connector
             .htlc_funded(htlc_params, htlc_deployment, start_of_swap)
             .await
@@ -119,14 +117,40 @@ impl<B: ledger::bitcoin::Bitcoin + ledger::bitcoin::Network> HtlcFunded<B, asset
 }
 
 #[async_trait::async_trait]
-impl<B: ledger::bitcoin::Bitcoin + ledger::bitcoin::Network> HtlcDeployed<B, asset::Bitcoin>
-    for Facade
-{
+impl HtlcFunded<ledger::bitcoin::Testnet, asset::Bitcoin> for Facade {
+    async fn htlc_funded(
+        &self,
+        htlc_params: HtlcParams<ledger::bitcoin::Testnet, asset::Bitcoin>,
+        htlc_deployment: &Deployed<ledger::bitcoin::Testnet>,
+        start_of_swap: NaiveDateTime,
+    ) -> anyhow::Result<Funded<ledger::bitcoin::Testnet, asset::Bitcoin>> {
+        self.bitcoin_connector
+            .htlc_funded(htlc_params, htlc_deployment, start_of_swap)
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl HtlcFunded<ledger::bitcoin::Regtest, asset::Bitcoin> for Facade {
+    async fn htlc_funded(
+        &self,
+        htlc_params: HtlcParams<ledger::bitcoin::Regtest, asset::Bitcoin>,
+        htlc_deployment: &Deployed<ledger::bitcoin::Regtest>,
+        start_of_swap: NaiveDateTime,
+    ) -> anyhow::Result<Funded<ledger::bitcoin::Regtest, asset::Bitcoin>> {
+        self.bitcoin_connector
+            .htlc_funded(htlc_params, htlc_deployment, start_of_swap)
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl HtlcDeployed<ledger::bitcoin::Mainnet, asset::Bitcoin> for Facade {
     async fn htlc_deployed(
         &self,
-        htlc_params: HtlcParams<B, asset::Bitcoin>,
+        htlc_params: HtlcParams<ledger::bitcoin::Mainnet, asset::Bitcoin>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Deployed<B>> {
+    ) -> anyhow::Result<Deployed<ledger::bitcoin::Mainnet>> {
         self.bitcoin_connector
             .htlc_deployed(htlc_params, start_of_swap)
             .await
@@ -134,15 +158,39 @@ impl<B: ledger::bitcoin::Bitcoin + ledger::bitcoin::Network> HtlcDeployed<B, ass
 }
 
 #[async_trait::async_trait]
-impl<B: ledger::bitcoin::Bitcoin + ledger::bitcoin::Network> HtlcRedeemed<B, asset::Bitcoin>
-    for Facade
-{
+impl HtlcDeployed<ledger::bitcoin::Testnet, asset::Bitcoin> for Facade {
+    async fn htlc_deployed(
+        &self,
+        htlc_params: HtlcParams<ledger::bitcoin::Testnet, asset::Bitcoin>,
+        start_of_swap: NaiveDateTime,
+    ) -> anyhow::Result<Deployed<ledger::bitcoin::Testnet>> {
+        self.bitcoin_connector
+            .htlc_deployed(htlc_params, start_of_swap)
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl HtlcDeployed<ledger::bitcoin::Regtest, asset::Bitcoin> for Facade {
+    async fn htlc_deployed(
+        &self,
+        htlc_params: HtlcParams<ledger::bitcoin::Regtest, asset::Bitcoin>,
+        start_of_swap: NaiveDateTime,
+    ) -> anyhow::Result<Deployed<ledger::bitcoin::Regtest>> {
+        self.bitcoin_connector
+            .htlc_deployed(htlc_params, start_of_swap)
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl HtlcRedeemed<ledger::bitcoin::Mainnet, asset::Bitcoin> for Facade {
     async fn htlc_redeemed(
         &self,
-        htlc_params: HtlcParams<B, asset::Bitcoin>,
-        htlc_deployment: &Deployed<B>,
+        htlc_params: HtlcParams<ledger::bitcoin::Mainnet, asset::Bitcoin>,
+        htlc_deployment: &Deployed<ledger::bitcoin::Mainnet>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Redeemed<B>> {
+    ) -> anyhow::Result<Redeemed<ledger::bitcoin::Mainnet>> {
         self.bitcoin_connector
             .htlc_redeemed(htlc_params, htlc_deployment, start_of_swap)
             .await
@@ -150,15 +198,69 @@ impl<B: ledger::bitcoin::Bitcoin + ledger::bitcoin::Network> HtlcRedeemed<B, ass
 }
 
 #[async_trait::async_trait]
-impl<B: ledger::bitcoin::Bitcoin + ledger::bitcoin::Network> HtlcRefunded<B, asset::Bitcoin>
-    for Facade
-{
+impl HtlcRedeemed<ledger::bitcoin::Testnet, asset::Bitcoin> for Facade {
+    async fn htlc_redeemed(
+        &self,
+        htlc_params: HtlcParams<ledger::bitcoin::Testnet, asset::Bitcoin>,
+        htlc_deployment: &Deployed<ledger::bitcoin::Testnet>,
+        start_of_swap: NaiveDateTime,
+    ) -> anyhow::Result<Redeemed<ledger::bitcoin::Testnet>> {
+        self.bitcoin_connector
+            .htlc_redeemed(htlc_params, htlc_deployment, start_of_swap)
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl HtlcRedeemed<ledger::bitcoin::Regtest, asset::Bitcoin> for Facade {
+    async fn htlc_redeemed(
+        &self,
+        htlc_params: HtlcParams<ledger::bitcoin::Regtest, asset::Bitcoin>,
+        htlc_deployment: &Deployed<ledger::bitcoin::Regtest>,
+        start_of_swap: NaiveDateTime,
+    ) -> anyhow::Result<Redeemed<ledger::bitcoin::Regtest>> {
+        self.bitcoin_connector
+            .htlc_redeemed(htlc_params, htlc_deployment, start_of_swap)
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl HtlcRefunded<ledger::bitcoin::Mainnet, asset::Bitcoin> for Facade {
     async fn htlc_refunded(
         &self,
-        htlc_params: HtlcParams<B, asset::Bitcoin>,
-        htlc_deployment: &Deployed<B>,
+        htlc_params: HtlcParams<ledger::bitcoin::Mainnet, asset::Bitcoin>,
+        htlc_deployment: &Deployed<ledger::bitcoin::Mainnet>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Refunded<B>> {
+    ) -> anyhow::Result<Refunded<ledger::bitcoin::Mainnet>> {
+        self.bitcoin_connector
+            .htlc_refunded(htlc_params, htlc_deployment, start_of_swap)
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl HtlcRefunded<ledger::bitcoin::Testnet, asset::Bitcoin> for Facade {
+    async fn htlc_refunded(
+        &self,
+        htlc_params: HtlcParams<ledger::bitcoin::Testnet, asset::Bitcoin>,
+        htlc_deployment: &Deployed<ledger::bitcoin::Testnet>,
+        start_of_swap: NaiveDateTime,
+    ) -> anyhow::Result<Refunded<ledger::bitcoin::Testnet>> {
+        self.bitcoin_connector
+            .htlc_refunded(htlc_params, htlc_deployment, start_of_swap)
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl HtlcRefunded<ledger::bitcoin::Regtest, asset::Bitcoin> for Facade {
+    async fn htlc_refunded(
+        &self,
+        htlc_params: HtlcParams<ledger::bitcoin::Regtest, asset::Bitcoin>,
+        htlc_deployment: &Deployed<ledger::bitcoin::Regtest>,
+        start_of_swap: NaiveDateTime,
+    ) -> anyhow::Result<Refunded<ledger::bitcoin::Regtest>> {
         self.bitcoin_connector
             .htlc_refunded(htlc_params, htlc_deployment, start_of_swap)
             .await

--- a/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
@@ -20,15 +20,15 @@ use anyhow::Context;
 use chrono::NaiveDateTime;
 
 #[async_trait::async_trait]
-impl<Bitcoin: bitcoin::Bitcoin + bitcoin::Network> HtlcFunded<Bitcoin, asset::Bitcoin>
+impl<B: bitcoin::Bitcoin + bitcoin::Network> HtlcFunded<B, asset::Bitcoin>
     for Cache<BitcoindConnector>
 {
     async fn htlc_funded(
         &self,
-        _htlc_params: HtlcParams<Bitcoin, asset::Bitcoin>,
-        htlc_deployment: &Deployed<Bitcoin>,
+        _htlc_params: HtlcParams<B, asset::Bitcoin>,
+        htlc_deployment: &Deployed<B>,
         _start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Funded<Bitcoin, asset::Bitcoin>> {
+    ) -> anyhow::Result<Funded<B, asset::Bitcoin>> {
         let tx = &htlc_deployment.transaction;
         let asset =
             asset::Bitcoin::from_sat(tx.output[htlc_deployment.location.vout as usize].value);
@@ -41,14 +41,14 @@ impl<Bitcoin: bitcoin::Bitcoin + bitcoin::Network> HtlcFunded<Bitcoin, asset::Bi
 }
 
 #[async_trait::async_trait]
-impl<Bitcoin: bitcoin::Bitcoin + bitcoin::Network> HtlcDeployed<Bitcoin, asset::Bitcoin>
+impl<B: bitcoin::Bitcoin + bitcoin::Network> HtlcDeployed<B, asset::Bitcoin>
     for Cache<BitcoindConnector>
 {
     async fn htlc_deployed(
         &self,
-        htlc_params: HtlcParams<Bitcoin, asset::Bitcoin>,
+        htlc_params: HtlcParams<B, asset::Bitcoin>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Deployed<Bitcoin>> {
+    ) -> anyhow::Result<Deployed<B>> {
         let connector = self.clone();
         let pattern = TransactionPattern {
             to_address: Some(htlc_params.compute_address()),
@@ -75,15 +75,15 @@ impl<Bitcoin: bitcoin::Bitcoin + bitcoin::Network> HtlcDeployed<Bitcoin, asset::
 }
 
 #[async_trait::async_trait]
-impl<Bitcoin: bitcoin::Bitcoin + bitcoin::Network> HtlcRedeemed<Bitcoin, asset::Bitcoin>
+impl<B: bitcoin::Bitcoin + bitcoin::Network> HtlcRedeemed<B, asset::Bitcoin>
     for Cache<BitcoindConnector>
 {
     async fn htlc_redeemed(
         &self,
-        htlc_params: HtlcParams<Bitcoin, asset::Bitcoin>,
-        htlc_deployment: &Deployed<Bitcoin>,
+        htlc_params: HtlcParams<B, asset::Bitcoin>,
+        htlc_deployment: &Deployed<B>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Redeemed<Bitcoin>> {
+    ) -> anyhow::Result<Redeemed<B>> {
         let connector = self.clone();
         let pattern = TransactionPattern {
             to_address: None,
@@ -105,15 +105,15 @@ impl<Bitcoin: bitcoin::Bitcoin + bitcoin::Network> HtlcRedeemed<Bitcoin, asset::
 }
 
 #[async_trait::async_trait]
-impl<Bitcoin: bitcoin::Bitcoin + bitcoin::Network> HtlcRefunded<Bitcoin, asset::Bitcoin>
+impl<B: bitcoin::Bitcoin + bitcoin::Network> HtlcRefunded<B, asset::Bitcoin>
     for Cache<BitcoindConnector>
 {
     async fn htlc_refunded(
         &self,
-        _htlc_params: HtlcParams<Bitcoin, asset::Bitcoin>,
-        htlc_deployment: &Deployed<Bitcoin>,
+        _htlc_params: HtlcParams<B, asset::Bitcoin>,
+        htlc_deployment: &Deployed<B>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Refunded<Bitcoin>> {
+    ) -> anyhow::Result<Refunded<B>> {
         let connector = self.clone();
         let pattern = TransactionPattern {
             to_address: None,

--- a/cnd/src/swap_protocols/rfc003/bitcoin/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bitcoin/mod.rs
@@ -2,7 +2,10 @@ mod extract_secret;
 mod htlc_events;
 
 use crate::swap_protocols::{
-    ledger,
+    ledger::{
+        self,
+        bitcoin::{Mainnet, Regtest, Testnet},
+    },
     rfc003::{create_swap::HtlcParams, Ledger},
 };
 use ::bitcoin::{
@@ -15,6 +18,24 @@ pub use self::htlc_events::*;
 use crate::{asset, bitcoin::PublicKey};
 
 impl<B: ledger::Bitcoin> Ledger for B {
+    type HtlcLocation = OutPoint;
+    type Identity = PublicKey;
+    type Transaction = Transaction;
+}
+
+impl Ledger for Mainnet {
+    type HtlcLocation = OutPoint;
+    type Identity = PublicKey;
+    type Transaction = Transaction;
+}
+
+impl Ledger for Testnet {
+    type HtlcLocation = OutPoint;
+    type Identity = PublicKey;
+    type Transaction = Transaction;
+}
+
+impl Ledger for Regtest {
     type HtlcLocation = OutPoint;
     type Identity = PublicKey;
     type Transaction = Transaction;


### PR DESCRIPTION
    Currently we are using a trait bound bound to `Bitcoin`.  Due to the
    fact that rustc does not use trait bounds when differentiating impl
    blocks this is currently buggy, the impl blocks are actually blanket
    implementations.  This currently works because we only use the
    implementations for the bitcoin side, as soon as we try to add the
    ethereum side this breaks.

    Attempt to unroll the `Bitcoin` trait and use concrete network types.
    This all goes ok until we get to the database layer.  Here we cannot
    unroll it because our current db implementation does not allow different
    types to be in the same column (by design).  With concrete network types
    all the database tables break - we would need to 'unroll' the tables
    also i.e., triple the tables, one for each network.
