### PR TITLE
Remove the `Asset` trait

### DIFF
--- a/cnd/src/asset/mod.rs
+++ b/cnd/src/asset/mod.rs
@@ -6,9 +6,8 @@ pub use self::{
 };
 use crate::asset;
 use derivative::Derivative;
-use std::fmt::Debug;
 
-pub trait Asset: Clone + Debug + Send + Sync + 'static + Ord {}
+pub trait Asset: Clone + Send + Sync + 'static + Ord {}
 
 impl Asset for Bitcoin {}
 

--- a/cnd/src/asset/mod.rs
+++ b/cnd/src/asset/mod.rs
@@ -7,7 +7,7 @@ pub use self::{
 use crate::asset;
 use derivative::Derivative;
 
-pub trait Asset: Clone + Send + Sync + 'static + Ord {}
+pub trait Asset: Send + Sync + 'static + Ord {}
 
 impl Asset for Bitcoin {}
 

--- a/cnd/src/asset/mod.rs
+++ b/cnd/src/asset/mod.rs
@@ -7,14 +7,6 @@ pub use self::{
 use crate::asset;
 use derivative::Derivative;
 
-pub trait Asset: Send + Sync + 'static + Ord {}
-
-impl Asset for Bitcoin {}
-
-impl Asset for Ether {}
-
-impl Asset for Erc20 {}
-
 #[derive(Clone, Derivative, PartialEq)]
 #[derivative(Debug = "transparent")]
 pub enum AssetKind {

--- a/cnd/src/asset/mod.rs
+++ b/cnd/src/asset/mod.rs
@@ -6,15 +6,9 @@ pub use self::{
 };
 use crate::asset;
 use derivative::Derivative;
-use std::{
-    fmt::{Debug, Display},
-    hash::Hash,
-};
+use std::fmt::Debug;
 
-pub trait Asset:
-    Clone + Debug + Display + Send + Sync + 'static + PartialEq + Eq + Hash + Ord
-{
-}
+pub trait Asset: Clone + Debug + Send + Sync + 'static + Ord {}
 
 impl Asset for Bitcoin {}
 

--- a/cnd/src/db/load_swaps.rs
+++ b/cnd/src/db/load_swaps.rs
@@ -1,5 +1,5 @@
 use crate::{
-    asset::{self, Asset},
+    asset::{self},
     db::{
         schema,
         wrapper_types::{
@@ -41,8 +41,6 @@ pub trait LoadAcceptedSwap<AL, BL, AA, BA>
 where
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
 {
     async fn load_accepted_swap(
         &self,

--- a/cnd/src/http_api/routes/rfc003/handlers/action.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/action.rs
@@ -183,8 +183,7 @@ trait SelectAction<Accept, Decline, Deploy, Fund, Redeem, Refund>:
 
 fn rfc003_accept_response<AI, BI>(message: rfc003::messages::Accept<AI, BI>) -> Response
 where
-    AI: Serialize,
-    BI: Serialize,
+    rfc003::messages::AcceptResponseBody<AI, BI>: Serialize,
 {
     Response::empty()
         .with_header(

--- a/cnd/src/http_api/routes/rfc003/handlers/action.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/action.rs
@@ -117,7 +117,7 @@ pub async fn handle_action(
 
                 let swap_request = state.request();
                 let seed = dependencies.derive_swap_seed(swap_id);
-                let state = State::declined(swap_request, decline_message, seed);
+                let state = State::declined(swap_request.clone(), decline_message, seed);
                 StateStore::insert(&dependencies, swap_id, state);
 
                 Ok(ActionResponseBody::None)

--- a/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
@@ -42,6 +42,7 @@ where
     BA: Asset,
     rfc003::Request<AL, BL, AA, BA>: TryInto<OutboundRequest>,
     <rfc003::Request<AL, BL, AA, BA> as TryInto<OutboundRequest>>::Error: Debug,
+    rfc003::Request<AL, BL, AA, BA>: Clone,
     Facade: LoadAcceptedSwap<AL, BL, AA, BA>
         + HtlcFunded<AL, AA>
         + HtlcFunded<BL, BA>
@@ -81,7 +82,7 @@ where
                 Err(decline) => {
                     tracing::info!("Swap declined: {}", decline.swap_id);
                     let state = State::declined(swap_request.clone(), decline, seed);
-                    StateStore::insert(&dependencies, id, state.clone());
+                    StateStore::insert(&dependencies, id, state);
                     Save::save(&dependencies, decline).await?;
                 }
             };

--- a/cnd/src/http_api/routes/rfc003/swap_state.rs
+++ b/cnd/src/http_api/routes/rfc003/swap_state.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::type_repetition_in_bounds)]
 use crate::{
-    asset::Asset,
     http_api::{Http, SwapStatus},
     swap_protocols::rfc003::{self, Ledger, SecretHash},
     timestamp::Timestamp,
@@ -56,8 +55,6 @@ impl<AL, BL, AA, BA> From<rfc003::SwapCommunication<AL, BL, AA, BA>>
 where
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
 {
     fn from(communication: rfc003::SwapCommunication<AL, BL, AA, BA>) -> Self {
         use rfc003::SwapCommunication::*;
@@ -99,7 +96,6 @@ where
 impl<H, T, A> From<rfc003::LedgerState<H, T, A>> for LedgerState<H, T>
 where
     rfc003::LedgerState<H, T, A>: Clone,
-    A: Asset,
 {
     fn from(ledger_state: rfc003::LedgerState<H, T, A>) -> Self {
         use self::rfc003::LedgerState::*;

--- a/cnd/src/http_api/swap_resource.rs
+++ b/cnd/src/http_api/swap_resource.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::type_repetition_in_bounds)]
 
 use crate::{
-    asset::Asset,
     db::{Swap, SwapTypes},
     http_api::{
         action::ToSirenAction,
@@ -58,8 +57,6 @@ where
     HttpAsset: From<BA>,
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
 {
     fn from(request: rfc003::Request<AL, BL, AA, BA>) -> Self {
         Self {

--- a/cnd/src/http_api/swap_resource.rs
+++ b/cnd/src/http_api/swap_resource.rs
@@ -111,7 +111,7 @@ where
         let communication = SwapCommunication::from(state.swap_communication.clone());
         let alpha_ledger = LedgerState::from(state.alpha_ledger_state.clone());
         let beta_ledger = LedgerState::from(state.beta_ledger_state.clone());
-        let parameters = SwapParameters::from(state.clone().request());
+        let parameters = SwapParameters::from(state.request().clone());
         let actions = state.actions();
 
         let status = SwapStatus::new(

--- a/cnd/src/init_swap.rs
+++ b/cnd/src/init_swap.rs
@@ -1,5 +1,4 @@
 use crate::{
-    asset::Asset,
     db::AcceptedSwap,
     seed::DeriveSwapSeed,
     swap_protocols::{
@@ -33,8 +32,8 @@ where
         + HtlcRefunded<BL, BA>,
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
+    AA: Ord + Send + Sync + 'static,
+    BA: Ord + Send + Sync + 'static,
     Request<AL, BL, AA, BA>: Clone,
 {
     let (request, accept, _) = &accepted;

--- a/cnd/src/network/mod.rs
+++ b/cnd/src/network/mod.rs
@@ -3,7 +3,7 @@ pub mod transport;
 pub use transport::ComitTransport;
 
 use crate::{
-    asset::{Asset, AssetKind},
+    asset::AssetKind,
     btsieve::{bitcoin, bitcoin::BitcoindConnector, ethereum, ethereum::Web3Connector},
     comit_api::LedgerKind,
     config::Settings,
@@ -632,8 +632,8 @@ async fn insert_state_for_bob<AL, BL, AA, BA, DB>(
 where
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
+    AA: Send + 'static,
+    BA: Send + 'static,
     DB: Save<Request<AL, BL, AA, BA>> + Save<Swap>,
     Request<AL, BL, AA, BA>: Clone,
 {
@@ -727,9 +727,7 @@ pub trait SendRequest {
     where
         AL: Ledger,
         BL: Ledger,
-        AA: Asset,
-        BA: Asset,
-        rfc003::Request<AL, BL, AA, BA>: TryInto<OutboundRequest>,
+        rfc003::Request<AL, BL, AA, BA>: TryInto<OutboundRequest> + Send + 'static,
         <rfc003::Request<AL, BL, AA, BA> as TryInto<OutboundRequest>>::Error: Debug;
 }
 
@@ -743,9 +741,7 @@ impl SendRequest for Swarm {
     where
         AL: Ledger,
         BL: Ledger,
-        AA: Asset,
-        BA: Asset,
-        rfc003::Request<AL, BL, AA, BA>: TryInto<OutboundRequest>,
+        rfc003::Request<AL, BL, AA, BA>: TryInto<OutboundRequest> + Send + 'static,
         <rfc003::Request<AL, BL, AA, BA> as TryInto<OutboundRequest>>::Error: Debug,
     {
         let id = request.swap_id;
@@ -867,8 +863,6 @@ fn rfc003_swap_request<AL, BL, AA, BA>(
 where
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
 {
     rfc003::Request::<AL, BL, AA, BA> {
         swap_id: id,

--- a/cnd/src/network/mod.rs
+++ b/cnd/src/network/mod.rs
@@ -635,6 +635,7 @@ where
     AA: Asset,
     BA: Asset,
     DB: Save<Request<AL, BL, AA, BA>> + Save<Swap>,
+    Request<AL, BL, AA, BA>: Clone,
 {
     let id = swap_request.swap_id;
     let seed = seed.derive_swap_seed(id);

--- a/cnd/src/quickcheck.rs
+++ b/cnd/src/quickcheck.rs
@@ -1,6 +1,6 @@
 use crate::{
     asset,
-    asset::{ethereum::FromWei, Asset},
+    asset::ethereum::FromWei,
     db::Swap,
     ethereum::Bytes,
     swap_protocols::{
@@ -242,15 +242,13 @@ impl<AL, BL, AA, BA> Arbitrary for Quickcheck<Request<AL, BL, AA, BA>>
 where
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
     Quickcheck<AL>: Arbitrary,
     Quickcheck<BL>: Arbitrary,
     Quickcheck<AA>: Arbitrary,
     Quickcheck<BA>: Arbitrary,
     Quickcheck<AL::Identity>: Arbitrary,
     Quickcheck<BL::Identity>: Arbitrary,
-    Request<AL, BL, AA, BA>: Clone,
+    Request<AL, BL, AA, BA>: Clone + Send + 'static,
 {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         Quickcheck(Request {

--- a/cnd/src/quickcheck.rs
+++ b/cnd/src/quickcheck.rs
@@ -250,6 +250,7 @@ where
     Quickcheck<BA>: Arbitrary,
     Quickcheck<AL::Identity>: Arbitrary,
     Quickcheck<BL::Identity>: Arbitrary,
+    Request<AL, BL, AA, BA>: Clone,
 {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         Quickcheck(Request {

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -60,7 +60,7 @@ impl StateStore for Facade {
 
     fn get<A>(&self, key: &SwapId) -> Result<Option<A>, state_store::Error>
     where
-        A: ActorState,
+        A: ActorState + Clone,
     {
         self.state_store.get(key)
     }
@@ -130,7 +130,7 @@ impl HtlcFunded<((bitcoin::Mainnet, bitcoin::Testnet, bitcoin::Regtest)), asset:
 {
     async fn htlc_funded(
         &self,
-        htlc_params: HtlcParams<__TYPE0__, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        htlc_params: &HtlcParams<'_, __TYPE0__, asset::Bitcoin, crate::bitcoin::PublicKey>,
         htlc_deployment: &Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Funded<::bitcoin::Transaction, asset::Bitcoin>> {
@@ -147,7 +147,7 @@ impl HtlcDeployed<((bitcoin::Mainnet, bitcoin::Testnet, bitcoin::Regtest)), asse
 {
     async fn htlc_deployed(
         &self,
-        htlc_params: HtlcParams<__TYPE0__, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        htlc_params: &HtlcParams<'_, __TYPE0__, asset::Bitcoin, crate::bitcoin::PublicKey>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>> {
         self.bitcoin_connector
@@ -163,7 +163,7 @@ impl HtlcRedeemed<((bitcoin::Mainnet, bitcoin::Testnet, bitcoin::Regtest)), asse
 {
     async fn htlc_redeemed(
         &self,
-        htlc_params: HtlcParams<__TYPE0__, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        htlc_params: &HtlcParams<'_, __TYPE0__, asset::Bitcoin, crate::bitcoin::PublicKey>,
         htlc_deployment: &Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<::bitcoin::Transaction>> {
@@ -180,7 +180,7 @@ impl HtlcRefunded<((bitcoin::Mainnet, bitcoin::Testnet, bitcoin::Regtest)), asse
 {
     async fn htlc_refunded(
         &self,
-        htlc_params: HtlcParams<__TYPE0__, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        htlc_params: &HtlcParams<'_, __TYPE0__, asset::Bitcoin, crate::bitcoin::PublicKey>,
         htlc_deployment: &Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<::bitcoin::Transaction>> {
@@ -195,7 +195,7 @@ impl HtlcRefunded<((bitcoin::Mainnet, bitcoin::Testnet, bitcoin::Regtest)), asse
 impl HtlcFunded<Ethereum, ((asset::Ether, asset::Erc20))> for Facade {
     async fn htlc_funded(
         &self,
-        htlc_params: HtlcParams<Ethereum, __TYPE0__, crate::ethereum::Address>,
+        htlc_params: &HtlcParams<'_, Ethereum, __TYPE0__, crate::ethereum::Address>,
         htlc_deployment: &Deployed<crate::ethereum::Transaction, crate::ethereum::Address>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Funded<crate::ethereum::Transaction, __TYPE0__>> {
@@ -210,7 +210,7 @@ impl HtlcFunded<Ethereum, ((asset::Ether, asset::Erc20))> for Facade {
 impl HtlcDeployed<Ethereum, ((asset::Ether, asset::Erc20))> for Facade {
     async fn htlc_deployed(
         &self,
-        htlc_params: HtlcParams<Ethereum, __TYPE0__, crate::ethereum::Address>,
+        htlc_params: &HtlcParams<'_, Ethereum, __TYPE0__, crate::ethereum::Address>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Deployed<crate::ethereum::Transaction, crate::ethereum::Address>> {
         self.ethereum_connector
@@ -224,7 +224,7 @@ impl HtlcDeployed<Ethereum, ((asset::Ether, asset::Erc20))> for Facade {
 impl HtlcRedeemed<Ethereum, ((asset::Ether, asset::Erc20))> for Facade {
     async fn htlc_redeemed(
         &self,
-        htlc_params: HtlcParams<Ethereum, __TYPE0__, crate::ethereum::Address>,
+        htlc_params: &HtlcParams<'_, Ethereum, __TYPE0__, crate::ethereum::Address>,
         htlc_deployment: &Deployed<crate::ethereum::Transaction, crate::ethereum::Address>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<crate::ethereum::Transaction>> {
@@ -239,7 +239,7 @@ impl HtlcRedeemed<Ethereum, ((asset::Ether, asset::Erc20))> for Facade {
 impl HtlcRefunded<Ethereum, ((asset::Ether, asset::Erc20))> for Facade {
     async fn htlc_refunded(
         &self,
-        htlc_params: HtlcParams<Ethereum, __TYPE0__, crate::ethereum::Address>,
+        htlc_params: &HtlcParams<'_, Ethereum, __TYPE0__, crate::ethereum::Address>,
         htlc_deployment: &Deployed<crate::ethereum::Transaction, crate::ethereum::Address>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<crate::ethereum::Transaction>> {

--- a/cnd/src/swap_protocols/rfc003/actions/bitcoin.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/bitcoin.rs
@@ -20,13 +20,13 @@ where
     type FundActionOutput = SendToAddress;
 
     fn fund_action(
-        htlc_params: HtlcParams<B, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        htlc_params: HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>,
     ) -> Self::FundActionOutput {
         let to = htlc_params.compute_address();
 
         SendToAddress {
             to,
-            amount: htlc_params.asset,
+            amount: *htlc_params.asset,
             network: B::network(),
         }
     }
@@ -39,7 +39,7 @@ where
     type RefundActionOutput = SpendOutput;
 
     fn refund_action(
-        htlc_params: HtlcParams<B, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        htlc_params: HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>,
         htlc_location: OutPoint,
         secret_source: &dyn DeriveIdentities,
         fund_transaction: &Transaction,
@@ -64,7 +64,7 @@ where
     type RedeemActionOutput = SpendOutput;
 
     fn redeem_action(
-        htlc_params: HtlcParams<B, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        htlc_params: HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>,
         htlc_location: OutPoint,
         secret_source: &dyn DeriveIdentities,
         secret: Secret,
@@ -74,7 +74,7 @@ where
         SpendOutput {
             output: PrimedInput::new(
                 htlc_location,
-                htlc_params.asset.into(),
+                htlc_params.asset.clone().into(),
                 htlc.unlock_with_secret(
                     &*crate::SECP,
                     secret_source.derive_redeem_identity(),

--- a/cnd/src/swap_protocols/rfc003/actions/erc20.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/erc20.rs
@@ -11,7 +11,7 @@ use crate::{
 use blockchain_contracts::ethereum::rfc003::erc20_htlc::Erc20Htlc;
 
 pub fn deploy_action(
-    htlc_params: HtlcParams<Ethereum, asset::Erc20, crate::ethereum::Address>,
+    htlc_params: HtlcParams<'_, Ethereum, asset::Erc20, crate::ethereum::Address>,
 ) -> DeployContract {
     let chain_id = htlc_params.ledger.chain_id;
     let htlc = Erc20Htlc::from(htlc_params);
@@ -26,7 +26,7 @@ pub fn deploy_action(
 }
 
 pub fn fund_action(
-    htlc_params: HtlcParams<Ethereum, asset::Erc20, crate::ethereum::Address>,
+    htlc_params: HtlcParams<'_, Ethereum, asset::Erc20, crate::ethereum::Address>,
     to_erc20_contract: crate::ethereum::Address,
     beta_htlc_location: crate::ethereum::Address,
 ) -> CallContract {
@@ -34,8 +34,10 @@ pub fn fund_action(
     let gas_limit = Erc20Htlc::fund_tx_gas_limit();
     let beta_htlc_address = blockchain_contracts::ethereum::Address(beta_htlc_location.into());
 
-    let data =
-        Erc20Htlc::transfer_erc20_tx_payload(htlc_params.asset.quantity.into(), beta_htlc_address);
+    let data = Erc20Htlc::transfer_erc20_tx_payload(
+        htlc_params.asset.quantity.clone().into(),
+        beta_htlc_address,
+    );
 
     CallContract {
         to: to_erc20_contract,

--- a/cnd/src/swap_protocols/rfc003/actions/ether.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/ether.rs
@@ -18,7 +18,7 @@ impl FundAction<Ethereum, asset::Ether> for (Ethereum, asset::Ether) {
     type FundActionOutput = DeployContract;
 
     fn fund_action(
-        htlc_params: HtlcParams<Ethereum, asset::Ether, crate::ethereum::Address>,
+        htlc_params: HtlcParams<'_, Ethereum, asset::Ether, crate::ethereum::Address>,
     ) -> Self::FundActionOutput {
         let htlc = EtherHtlc::from(htlc_params.clone());
         let gas_limit = EtherHtlc::deploy_tx_gas_limit();
@@ -35,7 +35,7 @@ impl RefundAction<Ethereum, asset::Ether> for (Ethereum, asset::Ether) {
     type RefundActionOutput = CallContract;
 
     fn refund_action(
-        htlc_params: HtlcParams<Ethereum, asset::Ether, crate::ethereum::Address>,
+        htlc_params: HtlcParams<'_, Ethereum, asset::Ether, crate::ethereum::Address>,
         htlc_location: identity::Ethereum,
         _secret_source: &dyn DeriveIdentities,
         _fund_transaction: &Transaction,
@@ -55,7 +55,7 @@ impl RedeemAction<Ethereum, asset::Ether> for (Ethereum, asset::Ether) {
     type RedeemActionOutput = CallContract;
 
     fn redeem_action(
-        htlc_params: HtlcParams<Ethereum, asset::Ether, crate::ethereum::Address>,
+        htlc_params: HtlcParams<'_, Ethereum, asset::Ether, crate::ethereum::Address>,
         htlc_location: identity::Ethereum,
         _secret_source: &dyn DeriveIdentities,
         secret: Secret,

--- a/cnd/src/swap_protocols/rfc003/actions/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/mod.rs
@@ -31,7 +31,7 @@ where
 {
     type FundActionOutput;
 
-    fn fund_action(htlc_params: HtlcParams<L, A, L::Identity>) -> Self::FundActionOutput;
+    fn fund_action(htlc_params: HtlcParams<'_, L, A, L::Identity>) -> Self::FundActionOutput;
 }
 
 pub trait RefundAction<L, A>
@@ -42,7 +42,7 @@ where
     type RefundActionOutput;
 
     fn refund_action(
-        htlc_params: HtlcParams<L, A, L::Identity>,
+        htlc_params: HtlcParams<'_, L, A, L::Identity>,
         htlc_location: L::HtlcLocation,
         secret_source: &dyn DeriveIdentities,
         fund_transaction: &L::Transaction,
@@ -57,7 +57,7 @@ where
     type RedeemActionOutput;
 
     fn redeem_action(
-        htlc_params: HtlcParams<L, A, L::Identity>,
+        htlc_params: HtlcParams<'_, L, A, L::Identity>,
         htlc_location: L::HtlcLocation,
         secret_source: &dyn DeriveIdentities,
         secret: Secret,

--- a/cnd/src/swap_protocols/rfc003/actions/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/mod.rs
@@ -2,10 +2,7 @@ pub mod bitcoin;
 pub mod erc20;
 pub mod ether;
 
-use crate::{
-    asset::Asset,
-    swap_protocols::rfc003::{create_swap::HtlcParams, DeriveIdentities, Ledger, Secret},
-};
+use crate::swap_protocols::rfc003::{create_swap::HtlcParams, DeriveIdentities, Ledger, Secret};
 use std::marker::PhantomData;
 
 /// Defines the set of actions available in the RFC003 protocol
@@ -27,7 +24,6 @@ pub enum Action<Accept, Decline, Deploy, Fund, Redeem, Refund> {
 pub trait FundAction<L, A>
 where
     L: Ledger,
-    A: Asset,
 {
     type FundActionOutput;
 
@@ -37,7 +33,6 @@ where
 pub trait RefundAction<L, A>
 where
     L: Ledger,
-    A: Asset,
 {
     type RefundActionOutput;
 
@@ -52,7 +47,6 @@ where
 pub trait RedeemAction<L, A>
 where
     L: Ledger,
-    A: Asset,
 {
     type RedeemActionOutput;
 

--- a/cnd/src/swap_protocols/rfc003/actor_state.rs
+++ b/cnd/src/swap_protocols/rfc003/actor_state.rs
@@ -1,13 +1,10 @@
-use crate::{
-    asset::Asset,
-    swap_protocols::rfc003::{ledger_state::LedgerState, Ledger},
-};
+use crate::swap_protocols::rfc003::{ledger_state::LedgerState, Ledger};
 
-pub trait ActorState: Send + 'static {
+pub trait ActorState: 'static {
     type AL: Ledger;
     type BL: Ledger;
-    type AA: Asset;
-    type BA: Asset;
+    type AA;
+    type BA;
 
     fn expected_alpha_asset(&self) -> &Self::AA;
     fn expected_beta_asset(&self) -> &Self::BA;

--- a/cnd/src/swap_protocols/rfc003/actor_state.rs
+++ b/cnd/src/swap_protocols/rfc003/actor_state.rs
@@ -2,9 +2,8 @@ use crate::{
     asset::Asset,
     swap_protocols::rfc003::{ledger_state::LedgerState, Ledger},
 };
-use std::fmt::Debug;
 
-pub trait ActorState: Debug + Clone + Send + Sync + 'static {
+pub trait ActorState: Clone + Send + Sync + 'static {
     type AL: Ledger;
     type BL: Ledger;
     type AA: Asset;

--- a/cnd/src/swap_protocols/rfc003/actor_state.rs
+++ b/cnd/src/swap_protocols/rfc003/actor_state.rs
@@ -3,7 +3,7 @@ use crate::{
     swap_protocols::rfc003::{ledger_state::LedgerState, Ledger},
 };
 
-pub trait ActorState: Send + Sync + 'static {
+pub trait ActorState: Send + 'static {
     type AL: Ledger;
     type BL: Ledger;
     type AA: Asset;

--- a/cnd/src/swap_protocols/rfc003/actor_state.rs
+++ b/cnd/src/swap_protocols/rfc003/actor_state.rs
@@ -3,14 +3,14 @@ use crate::{
     swap_protocols::rfc003::{ledger_state::LedgerState, Ledger},
 };
 
-pub trait ActorState: Clone + Send + Sync + 'static {
+pub trait ActorState: Send + Sync + 'static {
     type AL: Ledger;
     type BL: Ledger;
     type AA: Asset;
     type BA: Asset;
 
-    fn expected_alpha_asset(&self) -> Self::AA;
-    fn expected_beta_asset(&self) -> Self::BA;
+    fn expected_alpha_asset(&self) -> &Self::AA;
+    fn expected_beta_asset(&self) -> &Self::BA;
 
     fn alpha_ledger_mut(
         &mut self,

--- a/cnd/src/swap_protocols/rfc003/alice/actions/erc20.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/actions/erc20.rs
@@ -1,5 +1,5 @@
 use crate::{
-    asset::{self, Asset},
+    asset::{self},
     swap_protocols::{
         actions::{ethereum, Actions},
         ledger::Ethereum,
@@ -16,7 +16,6 @@ use std::convert::Infallible;
 impl<BL, BA> Actions for alice::State<Ethereum, BL, asset::Erc20, BA>
 where
     BL: Ledger,
-    BA: Asset,
     (BL, BA): RedeemAction<BL, BA>,
 {
     #[allow(clippy::type_complexity)]
@@ -74,7 +73,6 @@ where
 impl<AL, AA> Actions for alice::State<AL, Ethereum, AA, asset::Erc20>
 where
     AL: Ledger,
-    AA: Asset,
     (AL, AA): FundAction<AL, AA> + RefundAction<AL, AA>,
 {
     #[allow(clippy::type_complexity)]

--- a/cnd/src/swap_protocols/rfc003/alice/actions/generic_impl.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/actions/generic_impl.rs
@@ -1,13 +1,10 @@
-use crate::{
-    asset::Asset,
-    swap_protocols::{
-        actions::Actions,
-        rfc003::{
-            actions::{Accept, Action, Decline, FundAction, RedeemAction, RefundAction},
-            alice,
-            create_swap::HtlcParams,
-            DeriveSecret, Ledger, LedgerState, SwapCommunication,
-        },
+use crate::swap_protocols::{
+    actions::Actions,
+    rfc003::{
+        actions::{Accept, Action, Decline, FundAction, RedeemAction, RefundAction},
+        alice,
+        create_swap::HtlcParams,
+        DeriveSecret, Ledger, LedgerState, SwapCommunication,
     },
 };
 use std::convert::Infallible;
@@ -16,8 +13,6 @@ impl<AL, BL, AA, BA> Actions for alice::State<AL, BL, AA, BA>
 where
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
     (AL, AA): FundAction<AL, AA> + RefundAction<AL, AA>,
     (BL, BA): RedeemAction<BL, BA>,
 {

--- a/cnd/src/swap_protocols/rfc003/alice/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/mod.rs
@@ -73,8 +73,8 @@ where
         }
     }
 
-    pub fn request(&self) -> messages::Request<AL, BL, AA, BA> {
-        self.swap_communication.request().clone()
+    pub fn request(&self) -> &messages::Request<AL, BL, AA, BA> {
+        self.swap_communication.request()
     }
 }
 
@@ -90,12 +90,12 @@ where
     type AA = AA;
     type BA = BA;
 
-    fn expected_alpha_asset(&self) -> Self::AA {
-        self.swap_communication.request().alpha_asset.clone()
+    fn expected_alpha_asset(&self) -> &Self::AA {
+        &self.swap_communication.request().alpha_asset
     }
 
-    fn expected_beta_asset(&self) -> Self::BA {
-        self.swap_communication.request().beta_asset.clone()
+    fn expected_beta_asset(&self) -> &Self::BA {
+        &self.swap_communication.request().beta_asset
     }
 
     fn alpha_ledger_mut(&mut self) -> &mut LedgerState<AL::HtlcLocation, AL::Transaction, AA> {

--- a/cnd/src/swap_protocols/rfc003/alice/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/mod.rs
@@ -3,7 +3,6 @@ mod actions;
 pub use self::actions::*;
 
 use crate::{
-    asset::Asset,
     seed::SwapSeed,
     swap_protocols::rfc003::{
         ledger::Ledger, ledger_state::LedgerState, messages, ActorState, SwapCommunication,
@@ -17,8 +16,6 @@ pub struct State<AL, BL, AA, BA>
 where
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
 {
     pub swap_communication: SwapCommunication<AL, BL, AA, BA>,
     pub alpha_ledger_state: LedgerState<AL::HtlcLocation, AL::Transaction, AA>,
@@ -32,8 +29,6 @@ impl<AL, BL, AA, BA> State<AL, BL, AA, BA>
 where
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
 {
     pub fn proposed(request: messages::Request<AL, BL, AA, BA>, secret_source: SwapSeed) -> Self {
         Self {
@@ -82,8 +77,8 @@ impl<AL, BL, AA, BA> ActorState for State<AL, BL, AA, BA>
 where
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
+    AA: 'static,
+    BA: 'static,
 {
     type AL = AL;
     type BL = BL;

--- a/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
@@ -26,7 +26,7 @@ where
 {
     async fn htlc_funded(
         &self,
-        _htlc_params: HtlcParams<B, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        _htlc_params: &HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>,
         htlc_deployment: &Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>,
         _start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Funded<::bitcoin::Transaction, asset::Bitcoin>> {
@@ -48,7 +48,7 @@ where
 {
     async fn htlc_deployed(
         &self,
-        htlc_params: HtlcParams<B, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        htlc_params: &HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>> {
         let connector = self.clone();
@@ -83,7 +83,7 @@ where
 {
     async fn htlc_redeemed(
         &self,
-        htlc_params: HtlcParams<B, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        htlc_params: &HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>,
         htlc_deployment: &Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<::bitcoin::Transaction>> {
@@ -114,7 +114,7 @@ where
 {
     async fn htlc_refunded(
         &self,
-        _htlc_params: HtlcParams<B, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        _htlc_params: &HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>,
         htlc_deployment: &Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<::bitcoin::Transaction>> {

--- a/cnd/src/swap_protocols/rfc003/bitcoin/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bitcoin/mod.rs
@@ -23,13 +23,13 @@ where
     type Transaction = Transaction;
 }
 
-impl<B> From<HtlcParams<B, asset::Bitcoin, crate::bitcoin::PublicKey>> for BitcoinHtlc
+impl<B> From<HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>> for BitcoinHtlc
 where
     B: ledger::Bitcoin,
 {
-    fn from(htlc_params: HtlcParams<B, asset::Bitcoin, crate::bitcoin::PublicKey>) -> Self {
-        let refund_public_key = ::bitcoin::PublicKey::from(htlc_params.refund_identity);
-        let redeem_public_key = ::bitcoin::PublicKey::from(htlc_params.redeem_identity);
+    fn from(htlc_params: HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>) -> Self {
+        let refund_public_key = ::bitcoin::PublicKey::from(*htlc_params.refund_identity);
+        let redeem_public_key = ::bitcoin::PublicKey::from(*htlc_params.redeem_identity);
 
         let refund_identity = hash160::Hash::hash(&refund_public_key.key.serialize());
         let redeem_identity = hash160::Hash::hash(&redeem_public_key.key.serialize());
@@ -43,7 +43,7 @@ where
     }
 }
 
-impl<B> HtlcParams<B, asset::Bitcoin, crate::bitcoin::PublicKey>
+impl<B> HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>
 where
     B: ledger::Bitcoin + ledger::bitcoin::Network,
 {

--- a/cnd/src/swap_protocols/rfc003/bob/actions/erc20.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/actions/erc20.rs
@@ -1,5 +1,5 @@
 use crate::{
-    asset::{self, Asset},
+    asset::{self},
     swap_protocols::{
         actions::{ethereum, Actions},
         ledger::Ethereum,
@@ -16,7 +16,6 @@ use std::convert::Infallible;
 impl<AL, AA> Actions for bob::State<AL, Ethereum, AA, asset::Erc20>
 where
     AL: Ledger,
-    AA: Asset,
     (AL, AA): RedeemAction<AL, AA>,
 {
     #[allow(clippy::type_complexity)]
@@ -86,7 +85,6 @@ where
 impl<BL, BA> Actions for bob::State<Ethereum, BL, asset::Erc20, BA>
 where
     BL: Ledger,
-    BA: Asset,
     (BL, BA): FundAction<BL, BA> + RefundAction<BL, BA>,
 {
     #[allow(clippy::type_complexity)]

--- a/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
@@ -1,13 +1,10 @@
-use crate::{
-    asset::Asset,
-    swap_protocols::{
-        actions::Actions,
-        rfc003::{
-            actions::{Accept, Action, Decline, FundAction, RedeemAction, RefundAction},
-            bob,
-            create_swap::HtlcParams,
-            Ledger, LedgerState, SwapCommunication,
-        },
+use crate::swap_protocols::{
+    actions::Actions,
+    rfc003::{
+        actions::{Accept, Action, Decline, FundAction, RedeemAction, RefundAction},
+        bob,
+        create_swap::HtlcParams,
+        Ledger, LedgerState, SwapCommunication,
     },
 };
 use std::convert::Infallible;
@@ -16,8 +13,6 @@ impl<AL, BL, AA, BA> Actions for bob::State<AL, BL, AA, BA>
 where
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
     (BL, BA): FundAction<BL, BA> + RefundAction<BL, BA>,
     (AL, AA): RedeemAction<AL, AA>,
 {

--- a/cnd/src/swap_protocols/rfc003/bob/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/mod.rs
@@ -1,11 +1,8 @@
 pub mod actions;
 
-use crate::{
-    asset::Asset,
-    swap_protocols::rfc003::{
-        self, ledger::Ledger, ledger_state::LedgerState, messages::Request, Accept, ActorState,
-        Decline, DeriveIdentities, SwapCommunication,
-    },
+use crate::swap_protocols::rfc003::{
+    self, ledger::Ledger, ledger_state::LedgerState, messages::Request, Accept, ActorState,
+    Decline, DeriveIdentities, SwapCommunication,
 };
 use derivative::Derivative;
 use futures::sync::oneshot;
@@ -24,8 +21,6 @@ pub struct State<AL, BL, AA, BA>
 where
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
 {
     pub swap_communication: SwapCommunication<AL, BL, AA, BA>,
     pub alpha_ledger_state: LedgerState<AL::HtlcLocation, AL::Transaction, AA>,
@@ -39,8 +34,6 @@ impl<AL, BL, AA, BA> State<AL, BL, AA, BA>
 where
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
 {
     pub fn proposed(
         request: Request<AL, BL, AA, BA>,
@@ -96,8 +89,8 @@ impl<AL, BL, AA, BA> ActorState for State<AL, BL, AA, BA>
 where
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
+    AA: 'static,
+    BA: 'static,
 {
     type AL = AL;
     type BL = BL;

--- a/cnd/src/swap_protocols/rfc003/bob/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/mod.rs
@@ -83,11 +83,11 @@ where
         }
     }
 
-    pub fn request(&self) -> Request<AL, BL, AA, BA> {
+    pub fn request(&self) -> &Request<AL, BL, AA, BA> {
         match &self.swap_communication {
             SwapCommunication::Accepted { request, .. }
             | SwapCommunication::Proposed { request, .. }
-            | SwapCommunication::Declined { request, .. } => request.clone(),
+            | SwapCommunication::Declined { request, .. } => request,
         }
     }
 }
@@ -104,12 +104,12 @@ where
     type AA = AA;
     type BA = BA;
 
-    fn expected_alpha_asset(&self) -> Self::AA {
-        self.swap_communication.request().alpha_asset.clone()
+    fn expected_alpha_asset(&self) -> &Self::AA {
+        &self.swap_communication.request().alpha_asset
     }
 
-    fn expected_beta_asset(&self) -> Self::BA {
-        self.swap_communication.request().beta_asset.clone()
+    fn expected_beta_asset(&self) -> &Self::BA {
+        &self.swap_communication.request().beta_asset
     }
 
     fn alpha_ledger_mut(&mut self) -> &mut LedgerState<AL::HtlcLocation, AL::Transaction, AA> {

--- a/cnd/src/swap_protocols/rfc003/ethereum/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/ethereum/htlc_events.rs
@@ -30,7 +30,7 @@ lazy_static::lazy_static! {
 impl HtlcFunded<Ethereum, Ether> for Cache<Web3Connector> {
     async fn htlc_funded(
         &self,
-        _htlc_params: HtlcParams<Ethereum, Ether, Address>,
+        _htlc_params: &HtlcParams<'_, Ethereum, Ether, Address>,
         deploy_transaction: &Deployed<Transaction, Address>,
         _start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Funded<Transaction, Ether>> {
@@ -45,7 +45,7 @@ impl HtlcFunded<Ethereum, Ether> for Cache<Web3Connector> {
 impl HtlcDeployed<Ethereum, Ether> for Cache<Web3Connector> {
     async fn htlc_deployed(
         &self,
-        htlc_params: HtlcParams<Ethereum, Ether, Address>,
+        htlc_params: &HtlcParams<'_, Ethereum, Ether, Address>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Deployed<Transaction, Address>> {
         let connector = self.clone();
@@ -65,7 +65,7 @@ impl HtlcDeployed<Ethereum, Ether> for Cache<Web3Connector> {
 impl HtlcRedeemed<Ethereum, Ether> for Cache<Web3Connector> {
     async fn htlc_redeemed(
         &self,
-        _htlc_params: HtlcParams<Ethereum, Ether, Address>,
+        _htlc_params: &HtlcParams<'_, Ethereum, Ether, Address>,
         htlc_deployment: &Deployed<Transaction, Address>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<Transaction>> {
@@ -94,7 +94,7 @@ impl HtlcRedeemed<Ethereum, Ether> for Cache<Web3Connector> {
 impl HtlcRefunded<Ethereum, Ether> for Cache<Web3Connector> {
     async fn htlc_refunded(
         &self,
-        _htlc_params: HtlcParams<Ethereum, Ether, Address>,
+        _htlc_params: &HtlcParams<'_, Ethereum, Ether, Address>,
         htlc_deployment: &Deployed<Transaction, Address>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<Transaction>> {
@@ -116,7 +116,7 @@ impl HtlcRefunded<Ethereum, Ether> for Cache<Web3Connector> {
 impl HtlcFunded<Ethereum, Erc20> for Cache<Web3Connector> {
     async fn htlc_funded(
         &self,
-        htlc_params: HtlcParams<Ethereum, Erc20, Address>,
+        htlc_params: &HtlcParams<'_, Ethereum, Erc20, Address>,
         htlc_deployment: &Deployed<Transaction, Address>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Funded<Transaction, Erc20>> {
@@ -146,13 +146,13 @@ impl HtlcFunded<Ethereum, Erc20> for Cache<Web3Connector> {
 impl HtlcDeployed<Ethereum, Erc20> for Cache<Web3Connector> {
     async fn htlc_deployed(
         &self,
-        htlc_params: HtlcParams<Ethereum, Erc20, Address>,
+        htlc_params: &HtlcParams<'_, Ethereum, Erc20, Address>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Deployed<Transaction, Address>> {
         let connector = self.clone();
 
         let (transaction, location) =
-            watch_for_contract_creation(connector, start_of_swap, htlc_params.bytecode())
+            watch_for_contract_creation(connector, start_of_swap, htlc_params.clone().bytecode())
                 .instrument(tracing::info_span!("htlc_deployed"))
                 .await?;
 
@@ -167,7 +167,7 @@ impl HtlcDeployed<Ethereum, Erc20> for Cache<Web3Connector> {
 impl HtlcRedeemed<Ethereum, Erc20> for Cache<Web3Connector> {
     async fn htlc_redeemed(
         &self,
-        _htlc_params: HtlcParams<Ethereum, Erc20, Address>,
+        _htlc_params: &HtlcParams<'_, Ethereum, Erc20, Address>,
         htlc_deployment: &Deployed<Transaction, Address>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<Transaction>> {
@@ -196,7 +196,7 @@ impl HtlcRedeemed<Ethereum, Erc20> for Cache<Web3Connector> {
 impl HtlcRefunded<Ethereum, Erc20> for Cache<Web3Connector> {
     async fn htlc_refunded(
         &self,
-        _htlc_params: HtlcParams<Ethereum, Erc20, Address>,
+        _htlc_params: &HtlcParams<'_, Ethereum, Erc20, Address>,
         htlc_deployment: &Deployed<Transaction, Address>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<Transaction>> {

--- a/cnd/src/swap_protocols/rfc003/ethereum/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/ethereum/mod.rs
@@ -46,12 +46,10 @@ impl Ledger for Ethereum {
     type Transaction = Transaction;
 }
 
-impl From<HtlcParams<Ethereum, asset::Ether, crate::ethereum::Address>> for EtherHtlc {
-    fn from(htlc_params: HtlcParams<Ethereum, asset::Ether, crate::ethereum::Address>) -> Self {
-        let refund_address =
-            blockchain_contracts::ethereum::Address(htlc_params.refund_identity.into());
-        let redeem_address =
-            blockchain_contracts::ethereum::Address(htlc_params.redeem_identity.into());
+impl From<HtlcParams<'_, Ethereum, asset::Ether, crate::ethereum::Address>> for EtherHtlc {
+    fn from(htlc_params: HtlcParams<'_, Ethereum, asset::Ether, crate::ethereum::Address>) -> Self {
+        let refund_address = blockchain_contracts::ethereum::Address(htlc_params.refund_identity.0);
+        let redeem_address = blockchain_contracts::ethereum::Address(htlc_params.redeem_identity.0);
 
         EtherHtlc::new(
             htlc_params.expiry.into(),
@@ -62,18 +60,16 @@ impl From<HtlcParams<Ethereum, asset::Ether, crate::ethereum::Address>> for Ethe
     }
 }
 
-impl HtlcParams<Ethereum, asset::Ether, crate::ethereum::Address> {
+impl HtlcParams<'_, Ethereum, asset::Ether, crate::ethereum::Address> {
     pub fn bytecode(&self) -> Bytes {
         EtherHtlc::from(self.clone()).into()
     }
 }
 
-impl From<HtlcParams<Ethereum, asset::Erc20, crate::ethereum::Address>> for Erc20Htlc {
-    fn from(htlc_params: HtlcParams<Ethereum, asset::Erc20, crate::ethereum::Address>) -> Self {
-        let refund_address =
-            blockchain_contracts::ethereum::Address(htlc_params.refund_identity.into());
-        let redeem_address =
-            blockchain_contracts::ethereum::Address(htlc_params.redeem_identity.into());
+impl From<HtlcParams<'_, Ethereum, asset::Erc20, crate::ethereum::Address>> for Erc20Htlc {
+    fn from(htlc_params: HtlcParams<'_, Ethereum, asset::Erc20, crate::ethereum::Address>) -> Self {
+        let refund_address = blockchain_contracts::ethereum::Address(htlc_params.refund_identity.0);
+        let redeem_address = blockchain_contracts::ethereum::Address(htlc_params.redeem_identity.0);
         let token_contract_address =
             blockchain_contracts::ethereum::Address(htlc_params.asset.token_contract.into());
 
@@ -83,12 +79,12 @@ impl From<HtlcParams<Ethereum, asset::Erc20, crate::ethereum::Address>> for Erc2
             redeem_address,
             htlc_params.secret_hash.into(),
             token_contract_address,
-            htlc_params.asset.quantity.into(),
+            htlc_params.asset.quantity.clone().into(),
         )
     }
 }
 
-impl HtlcParams<Ethereum, asset::Erc20, crate::ethereum::Address> {
+impl HtlcParams<'_, Ethereum, asset::Erc20, crate::ethereum::Address> {
     pub fn bytecode(self) -> Bytes {
         Erc20Htlc::from(self).into()
     }

--- a/cnd/src/swap_protocols/rfc003/events/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/events/mod.rs
@@ -2,10 +2,7 @@
 // see: https://github.com/rust-lang/rust/issues/21903
 #![allow(type_alias_bounds)]
 
-use crate::{
-    asset::Asset,
-    swap_protocols::rfc003::{create_swap::HtlcParams, ledger::Ledger, Secret},
-};
+use crate::swap_protocols::rfc003::{create_swap::HtlcParams, ledger::Ledger, Secret};
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 
@@ -36,7 +33,6 @@ pub struct Refunded<T> {
 pub trait HtlcFunded<L, A>: Send + Sync + Sized + 'static
 where
     L: Ledger,
-    A: Asset,
 {
     async fn htlc_funded(
         &self,
@@ -50,7 +46,6 @@ where
 pub trait HtlcDeployed<L, A>: Send + Sync + Sized + 'static
 where
     L: Ledger,
-    A: Asset,
 {
     async fn htlc_deployed(
         &self,
@@ -63,7 +58,6 @@ where
 pub trait HtlcRedeemed<L, A>: Send + Sync + Sized + 'static
 where
     L: Ledger,
-    A: Asset,
 {
     async fn htlc_redeemed(
         &self,
@@ -77,7 +71,6 @@ where
 pub trait HtlcRefunded<L, A>: Send + Sync + Sized + 'static
 where
     L: Ledger,
-    A: Asset,
 {
     async fn htlc_refunded(
         &self,

--- a/cnd/src/swap_protocols/rfc003/events/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/events/mod.rs
@@ -40,7 +40,7 @@ where
 {
     async fn htlc_funded(
         &self,
-        htlc_params: HtlcParams<L, A, L::Identity>,
+        htlc_params: &HtlcParams<'_, L, A, L::Identity>,
         htlc_deployment: &Deployed<L::Transaction, L::HtlcLocation>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Funded<L::Transaction, A>>;
@@ -54,7 +54,7 @@ where
 {
     async fn htlc_deployed(
         &self,
-        htlc_params: HtlcParams<L, A, L::Identity>,
+        htlc_params: &HtlcParams<'_, L, A, L::Identity>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Deployed<L::Transaction, L::HtlcLocation>>;
 }
@@ -67,7 +67,7 @@ where
 {
     async fn htlc_redeemed(
         &self,
-        htlc_params: HtlcParams<L, A, L::Identity>,
+        htlc_params: &HtlcParams<'_, L, A, L::Identity>,
         htlc_deployment: &Deployed<L::Transaction, L::HtlcLocation>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<L::Transaction>>;
@@ -81,7 +81,7 @@ where
 {
     async fn htlc_refunded(
         &self,
-        htlc_params: HtlcParams<L, A, L::Identity>,
+        htlc_params: &HtlcParams<'_, L, A, L::Identity>,
         htlc_deployment: &Deployed<L::Transaction, L::HtlcLocation>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<L::Transaction>>;

--- a/cnd/src/swap_protocols/rfc003/ledger_state.rs
+++ b/cnd/src/swap_protocols/rfc003/ledger_state.rs
@@ -1,9 +1,6 @@
-use crate::{
-    asset::Asset,
-    swap_protocols::rfc003::{
-        events::{Deployed, Funded, Redeemed, Refunded},
-        Secret,
-    },
+use crate::swap_protocols::rfc003::{
+    events::{Deployed, Funded, Redeemed, Refunded},
+    Secret,
 };
 use serde::Serialize;
 use strum_macros::EnumDiscriminants;
@@ -49,10 +46,7 @@ pub enum LedgerState<H, T, A> {
     },
 }
 
-impl<T, H, A> LedgerState<H, T, A>
-where
-    A: Asset,
-{
+impl<T, H, A> LedgerState<H, T, A> {
     pub fn transition_to_deployed(&mut self, deployed: Deployed<T, H>) {
         let Deployed {
             transaction,

--- a/cnd/src/swap_protocols/rfc003/messages.rs
+++ b/cnd/src/swap_protocols/rfc003/messages.rs
@@ -1,5 +1,5 @@
 use crate::{
-    asset::{self, Asset, AssetKind},
+    asset::{self, AssetKind},
     bitcoin::PublicKey,
     comit_api::LedgerKind,
     ethereum::Address,
@@ -25,8 +25,6 @@ pub struct Request<AL, BL, AA, BA>
 where
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
 {
     pub swap_id: SwapId,
     pub alpha_ledger: AL,
@@ -400,8 +398,6 @@ impl<AL, BL, AA, BA> From<Request<AL, BL, AA, BA>> for RequestBody<AL::Identity,
 where
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
 {
     fn from(request: Request<AL, BL, AA, BA>) -> Self {
         RequestBody {

--- a/cnd/src/swap_protocols/rfc003/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/mod.rs
@@ -26,7 +26,7 @@ pub use self::{
 
 pub use self::messages::{Accept, Decline, Request};
 
-use crate::{asset::Asset, seed::SwapSeed};
+use crate::seed::SwapSeed;
 use ::bitcoin::secp256k1::SecretKey;
 
 /// Swap request response as received from peer node acting as Bob.
@@ -38,8 +38,6 @@ pub enum SwapCommunication<AL, BL, AA, BA>
 where
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
 {
     Proposed {
         request: Request<AL, BL, AA, BA>,
@@ -58,8 +56,6 @@ impl<AL, BL, AA, BA> SwapCommunication<AL, BL, AA, BA>
 where
     AL: Ledger,
     BL: Ledger,
-    AA: Asset,
-    BA: Asset,
 {
     pub fn request(&self) -> &Request<AL, BL, AA, BA> {
         match self {

--- a/cnd/src/swap_protocols/rfc003/state_store.rs
+++ b/cnd/src/swap_protocols/rfc003/state_store.rs
@@ -35,7 +35,7 @@ pub trait StateStore: Send + Sync + 'static {
 
 #[derive(Default, Debug)]
 pub struct InMemoryStateStore {
-    states: Mutex<HashMap<SwapId, Box<dyn Any + Send + Sync>>>,
+    states: Mutex<HashMap<SwapId, Box<dyn Any + Send>>>,
 }
 
 impl StateStore for InMemoryStateStore {


### PR DESCRIPTION
I recommend going through this PR commit by commit as the messages include useful information on why I did certain things.

In general, I made the following decisions and learnings:

### Say what you actually mean:

This refers to settings trait bounds like: 

```rust
rfc003::Request<AL, BL, AA, BA>: Clone
```
instead of 
```rust
AL: Clone,
BL: Clone,
AA: Clone,
BA: Clone
```
From the latter, the compiler can infer that `Request` is also Clone but it is much more verbose.
The form only tells the compiler that you would like `Request` to be `Clone` _because you actually call `.clone()` on it_.
Whether or not that is valid for a _specific_ set of type parameters is then figured out later.

### Allow auto traits to bubble up:

The last point (say what you actually mean) is great for traits that provide functionality (`Clone`, `Serialize`, etc) but doesn't work that well for auto-traits like `Send` or `Sync`.

Those are (among other rules) automatically implemented by the compiler if all the inner fields implement them.

At first, the same reasoning seems to apply as in: 
```rust
rfc003::Request<AL, BL, AA, BA>: Send
```

Unfortunately, it doesn't scale that well because `Send` is not actually a function you call on a struct. As soon as you disassemble the original struct (like we do with `Request`) and spread the data over different ones (`OngoingSwap`, `Funded`, etc) the trait bound you stated no longer works and you would have to restate them:

```rust
rfc003::Request<AL, BL, AA, BA>: Send,
OngoingSwap<AL, BL, AA, BA>: Send,
Funded<AL::Transaction, AA>: Send,
...
```

For situations like this, I then opted for just stating:

```rust
AA: Send + Sync + 'static
```

That way, anything that contains `AA` will be `Send` as-long as everything else is `Send`.

It only applies to a few functions anyway. Hopefully we can minimize that in the future by having an even flatter call-hierachy of functions with type variables (as soon as we fill in type variables, the compiler can verify the bound and shuts up).

Fixes #2036.