### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.6.0 - 2020-02-13
+
 ### Fixed
 - Ensure that failed Ethereum transactions are ignored during a swap.
 
@@ -68,7 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move config files to standard location based on platform (OSX, Windows, Linux).
 - Align implementation with RFC-002 to use the decision header instead of status codes.
 
-[Unreleased]: https://github.com/comit-network/comit-rs/compare/0.5.1...HEAD
+[Unreleased]: https://github.com/comit-network/comit-rs/compare/0.6.0...HEAD
+[0.6.0]: https://github.com/comit-network/comit-rs/compare/0.5.1...0.6.0
 [0.5.1]: https://github.com/comit-network/comit-rs/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/comit-network/comit-rs/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/comit-network/comit-rs/compare/0.3.0...0.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "cnd"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "ambassador",
  "anyhow",

--- a/api_tests/lib_sdk/actor_test.ts
+++ b/api_tests/lib_sdk/actor_test.ts
@@ -48,9 +48,7 @@ export function twoActorTest(
     name: string,
     testFn: (actors: Actors) => Promise<void>
 ) {
-    it(name, async function() {
-        nActorTest(name, ["alice", "bob"], testFn);
-    });
+    nActorTest(name, ["alice", "bob"], testFn);
 }
 
 /*

--- a/api_tests/lib_sdk/create_actor.ts
+++ b/api_tests/lib_sdk/create_actor.ts
@@ -13,7 +13,7 @@ export async function createActor(
             appenders: {
                 file: {
                     type: "file",
-                    filename: "log/tests/" + logFileName,
+                    filename: "log/tests/" + logFileName.replace(/\//g, "_"),
                 },
             },
             categories: {
@@ -21,7 +21,7 @@ export async function createActor(
             },
         }).getLogger(whoAmI);
 
-    const alice = await Actor.newInstance(
+    const actor = await Actor.newInstance(
         loggerFactory,
         name,
         global.ledgerConfigs,
@@ -29,5 +29,5 @@ export async function createActor(
         global.logRoot
     );
 
-    return Promise.resolve(alice);
+    return actor;
 }

--- a/api_tests/package.json
+++ b/api_tests/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "@iarna/toml": "^2.2.3",
         "@types/bitcoinjs-lib": "^5.0.0",
-        "@types/chai": "^4.2.8",
+        "@types/chai": "^4.2.9",
         "@types/chai-as-promised": "^7.1.2",
         "@types/chai-json-schema": "^1.4.5",
         "@types/chai-subset": "^1.3.3",

--- a/api_tests/yarn.lock
+++ b/api_tests/yarn.lock
@@ -51,10 +51,10 @@
   dependencies:
     "@types/chai" "*"
 
-"@types/chai@*", "@types/chai@4", "@types/chai@^4.2.8":
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.8.tgz#c8d645506db0d15f4aafd4dfa873f443ad87ea59"
-  integrity sha512-U1bQiWbln41Yo6EeHMr+34aUhvrMVyrhn9lYfPSpLTCrZlGxU4Rtn1bocX+0p2Fc/Jkd2FanCEXdw0WNfHHM0w==
+"@types/chai@*", "@types/chai@4", "@types/chai@^4.2.9":
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.9.tgz#194332625ed2ae914aef00b8d5ca3b77e7924cc6"
+  integrity sha512-NeXgZj+MFL4izGqA4sapdYzkzQG+MtGra9vhQ58dnmDY++VgJaRUws+aLVV5zRJCYJl/8s9IjMmhiUw1WsKSmw==
 
 "@types/cookiejar@*":
   version "2.1.1"

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["CoBloX developers <team@coblox.tech>"]
 name = "cnd"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2018"
 description = "Reference implementation of a COMIT network daemon."
 


### PR DESCRIPTION
### Fixed
- Ensure that failed Ethereum transactions are ignored during a swap.

### Changed
- Upgrade `blockchain-contracts` crate to 0.3.1. Ether and Erc20 HTLCs now use `revert` to fail the Ethereum transaction if the redeem or refund are unsuccessful.