### PR TITLE
1844 simpler config

### DIFF
--- a/api_tests/lib/config.ts
+++ b/api_tests/lib/config.ts
@@ -60,13 +60,22 @@ interface LedgerConnectors {
     ethereum?: EthereumConnector;
 }
 
+interface Parity {
+    node_url: string;
+}
+
 interface EthereumConnector {
+    chain_id: number;
+    parity: Parity;
+}
+
+interface Bitcoind {
     node_url: string;
 }
 
 interface BitcoinConnector {
-    node_url: string;
     network: string;
+    bitcoind: Bitcoind;
 }
 
 export const ALICE_CONFIG = new E2ETestActorConfig(
@@ -107,14 +116,19 @@ function createLedgerConnectors(ledgerConfig: LedgerConfig): LedgerConnectors {
 
 function bitcoinConnector(nodeConfig: BitcoinNodeConfig): BitcoinConnector {
     return {
-        node_url: `http://${nodeConfig.host}:${nodeConfig.rpcPort}`,
+        bitcoind: {
+            node_url: `http://${nodeConfig.host}:${nodeConfig.rpcPort}`,
+        },
         network: nodeConfig.network,
     };
 }
 
 function ethereumConnector(nodeConfig: EthereumNodeConfig): EthereumConnector {
     return {
-        node_url: nodeConfig.rpc_url,
+        chain_id: 17,
+        parity: {
+            node_url: nodeConfig.rpc_url,
+        },
     };
 }
 

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -58,9 +58,9 @@ fn main() -> anyhow::Result<()> {
 
     const BITCOIN_BLOCK_CACHE_CAPACITY: usize = 144;
     let bitcoin_connector = {
-        let config::Bitcoin { node_url, network } = settings.clone().bitcoin;
+        let config::Bitcoin { network, bitcoind } = settings.clone().bitcoin;
         bitcoin::Cache::new(
-            BitcoindConnector::new(node_url, network)?,
+            BitcoindConnector::new(bitcoind.node_url, network)?,
             BITCOIN_BLOCK_CACHE_CAPACITY,
         )
     };
@@ -68,7 +68,7 @@ fn main() -> anyhow::Result<()> {
     const ETHEREUM_BLOCK_CACHE_CAPACITY: usize = 720;
     const ETHEREUM_RECEIPT_CACHE_CAPACITY: usize = 720;
     let ethereum_connector = ethereum::Cache::new(
-        Web3Connector::new(settings.clone().ethereum.node_url),
+        Web3Connector::new(settings.clone().ethereum.parity.node_url),
         ETHEREUM_BLOCK_CACHE_CAPACITY,
         ETHEREUM_RECEIPT_CACHE_CAPACITY,
     );


### PR DESCRIPTION
Resolves #1844

As discussed in the ticket, the goal is to 
* let cnd come up with some smart defaults: 
  * right now I default to regtest, in the future we might want to change this to mainnet
* let the user configure everything
  * you can find a full example in the e2e tests (ignoring blockchain explorers right now)
* I propose to manually call verify once the configs were loaded 
  * for this I'll create a follow-up ticket once this is merged.

What do you think? 