### PR TITLE
Fix logging in e2e tests

### DIFF
--- a/api_tests/lib_sdk/actor_test.ts
+++ b/api_tests/lib_sdk/actor_test.ts
@@ -48,9 +48,7 @@ export function twoActorTest(
     name: string,
     testFn: (actors: Actors) => Promise<void>
 ) {
-    it(name, async function() {
-        nActorTest(name, ["alice", "bob"], testFn);
-    });
+    nActorTest(name, ["alice", "bob"], testFn);
 }
 
 /*

--- a/api_tests/lib_sdk/create_actor.ts
+++ b/api_tests/lib_sdk/create_actor.ts
@@ -13,7 +13,7 @@ export async function createActor(
             appenders: {
                 file: {
                     type: "file",
-                    filename: "log/tests/" + logFileName,
+                    filename: "log/tests/" + logFileName.replace(/\//g, "_"),
                 },
             },
             categories: {
@@ -21,7 +21,7 @@ export async function createActor(
             },
         }).getLogger(whoAmI);
 
-    const alice = await Actor.newInstance(
+    const actor = await Actor.newInstance(
         loggerFactory,
         name,
         global.ledgerConfigs,
@@ -29,5 +29,5 @@ export async function createActor(
         global.logRoot
     );
 
-    return Promise.resolve(alice);
+    return actor;
 }


### PR DESCRIPTION
Remove nested it block. This allows for `console.log()` to print
in stdout and `log/tests` files to be written.
Also avoid nested log folder by doing `String.replace()`, `/` -> `_`
in log filenames.