### PR TITLE
Don't delete the head of release branches

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -34,6 +34,7 @@ pull_request_rules:
   - name: Delete branch if the pull request is merged
     conditions:
       - merged
+      - head~=^(?!release.*).*$
     actions:
       delete_head_branch:
   - name: nag if changelog is not updated


### PR DESCRIPTION
We need to keep the head of release branches around to merge them back into dev.