### PR TITLE
Remove the `Into<LedgeKind>` trait bound from Ledger

### DIFF
--- a/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
@@ -21,8 +21,9 @@ use crate::{
 };
 use anyhow::Context;
 use futures_core::future::TryFutureExt;
+use libp2p_comit::frame::OutboundRequest;
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use std::{convert::TryInto, fmt::Debug, str::FromStr};
 
 async fn initiate_request<AL, BL, AA, BA>(
     dependencies: Facade,
@@ -39,6 +40,8 @@ where
     BL: Ledger,
     AA: Asset,
     BA: Asset,
+    rfc003::Request<AL, BL, AA, BA>: TryInto<OutboundRequest>,
+    <rfc003::Request<AL, BL, AA, BA> as TryInto<OutboundRequest>>::Error: Debug,
     Facade: LoadAcceptedSwap<AL, BL, AA, BA>
         + HtlcFunded<AL, AA>
         + HtlcFunded<BL, BA>

--- a/cnd/src/network/mod.rs
+++ b/cnd/src/network/mod.rs
@@ -38,14 +38,15 @@ use libp2p::{
     Multiaddr, NetworkBehaviour, PeerId,
 };
 use libp2p_comit::{
-    frame::{self, OutboundRequest, Response, ValidatedInboundRequest},
+    frame::{OutboundRequest, Response, ValidatedInboundRequest},
     handler,
     handler::{ComitHandler, ProtocolInEvent, ProtocolOutEvent},
     BehaviourOutEvent, Comit, PendingInboundRequest,
 };
 use std::{
     collections::{HashMap, HashSet},
-    fmt::Display,
+    convert::TryInto,
+    fmt::{Debug, Display},
     io,
     sync::Arc,
 };
@@ -726,7 +727,9 @@ pub trait SendRequest {
         AL: Ledger,
         BL: Ledger,
         AA: Asset,
-        BA: Asset;
+        BA: Asset,
+        rfc003::Request<AL, BL, AA, BA>: TryInto<OutboundRequest>,
+        <rfc003::Request<AL, BL, AA, BA> as TryInto<OutboundRequest>>::Error: Debug;
 }
 
 #[async_trait]
@@ -741,9 +744,12 @@ impl SendRequest for Swarm {
         BL: Ledger,
         AA: Asset,
         BA: Asset,
+        rfc003::Request<AL, BL, AA, BA>: TryInto<OutboundRequest>,
+        <rfc003::Request<AL, BL, AA, BA> as TryInto<OutboundRequest>>::Error: Debug,
     {
         let id = request.swap_id;
-        let request = build_outbound_request(request)
+        let request = request
+            .try_into()
             .expect("constructing a frame::OutoingRequest should never fail!");
 
         let result = {
@@ -876,39 +882,4 @@ where
         beta_expiry: body.beta_expiry,
         secret_hash: body.secret_hash,
     }
-}
-
-fn build_outbound_request<AL, BL, AA, BA>(
-    request: rfc003::Request<AL, BL, AA, BA>,
-) -> Result<frame::OutboundRequest, serde_json::Error>
-where
-    AL: Ledger,
-    BL: Ledger,
-    AA: Asset,
-    BA: Asset,
-{
-    let alpha_ledger_refund_identity = request.alpha_ledger_refund_identity;
-    let beta_ledger_redeem_identity = request.beta_ledger_redeem_identity;
-    let alpha_expiry = request.alpha_expiry;
-    let beta_expiry = request.beta_expiry;
-    let secret_hash = request.secret_hash;
-    let protocol = SwapProtocol::Rfc003(request.hash_function);
-
-    Ok(frame::OutboundRequest::new("SWAP")
-        .with_header("id", request.swap_id.to_header()?)
-        .with_header("alpha_ledger", request.alpha_ledger.into().to_header()?)
-        .with_header("beta_ledger", request.beta_ledger.into().to_header()?)
-        .with_header("alpha_asset", request.alpha_asset.into().to_header()?)
-        .with_header("beta_asset", request.beta_asset.into().to_header()?)
-        .with_header("protocol", protocol.to_header()?)
-        .with_body(serde_json::to_value(rfc003::messages::RequestBody::<
-            AL::Identity,
-            BL::Identity,
-        > {
-            alpha_ledger_refund_identity,
-            beta_ledger_redeem_identity,
-            alpha_expiry,
-            beta_expiry,
-            secret_hash,
-        })?))
 }

--- a/cnd/src/network/mod.rs
+++ b/cnd/src/network/mod.rs
@@ -16,6 +16,7 @@ use crate::{
             self, bob,
             messages::{Decision, DeclineResponseBody, Request, SwapDeclineReason},
             state_store::{InMemoryStateStore, StateStore},
+            Ledger,
         },
         HashFunction, Role, SwapId, SwapProtocol,
     },
@@ -628,8 +629,8 @@ async fn insert_state_for_bob<AL, BL, AA, BA, DB>(
     swap_request: Request<AL, BL, AA, BA>,
 ) -> anyhow::Result<()>
 where
-    AL: rfc003::Ledger,
-    BL: rfc003::Ledger,
+    AL: Ledger,
+    BL: Ledger,
     AA: Asset,
     BA: Asset,
     DB: Save<Request<AL, BL, AA, BA>> + Save<Swap>,
@@ -722,8 +723,8 @@ pub trait SendRequest {
         request: rfc003::Request<AL, BL, AA, BA>,
     ) -> Result<rfc003::Response<AL, BL>, RequestError>
     where
-        AL: rfc003::Ledger,
-        BL: rfc003::Ledger,
+        AL: Ledger,
+        BL: Ledger,
         AA: Asset,
         BA: Asset;
 }
