### PR TITLE
Request review from team instead of commenting

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,10 @@ pull_request_rules:
       - "status-failure=ci/circleci: debug-build-test"
     actions:
       comment:
-        message: "@comit-network/rust-devs The build on this dependency update is broken and needs attention."
+        message: "The build on this dependency update is broken and needs attention."
+      request_reviews:
+        teams:
+          - "@comit-network/rust-devs"
   - name: instruct bors to merge dependabot PRs with passing tests
     conditions:
       - "author=dependabot-preview[bot]"


### PR DESCRIPTION
It seems that linking the team doesn't work, hence we request a review instead in order to trigger notifications.