### PR TITLE
Introduce new GH workflow for releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
       - release-build-test:
           filters: # runs for "release/" branches and all tags.
             branches:
-              only: /^release.*$/
+              only: /^release\/*$/
             tags:
               only: /.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,6 @@ workflows:
               only: /^release.*$/
             tags:
               only: /.*/
-      - publish-github-release:
-          requires:
-            - release-build-test
-          filters: # runs for no branches and only for X.Y.Z.
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^\d+\.\d+\.\d+$/
 
 jobs:
   debug-build-test:
@@ -71,54 +63,6 @@ jobs:
           command: |
             export CND_BIN=~/comit/target/release/cnd
             make ci BUILD_ARGS='--release'
-      - store_artifacts:
-          path: api_tests/log
-      - run:
-          name: Consolidate release binaries
-          command: |
-            set -v
-            mkdir ~/artifacts
-            mv -v ~/comit/target/release/cnd ~/artifacts
-      - persist_to_workspace:
-          root: ~/artifacts
-          paths:
-            - cnd
-
-  publish-github-release:
-    working_directory: ~/comit
-    machine:
-      image: ubuntu-1604:201903-01
-    environment:
-      RUST_TEST_THREADS: "8"
-    steps:
-      - attach_workspace:
-          at: ~/artifacts
-      - checkout
-      - restore_caches
-      - install_rust
-      - install_node_devlibs
-      - print_current_versions
-      - setup_remote_docker
-      - run:
-          name: "Package & Publish Release on GitHub and Docker Hub"
-          command: |
-            set -v
-            VERSION=$(cargo pkgid -- cnd|cut -d# -f2)
-
-            # Let's abort if the git tag does not match the version in Cargo.toml as it would be fishy
-            test "${VERSION}" = "${CIRCLE_TAG}"
-
-            mkdir ~/package
-            cd ~/artifacts && tar czvf ~/package/comit-rs_${VERSION}_$(uname -s)_$(uname -m).tar.gz *
-            go get github.com/tcnksm/ghr
-            ls ~/package/
-            ghr -t ${GITHUB_TOKEN_FOR_RELEASES} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ~/package/
-
-            echo $DOCKER_HUB_TOKEN | docker login -u thomaseizinger --password-stdin
-
-            docker build . -t comitnetwork/cnd:${VERSION} -t comitnetwork/cnd:latest
-            docker push comitnetwork/cnd:${VERSION}
-            docker push comitnetwork/cnd:latest
 
 commands:
   install_node_devlibs:

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -1,0 +1,191 @@
+name: "Publish new release"
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+
+jobs:
+  build_binary:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/') # only merged release branches must trigger this
+    name: Build binary
+    strategy:
+      matrix:
+        os: [ubuntu, macos]
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - name: Checkout merge commit
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          override: true
+
+      - name: Build ${{ matrix.os }} release binary
+        id: build
+        run: make build BUILD_ARGS='--release'
+
+      - name: Extract version from branch name
+        id: extract-version
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#release/}
+
+          echo "::set-output name=version::$VERSION"
+
+      - name: Create archive
+        id: create-archive
+        run: |
+          MACHINE=$(uname -m)
+          KERNEL=$(uname -s)
+          VERSION=${{ steps.extract-version.outputs.version }}
+
+          ARCHIVE="cnd_${VERSION}_${KERNEL}_${MACHINE}.tar.gz"
+
+          tar -C ./target/release --create --file=$ARCHIVE cnd
+
+          echo "::set-output name=archive::$ARCHIVE"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ matrix.os }}-release-archive
+          path: ${{ steps.create-archive.outputs.archive }}
+
+  create_docker_image:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/') # only merged release branches must trigger this
+    name: Create and publish Docker image
+    needs: build_binary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout merge commit
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Download ubuntu release package
+        uses: actions/download-artifact@v1
+        with:
+          name: ubuntu-release-archive
+
+      - name: Move binary into correct place for Docker build
+        run: |
+          mkdir -p ./target/release
+
+          tar --extract -f ./ubuntu-release-archive/*.tar.gz -C ./target/release/
+
+      - name: Login to docker
+        uses: azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+
+      - name: Extract version from branch name
+        id: extract-version
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#release/}
+
+          echo "::set-output name=version::$VERSION"
+
+      - name: Publish docker image as ${{ steps.extract-version.outputs.version }} and latest
+        run: |
+          VERSION="${{ steps.extract-version.outputs.version }}"
+
+          docker build . -t comitnetwork/cnd:$VERSION -t comitnetwork/cnd:latest
+          docker push comitnetwork/cnd:$VERSION
+          docker push comitnetwork/cnd:latest
+
+
+  release:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/') # only merged release branches must trigger this
+    name: Create GitHub release
+    needs: build_binary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version from branch name
+        id: extract-version
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#release/}
+
+          echo "::set-output name=version::$VERSION"
+
+      - name: Download ubuntu release package
+        uses: actions/download-artifact@v1
+        with:
+          name: ubuntu-release-archive
+
+      - name: Download macos release package
+        uses: actions/download-artifact@v1
+        with:
+          name: macos-release-archive
+
+      - name: Detect archives to upload
+        id: detect-archives
+        run: |
+          echo "::set-output name=ubuntu-archive::$(cd ./ubuntu-release-archive/; echo *.tar.gz)"
+          echo "::set-output name=macos-archive::$(cd ./macos-release-archive/; echo *.tar.gz)"
+
+      - name: Create Release
+        id: create-release
+        uses: thomaseizinger/create-release@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
+          tag_name: ${{ steps.extract-version.outputs.version }}
+          name: ${{ steps.extract-version.outputs.version }}
+          draft: false
+          prerelease: false
+
+      - name: Upload ubuntu release binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./ubuntu-release-archive/${{ steps.detect-archives.outputs.ubuntu-archive }}
+          asset_name: ${{ steps.detect-archives.outputs.ubuntu-archive }}
+          asset_content_type: application/gzip
+
+      - name: Upload macos release binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./macos-release-archive/${{ steps.detect-archives.outputs.macos-archive }}
+          asset_name: ${{ steps.detect-archives.outputs.macos-archive }}
+          asset_content_type: application/gzip
+
+  merge_release_into_dev:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/') # only merged release branches must trigger this
+    name: Merge release-branch back into dev
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version from branch name
+        id: extract-version
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#release/}
+
+          echo "::set-output name=version::$VERSION"
+
+      - name: Create pull request for merging release-branch back into dev
+        uses: thomaseizinger/create-pull-request@1.0.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        head: release/${{ steps.extract-version.outputs.version }}
+        base: dev
+        title: Merge release ${{ steps.extract-version.outputs.version }} into dev branch
+        body: |
+          This PR merges the release branch for ${{ steps.extract-version.outputs.version }} back into dev.
+          This happens to ensure that the updates that happend on the release branch, i.e. CHANGELOG and manifest updates are also present on the dev branch.
+

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,22 @@
+# Releasing
+
+Releases of comit-rs are mostly automated.
+Here is what you need to know:
+
+The repository uses the GitFlow branching model.
+Hence, releases are started by branching a release-branch (`release/x.y.z`) off `dev`.
+
+1. Start with creating said release branch locally.
+1. Update the changelog to reflect the newest release.
+1. Bump necessary versions in the manifest files.
+1. Build to ensure the lock files are updated.
+1. Commit and push your changes
+1. Create a pull request targeting the __master__ branch.
+1. Get approvals and merge it.
+
+From here, [the automation](./.github/workflows/publish-new-release.yml) takes over and:
+
+1. Builds the release artifacts for Linux and MacOS.
+1. Pushes a new tag of the [comitnetwork/cnd](https://hub.docker.com/repository/docker/comitnetwork/cnd) docker image.
+1. Tags the merge commit and creates a release on GitHub with the binaries attached.
+1. Opens a PR to merge back to _dev_ branch: **Make sure to merge this one in a timely fashion**.


### PR DESCRIPTION
I've tested this to my best ability by creating dummy releases on push events to this branch. You can see the final successful execution here: https://github.com/comit-network/comit-rs/actions/runs/45203040

I did have to make a bunch of changes afterwards to use the actual variables etc.

Please focus your review on finding mistakes in that regards:

- referencing outputs that don't exist
- referencing env variables that don't exist
- etc

The overall workflow works like this:

- macos and ubuntu runners build artifacts in parallel. they create archives and upload them to github artifacts
- two ubuntu jobs trigger after this: releasing the docker image and creating the github release
- the docker job downloads only the ubuntu artifact, builds the image and publishes it on dockerhub
- the GH release job creates a new GH release, downloads the two artifacts and uploads them to the release. I went with the official upload-release-asset action because I had to separate the creation of the release from the uploading. I used my own fork of the create-release action for reasons stated in the readme: https://github.com/thomaseizinger/create-release#features

Fixes #1901.