### PR TITLE
Remove unused trait bound `Into<AssetKind>` from `Asset`

### DIFF
--- a/cnd/src/asset/mod.rs
+++ b/cnd/src/asset/mod.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 pub trait Asset:
-    Clone + Debug + Display + Send + Sync + 'static + PartialEq + Eq + Hash + Into<AssetKind> + Ord
+    Clone + Debug + Display + Send + Sync + 'static + PartialEq + Eq + Hash + Ord
 {
 }
 


### PR DESCRIPTION
Recently we removed the requirement for this trait bound and forgot to
remove the trait bound itself from the `Asset` trait.

Remove it now its unused.