### PR TITLE
Convert Bitcoin high fee test to new e2e test

### DIFF
--- a/api_tests/e2e/rfc003/eth_btc/bitcoin_high_fee.ts
+++ b/api_tests/e2e/rfc003/eth_btc/bitcoin_high_fee.ts
@@ -1,116 +1,22 @@
+import { twoActorTest } from "../../../lib_sdk/actor_test";
+import { AssetKind } from "../../../lib_sdk/asset";
 import { expect } from "chai";
-import "chai/register-should";
-import { ethers } from "ethers";
-import { Actor } from "../../../lib/actor";
-import * as bitcoin from "../../../lib/bitcoin";
-import { ActionKind, SwapRequest } from "../../../lib/comit";
-import "../../../lib/setup_chai";
-import { createTests, Step } from "../../../lib/test_creator";
-import { HarnessGlobal } from "../../../lib/util";
 
-declare var global: HarnessGlobal;
+setTimeout(function() {
+    twoActorTest("rfc003-eth-btc-alice-redeems-with-high-fee", async function({
+        alice,
+        bob,
+    }) {
+        await alice.sendRequest(AssetKind.Ether, AssetKind.Bitcoin);
+        await bob.accept();
 
-(async function() {
-    const alice = new Actor(
-        "alice",
-        {
-            ledgerConfig: global.ledgerConfigs,
-            addressForIncomingBitcoinPayments:
-                "bcrt1qs2aderg3whgu0m8uadn6dwxjf7j3wx97kk2qqtrum89pmfcxknhsf89pj0",
-        },
-        null,
-        {
-            bitcoinFeePerWU: 100000000,
-        }
-    );
-    const bob = new Actor(
-        "bob",
-        {
-            ledgerConfig: global.ledgerConfigs,
-            addressForIncomingBitcoinPayments:
-                "bcrt1qs2aderg3whgu0m8uadn6dwxjf7j3wx97kk2qqtrum89pmfcxknhsf89pj0",
-        },
-        null,
-        {
-            bitcoinFeePerWU: 100000000,
-        }
-    );
+        await alice.fund();
+        await bob.fund();
 
-    const alphaAssetQuantity = ethers.utils.parseEther("10");
-    const betaAssetQuantity = 100000000;
+        const responsePromise = alice.redeemWithHighFee();
 
-    const alphaExpiry = new Date("2080-06-11T23:00:00Z").getTime() / 1000;
-    const betaExpiry = new Date("2080-06-11T13:00:00Z").getTime() / 1000;
-
-    await bitcoin.ensureFunding();
-    await alice.wallet.eth().fund("11");
-    await alice.wallet.btc().fund(0.1);
-    await bob.wallet.eth().fund("0.1");
-    await bob.wallet.btc().fund(10);
-
-    const swapRequest: SwapRequest = {
-        alpha_ledger: {
-            name: "ethereum",
-            chain_id: 17,
-        },
-        beta_ledger: {
-            name: "bitcoin",
-            network: "regtest",
-        },
-        alpha_asset: {
-            name: "ether",
-            quantity: alphaAssetQuantity.toString(),
-        },
-        beta_asset: {
-            name: "bitcoin",
-            quantity: betaAssetQuantity.toString(),
-        },
-        alpha_ledger_refund_identity: alice.wallet.eth().address(),
-        alpha_expiry: alphaExpiry,
-        beta_expiry: betaExpiry,
-        peer: await bob.peerId(),
-    };
-
-    const steps: Step[] = [
-        {
-            actor: bob,
-            action: ActionKind.Accept,
-            waitUntil: state => state.communication.status === "ACCEPTED",
-        },
-        {
-            actor: alice,
-            action: ActionKind.Fund,
-            waitUntil: state => state.alpha_ledger.status === "FUNDED",
-        },
-        {
-            actor: bob,
-            action: ActionKind.Fund,
-            waitUntil: state => state.beta_ledger.status === "FUNDED",
-        },
-        {
-            actor: alice,
-            action: {
-                kind: ActionKind.Redeem,
-                test: response => {
-                    expect(response).to.have.status(400);
-                    expect(response.body.title).to.equal("Fee is too high.");
-                },
-            },
-        },
-        {
-            actor: bob,
-            action: {
-                kind: ActionKind.Refund,
-                test: response => {
-                    expect(response).to.have.status(400);
-                    expect(response.body.title).to.equal("Fee is too high.");
-                },
-            },
-        },
-    ];
-
-    describe("RFC003: Ether for Bitcoin - Redeem/Refund Bitcoin with high fee", () => {
-        createTests(alice, bob, steps, "/swaps/rfc003", "/swaps", swapRequest);
+        await expect(responsePromise).to.be.rejected;
     });
+
     run();
-})();
+}, 0);

--- a/api_tests/lib_sdk/actors/actor.ts
+++ b/api_tests/lib_sdk/actors/actor.ts
@@ -273,7 +273,7 @@ export class Actor {
         response.data.payload.amount = amount * 1.01;
 
         const txid = await this.swap.doLedgerAction(response.data);
-        this.logger.debug("Funded swap %s in %s", this.swap.self, txid);
+        this.logger.debug("Overfunded swap %s in %s", this.swap.self, txid);
     }
 
     public async underfund() {
@@ -285,7 +285,7 @@ export class Actor {
         response.data.payload.amount = amount * 0.01;
 
         const txid = await this.swap.doLedgerAction(response.data);
-        this.logger.debug("Funded swap %s in %s", this.swap.self, txid);
+        this.logger.debug("Underfunded swap %s in %s", this.swap.self, txid);
     }
 
     public async refund() {
@@ -345,6 +345,16 @@ export class Actor {
                 await this.actors.bob.assertAlphaRedeemed();
                 break;
         }
+    }
+
+    public async redeemWithHighFee() {
+        // Hack the bitcoin fee per WU returned by the wallet
+        this.wallets.bitcoin.inner.getFee = () => "100000000";
+
+        return this.swap.tryExecuteAction("redeem", {
+            maxTimeoutSecs: 10,
+            tryIntervalSecs: 1,
+        });
     }
 
     public async currentSwapIsAccepted() {


### PR DESCRIPTION
Note, that the old test asserted the status (`400`). In order to achieve this in the new test framework, we have to configure axios properly in the SDK, as recorded here: https://github.com/comit-network/comit-js-sdk/issues/122

I added a follow up ticket for this: https://github.com/comit-network/comit-rs/issues/2046