### PR TITLE
Relax trait bounds on structs

### DIFF
--- a/cnd/src/db/integration_tests/db_roundtrips.rs
+++ b/cnd/src/db/integration_tests/db_roundtrips.rs
@@ -8,7 +8,7 @@ use crate::{
     quickcheck::Quickcheck,
     swap_protocols::{
         ledger::Ethereum,
-        rfc003::{Accept, Request},
+        rfc003::{Accept, Ledger, Request},
     },
 };
 use std::path::Path;
@@ -22,7 +22,7 @@ macro_rules! db_roundtrip_test {
             fn [<roundtrip_test_ $alpha_ledger _ $beta_ledger _ $alpha_asset _ $beta_asset>]() {
                 fn prop(swap: Quickcheck<Swap>,
                         request: Quickcheck<Request<$alpha_ledger, $beta_ledger, $alpha_asset, $beta_asset>>,
-                        accept: Quickcheck<Accept<$alpha_ledger, $beta_ledger>>,
+                        accept: Quickcheck<Accept<<$alpha_ledger as Ledger>::Identity, <$beta_ledger as Ledger>::Identity>>,
                 ) -> anyhow::Result<bool> {
 
                     // unpack the swap from the generic newtype
@@ -72,7 +72,7 @@ macro_rules! db_roundtrip_test {
                 quickcheck::quickcheck(prop as fn(
                     Quickcheck<Swap>,
                     Quickcheck<Request<$alpha_ledger, $beta_ledger, $alpha_asset, $beta_asset>>,
-                    Quickcheck<Accept<$alpha_ledger, $beta_ledger>>,
+                    Quickcheck<Accept<<$alpha_ledger as Ledger>::Identity, <$beta_ledger as Ledger>::Identity>>,
                 ) -> anyhow::Result<bool>);
             }
         }

--- a/cnd/src/db/load_swaps.rs
+++ b/cnd/src/db/load_swaps.rs
@@ -30,7 +30,11 @@ use schema::{
     rfc003_ethereum_bitcoin_ether_bitcoin_request_messages,
 };
 
-pub type AcceptedSwap<AL, BL, AA, BA> = (Request<AL, BL, AA, BA>, Accept<AL, BL>, NaiveDateTime);
+pub type AcceptedSwap<AL, BL, AA, BA> = (
+    Request<AL, BL, AA, BA>,
+    Accept<<AL as Ledger>::Identity, <BL as Ledger>::Identity>,
+    NaiveDateTime,
+);
 
 #[async_trait]
 pub trait LoadAcceptedSwap<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {

--- a/cnd/src/db/save.rs
+++ b/cnd/src/db/save.rs
@@ -371,21 +371,12 @@ struct InsertableEthereumBitcoinAcceptMessage {
     bitcoin_refund_identity: Text<bitcoin::PublicKey>,
 }
 
-#[impl_template]
 #[async_trait]
-impl
-    Save<
-        Accept<
-            Ethereum,
-            ((
-                ledger::bitcoin::Mainnet,
-                ledger::bitcoin::Testnet,
-                ledger::bitcoin::Regtest,
-            )),
-        >,
-    > for Sqlite
-{
-    async fn save(&self, message: Accept<Ethereum, __TYPE0__>) -> anyhow::Result<()> {
+impl Save<Accept<crate::ethereum::Address, crate::bitcoin::PublicKey>> for Sqlite {
+    async fn save(
+        &self,
+        message: Accept<crate::ethereum::Address, crate::bitcoin::PublicKey>,
+    ) -> anyhow::Result<()> {
         let Accept {
             swap_id,
             alpha_ledger_redeem_identity,
@@ -417,21 +408,12 @@ struct InsertableBitcoinEthereumAcceptMessage {
     ethereum_refund_identity: Text<EthereumAddress>,
 }
 
-#[impl_template]
 #[async_trait]
-impl
-    Save<
-        Accept<
-            ((
-                ledger::bitcoin::Mainnet,
-                ledger::bitcoin::Testnet,
-                ledger::bitcoin::Regtest,
-            )),
-            Ethereum,
-        >,
-    > for Sqlite
-{
-    async fn save(&self, message: Accept<__TYPE0__, Ethereum>) -> anyhow::Result<()> {
+impl Save<Accept<crate::bitcoin::PublicKey, crate::ethereum::Address>> for Sqlite {
+    async fn save(
+        &self,
+        message: Accept<crate::bitcoin::PublicKey, crate::ethereum::Address>,
+    ) -> anyhow::Result<()> {
         let Accept {
             swap_id,
             alpha_ledger_redeem_identity,

--- a/cnd/src/http_api/routes/rfc003/accept.rs
+++ b/cnd/src/http_api/routes/rfc003/accept.rs
@@ -46,12 +46,14 @@ fn ethereum_bitcoin_accept_required_fields() -> Vec<siren::Field> {
     }]
 }
 
-impl IntoAcceptMessage<Ethereum, bitcoin::Regtest> for OnlyRedeem<ethereum::Address> {
+impl IntoAcceptMessage<ethereum::Address, crate::bitcoin::PublicKey>
+    for OnlyRedeem<ethereum::Address>
+{
     fn into_accept_message(
         self,
         id: SwapId,
         secret_source: &dyn DeriveIdentities,
-    ) -> messages::Accept<Ethereum, bitcoin::Regtest> {
+    ) -> messages::Accept<ethereum::Address, crate::bitcoin::PublicKey> {
         let beta_ledger_refund_identity = crate::bitcoin::PublicKey::from_secret_key(
             &*crate::SECP,
             &secret_source.derive_refund_identity(),
@@ -97,12 +99,14 @@ fn bitcoin_ethereum_accept_required_fields() -> Vec<siren::Field> {
     }]
 }
 
-impl IntoAcceptMessage<bitcoin::Regtest, Ethereum> for OnlyRefund<ethereum::Address> {
+impl IntoAcceptMessage<crate::bitcoin::PublicKey, crate::ethereum::Address>
+    for OnlyRefund<ethereum::Address>
+{
     fn into_accept_message(
         self,
         id: SwapId,
         secret_source: &dyn DeriveIdentities,
-    ) -> messages::Accept<bitcoin::Regtest, Ethereum> {
+    ) -> messages::Accept<crate::bitcoin::PublicKey, crate::ethereum::Address> {
         let alpha_ledger_redeem_identity = crate::bitcoin::PublicKey::from_secret_key(
             &*crate::SECP,
             &secret_source.derive_redeem_identity(),

--- a/cnd/src/http_api/routes/rfc003/handlers/action.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/action.rs
@@ -72,7 +72,7 @@ pub async fn handle_action(
 
                 tracing::trace!("received accept action: {}", swap_id);
 
-                let response = rfc003_accept_response(accept_message);
+                let response = rfc003_accept_response::<AL, BL>(accept_message);
                 channel.send(response).map_err(|_| {
                     anyhow::anyhow!(
                         "failed to send response through channel for swap {}",
@@ -181,7 +181,7 @@ trait SelectAction<Accept, Decline, Deploy, Fund, Redeem, Refund>:
 }
 
 fn rfc003_accept_response<AL: rfc003::Ledger, BL: rfc003::Ledger>(
-    message: rfc003::messages::Accept<AL, BL>,
+    message: rfc003::messages::Accept<AL::Identity, BL::Identity>,
 ) -> Response {
     Response::empty()
         .with_header(

--- a/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
@@ -31,7 +31,10 @@ async fn initiate_request<AL, BL, AA, BA>(
     swap_request: rfc003::Request<AL, BL, AA, BA>,
 ) -> anyhow::Result<()>
 where
-    Sqlite: Save<Request<AL, BL, AA, BA>> + Save<Accept<AL, BL>> + Save<Swap> + Save<Decline>,
+    Sqlite: Save<Request<AL, BL, AA, BA>>
+        + Save<Accept<AL::Identity, BL::Identity>>
+        + Save<Swap>
+        + Save<Decline>,
     AL: Ledger,
     BL: Ledger,
     AA: Asset,

--- a/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
@@ -368,7 +368,6 @@ pub async fn handle_post_swap(
             );
             initiate_request(dependencies, id, peer, request).await?;
         }
-
         SwapRequestBody {
             alpha_ledger: HttpLedger::Ethereum(alpha_ledger),
             beta_ledger: HttpLedger::BitcoinRegtest,

--- a/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
@@ -37,8 +37,8 @@ where
     AA: Asset,
     BA: Asset,
     Facade: LoadAcceptedSwap<AL, BL, AA, BA>
-        + HtlcFunded<AL, AA, AL::Transaction>
-        + HtlcFunded<BL, BA, BL::Transaction>
+        + HtlcFunded<AL, AA>
+        + HtlcFunded<BL, BA>
         + HtlcDeployed<AL, AA>
         + HtlcDeployed<BL, BA>
         + HtlcRedeemed<AL, AA>

--- a/cnd/src/http_api/routes/rfc003/swap_state.rs
+++ b/cnd/src/http_api/routes/rfc003/swap_state.rs
@@ -91,11 +91,11 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> From<rfc003::SwapCommunicatio
     }
 }
 
-impl<T, H, A: Asset> From<rfc003::LedgerState<T, H, A>> for LedgerState<H, T>
+impl<H, T, A: Asset> From<rfc003::LedgerState<H, T, A>> for LedgerState<H, T>
 where
-    rfc003::LedgerState<T, H, A>: Clone,
+    rfc003::LedgerState<H, T, A>: Clone,
 {
-    fn from(ledger_state: rfc003::LedgerState<T, H, A>) -> Self {
+    fn from(ledger_state: rfc003::LedgerState<H, T, A>) -> Self {
         use self::rfc003::LedgerState::*;
         let status = ledger_state.clone().into();
         match ledger_state {

--- a/cnd/src/http_api/routes/rfc003/swap_state.rs
+++ b/cnd/src/http_api/routes/rfc003/swap_state.rs
@@ -91,10 +91,11 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> From<rfc003::SwapCommunicatio
     }
 }
 
-impl<L: Ledger, A: Asset> From<rfc003::LedgerState<L, A>>
-    for LedgerState<L::HtlcLocation, L::Transaction>
+impl<T, H, A: Asset> From<rfc003::LedgerState<T, H, A>> for LedgerState<H, T>
+where
+    rfc003::LedgerState<T, H, A>: Clone,
 {
-    fn from(ledger_state: rfc003::LedgerState<L, A>) -> Self {
+    fn from(ledger_state: rfc003::LedgerState<T, H, A>) -> Self {
         use self::rfc003::LedgerState::*;
         let status = ledger_state.clone().into();
         match ledger_state {

--- a/cnd/src/init_swap.rs
+++ b/cnd/src/init_swap.rs
@@ -23,8 +23,8 @@ where
     D: StateStore
         + Clone
         + DeriveSwapSeed
-        + HtlcFunded<AL, AA, AL::Transaction>
-        + HtlcFunded<BL, BA, BL::Transaction>
+        + HtlcFunded<AL, AA>
+        + HtlcFunded<BL, BA>
         + HtlcDeployed<AL, AA>
         + HtlcDeployed<BL, BA>
         + HtlcRedeemed<AL, AA>

--- a/cnd/src/network/mod.rs
+++ b/cnd/src/network/mod.rs
@@ -851,7 +851,7 @@ fn rfc003_swap_request<AL: rfc003::Ledger, BL: rfc003::Ledger, AA: Asset, BA: As
     alpha_asset: AA,
     beta_asset: BA,
     hash_function: HashFunction,
-    body: rfc003::messages::RequestBody<AL, BL>,
+    body: rfc003::messages::RequestBody<AL::Identity, BL::Identity>,
 ) -> rfc003::Request<AL, BL, AA, BA> {
     rfc003::Request::<AL, BL, AA, BA> {
         swap_id: id,
@@ -886,8 +886,8 @@ fn build_outbound_request<AL: rfc003::Ledger, BL: rfc003::Ledger, AA: Asset, BA:
         .with_header("beta_asset", request.beta_asset.into().to_header()?)
         .with_header("protocol", protocol.to_header()?)
         .with_body(serde_json::to_value(rfc003::messages::RequestBody::<
-            AL,
-            BL,
+            AL::Identity,
+            BL::Identity,
         > {
             alpha_ledger_refund_identity,
             beta_ledger_redeem_identity,

--- a/cnd/src/network/mod.rs
+++ b/cnd/src/network/mod.rs
@@ -763,9 +763,10 @@ impl SendRequest for Swarm {
 
                 match decision {
                     Some(Decision::Accepted) => {
-                        match serde_json::from_value::<rfc003::messages::AcceptResponseBody<AL, BL>>(
-                            response.body().clone(),
-                        ) {
+                        match serde_json::from_value::<
+                            rfc003::messages::AcceptResponseBody<AL::Identity, BL::Identity>,
+                        >(response.body().clone())
+                        {
                             Ok(body) => Ok(Ok(rfc003::Accept {
                                 swap_id: id,
                                 beta_ledger_refund_identity: body.beta_ledger_refund_identity,

--- a/cnd/src/quickcheck.rs
+++ b/cnd/src/quickcheck.rs
@@ -268,18 +268,18 @@ where
     }
 }
 
-impl<AL, BL> Arbitrary for Quickcheck<Accept<AL, BL>>
+impl<AI, BI> Arbitrary for Quickcheck<Accept<AI, BI>>
 where
-    AL: Ledger,
-    BL: Ledger,
-    Quickcheck<AL::Identity>: Arbitrary,
-    Quickcheck<BL::Identity>: Arbitrary,
+    AI: Copy + Clone + Send,
+    BI: Copy + Clone + Send,
+    Quickcheck<AI>: Arbitrary,
+    Quickcheck<BI>: Arbitrary,
 {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         Quickcheck(Accept {
             swap_id: *Quickcheck::<SwapId>::arbitrary(g),
-            alpha_ledger_redeem_identity: *Quickcheck::<AL::Identity>::arbitrary(g),
-            beta_ledger_refund_identity: *Quickcheck::<BL::Identity>::arbitrary(g),
+            alpha_ledger_redeem_identity: *Quickcheck::<AI>::arbitrary(g),
+            beta_ledger_refund_identity: *Quickcheck::<BI>::arbitrary(g),
         })
     }
 }

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -105,12 +105,8 @@ where
 
 #[impl_template]
 #[async_trait::async_trait]
-impl
-    HtlcFunded<
-        ((bitcoin::Mainnet, bitcoin::Testnet, bitcoin::Regtest)),
-        asset::Bitcoin,
-        ::bitcoin::Transaction,
-    > for Facade
+impl HtlcFunded<((bitcoin::Mainnet, bitcoin::Testnet, bitcoin::Regtest)), asset::Bitcoin>
+    for Facade
 {
     async fn htlc_funded(
         &self,
@@ -176,7 +172,7 @@ impl HtlcRefunded<((bitcoin::Mainnet, bitcoin::Testnet, bitcoin::Regtest)), asse
 
 #[impl_template]
 #[async_trait::async_trait]
-impl HtlcFunded<Ethereum, ((asset::Ether, asset::Erc20)), crate::ethereum::Transaction> for Facade {
+impl HtlcFunded<Ethereum, ((asset::Ether, asset::Erc20))> for Facade {
     async fn htlc_funded(
         &self,
         htlc_params: HtlcParams<Ethereum, __TYPE0__>,

--- a/cnd/src/swap_protocols/rfc003/actor_state.rs
+++ b/cnd/src/swap_protocols/rfc003/actor_state.rs
@@ -13,8 +13,20 @@ pub trait ActorState: Debug + Clone + Send + Sync + 'static {
     fn expected_alpha_asset(&self) -> Self::AA;
     fn expected_beta_asset(&self) -> Self::BA;
 
-    fn alpha_ledger_mut(&mut self) -> &mut LedgerState<Self::AL, Self::AA>;
-    fn beta_ledger_mut(&mut self) -> &mut LedgerState<Self::BL, Self::BA>;
+    fn alpha_ledger_mut(
+        &mut self,
+    ) -> &mut LedgerState<
+        <Self::AL as Ledger>::Transaction,
+        <Self::AL as Ledger>::HtlcLocation,
+        Self::AA,
+    >;
+    fn beta_ledger_mut(
+        &mut self,
+    ) -> &mut LedgerState<
+        <Self::BL as Ledger>::Transaction,
+        <Self::BL as Ledger>::HtlcLocation,
+        Self::BA,
+    >;
 
     /// Returns true if the current swap failed at some stage.
     fn swap_failed(&self) -> bool;

--- a/cnd/src/swap_protocols/rfc003/actor_state.rs
+++ b/cnd/src/swap_protocols/rfc003/actor_state.rs
@@ -16,15 +16,15 @@ pub trait ActorState: Debug + Clone + Send + Sync + 'static {
     fn alpha_ledger_mut(
         &mut self,
     ) -> &mut LedgerState<
-        <Self::AL as Ledger>::Transaction,
         <Self::AL as Ledger>::HtlcLocation,
+        <Self::AL as Ledger>::Transaction,
         Self::AA,
     >;
     fn beta_ledger_mut(
         &mut self,
     ) -> &mut LedgerState<
-        <Self::BL as Ledger>::Transaction,
         <Self::BL as Ledger>::HtlcLocation,
+        <Self::BL as Ledger>::Transaction,
         Self::BA,
     >;
 

--- a/cnd/src/swap_protocols/rfc003/alice/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/mod.rs
@@ -35,7 +35,7 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
 
     pub fn accepted(
         request: messages::Request<AL, BL, AA, BA>,
-        response: messages::Accept<AL, BL>,
+        response: messages::Accept<AL::Identity, BL::Identity>,
         secret_source: SwapSeed,
     ) -> Self {
         Self {

--- a/cnd/src/swap_protocols/rfc003/alice/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/mod.rs
@@ -15,8 +15,8 @@ use derivative::Derivative;
 #[derivative(Debug, PartialEq)]
 pub struct State<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
     pub swap_communication: SwapCommunication<AL, BL, AA, BA>,
-    pub alpha_ledger_state: LedgerState<AL::Transaction, AL::HtlcLocation, AA>,
-    pub beta_ledger_state: LedgerState<BL::Transaction, BL::HtlcLocation, BA>,
+    pub alpha_ledger_state: LedgerState<AL::HtlcLocation, AL::Transaction, AA>,
+    pub beta_ledger_state: LedgerState<BL::HtlcLocation, BL::Transaction, BA>,
     #[derivative(Debug = "ignore", PartialEq = "ignore")]
     pub secret_source: SwapSeed, // Used to derive identities and also to generate the secret.
     pub failed: bool,
@@ -80,11 +80,11 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> ActorState for State<AL, BL, 
         self.swap_communication.request().beta_asset.clone()
     }
 
-    fn alpha_ledger_mut(&mut self) -> &mut LedgerState<AL::Transaction, AL::HtlcLocation, AA> {
+    fn alpha_ledger_mut(&mut self) -> &mut LedgerState<AL::HtlcLocation, AL::Transaction, AA> {
         &mut self.alpha_ledger_state
     }
 
-    fn beta_ledger_mut(&mut self) -> &mut LedgerState<BL::Transaction, BL::HtlcLocation, BA> {
+    fn beta_ledger_mut(&mut self) -> &mut LedgerState<BL::HtlcLocation, BL::Transaction, BA> {
         &mut self.beta_ledger_state
     }
 

--- a/cnd/src/swap_protocols/rfc003/alice/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/mod.rs
@@ -15,8 +15,8 @@ use derivative::Derivative;
 #[derivative(Debug, PartialEq)]
 pub struct State<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
     pub swap_communication: SwapCommunication<AL, BL, AA, BA>,
-    pub alpha_ledger_state: LedgerState<AL, AA>,
-    pub beta_ledger_state: LedgerState<BL, BA>,
+    pub alpha_ledger_state: LedgerState<AL::Transaction, AL::HtlcLocation, AA>,
+    pub beta_ledger_state: LedgerState<BL::Transaction, BL::HtlcLocation, BA>,
     #[derivative(Debug = "ignore", PartialEq = "ignore")]
     pub secret_source: SwapSeed, // Used to derive identities and also to generate the secret.
     pub failed: bool,
@@ -80,11 +80,11 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> ActorState for State<AL, BL, 
         self.swap_communication.request().beta_asset.clone()
     }
 
-    fn alpha_ledger_mut(&mut self) -> &mut LedgerState<AL, AA> {
+    fn alpha_ledger_mut(&mut self) -> &mut LedgerState<AL::Transaction, AL::HtlcLocation, AA> {
         &mut self.alpha_ledger_state
     }
 
-    fn beta_ledger_mut(&mut self) -> &mut LedgerState<BL, BA> {
+    fn beta_ledger_mut(&mut self) -> &mut LedgerState<BL::Transaction, BL::HtlcLocation, BA> {
         &mut self.beta_ledger_state
     }
 

--- a/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
@@ -20,8 +20,8 @@ use anyhow::Context;
 use chrono::NaiveDateTime;
 
 #[async_trait::async_trait]
-impl<Bitcoin: bitcoin::Bitcoin + bitcoin::Network>
-    HtlcFunded<Bitcoin, asset::Bitcoin, ::bitcoin::Transaction> for Cache<BitcoindConnector>
+impl<Bitcoin: bitcoin::Bitcoin + bitcoin::Network> HtlcFunded<Bitcoin, asset::Bitcoin>
+    for Cache<BitcoindConnector>
 {
     async fn htlc_funded(
         &self,

--- a/cnd/src/swap_protocols/rfc003/bob/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/mod.rs
@@ -19,8 +19,8 @@ pub type ResponseSender<AL: Ledger, BL: Ledger> =
 #[derivative(Debug)]
 pub struct State<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
     pub swap_communication: SwapCommunication<AL, BL, AA, BA>,
-    pub alpha_ledger_state: LedgerState<AL::Transaction, AL::HtlcLocation, AA>,
-    pub beta_ledger_state: LedgerState<BL::Transaction, BL::HtlcLocation, BA>,
+    pub alpha_ledger_state: LedgerState<AL::HtlcLocation, AL::Transaction, AA>,
+    pub beta_ledger_state: LedgerState<BL::HtlcLocation, BL::Transaction, BA>,
     #[derivative(Debug = "ignore")]
     pub secret_source: Arc<dyn DeriveIdentities>,
     pub failed: bool, // Gets set on any error during the execution of a swap.
@@ -91,11 +91,11 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> ActorState for State<AL, BL, 
         self.swap_communication.request().beta_asset.clone()
     }
 
-    fn alpha_ledger_mut(&mut self) -> &mut LedgerState<AL::Transaction, AL::HtlcLocation, AA> {
+    fn alpha_ledger_mut(&mut self) -> &mut LedgerState<AL::HtlcLocation, AL::Transaction, AA> {
         &mut self.alpha_ledger_state
     }
 
-    fn beta_ledger_mut(&mut self) -> &mut LedgerState<BL::Transaction, BL::HtlcLocation, BA> {
+    fn beta_ledger_mut(&mut self) -> &mut LedgerState<BL::HtlcLocation, BL::Transaction, BA> {
         &mut self.beta_ledger_state
     }
 

--- a/cnd/src/swap_protocols/rfc003/bob/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/mod.rs
@@ -19,8 +19,8 @@ pub type ResponseSender<AL: Ledger, BL: Ledger> =
 #[derivative(Debug)]
 pub struct State<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
     pub swap_communication: SwapCommunication<AL, BL, AA, BA>,
-    pub alpha_ledger_state: LedgerState<AL, AA>,
-    pub beta_ledger_state: LedgerState<BL, BA>,
+    pub alpha_ledger_state: LedgerState<AL::Transaction, AL::HtlcLocation, AA>,
+    pub beta_ledger_state: LedgerState<BL::Transaction, BL::HtlcLocation, BA>,
     #[derivative(Debug = "ignore")]
     pub secret_source: Arc<dyn DeriveIdentities>,
     pub failed: bool, // Gets set on any error during the execution of a swap.
@@ -91,11 +91,11 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> ActorState for State<AL, BL, 
         self.swap_communication.request().beta_asset.clone()
     }
 
-    fn alpha_ledger_mut(&mut self) -> &mut LedgerState<AL, AA> {
+    fn alpha_ledger_mut(&mut self) -> &mut LedgerState<AL::Transaction, AL::HtlcLocation, AA> {
         &mut self.alpha_ledger_state
     }
 
-    fn beta_ledger_mut(&mut self) -> &mut LedgerState<BL, BA> {
+    fn beta_ledger_mut(&mut self) -> &mut LedgerState<BL::Transaction, BL::HtlcLocation, BA> {
         &mut self.beta_ledger_state
     }
 

--- a/cnd/src/swap_protocols/rfc003/bob/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/mod.rs
@@ -42,7 +42,7 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
 
     pub fn accepted(
         request: Request<AL, BL, AA, BA>,
-        response: Accept<AL, BL>,
+        response: Accept<AL::Identity, BL::Identity>,
         secret_source: impl DeriveIdentities,
     ) -> Self {
         Self {

--- a/cnd/src/swap_protocols/rfc003/create_swap.rs
+++ b/cnd/src/swap_protocols/rfc003/create_swap.rs
@@ -195,7 +195,7 @@ pub struct HtlcParams<L: Ledger, A: Asset> {
 impl<L: Ledger, A: Asset> HtlcParams<L, A> {
     pub fn new_alpha_params<BL: Ledger, BA: Asset>(
         request: &rfc003::Request<L, BL, A, BA>,
-        accept_response: &rfc003::Accept<L, BL>,
+        accept_response: &rfc003::Accept<L::Identity, BL::Identity>,
     ) -> Self {
         HtlcParams {
             asset: request.alpha_asset.clone(),
@@ -209,7 +209,7 @@ impl<L: Ledger, A: Asset> HtlcParams<L, A> {
 
     pub fn new_beta_params<AL: Ledger, AA: Asset>(
         request: &rfc003::Request<AL, L, AA, A>,
-        accept_response: &rfc003::Accept<AL, L>,
+        accept_response: &rfc003::Accept<AL::Identity, L::Identity>,
     ) -> Self {
         HtlcParams {
             asset: request.beta_asset.clone(),
@@ -245,7 +245,10 @@ where
 }
 
 impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> OngoingSwap<AL, BL, AA, BA> {
-    pub fn new(request: Request<AL, BL, AA, BA>, accept: Accept<AL, BL>) -> Self {
+    pub fn new(
+        request: Request<AL, BL, AA, BA>,
+        accept: Accept<AL::Identity, BL::Identity>,
+    ) -> Self {
         OngoingSwap {
             alpha_ledger: request.alpha_ledger,
             beta_ledger: request.beta_ledger,

--- a/cnd/src/swap_protocols/rfc003/create_swap.rs
+++ b/cnd/src/swap_protocols/rfc003/create_swap.rs
@@ -39,8 +39,8 @@ pub async fn create_swap<D, A: ActorState>(
     accepted: AcceptedSwap<A::AL, A::BL, A::AA, A::BA>,
 ) where
     D: StateStore
-        + HtlcFunded<A::AL, A::AA, <<A as ActorState>::AL as Ledger>::Transaction>
-        + HtlcFunded<A::BL, A::BA, <<A as ActorState>::BL as Ledger>::Transaction>
+        + HtlcFunded<A::AL, A::AA>
+        + HtlcFunded<A::BL, A::BA>
         + HtlcDeployed<A::AL, A::AA>
         + HtlcDeployed<A::BL, A::BA>
         + HtlcRedeemed<A::AL, A::AA>
@@ -102,10 +102,7 @@ where
     BL: Ledger,
     AA: Asset,
     BA: Asset,
-    D: HtlcFunded<AL, AA, <AL as Ledger>::Transaction>
-        + HtlcDeployed<AL, AA>
-        + HtlcRedeemed<AL, AA>
-        + HtlcRefunded<AL, AA>,
+    D: HtlcFunded<AL, AA> + HtlcDeployed<AL, AA> + HtlcRedeemed<AL, AA> + HtlcRefunded<AL, AA>,
 {
     let deployed = dependencies
         .htlc_deployed(htlc_params.clone(), start_of_swap)
@@ -152,10 +149,7 @@ where
     BL: Ledger,
     AA: Asset,
     BA: Asset,
-    D: HtlcFunded<BL, BA, BL::Transaction>
-        + HtlcDeployed<BL, BA>
-        + HtlcRedeemed<BL, BA>
-        + HtlcRefunded<BL, BA>,
+    D: HtlcFunded<BL, BA> + HtlcDeployed<BL, BA> + HtlcRedeemed<BL, BA> + HtlcRefunded<BL, BA>,
 {
     let deployed = dependencies
         .htlc_deployed(htlc_params.clone(), start_of_swap)

--- a/cnd/src/swap_protocols/rfc003/ethereum/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/ethereum/htlc_events.rs
@@ -29,7 +29,7 @@ lazy_static::lazy_static! {
 }
 
 #[async_trait::async_trait]
-impl HtlcFunded<Ethereum, asset::Ether, ethereum::Transaction> for Cache<Web3Connector> {
+impl HtlcFunded<Ethereum, asset::Ether> for Cache<Web3Connector> {
     async fn htlc_funded(
         &self,
         _htlc_params: HtlcParams<Ethereum, asset::Ether>,
@@ -172,7 +172,7 @@ mod erc20 {
     use asset::ethereum::FromWei;
 
     #[async_trait::async_trait]
-    impl HtlcFunded<Ethereum, asset::Erc20, ethereum::Transaction> for Cache<Web3Connector> {
+    impl HtlcFunded<Ethereum, asset::Erc20> for Cache<Web3Connector> {
         async fn htlc_funded(
             &self,
             htlc_params: HtlcParams<Ethereum, asset::Erc20>,

--- a/cnd/src/swap_protocols/rfc003/events/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/events/mod.rs
@@ -33,13 +33,13 @@ pub struct Refunded<T> {
 }
 
 #[async_trait::async_trait]
-pub trait HtlcFunded<L: Ledger, A: Asset, T>: Send + Sync + Sized + 'static {
+pub trait HtlcFunded<L: Ledger, A: Asset>: Send + Sync + Sized + 'static {
     async fn htlc_funded(
         &self,
         htlc_params: HtlcParams<L, A>,
-        htlc_deployment: &Deployed<T, L::HtlcLocation>,
+        htlc_deployment: &Deployed<L::Transaction, L::HtlcLocation>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Funded<T, A>>;
+    ) -> anyhow::Result<Funded<L::Transaction, A>>;
 }
 
 #[async_trait::async_trait]

--- a/cnd/src/swap_protocols/rfc003/ledger_state.rs
+++ b/cnd/src/swap_protocols/rfc003/ledger_state.rs
@@ -2,7 +2,6 @@ use crate::{
     asset::Asset,
     swap_protocols::rfc003::{
         events::{Deployed, Funded, Redeemed, Refunded},
-        ledger::Ledger,
         Secret,
     },
 };
@@ -15,43 +14,43 @@ use strum_macros::EnumDiscriminants;
     derive(Serialize, Display),
     serde(rename_all = "SCREAMING_SNAKE_CASE")
 )]
-pub enum LedgerState<L: Ledger, A> {
+pub enum LedgerState<T, H, A> {
     NotDeployed,
     Deployed {
-        htlc_location: L::HtlcLocation,
-        deploy_transaction: L::Transaction,
+        htlc_location: H,
+        deploy_transaction: T,
     },
     Funded {
-        htlc_location: L::HtlcLocation,
-        deploy_transaction: L::Transaction,
-        fund_transaction: L::Transaction,
+        htlc_location: H,
+        deploy_transaction: T,
+        fund_transaction: T,
         asset: A,
     },
     Redeemed {
-        htlc_location: L::HtlcLocation,
-        deploy_transaction: L::Transaction,
-        fund_transaction: L::Transaction,
-        redeem_transaction: L::Transaction,
+        htlc_location: H,
+        deploy_transaction: T,
+        fund_transaction: T,
+        redeem_transaction: T,
         asset: A,
         secret: Secret,
     },
     Refunded {
-        htlc_location: L::HtlcLocation,
-        deploy_transaction: L::Transaction,
-        fund_transaction: L::Transaction,
-        refund_transaction: L::Transaction,
+        htlc_location: H,
+        deploy_transaction: T,
+        fund_transaction: T,
+        refund_transaction: T,
         asset: A,
     },
     IncorrectlyFunded {
-        htlc_location: L::HtlcLocation,
-        deploy_transaction: L::Transaction,
-        fund_transaction: L::Transaction,
+        htlc_location: H,
+        deploy_transaction: T,
+        fund_transaction: T,
         asset: A,
     },
 }
 
-impl<L: Ledger, A: Asset> LedgerState<L, A> {
-    pub fn transition_to_deployed(&mut self, deployed: Deployed<L::Transaction, L::HtlcLocation>) {
+impl<T, H, A: Asset> LedgerState<T, H, A> {
+    pub fn transition_to_deployed(&mut self, deployed: Deployed<T, H>) {
         let Deployed {
             transaction,
             location,
@@ -68,7 +67,7 @@ impl<L: Ledger, A: Asset> LedgerState<L, A> {
         }
     }
 
-    pub fn transition_to_funded(&mut self, funded: Funded<L::Transaction, A>) {
+    pub fn transition_to_funded(&mut self, funded: Funded<T, A>) {
         let Funded { transaction, asset } = funded;
 
         match std::mem::replace(self, LedgerState::NotDeployed) {
@@ -87,7 +86,7 @@ impl<L: Ledger, A: Asset> LedgerState<L, A> {
         }
     }
 
-    pub fn transition_to_incorrectly_funded(&mut self, funded: Funded<L::Transaction, A>) {
+    pub fn transition_to_incorrectly_funded(&mut self, funded: Funded<T, A>) {
         let Funded { transaction, asset } = funded;
 
         match std::mem::replace(self, LedgerState::NotDeployed) {
@@ -106,7 +105,7 @@ impl<L: Ledger, A: Asset> LedgerState<L, A> {
         }
     }
 
-    pub fn transition_to_redeemed(&mut self, redeemed: Redeemed<L::Transaction>) {
+    pub fn transition_to_redeemed(&mut self, redeemed: Redeemed<T>) {
         let Redeemed {
             transaction,
             secret,
@@ -132,7 +131,7 @@ impl<L: Ledger, A: Asset> LedgerState<L, A> {
         }
     }
 
-    pub fn transition_to_refunded(&mut self, refunded: Refunded<L::Transaction>) {
+    pub fn transition_to_refunded(&mut self, refunded: Refunded<T>) {
         let Refunded { transaction } = refunded;
 
         match std::mem::replace(self, LedgerState::NotDeployed) {

--- a/cnd/src/swap_protocols/rfc003/ledger_state.rs
+++ b/cnd/src/swap_protocols/rfc003/ledger_state.rs
@@ -14,7 +14,7 @@ use strum_macros::EnumDiscriminants;
     derive(Serialize, Display),
     serde(rename_all = "SCREAMING_SNAKE_CASE")
 )]
-pub enum LedgerState<T, H, A> {
+pub enum LedgerState<H, T, A> {
     NotDeployed,
     Deployed {
         htlc_location: H,
@@ -49,7 +49,7 @@ pub enum LedgerState<T, H, A> {
     },
 }
 
-impl<T, H, A: Asset> LedgerState<T, H, A> {
+impl<T, H, A: Asset> LedgerState<H, T, A> {
     pub fn transition_to_deployed(&mut self, deployed: Deployed<T, H>) {
         let Deployed {
             transaction,

--- a/cnd/src/swap_protocols/rfc003/ledger_state.rs
+++ b/cnd/src/swap_protocols/rfc003/ledger_state.rs
@@ -15,7 +15,7 @@ use strum_macros::EnumDiscriminants;
     derive(Serialize, Display),
     serde(rename_all = "SCREAMING_SNAKE_CASE")
 )]
-pub enum LedgerState<L: Ledger, A: Asset> {
+pub enum LedgerState<L: Ledger, A> {
     NotDeployed,
     Deployed {
         htlc_location: L::HtlcLocation,

--- a/cnd/src/swap_protocols/rfc003/messages.rs
+++ b/cnd/src/swap_protocols/rfc003/messages.rs
@@ -32,10 +32,10 @@ pub struct Request<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
 /// This does _not_ represent the actual network message, that is why it also
 /// does not implement Serialize.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct Accept<AL: Ledger, BL: Ledger> {
+pub struct Accept<AI, BI> {
     pub swap_id: SwapId,
-    pub beta_ledger_refund_identity: BL::Identity,
-    pub alpha_ledger_redeem_identity: AL::Identity,
+    pub beta_ledger_refund_identity: BI,
+    pub alpha_ledger_redeem_identity: AI,
 }
 
 /// High-level message that represents declining a Swap request
@@ -88,12 +88,12 @@ pub enum SwapDeclineReason {
     BadJsonField,
 }
 
-pub trait IntoAcceptMessage<AL: Ledger, BL: Ledger> {
+pub trait IntoAcceptMessage<AI, BI> {
     fn into_accept_message(
         self,
         id: SwapId,
         secret_source: &dyn DeriveIdentities,
-    ) -> Accept<AL, BL>;
+    ) -> Accept<AI, BI>;
 }
 
 #[cfg(test)]

--- a/cnd/src/swap_protocols/rfc003/messages.rs
+++ b/cnd/src/swap_protocols/rfc003/messages.rs
@@ -50,9 +50,9 @@ pub struct Decline {
 
 /// Body of the rfc003 request message
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-pub struct RequestBody<AL: Ledger, BL: Ledger> {
-    pub alpha_ledger_refund_identity: AL::Identity,
-    pub beta_ledger_redeem_identity: BL::Identity,
+pub struct RequestBody<AI, BI> {
+    pub alpha_ledger_refund_identity: AI,
+    pub beta_ledger_redeem_identity: BI,
     pub alpha_expiry: Timestamp,
     pub beta_expiry: Timestamp,
     pub secret_hash: SecretHash,

--- a/cnd/src/swap_protocols/rfc003/messages.rs
+++ b/cnd/src/swap_protocols/rfc003/messages.rs
@@ -66,9 +66,9 @@ pub enum Decision {
 
 /// Body of the rfc003 accept message
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct AcceptResponseBody<AL: Ledger, BL: Ledger> {
-    pub beta_ledger_refund_identity: BL::Identity,
-    pub alpha_ledger_redeem_identity: AL::Identity,
+pub struct AcceptResponseBody<AI, BI> {
+    pub beta_ledger_refund_identity: BI,
+    pub alpha_ledger_redeem_identity: AI,
 }
 
 /// Body of the rfc003 decline message

--- a/cnd/src/swap_protocols/rfc003/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/mod.rs
@@ -30,7 +30,8 @@ use crate::{asset::Asset, seed::SwapSeed};
 use ::bitcoin::secp256k1::SecretKey;
 
 /// Swap request response as received from peer node acting as Bob.
-pub type Response<AL, BL> = Result<Accept<AL, BL>, Decline>;
+pub type Response<AL, BL> =
+    Result<Accept<<AL as Ledger>::Identity, <BL as Ledger>::Identity>, Decline>;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum SwapCommunication<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
@@ -39,7 +40,7 @@ pub enum SwapCommunication<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
     },
     Accepted {
         request: Request<AL, BL, AA, BA>,
-        response: Accept<AL, BL>,
+        response: Accept<AL::Identity, BL::Identity>,
     },
     Declined {
         request: Request<AL, BL, AA, BA>,


### PR DESCRIPTION
Time for a new PR.

`Request` needs to keep the `Ledger` trait bounds due to the fact that it contains the ledger.
Hopefully, with the REST API routes we introduce with lightning, this will go away.
This will then free a bunch of other structs.

Works Towards #2037