@@ -736,8 +737,8 @@ impl SendRequest for Swarm {
         request: rfc003::Request<AL, BL, AA, BA>,
     ) -> Result<rfc003::Response<AL, BL>, RequestError>
     where
-        AL: rfc003::Ledger,
-        BL: rfc003::Ledger,
+        AL: Ledger,
+        BL: Ledger,
         AA: Asset,
         BA: Asset,
     {
@@ -857,8 +858,8 @@ fn rfc003_swap_request<AL, BL, AA, BA>(
     body: rfc003::messages::RequestBody<AL::Identity, BL::Identity>,
 ) -> rfc003::Request<AL, BL, AA, BA>
 where
-    AL: rfc003::Ledger,
-    BL: rfc003::Ledger,
+    AL: Ledger,
+    BL: Ledger,
     AA: Asset,
     BA: Asset,
 {
@@ -881,8 +882,8 @@ fn build_outbound_request<AL, BL, AA, BA>(
     request: rfc003::Request<AL, BL, AA, BA>,
 ) -> Result<frame::OutboundRequest, serde_json::Error>
 where
-    AL: rfc003::Ledger,
-    BL: rfc003::Ledger,
+    AL: Ledger,
+    BL: Ledger,
     AA: Asset,
     BA: Asset,
 {

--- a/cnd/src/swap_protocols/ledger/bitcoin.rs
+++ b/cnd/src/swap_protocols/ledger/bitcoin.rs
@@ -10,7 +10,7 @@ pub struct Testnet;
 pub struct Regtest;
 
 pub trait Bitcoin:
-    Sized + std::fmt::Debug + std::hash::Hash + Eq + Sync + Copy + Send + Into<LedgerKind> + 'static
+    Sized + std::fmt::Debug + std::hash::Hash + Eq + Sync + Copy + Send + 'static
 {
 }
 

--- a/cnd/src/swap_protocols/mod.rs
+++ b/cnd/src/swap_protocols/mod.rs
@@ -5,7 +5,7 @@ pub mod rfc003;
 mod swap_id;
 
 pub use self::{facade::*, swap_id::*};
-use crate::comit_api::LedgerKind;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(

--- a/cnd/src/swap_protocols/rfc003/ledger.rs
+++ b/cnd/src/swap_protocols/rfc003/ledger.rs
@@ -1,9 +1,8 @@
-use crate::swap_protocols::LedgerKind;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{fmt::Debug, hash::Hash};
 
 pub trait Ledger:
-    Clone + Copy + Debug + Send + Sync + 'static + PartialEq + Eq + Hash + Into<LedgerKind> + Sized
+    Clone + Copy + Debug + Send + Sync + 'static + PartialEq + Eq + Hash + Sized
 {
     type HtlcLocation: PartialEq + Debug + Clone + DeserializeOwned + Serialize + Send + Sync;
     type Identity: Clone

--- a/cnd/src/swap_protocols/rfc003/messages.rs
+++ b/cnd/src/swap_protocols/rfc003/messages.rs
@@ -1,12 +1,20 @@
 use crate::{
-    asset::Asset,
+    asset::{self, Asset, AssetKind},
+    bitcoin::PublicKey,
+    comit_api::LedgerKind,
+    ethereum::Address,
+    libp2p_comit_ext::ToHeader,
     swap_protocols::{
+        ledger::{bitcoin, Ethereum},
         rfc003::{DeriveIdentities, Ledger, SecretHash},
-        HashFunction, SwapId,
+        HashFunction, SwapId, SwapProtocol,
     },
     timestamp::Timestamp,
 };
+use anyhow;
+use libp2p_comit::frame::OutboundRequest;
 use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
 
 /// High-level message that represents a Swap request to another party
 ///
@@ -25,6 +33,330 @@ pub struct Request<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
     pub alpha_expiry: Timestamp,
     pub beta_expiry: Timestamp,
     pub secret_hash: SecretHash,
+}
+
+impl TryFrom<Request<bitcoin::Mainnet, Ethereum, asset::Bitcoin, asset::Ether>>
+    for OutboundRequest
+{
+    type Error = anyhow::Error;
+
+    fn try_from(
+        request: Request<bitcoin::Mainnet, Ethereum, asset::Bitcoin, asset::Ether>,
+    ) -> anyhow::Result<Self> {
+        let request_body: RequestBody<PublicKey, Address> = RequestBody::from(request.clone());
+        let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
+
+        let alpha_ledger = LedgerKind::BitcoinMainnet.to_header()?;
+        let beta_ledger = LedgerKind::Ethereum(request.beta_ledger).to_header()?;
+        let alpha_asset = AssetKind::Bitcoin(request.alpha_asset).to_header()?;
+        let beta_asset = AssetKind::Ether(request.beta_asset).to_header()?;
+
+        Ok(OutboundRequest::new("SWAP")
+            .with_header("id", request.swap_id.to_header()?)
+            .with_header("alpha_ledger", alpha_ledger)
+            .with_header("beta_ledger", beta_ledger)
+            .with_header("alpha_asset", alpha_asset)
+            .with_header("beta_asset", beta_asset)
+            .with_header("protocol", protocol)
+            .with_body(serde_json::to_value(request_body)?))
+    }
+}
+
+impl TryFrom<Request<bitcoin::Testnet, Ethereum, asset::Bitcoin, asset::Ether>>
+    for OutboundRequest
+{
+    type Error = anyhow::Error;
+
+    fn try_from(
+        request: Request<bitcoin::Testnet, Ethereum, asset::Bitcoin, asset::Ether>,
+    ) -> anyhow::Result<Self> {
+        let request_body: RequestBody<PublicKey, Address> = RequestBody::from(request.clone());
+        let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
+
+        let alpha_ledger = LedgerKind::BitcoinTestnet.to_header()?;
+        let beta_ledger = LedgerKind::Ethereum(request.beta_ledger).to_header()?;
+        let alpha_asset = AssetKind::Bitcoin(request.alpha_asset).to_header()?;
+        let beta_asset = AssetKind::Ether(request.beta_asset).to_header()?;
+
+        Ok(OutboundRequest::new("SWAP")
+            .with_header("id", request.swap_id.to_header()?)
+            .with_header("alpha_ledger", alpha_ledger)
+            .with_header("beta_ledger", beta_ledger)
+            .with_header("alpha_asset", alpha_asset)
+            .with_header("beta_asset", beta_asset)
+            .with_header("protocol", protocol)
+            .with_body(serde_json::to_value(request_body)?))
+    }
+}
+
+impl TryFrom<Request<bitcoin::Regtest, Ethereum, asset::Bitcoin, asset::Ether>>
+    for OutboundRequest
+{
+    type Error = anyhow::Error;
+
+    fn try_from(
+        request: Request<bitcoin::Regtest, Ethereum, asset::Bitcoin, asset::Ether>,
+    ) -> anyhow::Result<Self> {
+        let request_body: RequestBody<PublicKey, Address> = RequestBody::from(request.clone());
+        let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
+
+        let alpha_ledger = LedgerKind::BitcoinRegtest.to_header()?;
+        let beta_ledger = LedgerKind::Ethereum(request.beta_ledger).to_header()?;
+        let alpha_asset = AssetKind::Bitcoin(request.alpha_asset).to_header()?;
+        let beta_asset = AssetKind::Ether(request.beta_asset).to_header()?;
+
+        Ok(OutboundRequest::new("SWAP")
+            .with_header("id", request.swap_id.to_header()?)
+            .with_header("alpha_ledger", alpha_ledger)
+            .with_header("beta_ledger", beta_ledger)
+            .with_header("alpha_asset", alpha_asset)
+            .with_header("beta_asset", beta_asset)
+            .with_header("protocol", protocol)
+            .with_body(serde_json::to_value(request_body)?))
+    }
+}
+
+impl TryFrom<Request<bitcoin::Mainnet, Ethereum, asset::Bitcoin, asset::Erc20>>
+    for OutboundRequest
+{
+    type Error = anyhow::Error;
+
+    fn try_from(
+        request: Request<bitcoin::Mainnet, Ethereum, asset::Bitcoin, asset::Erc20>,
+    ) -> anyhow::Result<Self> {
+        let request_body: RequestBody<PublicKey, Address> = RequestBody::from(request.clone());
+        let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
+
+        let alpha_ledger = LedgerKind::BitcoinMainnet.to_header()?;
+        let beta_ledger = LedgerKind::Ethereum(request.beta_ledger).to_header()?;
+        let alpha_asset = AssetKind::Bitcoin(request.alpha_asset).to_header()?;
+        let beta_asset = AssetKind::Erc20(request.beta_asset).to_header()?;
+
+        Ok(OutboundRequest::new("SWAP")
+            .with_header("id", request.swap_id.to_header()?)
+            .with_header("alpha_ledger", alpha_ledger)
+            .with_header("beta_ledger", beta_ledger)
+            .with_header("alpha_asset", alpha_asset)
+            .with_header("beta_asset", beta_asset)
+            .with_header("protocol", protocol)
+            .with_body(serde_json::to_value(request_body)?))
+    }
+}
+
+impl TryFrom<Request<bitcoin::Testnet, Ethereum, asset::Bitcoin, asset::Erc20>>
+    for OutboundRequest
+{
+    type Error = anyhow::Error;
+
+    fn try_from(
+        request: Request<bitcoin::Testnet, Ethereum, asset::Bitcoin, asset::Erc20>,
+    ) -> anyhow::Result<Self> {
+        let request_body: RequestBody<PublicKey, Address> = RequestBody::from(request.clone());
+        let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
+
+        let alpha_ledger = LedgerKind::BitcoinTestnet.to_header()?;
+        let beta_ledger = LedgerKind::Ethereum(request.beta_ledger).to_header()?;
+        let alpha_asset = AssetKind::Bitcoin(request.alpha_asset).to_header()?;
+        let beta_asset = AssetKind::Erc20(request.beta_asset).to_header()?;
+
+        Ok(OutboundRequest::new("SWAP")
+            .with_header("id", request.swap_id.to_header()?)
+            .with_header("alpha_ledger", alpha_ledger)
+            .with_header("beta_ledger", beta_ledger)
+            .with_header("alpha_asset", alpha_asset)
+            .with_header("beta_asset", beta_asset)
+            .with_header("protocol", protocol)
+            .with_body(serde_json::to_value(request_body)?))
+    }
+}
+
+impl TryFrom<Request<bitcoin::Regtest, Ethereum, asset::Bitcoin, asset::Erc20>>
+    for OutboundRequest
+{
+    type Error = anyhow::Error;
+
+    fn try_from(
+        request: Request<bitcoin::Regtest, Ethereum, asset::Bitcoin, asset::Erc20>,
+    ) -> anyhow::Result<Self> {
+        let request_body: RequestBody<PublicKey, Address> = RequestBody::from(request.clone());
+        let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
+
+        let alpha_ledger = LedgerKind::BitcoinRegtest.to_header()?;
+        let beta_ledger = LedgerKind::Ethereum(request.beta_ledger).to_header()?;
+        let alpha_asset = AssetKind::Bitcoin(request.alpha_asset).to_header()?;
+        let beta_asset = AssetKind::Erc20(request.beta_asset).to_header()?;
+
+        Ok(OutboundRequest::new("SWAP")
+            .with_header("id", request.swap_id.to_header()?)
+            .with_header("alpha_ledger", alpha_ledger)
+            .with_header("beta_ledger", beta_ledger)
+            .with_header("alpha_asset", alpha_asset)
+            .with_header("beta_asset", beta_asset)
+            .with_header("protocol", protocol)
+            .with_body(serde_json::to_value(request_body)?))
+    }
+}
+
+impl TryFrom<Request<Ethereum, bitcoin::Mainnet, asset::Ether, asset::Bitcoin>>
+    for OutboundRequest
+{
+    type Error = anyhow::Error;
+
+    fn try_from(
+        request: Request<Ethereum, bitcoin::Mainnet, asset::Ether, asset::Bitcoin>,
+    ) -> anyhow::Result<Self> {
+        let request_body: RequestBody<Address, PublicKey> = RequestBody::from(request.clone());
+        let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
+
+        let alpha_ledger = LedgerKind::Ethereum(request.alpha_ledger).to_header()?;
+        let beta_ledger = LedgerKind::BitcoinMainnet.to_header()?;
+        let alpha_asset = AssetKind::Ether(request.alpha_asset).to_header()?;
+        let beta_asset = AssetKind::Bitcoin(request.beta_asset).to_header()?;
+
+        Ok(OutboundRequest::new("SWAP")
+            .with_header("id", request.swap_id.to_header()?)
+            .with_header("alpha_ledger", alpha_ledger)
+            .with_header("beta_ledger", beta_ledger)
+            .with_header("alpha_asset", alpha_asset)
+            .with_header("beta_asset", beta_asset)
+            .with_header("protocol", protocol)
+            .with_body(serde_json::to_value(request_body)?))
+    }
+}
+
+impl TryFrom<Request<Ethereum, bitcoin::Testnet, asset::Ether, asset::Bitcoin>>
+    for OutboundRequest
+{
+    type Error = anyhow::Error;
+
+    fn try_from(
+        request: Request<Ethereum, bitcoin::Testnet, asset::Ether, asset::Bitcoin>,
+    ) -> anyhow::Result<Self> {
+        let request_body: RequestBody<Address, PublicKey> = RequestBody::from(request.clone());
+        let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
+
+        let alpha_ledger = LedgerKind::Ethereum(request.alpha_ledger).to_header()?;
+        let beta_ledger = LedgerKind::BitcoinTestnet.to_header()?;
+        let alpha_asset = AssetKind::Ether(request.alpha_asset).to_header()?;
+        let beta_asset = AssetKind::Bitcoin(request.beta_asset).to_header()?;
+
+        Ok(OutboundRequest::new("SWAP")
+            .with_header("id", request.swap_id.to_header()?)
+            .with_header("beta_ledger", alpha_ledger)
+            .with_header("beta_ledger", beta_ledger)
+            .with_header("alpha_asset", alpha_asset)
+            .with_header("beta_asset", beta_asset)
+            .with_header("protocol", protocol)
+            .with_body(serde_json::to_value(request_body)?))
+    }
+}
+
+impl TryFrom<Request<Ethereum, bitcoin::Regtest, asset::Ether, asset::Bitcoin>>
+    for OutboundRequest
+{
+    type Error = anyhow::Error;
+
+    fn try_from(
+        request: Request<Ethereum, bitcoin::Regtest, asset::Ether, asset::Bitcoin>,
+    ) -> anyhow::Result<Self> {
+        let request_body: RequestBody<Address, PublicKey> = RequestBody::from(request.clone());
+        let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
+
+        let alpha_ledger = LedgerKind::Ethereum(request.alpha_ledger).to_header()?;
+        let beta_ledger = LedgerKind::BitcoinRegtest.to_header()?;
+        let alpha_asset = AssetKind::Ether(request.alpha_asset).to_header()?;
+        let beta_asset = AssetKind::Bitcoin(request.beta_asset).to_header()?;
+
+        Ok(OutboundRequest::new("SWAP")
+            .with_header("id", request.swap_id.to_header()?)
+            .with_header("alpha_ledger", alpha_ledger)
+            .with_header("beta_ledger", beta_ledger)
+            .with_header("alpha_asset", alpha_asset)
+            .with_header("beta_asset", beta_asset)
+            .with_header("protocol", protocol)
+            .with_body(serde_json::to_value(request_body)?))
+    }
+}
+
+impl TryFrom<Request<Ethereum, bitcoin::Mainnet, asset::Erc20, asset::Bitcoin>>
+    for OutboundRequest
+{
+    type Error = anyhow::Error;
+
+    fn try_from(
+        request: Request<Ethereum, bitcoin::Mainnet, asset::Erc20, asset::Bitcoin>,
+    ) -> anyhow::Result<Self> {
+        let request_body: RequestBody<Address, PublicKey> = RequestBody::from(request.clone());
+        let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
+
+        let alpha_ledger = LedgerKind::Ethereum(request.alpha_ledger).to_header()?;
+        let beta_ledger = LedgerKind::BitcoinMainnet.to_header()?;
+        let alpha_asset = AssetKind::Erc20(request.alpha_asset).to_header()?;
+        let beta_asset = AssetKind::Bitcoin(request.beta_asset).to_header()?;
+
+        Ok(OutboundRequest::new("SWAP")
+            .with_header("id", request.swap_id.to_header()?)
+            .with_header("alpha_ledger", alpha_ledger)
+            .with_header("beta_ledger", beta_ledger)
+            .with_header("alpha_asset", alpha_asset)
+            .with_header("beta_asset", beta_asset)
+            .with_header("protocol", protocol)
+            .with_body(serde_json::to_value(request_body)?))
+    }
+}
+
+impl TryFrom<Request<Ethereum, bitcoin::Testnet, asset::Erc20, asset::Bitcoin>>
+    for OutboundRequest
+{
+    type Error = anyhow::Error;
+
+    fn try_from(
+        request: Request<Ethereum, bitcoin::Testnet, asset::Erc20, asset::Bitcoin>,
+    ) -> anyhow::Result<Self> {
+        let request_body: RequestBody<Address, PublicKey> = RequestBody::from(request.clone());
+        let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
+
+        let alpha_ledger = LedgerKind::Ethereum(request.alpha_ledger).to_header()?;
+        let beta_ledger = LedgerKind::BitcoinTestnet.to_header()?;
+        let alpha_asset = AssetKind::Erc20(request.alpha_asset).to_header()?;
+        let beta_asset = AssetKind::Bitcoin(request.beta_asset).to_header()?;
+
+        Ok(OutboundRequest::new("SWAP")
+            .with_header("id", request.swap_id.to_header()?)
+            .with_header("alpha_ledger", alpha_ledger)
+            .with_header("beta_ledger", beta_ledger)
+            .with_header("alpha_asset", alpha_asset)
+            .with_header("beta_asset", beta_asset)
+            .with_header("protocol", protocol)
+            .with_body(serde_json::to_value(request_body)?))
+    }
+}
+
+impl TryFrom<Request<Ethereum, bitcoin::Regtest, asset::Erc20, asset::Bitcoin>>
+    for OutboundRequest
+{
+    type Error = anyhow::Error;
+
+    fn try_from(
+        request: Request<Ethereum, bitcoin::Regtest, asset::Erc20, asset::Bitcoin>,
+    ) -> anyhow::Result<Self> {
+        let request_body: RequestBody<Address, PublicKey> = RequestBody::from(request.clone());
+        let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
+
+        let alpha_ledger = LedgerKind::Ethereum(request.alpha_ledger).to_header()?;
+        let beta_ledger = LedgerKind::BitcoinRegtest.to_header()?;
+        let alpha_asset = AssetKind::Erc20(request.alpha_asset).to_header()?;
+        let beta_asset = AssetKind::Bitcoin(request.beta_asset).to_header()?;
+
+        Ok(OutboundRequest::new("SWAP")
+            .with_header("id", request.swap_id.to_header()?)
+            .with_header("alpha_ledger", alpha_ledger)
+            .with_header("beta_ledger", beta_ledger)
+            .with_header("alpha_asset", alpha_asset)
+            .with_header("beta_asset", beta_asset)
+            .with_header("protocol", protocol)
+            .with_body(serde_json::to_value(request_body)?))
+    }
 }
 
 /// High-level message that represents accepting a Swap request
@@ -56,6 +388,24 @@ pub struct RequestBody<AI, BI> {
     pub alpha_expiry: Timestamp,
     pub beta_expiry: Timestamp,
     pub secret_hash: SecretHash,
+}
+
+impl<AL, BL, AA, BA> From<Request<AL, BL, AA, BA>> for RequestBody<AL::Identity, BL::Identity>
+where
+    AL: Ledger,
+    BL: Ledger,
+    AA: Asset,
+    BA: Asset,
+{
+    fn from(request: Request<AL, BL, AA, BA>) -> Self {
+        RequestBody {
+            alpha_ledger_refund_identity: request.alpha_ledger_refund_identity,
+            beta_ledger_redeem_identity: request.beta_ledger_redeem_identity,
+            alpha_expiry: request.alpha_expiry,
+            beta_expiry: request.beta_expiry,
+            secret_hash: request.secret_hash,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]


### PR DESCRIPTION
We are in the process of attempting to remove the `Ledger` trait bound from various structs.  As a step towards that we can remove the `Into<LedgerKind>` trait bound from within the `Ledger` trait.

Doing so requires manually implementing conversion from an `rfc003::Request` to an `OutboundRequest` using concrete types.

Fixes: #2065
