### PR TITLE
LND sanity test follow-up proposal

### DIFF
--- a/api_tests/lib/actors/actor.ts
+++ b/api_tests/lib/actors/actor.ts
@@ -15,7 +15,6 @@ import { Wallet, Wallets } from "../wallets";
 import { Actors } from "./index";
 import { Entity } from "../../gen/siren";
 import { SwapDetails } from "comit-sdk/dist/src/cnd";
-import { CreateInvoiceResponse } from "ln-service";
 
 declare var global: HarnessGlobal;
 
@@ -843,12 +842,15 @@ export class Actor {
         return this.wallets.lightning.createInvoice(sats);
     }
 
-    public async payLnInvoice(invoice: CreateInvoiceResponse) {
-        return this.wallets.lightning.pay(invoice);
+    public async payLnInvoice(request: string) {
+        return this.wallets.lightning.pay(request);
     }
 
-    public async assertLnInvoiceSettled(invoice: CreateInvoiceResponse) {
-        await this.wallets.lightning.assertInvoiceSettled(invoice);
+    public async assertLnInvoiceSettled(id: string) {
+        const resp = await this.wallets.lightning.getInvoice(id);
+        if (!resp.is_confirmed) {
+            throw new Error(`Invoice ${id} is not confirmed}`);
+        }
     }
 }
 

--- a/api_tests/lib/actors/actor.ts
+++ b/api_tests/lib/actors/actor.ts
@@ -15,6 +15,7 @@ import { Wallet, Wallets } from "../wallets";
 import { Actors } from "./index";
 import { Entity } from "../../gen/siren";
 import { SwapDetails } from "comit-sdk/dist/src/cnd";
+import { CreateInvoiceResponse } from "ln-service";
 
 declare var global: HarnessGlobal;
 
@@ -836,6 +837,18 @@ export class Actor {
             await sleep(1000);
             return await this.pollSwapDetails(swapUrl, iteration);
         }
+    }
+
+    public async createLnInvoice(sats: number) {
+        return this.wallets.lightning.createInvoice(sats);
+    }
+
+    public async payLnInvoice(invoice: CreateInvoiceResponse) {
+        return this.wallets.lightning.pay(invoice);
+    }
+
+    public async assertLnInvoiceSettled(invoice: CreateInvoiceResponse) {
+        await this.wallets.lightning.assertInvoiceSettled(invoice);
     }
 }
 

--- a/api_tests/sanity/basic_lnd_payment.ts
+++ b/api_tests/sanity/basic_lnd_payment.ts
@@ -8,9 +8,9 @@ setTimeout(function() {
             { ledger: LedgerKind.Lightning, asset: AssetKind.Bitcoin },
             { ledger: LedgerKind.Bitcoin, asset: AssetKind.Bitcoin }
         );
-        const invoice = await bob.wallets.lightning.createInvoice(20000);
-        await alice.wallets.lightning.pay(invoice);
-        await bob.wallets.lightning.assertInvoiceSettled(invoice);
+        const invoice = await bob.createLnInvoice(20000);
+        await alice.payLnInvoice(invoice);
+        await bob.assertLnInvoiceSettled(invoice);
     });
 
     run();

--- a/api_tests/sanity/basic_lnd_payment.ts
+++ b/api_tests/sanity/basic_lnd_payment.ts
@@ -8,9 +8,9 @@ setTimeout(function() {
             { ledger: LedgerKind.Lightning, asset: AssetKind.Bitcoin },
             { ledger: LedgerKind.Bitcoin, asset: AssetKind.Bitcoin }
         );
-        const invoice = await bob.createLnInvoice(20000);
-        await alice.payLnInvoice(invoice);
-        await bob.assertLnInvoiceSettled(invoice);
+        const { id, request } = await bob.createLnInvoice(20000);
+        await alice.payLnInvoice(request);
+        await bob.assertLnInvoiceSettled(id);
     });
 
     run();


### PR DESCRIPTION
See commit messages.

https://github.com/comit-network/comit-rs/commit/b4881718bbc704061ba514d3098f04236ae4b7ca may be controversial because I am removing the comparison of the `tokens`. I couldn't really figure out, what these tokens are.

@D4nte What was the reason for asserting them? I left them out because they would bloat the interface of `createInvoice` if I would return them as-well.
My assumption was: if I give an ID to LND and it tells me it is confirmed, I don't need to check anything else?