### PR TITLE
Use where clauses

### DIFF
--- a/cnd/src/db/load_swaps.rs
+++ b/cnd/src/db/load_swaps.rs
@@ -37,7 +37,13 @@ pub type AcceptedSwap<AL, BL, AA, BA> = (
 );
 
 #[async_trait]
-pub trait LoadAcceptedSwap<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
+pub trait LoadAcceptedSwap<AL, BL, AA, BA>
+where
+    AL: Ledger,
+    BL: Ledger,
+    AA: Asset,
+    BA: Asset,
+{
     async fn load_accepted_swap(
         &self,
         swap_id: &SwapId,

--- a/cnd/src/http_api/routes/rfc003/swap_state.rs
+++ b/cnd/src/http_api/routes/rfc003/swap_state.rs
@@ -51,8 +51,13 @@ pub enum SwapCommunicationState {
     Declined,
 }
 
-impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> From<rfc003::SwapCommunication<AL, BL, AA, BA>>
+impl<AL, BL, AA, BA> From<rfc003::SwapCommunication<AL, BL, AA, BA>>
     for SwapCommunication<AL::Identity, BL::Identity>
+where
+    AL: Ledger,
+    BL: Ledger,
+    AA: Asset,
+    BA: Asset,
 {
     fn from(communication: rfc003::SwapCommunication<AL, BL, AA, BA>) -> Self {
         use rfc003::SwapCommunication::*;

--- a/cnd/src/init_swap.rs
+++ b/cnd/src/init_swap.rs
@@ -14,12 +14,16 @@ use crate::{
 };
 
 #[allow(clippy::cognitive_complexity)]
-pub fn init_accepted_swap<D, AL: Ledger, BL: Ledger, AA: Asset, BA: Asset>(
+pub fn init_accepted_swap<D, AL, BL, AA, BA>(
     dependencies: &D,
     accepted: AcceptedSwap<AL, BL, AA, BA>,
     role: Role,
 ) -> anyhow::Result<()>
 where
+    AL: Ledger,
+    BL: Ledger,
+    AA: Asset,
+    BA: Asset,
     D: StateStore
         + Clone
         + DeriveSwapSeed

--- a/cnd/src/network/mod.rs
+++ b/cnd/src/network/mod.rs
@@ -621,7 +621,7 @@ async fn handle_request(
 }
 
 #[allow(clippy::type_complexity)]
-async fn insert_state_for_bob<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset, DB>(
+async fn insert_state_for_bob<AL, BL, AA, BA, DB>(
     db: DB,
     seed: RootSeed,
     state_store: Arc<InMemoryStateStore>,
@@ -629,6 +629,10 @@ async fn insert_state_for_bob<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset, DB>(
     swap_request: Request<AL, BL, AA, BA>,
 ) -> anyhow::Result<()>
 where
+    AL: Ledger,
+    BL: Ledger,
+    AA: Asset,
+    BA: Asset,
     DB: Save<Request<AL, BL, AA, BA>> + Save<Swap>,
 {
     let id = swap_request.swap_id;

--- a/cnd/src/swap_protocols/rfc003/alice/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/mod.rs
@@ -13,7 +13,13 @@ use derivative::Derivative;
 
 #[derive(Clone, Derivative)]
 #[derivative(Debug, PartialEq)]
-pub struct State<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
+pub struct State<AL, BL, AA, BA>
+where
+    AL: Ledger,
+    BL: Ledger,
+    AA: Asset,
+    BA: Asset,
+{
     pub swap_communication: SwapCommunication<AL, BL, AA, BA>,
     pub alpha_ledger_state: LedgerState<AL::HtlcLocation, AL::Transaction, AA>,
     pub beta_ledger_state: LedgerState<BL::HtlcLocation, BL::Transaction, BA>,
@@ -22,7 +28,13 @@ pub struct State<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
     pub failed: bool,
 }
 
-impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
+impl<AL, BL, AA, BA> State<AL, BL, AA, BA>
+where
+    AL: Ledger,
+    BL: Ledger,
+    AA: Asset,
+    BA: Asset,
+{
     pub fn proposed(request: messages::Request<AL, BL, AA, BA>, secret_source: SwapSeed) -> Self {
         Self {
             swap_communication: SwapCommunication::Proposed { request },
@@ -66,7 +78,13 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
     }
 }
 
-impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> ActorState for State<AL, BL, AA, BA> {
+impl<AL, BL, AA, BA> ActorState for State<AL, BL, AA, BA>
+where
+    AL: Ledger,
+    BL: Ledger,
+    AA: Asset,
+    BA: Asset,
+{
     type AL = AL;
     type BL = BL;
     type AA = AA;

--- a/cnd/src/swap_protocols/rfc003/bob/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/mod.rs
@@ -17,7 +17,13 @@ pub type ResponseSender<AL: Ledger, BL: Ledger> =
 
 #[derive(Clone, Derivative)]
 #[derivative(Debug)]
-pub struct State<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
+pub struct State<AL, BL, AA, BA>
+where
+    AL: Ledger,
+    BL: Ledger,
+    AA: Asset,
+    BA: Asset,
+{
     pub swap_communication: SwapCommunication<AL, BL, AA, BA>,
     pub alpha_ledger_state: LedgerState<AL::HtlcLocation, AL::Transaction, AA>,
     pub beta_ledger_state: LedgerState<BL::HtlcLocation, BL::Transaction, BA>,
@@ -26,7 +32,13 @@ pub struct State<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
     pub failed: bool, // Gets set on any error during the execution of a swap.
 }
 
-impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
+impl<AL, BL, AA, BA> State<AL, BL, AA, BA>
+where
+    AL: Ledger,
+    BL: Ledger,
+    AA: Asset,
+    BA: Asset,
+{
     pub fn proposed(
         request: Request<AL, BL, AA, BA>,
         secret_source: impl DeriveIdentities,
@@ -77,7 +89,13 @@ impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> State<AL, BL, AA, BA> {
     }
 }
 
-impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> ActorState for State<AL, BL, AA, BA> {
+impl<AL, BL, AA, BA> ActorState for State<AL, BL, AA, BA>
+where
+    AL: Ledger,
+    BL: Ledger,
+    AA: Asset,
+    BA: Asset,
+{
     type AL = AL;
     type BL = BL;
     type AA = AA;

--- a/cnd/src/swap_protocols/rfc003/create_swap.rs
+++ b/cnd/src/swap_protocols/rfc003/create_swap.rs
@@ -202,11 +202,19 @@ pub struct HtlcParams<L, A: Asset, I> {
     pub secret_hash: SecretHash,
 }
 
-impl<L: Ledger, A: Asset> HtlcParams<L, A, L::Identity> {
-    pub fn new_alpha_params<BL: Ledger, BA: Asset>(
+impl<L, A> HtlcParams<L, A, L::Identity>
+where
+    L: Ledger,
+    A: Asset,
+{
+    pub fn new_alpha_params<BL, BA>(
         request: &rfc003::Request<L, BL, A, BA>,
         accept_response: &rfc003::Accept<L::Identity, BL::Identity>,
-    ) -> Self {
+    ) -> Self
+    where
+        BL: Ledger,
+        BA: Asset,
+    {
         HtlcParams {
             asset: request.alpha_asset.clone(),
             ledger: request.alpha_ledger,
@@ -217,10 +225,14 @@ impl<L: Ledger, A: Asset> HtlcParams<L, A, L::Identity> {
         }
     }
 
-    pub fn new_beta_params<AL: Ledger, AA: Asset>(
+    pub fn new_beta_params<AL, AA>(
         request: &rfc003::Request<AL, L, AA, A>,
         accept_response: &rfc003::Accept<AL::Identity, L::Identity>,
-    ) -> Self {
+    ) -> Self
+    where
+        AL: Ledger,
+        AA: Asset,
+    {
         HtlcParams {
             asset: request.beta_asset.clone(),
             ledger: request.beta_ledger,
@@ -254,7 +266,13 @@ where
     pub secret_hash: SecretHash,
 }
 
-impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> OngoingSwap<AL, BL, AA, BA> {
+impl<AL, BL, AA, BA> OngoingSwap<AL, BL, AA, BA>
+where
+    AL: Ledger,
+    BL: Ledger,
+    AA: Asset,
+    BA: Asset,
+{
     pub fn new(
         request: Request<AL, BL, AA, BA>,
         accept: Accept<AL::Identity, BL::Identity>,

--- a/cnd/src/swap_protocols/rfc003/messages.rs
+++ b/cnd/src/swap_protocols/rfc003/messages.rs
@@ -13,7 +13,13 @@ use serde::{Deserialize, Serialize};
 /// This does _not_ represent the actual network message, that is why it also
 /// does not implement Serialize.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Request<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
+pub struct Request<AL, BL, AA, BA>
+where
+    AL: Ledger,
+    BL: Ledger,
+    AA: Asset,
+    BA: Asset,
+{
     pub swap_id: SwapId,
     pub alpha_ledger: AL,
     pub beta_ledger: BL,

--- a/cnd/src/swap_protocols/rfc003/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/mod.rs
@@ -34,7 +34,13 @@ pub type Response<AL, BL> =
     Result<Accept<<AL as Ledger>::Identity, <BL as Ledger>::Identity>, Decline>;
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum SwapCommunication<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
+pub enum SwapCommunication<AL, BL, AA, BA>
+where
+    AL: Ledger,
+    BL: Ledger,
+    AA: Asset,
+    BA: Asset,
+{
     Proposed {
         request: Request<AL, BL, AA, BA>,
     },
@@ -48,7 +54,13 @@ pub enum SwapCommunication<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> {
     },
 }
 
-impl<AL: Ledger, BL: Ledger, AA: Asset, BA: Asset> SwapCommunication<AL, BL, AA, BA> {
+impl<AL, BL, AA, BA> SwapCommunication<AL, BL, AA, BA>
+where
+    AL: Ledger,
+    BL: Ledger,
+    AA: Asset,
+    BA: Asset,
+{
     pub fn request(&self) -> &Request<AL, BL, AA, BA> {
         match self {
             SwapCommunication::Accepted { request, .. } => request,


### PR DESCRIPTION
We would like to move the code base to using 'where clauses' instead of putting
the trait bound where the type is first mentioned.  This helps reduce the number
of merge conflicts when multiple developers work on the same area in the code
base.