### PR TITLE
Do not match failed eth tx

### DIFF
--- a/api_tests/e2e/rfc003/eth_btc/ignore_fail_eth_transactions.ts
+++ b/api_tests/e2e/rfc003/eth_btc/ignore_fail_eth_transactions.ts
@@ -9,7 +9,7 @@ setTimeout(function() {
         await alice.sendRequest(AssetKind.Ether, AssetKind.Bitcoin);
         await bob.accept();
 
-        await alice.fundLowGas();
+        await alice.fundLowGas("0x1b000");
 
         await alice.assertAlphaNotDeployed();
         await bob.assertAlphaNotDeployed();

--- a/api_tests/e2e/rfc003/eth_btc/ignore_fail_eth_transactions.ts
+++ b/api_tests/e2e/rfc003/eth_btc/ignore_fail_eth_transactions.ts
@@ -1,0 +1,21 @@
+import { twoActorTest } from "../../../lib_sdk/actor_test";
+import { AssetKind } from "../../../lib_sdk/asset";
+
+setTimeout(function() {
+    twoActorTest("rfc003-eth-btc-alpha-deploy-fails", async function({
+        alice,
+        bob,
+    }) {
+        await alice.sendRequest(AssetKind.Ether, AssetKind.Bitcoin);
+        await bob.accept();
+
+        await alice.fundLowGas();
+
+        await alice.assertAlphaNotDeployed();
+        await bob.assertAlphaNotDeployed();
+        await bob.assertBetaNotDeployed();
+        await alice.assertBetaNotDeployed();
+    });
+
+    run();
+}, 0);

--- a/api_tests/lib_sdk/actors/actor.ts
+++ b/api_tests/lib_sdk/actors/actor.ts
@@ -241,18 +241,23 @@ export class Actor {
         }
     }
 
-    public async fundLowGas() {
+    public async fundLowGas(hexGasLimit: string) {
         const response = await this.swap.tryExecuteAction("fund", {
             maxTimeoutSecs: 10,
             tryIntervalSecs: 1,
         });
-        response.data.payload.gas_limit = "0x1DBC8";
+        response.data.payload.gas_limit = hexGasLimit;
         const txid = await this.swap.doLedgerAction(response.data);
         this.logger.debug(
             "Deployed with low gas swap %s in %s",
             this.swap.self,
             txid
         );
+
+        const status = await this.wallets.ethereum.getTransactionStatus(txid);
+        if (status !== 0) {
+            throw new Error("Deploy with low gas transaction was successful.");
+        }
     }
 
     public async overfund() {

--- a/api_tests/lib_sdk/actors/actor.ts
+++ b/api_tests/lib_sdk/actors/actor.ts
@@ -241,6 +241,20 @@ export class Actor {
         }
     }
 
+    public async fundLowGas() {
+        const response = await this.swap.tryExecuteAction("fund", {
+            maxTimeoutSecs: 10,
+            tryIntervalSecs: 1,
+        });
+        response.data.payload.gas_limit = "0x1DBC8";
+        const txid = await this.swap.doLedgerAction(response.data);
+        this.logger.debug(
+            "Deployed with low gas swap %s in %s",
+            this.swap.self,
+            txid
+        );
+    }
+
     public async overfund() {
         const response = await this.swap.tryExecuteAction("fund", {
             maxTimeoutSecs: 10,

--- a/api_tests/lib_sdk/actors/actor.ts
+++ b/api_tests/lib_sdk/actors/actor.ts
@@ -446,10 +446,12 @@ export class Actor {
     }
 
     public async assertAlphaNotDeployed() {
+        await sleep(3000); // It is meaningless to assert before cnd processes a new block
         await this.assertLedgerState("alpha_ledger", "NOT_DEPLOYED");
     }
 
     public async assertBetaNotDeployed() {
+        await sleep(3000); // It is meaningless to assert before cnd processes a new block
         await this.assertLedgerState("beta_ledger", "NOT_DEPLOYED");
     }
 

--- a/api_tests/lib_sdk/utils.ts
+++ b/api_tests/lib_sdk/utils.ts
@@ -1,6 +1,6 @@
-export async function sleep(time: number) {
+export async function sleep(ms: number) {
     return new Promise(res => {
-        setTimeout(res, time);
+        setTimeout(res, ms);
     });
 }
 


### PR DESCRIPTION
I think I need #1996 first to be able to test that because rust-web3 lib fails the RPC call if there is not enough gas (meaning, I have difficulties to get a failed tx in the block). Hence I think it'd work if I am able to override the gas limit used to deploy the contract.

I found this bug because with #1985, I had a _out of gas_ issue at the htlc deployment but both Alice and Bob did "see" the deployment and could not see the redeem/refund.

Of course, redeem/refund was totally failing as the contract was not deployed at all.

Yes, this is a critical bug 🐛☠️☹️

Note: I believe this only applies to deploy as I don't think we would get the transaction in the block for a `revert` due to failed redeem/refund.

Note: Bug is proven with the [new test failing](https://github.com/comit-network/comit-rs/pull/2000/commits/623d846f287f89ebe5f105446080d383eee88881) at commit 623d846f287f89ebe5f105446080d383eee88881.