### PR TITLE
Add `identity` module

### DIFF
--- a/cnd/src/http_api/action.rs
+++ b/cnd/src/http_api/action.rs
@@ -309,10 +309,7 @@ impl IntoResponsePayload for Infallible {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{
-        ethereum::{Address as EthereumAddress, U256},
-        swap_protocols::ledger::ethereum::ChainId,
-    };
+    use crate::{ethereum::U256, identity, swap_protocols::ledger::ethereum::ChainId};
     use bitcoin::Address as BitcoinAddress;
     use std::str::FromStr;
 
@@ -340,7 +337,8 @@ mod test {
 
     #[test]
     fn call_contract_serializes_correctly_to_json_with_none() {
-        let addr = EthereumAddress::from_str("0A81e8be41b21f651a71aaB1A85c6813b8bBcCf8").unwrap();
+        let addr =
+            identity::Ethereum::from_str("0A81e8be41b21f651a71aaB1A85c6813b8bBcCf8").unwrap();
         let chain_id = ChainId::from(3);
         let contract = ActionResponseBody::EthereumCallContract {
             contract_address: addr,

--- a/cnd/src/identity.rs
+++ b/cnd/src/identity.rs
@@ -1,1 +1,0 @@
-pub use crate::{bitcoin::PublicKey as Bitcoin, ethereum::Address as Ethereum};

--- a/cnd/src/identity.rs
+++ b/cnd/src/identity.rs
@@ -1,0 +1,1 @@
+pub use crate::{bitcoin::PublicKey as Bitcoin, ethereum::Address as Ethereum};

--- a/cnd/src/lib.rs
+++ b/cnd/src/lib.rs
@@ -36,6 +36,7 @@ pub mod comit_api;
 pub mod config;
 pub mod ethereum;
 pub mod http_api;
+pub mod identity;
 pub mod init_swap;
 pub mod load_swaps;
 #[macro_use]

--- a/cnd/src/lib.rs
+++ b/cnd/src/lib.rs
@@ -53,10 +53,17 @@ use anyhow::Context;
 use directories::ProjectDirs;
 use std::path::{Path, PathBuf};
 
-/// Define domain specific terms using modules so that we can refer to things in
-/// an ergonomic fashion.
+/// Define domain specific terms using identity module so that we can refer to
+/// things in an ergonomic fashion e.g., `identity::Bitcoin`.
 pub mod identity {
     pub use crate::{bitcoin::PublicKey as Bitcoin, ethereum::Address as Ethereum};
+}
+
+/// Define domain specific terms using transaction module so that we can refer
+/// to things in an ergonomic fashion e.g., `transaction::Ethereum`.
+pub mod transaction {
+    pub use crate::ethereum::Transaction as Ethereum;
+    pub use bitcoin::Transaction as Bitcoin;
 }
 
 lazy_static::lazy_static! {

--- a/cnd/src/lib.rs
+++ b/cnd/src/lib.rs
@@ -36,7 +36,6 @@ pub mod comit_api;
 pub mod config;
 pub mod ethereum;
 pub mod http_api;
-pub mod identity;
 pub mod init_swap;
 pub mod load_swaps;
 #[macro_use]
@@ -53,6 +52,12 @@ pub mod timestamp;
 use anyhow::Context;
 use directories::ProjectDirs;
 use std::path::{Path, PathBuf};
+
+/// Define domain specific terms using modules so that we can refer to things in
+/// an ergonomic fashion.
+pub mod identity {
+    pub use crate::{bitcoin::PublicKey as Bitcoin, ethereum::Address as Ethereum};
+}
 
 lazy_static::lazy_static! {
     pub static ref SECP: ::bitcoin::secp256k1::Secp256k1<::bitcoin::secp256k1::All> =

--- a/cnd/src/swap_protocols/rfc003/actions/ether.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/ether.rs
@@ -1,6 +1,7 @@
 use crate::{
     asset,
-    ethereum::{Address as EthereumAddress, Bytes, Transaction},
+    ethereum::{Bytes, Transaction},
+    identity,
     swap_protocols::{
         actions::ethereum::{CallContract, DeployContract},
         ledger::Ethereum,
@@ -35,7 +36,7 @@ impl RefundAction<Ethereum, asset::Ether> for (Ethereum, asset::Ether) {
 
     fn refund_action(
         htlc_params: HtlcParams<Ethereum, asset::Ether, crate::ethereum::Address>,
-        htlc_location: EthereumAddress,
+        htlc_location: identity::Ethereum,
         _secret_source: &dyn DeriveIdentities,
         _fund_transaction: &Transaction,
     ) -> Self::RefundActionOutput {
@@ -55,7 +56,7 @@ impl RedeemAction<Ethereum, asset::Ether> for (Ethereum, asset::Ether) {
 
     fn redeem_action(
         htlc_params: HtlcParams<Ethereum, asset::Ether, crate::ethereum::Address>,
-        htlc_location: EthereumAddress,
+        htlc_location: identity::Ethereum,
         _secret_source: &dyn DeriveIdentities,
         secret: Secret,
     ) -> Self::RedeemActionOutput {


### PR DESCRIPTION
Our domain is cross chain.  We should have domain specific terms for
things in various chains.  We currently have the `asset` module and the
`ledger` module that do just this.

Add and `identity` module that defines an identity/address on a chain.
With this applied we can write

```
	let address = identity::Ethereum::new(...)
```
Instead of
```
	let address = ethereum::Address::new(...)
```
which is actually just a re-export of:
```
	let address = web3::types::Address::new(...)
```

Similarly we have `identity::Bitcoin` for the Bitcoin addresses.