### PR TITLE
Relax trait bound `SwapEvent`

### DIFF
--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -11,7 +11,7 @@ use crate::{
         ledger::{bitcoin, Ethereum},
         rfc003::{
             self,
-            create_swap::{HtlcParams, SwapEvent},
+            create_swap::{HtlcParams, SwapEventOnLedger},
             events::{
                 Deployed, Funded, HtlcDeployed, HtlcFunded, HtlcRedeemed, HtlcRefunded, Redeemed,
                 Refunded,
@@ -59,18 +59,10 @@ impl StateStore for Facade {
         self.state_store.get(key)
     }
 
-    #[allow(clippy::type_complexity)]
     fn update<A: ActorState>(
         &self,
         key: &SwapId,
-        update: SwapEvent<
-            <<A as ActorState>::AL as Ledger>::HtlcLocation,
-            <<A as ActorState>::AL as Ledger>::Transaction,
-            <<A as ActorState>::BL as Ledger>::HtlcLocation,
-            <<A as ActorState>::BL as Ledger>::Transaction,
-            A::AA,
-            A::BA,
-        >,
+        update: SwapEventOnLedger<<A as ActorState>::AL, <A as ActorState>::BL, A::AA, A::BA>,
     ) {
         self.state_store.update::<A>(key, update)
     }

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -59,7 +59,19 @@ impl StateStore for Facade {
         self.state_store.get(key)
     }
 
-    fn update<A: ActorState>(&self, key: &SwapId, update: SwapEvent<A::AL, A::BL, A::AA, A::BA>) {
+    #[allow(clippy::type_complexity)]
+    fn update<A: ActorState>(
+        &self,
+        key: &SwapId,
+        update: SwapEvent<
+            <<A as ActorState>::AL as Ledger>::HtlcLocation,
+            <<A as ActorState>::AL as Ledger>::Transaction,
+            <<A as ActorState>::BL as Ledger>::HtlcLocation,
+            <<A as ActorState>::BL as Ledger>::Transaction,
+            A::AA,
+            A::BA,
+        >,
+    ) {
         self.state_store.update::<A>(key, update)
     }
 }

--- a/cnd/src/swap_protocols/rfc003/create_swap.rs
+++ b/cnd/src/swap_protocols/rfc003/create_swap.rs
@@ -101,12 +101,9 @@ pub async fn create_swap<D, A: ActorState>(
 /// Returns a future that waits for events on alpha ledger to happen.
 ///
 /// Each event is yielded through the controller handle (co) of the coroutine.
-#[allow(clippy::type_complexity)]
 async fn watch_alpha_ledger<D, AL, AA, BL, BA>(
     dependencies: &D,
-    co: &Co<
-        SwapEvent<AL::HtlcLocation, AL::Transaction, BL::HtlcLocation, BL::Transaction, AA, BA>,
-    >,
+    co: &Co<SwapEventOnLedger<AL, BL, AA, BA>>,
     htlc_params: HtlcParams<AL, AA, AL::Identity>,
     start_of_swap: NaiveDateTime,
 ) -> anyhow::Result<()>
@@ -151,12 +148,9 @@ where
 /// Returns a future that waits for events on beta ledger to happen.
 ///
 /// Each event is yielded through the controller handle (co) of the coroutine.
-#[allow(clippy::type_complexity)]
 async fn watch_beta_ledger<D, AL, AA, BL, BA>(
     dependencies: &D,
-    co: &Co<
-        SwapEvent<AL::HtlcLocation, AL::Transaction, BL::HtlcLocation, BL::Transaction, AA, BA>,
-    >,
+    co: &Co<SwapEventOnLedger<AL, BL, AA, BA>>,
     htlc_params: HtlcParams<BL, BA, BL::Identity>,
     start_of_swap: NaiveDateTime,
 ) -> anyhow::Result<()>
@@ -303,6 +297,15 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> OngoingSwap<AL, BL, AA, BA> {
         }
     }
 }
+
+pub type SwapEventOnLedger<AL, BL, AA, BA> = SwapEvent<
+    <AL as Ledger>::HtlcLocation,
+    <AL as Ledger>::Transaction,
+    <BL as Ledger>::HtlcLocation,
+    <BL as Ledger>::Transaction,
+    AA,
+    BA,
+>;
 
 #[derive(Debug, Clone, PartialEq, strum_macros::Display)]
 pub enum SwapEvent<AH, AT, BH, BT, AA, BA>


### PR DESCRIPTION
Doing a separate PR as this commit may be seen as controversial.

The complexity can be decreased by introducing types.

I think this is the way forward as ultimately, we want to remove the `Ledger` trait bound as with han/herc20 we will have separate (or no) `Ledger` traits.

Resolves #2037.