### PR TITLE
Do not match failed Ethereum transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Ensure that failed Ethereum transactions are ignored during a swap.
+
 ### Changed
 - Upgrade `blockchain-contracts` crate to 0.3.1. Ether and Erc20 HTLCs now use `revert` to fail the Ethereum transaction if the redeem or refund are unsuccessful.
 

--- a/api_tests/e2e/rfc003/eth_btc/ignore_fail_eth_transactions.ts
+++ b/api_tests/e2e/rfc003/eth_btc/ignore_fail_eth_transactions.ts
@@ -9,7 +9,7 @@ setTimeout(function() {
         await alice.sendRequest(AssetKind.Ether, AssetKind.Bitcoin);
         await bob.accept();
 
-        await alice.fundLowGas();
+        await alice.fundLowGas("0x1b000");
 
         await alice.assertAlphaNotDeployed();
         await bob.assertAlphaNotDeployed();

--- a/api_tests/e2e/rfc003/eth_btc/ignore_fail_eth_transactions.ts
+++ b/api_tests/e2e/rfc003/eth_btc/ignore_fail_eth_transactions.ts
@@ -1,0 +1,21 @@
+import { twoActorTest } from "../../../lib_sdk/actor_test";
+import { AssetKind } from "../../../lib_sdk/asset";
+
+setTimeout(function() {
+    twoActorTest("rfc003-eth-btc-alpha-deploy-fails", async function({
+        alice,
+        bob,
+    }) {
+        await alice.sendRequest(AssetKind.Ether, AssetKind.Bitcoin);
+        await bob.accept();
+
+        await alice.fundLowGas();
+
+        await alice.assertAlphaNotDeployed();
+        await bob.assertAlphaNotDeployed();
+        await bob.assertBetaNotDeployed();
+        await alice.assertBetaNotDeployed();
+    });
+
+    run();
+}, 0);

--- a/api_tests/lib_sdk/actors/actor.ts
+++ b/api_tests/lib_sdk/actors/actor.ts
@@ -241,18 +241,23 @@ export class Actor {
         }
     }
 
-    public async fundLowGas() {
+    public async fundLowGas(hexGasLimit: string) {
         const response = await this.swap.tryExecuteAction("fund", {
             maxTimeoutSecs: 10,
             tryIntervalSecs: 1,
         });
-        response.data.payload.gas_limit = "0x1DBC8";
+        response.data.payload.gas_limit = hexGasLimit;
         const txid = await this.swap.doLedgerAction(response.data);
         this.logger.debug(
             "Deployed with low gas swap %s in %s",
             this.swap.self,
             txid
         );
+
+        const status = await this.wallets.ethereum.getTransactionStatus(txid);
+        if (status !== 0) {
+            throw new Error("Deploy with low gas transaction was successful.");
+        }
     }
 
     public async overfund() {

--- a/api_tests/lib_sdk/actors/actor.ts
+++ b/api_tests/lib_sdk/actors/actor.ts
@@ -241,6 +241,20 @@ export class Actor {
         }
     }
 
+    public async fundLowGas() {
+        const response = await this.swap.tryExecuteAction("fund", {
+            maxTimeoutSecs: 10,
+            tryIntervalSecs: 1,
+        });
+        response.data.payload.gas_limit = "0x1DBC8";
+        const txid = await this.swap.doLedgerAction(response.data);
+        this.logger.debug(
+            "Deployed with low gas swap %s in %s",
+            this.swap.self,
+            txid
+        );
+    }
+
     public async overfund() {
         const response = await this.swap.tryExecuteAction("fund", {
             maxTimeoutSecs: 10,

--- a/api_tests/lib_sdk/actors/actor.ts
+++ b/api_tests/lib_sdk/actors/actor.ts
@@ -446,10 +446,12 @@ export class Actor {
     }
 
     public async assertAlphaNotDeployed() {
+        await sleep(3000); // It is meaningless to assert before cnd processes a new block
         await this.assertLedgerState("alpha_ledger", "NOT_DEPLOYED");
     }
 
     public async assertBetaNotDeployed() {
+        await sleep(3000); // It is meaningless to assert before cnd processes a new block
         await this.assertLedgerState("beta_ledger", "NOT_DEPLOYED");
     }
 

--- a/api_tests/lib_sdk/utils.ts
+++ b/api_tests/lib_sdk/utils.ts
@@ -1,6 +1,6 @@
-export async function sleep(time: number) {
+export async function sleep(ms: number) {
     return new Promise(res => {
-        setTimeout(res, time);
+        setTimeout(res, ms);
     });
 }
 

--- a/cnd/src/swap_protocols/rfc003/actions/erc20.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/erc20.rs
@@ -11,7 +11,16 @@ use crate::{
 use blockchain_contracts::ethereum::rfc003::erc20_htlc::Erc20Htlc;
 
 pub fn deploy_action(htlc_params: HtlcParams<Ethereum, asset::Erc20>) -> DeployContract {
-    htlc_params.into()
+    let chain_id = htlc_params.ledger.chain_id;
+    let htlc = Erc20Htlc::from(htlc_params);
+    let gas_limit = Erc20Htlc::deploy_tx_gas_limit();
+
+    DeployContract {
+        data: htlc.into(),
+        amount: asset::Ether::zero(),
+        gas_limit: gas_limit.into(),
+        chain_id,
+    }
 }
 
 pub fn fund_action(

--- a/cnd/src/swap_protocols/rfc003/actions/ether.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/ether.rs
@@ -17,7 +17,15 @@ impl FundAction<Ethereum, asset::Ether> for (Ethereum, asset::Ether) {
     type FundActionOutput = DeployContract;
 
     fn fund_action(htlc_params: HtlcParams<Ethereum, asset::Ether>) -> Self::FundActionOutput {
-        htlc_params.into()
+        let htlc = EtherHtlc::from(htlc_params.clone());
+        let gas_limit = EtherHtlc::deploy_tx_gas_limit();
+
+        DeployContract {
+            data: htlc.into(),
+            amount: htlc_params.asset.clone(),
+            gas_limit: gas_limit.into(),
+            chain_id: htlc_params.ledger.chain_id,
+        }
     }
 }
 impl RefundAction<Ethereum, asset::Ether> for (Ethereum, asset::Ether) {

--- a/cnd/src/swap_protocols/rfc003/ethereum/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/ethereum/mod.rs
@@ -4,7 +4,6 @@ use crate::{
     asset,
     ethereum::{Address, Bytes, Transaction},
     swap_protocols::{
-        actions::ethereum::DeployContract,
         ledger::Ethereum,
         rfc003::{create_swap::HtlcParams, Ledger},
     },
@@ -92,34 +91,5 @@ impl From<HtlcParams<Ethereum, asset::Erc20>> for Erc20Htlc {
 impl HtlcParams<Ethereum, asset::Erc20> {
     pub fn bytecode(self) -> Bytes {
         Erc20Htlc::from(self).into()
-    }
-}
-
-impl From<HtlcParams<Ethereum, asset::Ether>> for DeployContract {
-    fn from(htlc_params: HtlcParams<Ethereum, asset::Ether>) -> Self {
-        let htlc = EtherHtlc::from(htlc_params.clone());
-        let gas_limit = EtherHtlc::deploy_tx_gas_limit();
-
-        DeployContract {
-            data: htlc.into(),
-            amount: htlc_params.asset.clone(),
-            gas_limit: gas_limit.into(),
-            chain_id: htlc_params.ledger.chain_id,
-        }
-    }
-}
-
-impl From<HtlcParams<Ethereum, asset::Erc20>> for DeployContract {
-    fn from(htlc_params: HtlcParams<Ethereum, asset::Erc20>) -> Self {
-        let chain_id = htlc_params.ledger.chain_id;
-        let htlc = Erc20Htlc::from(htlc_params);
-        let gas_limit = Erc20Htlc::deploy_tx_gas_limit();
-
-        DeployContract {
-            data: htlc.into(),
-            amount: asset::Ether::zero(),
-            gas_limit: gas_limit.into(),
-            chain_id,
-        }
     }
 }

--- a/cnd/tests/ethereum_pattern.rs
+++ b/cnd/tests/ethereum_pattern.rs
@@ -1,7 +1,7 @@
 pub mod ethereum_helper;
 
 use cnd::{
-    btsieve::ethereum::{Event, Topic, TransactionPattern},
+    btsieve::ethereum::{Event, Topic, TransactionPattern, TRANSACTION_STATUS_OK},
     ethereum::{Address, Block, Bytes, Transaction, TransactionReceipt},
 };
 use spectral::prelude::*;
@@ -35,8 +35,11 @@ fn cannot_skip_block_containing_transaction_with_event() {
 fn pattern_matches_block(pattern: TransactionPattern) -> bool {
     let block: Block<Transaction> = include_json_test_data!("./test_data/ethereum/block.json");
 
+    let mut receipt = TransactionReceipt::default();
+    receipt.status = Some(TRANSACTION_STATUS_OK.into());
+
     for transaction in block.transactions.into_iter() {
-        if pattern.matches(&transaction, None) {
+        if pattern.matches(&transaction, &receipt) {
             return true;
         }
     }


### PR DESCRIPTION
_Replaces #2000 because the force pushes were starting to get ugly_

I found this bug because with #1985, I had a _out of gas_ issue at the htlc deployment but both Alice and Bob did "see" the deployment and could not see the redeem/refund.

Of course, redeem/refund was totally failing as the contract was not deployed at all.

Yes, this is a critical bug 🐛☠️☹️

Note: I believe this only applies to deploy as I don't think we would get the transaction in the block for a `revert` due to failed redeem/refund.

Note: Bug is proven with the [new test failing](https://github.com/comit-network/comit-rs/pull/2000/commits/623d846f287f89ebe5f105446080d383eee88881) at commit 623d846f287f89ebe5f105446080d383eee88881: Alpha ledger is marked as funded: https://3843-130005855-gh.circle-artifacts.com/0/api_tests/log/tests/rfc003-eth-btc-alpha-deploy-fails.log