### PR TITLE
Remove the Identity associated type from Ledger

### DIFF
--- a/cnd/src/db/load_swaps.rs
+++ b/cnd/src/db/load_swaps.rs
@@ -13,7 +13,7 @@ use crate::{
         ledger::{bitcoin, Ethereum},
         rfc003::{
             messages::{Accept, Request},
-            Ledger, SecretHash,
+            SecretHash,
         },
         HashFunction, SwapId,
     },
@@ -38,11 +38,7 @@ pub type AcceptedSwap<AL, BL, AA, BA, AI, BI> = (
 );
 
 #[async_trait]
-pub trait LoadAcceptedSwap<AL, BL, AA, BA, AI, BI>
-where
-    AL: Ledger,
-    BL: Ledger,
-{
+pub trait LoadAcceptedSwap<AL, BL, AA, BA, AI, BI> {
     async fn load_accepted_swap(
         &self,
         swap_id: &SwapId,

--- a/cnd/src/db/load_swaps.rs
+++ b/cnd/src/db/load_swaps.rs
@@ -8,6 +8,7 @@ use crate::{
         },
         Sqlite,
     },
+    identity,
     swap_protocols::{
         ledger::{bitcoin, Ethereum},
         rfc003::{
@@ -30,14 +31,14 @@ use schema::{
     rfc003_ethereum_bitcoin_ether_bitcoin_request_messages,
 };
 
-pub type AcceptedSwap<AL, BL, AA, BA> = (
-    Request<AL, BL, AA, BA>,
-    Accept<<AL as Ledger>::Identity, <BL as Ledger>::Identity>,
+pub type AcceptedSwap<AL, BL, AA, BA, AI, BI> = (
+    Request<AL, BL, AA, BA, AI, BI>,
+    Accept<AI, BI>,
     NaiveDateTime,
 );
 
 #[async_trait]
-pub trait LoadAcceptedSwap<AL, BL, AA, BA>
+pub trait LoadAcceptedSwap<AL, BL, AA, BA, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
@@ -45,7 +46,7 @@ where
     async fn load_accepted_swap(
         &self,
         swap_id: &SwapId,
-    ) -> anyhow::Result<AcceptedSwap<AL, BL, AA, BA>>;
+    ) -> anyhow::Result<AcceptedSwap<AL, BL, AA, BA, AI, BI>>;
 }
 
 diesel::allow_tables_to_appear_in_same_query!(
@@ -95,6 +96,8 @@ impl From<BitcoinEthereumBitcoinEtherAcceptedSwap>
         Ethereum,
         asset::Bitcoin,
         asset::Ether,
+        identity::Bitcoin,
+        identity::Ethereum,
     >
 {
     fn from(record: BitcoinEthereumBitcoinEtherAcceptedSwap) -> Self {
@@ -132,12 +135,23 @@ impl
         Ethereum,
         asset::Bitcoin,
         asset::Ether,
+        identity::Bitcoin,
+        identity::Ethereum,
     > for Sqlite
 {
     async fn load_accepted_swap(
         &self,
         key: &SwapId,
-    ) -> anyhow::Result<AcceptedSwap<__TYPE0__, Ethereum, asset::Bitcoin, asset::Ether>> {
+    ) -> anyhow::Result<
+        AcceptedSwap<
+            __TYPE0__,
+            Ethereum,
+            asset::Bitcoin,
+            asset::Ether,
+            identity::Bitcoin,
+            identity::Ethereum,
+        >,
+    > {
         use schema::{
             rfc003_bitcoin_ethereum_accept_messages as accept_messages,
             rfc003_bitcoin_ethereum_bitcoin_ether_request_messages as request_messages,
@@ -205,6 +219,8 @@ impl From<EthereumBitcoinEtherBitcoinAcceptedSwap>
         ((bitcoin::Mainnet, bitcoin::Testnet, bitcoin::Regtest)),
         asset::Ether,
         asset::Bitcoin,
+        identity::Ethereum,
+        identity::Bitcoin,
     >
 {
     fn from(record: EthereumBitcoinEtherBitcoinAcceptedSwap) -> Self {
@@ -242,12 +258,23 @@ impl
         ((bitcoin::Mainnet, bitcoin::Testnet, bitcoin::Regtest)),
         asset::Ether,
         asset::Bitcoin,
+        identity::Ethereum,
+        identity::Bitcoin,
     > for Sqlite
 {
     async fn load_accepted_swap(
         &self,
         key: &SwapId,
-    ) -> anyhow::Result<AcceptedSwap<Ethereum, __TYPE0__, asset::Ether, asset::Bitcoin>> {
+    ) -> anyhow::Result<
+        AcceptedSwap<
+            Ethereum,
+            __TYPE0__,
+            asset::Ether,
+            asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
+        >,
+    > {
         use schema::{
             rfc003_ethereum_bitcoin_accept_messages as accept_messages,
             rfc003_ethereum_bitcoin_ether_bitcoin_request_messages as request_messages,
@@ -316,6 +343,8 @@ impl From<BitcoinEthereumBitcoinErc20AcceptedSwap>
         Ethereum,
         asset::Bitcoin,
         asset::Erc20,
+        identity::Bitcoin,
+        identity::Ethereum,
     >
 {
     fn from(record: BitcoinEthereumBitcoinErc20AcceptedSwap) -> Self {
@@ -356,12 +385,23 @@ impl
         Ethereum,
         asset::Bitcoin,
         asset::Erc20,
+        identity::Bitcoin,
+        identity::Ethereum,
     > for Sqlite
 {
     async fn load_accepted_swap(
         &self,
         key: &SwapId,
-    ) -> anyhow::Result<AcceptedSwap<__TYPE0__, Ethereum, asset::Bitcoin, asset::Erc20>> {
+    ) -> anyhow::Result<
+        AcceptedSwap<
+            __TYPE0__,
+            Ethereum,
+            asset::Bitcoin,
+            asset::Erc20,
+            identity::Bitcoin,
+            identity::Ethereum,
+        >,
+    > {
         use schema::{
             rfc003_bitcoin_ethereum_accept_messages as accept_messages,
             rfc003_bitcoin_ethereum_bitcoin_erc20_request_messages as request_messages,
@@ -431,6 +471,8 @@ impl From<EthereumBitcoinErc20BitcoinAcceptedSwap>
         ((bitcoin::Mainnet, bitcoin::Testnet, bitcoin::Regtest)),
         asset::Erc20,
         asset::Bitcoin,
+        identity::Ethereum,
+        identity::Bitcoin,
     >
 {
     fn from(record: EthereumBitcoinErc20BitcoinAcceptedSwap) -> Self {
@@ -471,12 +513,23 @@ impl
         ((bitcoin::Mainnet, bitcoin::Testnet, bitcoin::Regtest)),
         asset::Erc20,
         asset::Bitcoin,
+        identity::Ethereum,
+        identity::Bitcoin,
     > for Sqlite
 {
     async fn load_accepted_swap(
         &self,
         key: &SwapId,
-    ) -> anyhow::Result<AcceptedSwap<Ethereum, __TYPE0__, asset::Erc20, asset::Bitcoin>> {
+    ) -> anyhow::Result<
+        AcceptedSwap<
+            Ethereum,
+            __TYPE0__,
+            asset::Erc20,
+            asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
+        >,
+    > {
         use schema::{
             rfc003_ethereum_bitcoin_accept_messages as accept_messages,
             rfc003_ethereum_bitcoin_erc20_bitcoin_request_messages as request_messages,

--- a/cnd/src/db/save.rs
+++ b/cnd/src/db/save.rs
@@ -8,6 +8,7 @@ use crate::{
         },
         Sqlite, Swap,
     },
+    identity,
     swap_protocols::{
         ledger::{self, Ethereum},
         rfc003::{Accept, Decline, Request, SecretHash},
@@ -88,12 +89,21 @@ impl
             Ethereum,
             asset::Bitcoin,
             asset::Ether,
+            identity::Bitcoin,
+            identity::Ethereum,
         >,
     > for Sqlite
 {
     async fn save(
         &self,
-        message: Request<__TYPE0__, Ethereum, asset::Bitcoin, asset::Ether>,
+        message: Request<
+            __TYPE0__,
+            Ethereum,
+            asset::Bitcoin,
+            asset::Ether,
+            identity::Bitcoin,
+            identity::Ethereum,
+        >,
     ) -> anyhow::Result<()> {
         let Request {
             swap_id,
@@ -164,12 +174,21 @@ impl
             Ethereum,
             asset::Bitcoin,
             asset::Erc20,
+            identity::Bitcoin,
+            identity::Ethereum,
         >,
     > for Sqlite
 {
     async fn save(
         &self,
-        message: Request<__TYPE0__, Ethereum, asset::Bitcoin, asset::Erc20>,
+        message: Request<
+            __TYPE0__,
+            Ethereum,
+            asset::Bitcoin,
+            asset::Erc20,
+            identity::Bitcoin,
+            identity::Ethereum,
+        >,
     ) -> anyhow::Result<()> {
         let Request {
             swap_id,
@@ -240,12 +259,21 @@ impl
             )),
             asset::Ether,
             asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
         >,
     > for Sqlite
 {
     async fn save(
         &self,
-        message: Request<Ethereum, __TYPE0__, asset::Ether, asset::Bitcoin>,
+        message: Request<
+            Ethereum,
+            __TYPE0__,
+            asset::Ether,
+            asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
+        >,
     ) -> anyhow::Result<()> {
         let Request {
             swap_id,
@@ -316,12 +344,21 @@ impl
             )),
             asset::Erc20,
             asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
         >,
     > for Sqlite
 {
     async fn save(
         &self,
-        message: Request<Ethereum, __TYPE0__, asset::Erc20, asset::Bitcoin>,
+        message: Request<
+            Ethereum,
+            __TYPE0__,
+            asset::Erc20,
+            asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
+        >,
     ) -> anyhow::Result<()> {
         let Request {
             swap_id,
@@ -372,10 +409,10 @@ struct InsertableEthereumBitcoinAcceptMessage {
 }
 
 #[async_trait]
-impl Save<Accept<crate::ethereum::Address, crate::bitcoin::PublicKey>> for Sqlite {
+impl Save<Accept<identity::Ethereum, identity::Bitcoin>> for Sqlite {
     async fn save(
         &self,
-        message: Accept<crate::ethereum::Address, crate::bitcoin::PublicKey>,
+        message: Accept<identity::Ethereum, identity::Bitcoin>,
     ) -> anyhow::Result<()> {
         let Accept {
             swap_id,
@@ -409,10 +446,10 @@ struct InsertableBitcoinEthereumAcceptMessage {
 }
 
 #[async_trait]
-impl Save<Accept<crate::bitcoin::PublicKey, crate::ethereum::Address>> for Sqlite {
+impl Save<Accept<identity::Bitcoin, identity::Ethereum>> for Sqlite {
     async fn save(
         &self,
-        message: Accept<crate::bitcoin::PublicKey, crate::ethereum::Address>,
+        message: Accept<identity::Bitcoin, identity::Ethereum>,
     ) -> anyhow::Result<()> {
         let Accept {
             swap_id,

--- a/cnd/src/db/with_swap_types.rs
+++ b/cnd/src/db/with_swap_types.rs
@@ -9,12 +9,12 @@ macro_rules! _match_role {
         match $role {
             Role::Alice => {
                 #[allow(dead_code)]
-                type ROLE = alice::State<AL, BL, AA, BA>;
+                type ROLE = alice::State<AL, BL, AA, BA, AI, BI>;
                 $fn
             }
             Role::Bob => {
                 #[allow(dead_code)]
-                type ROLE = bob::State<AL, BL, AA, BA>;
+                type ROLE = bob::State<AL, BL, AA, BA, AI, BI>;
                 $fn
             }
         }
@@ -27,7 +27,7 @@ macro_rules! with_swap_types {
         use crate::{
             asset,
             db::{AssetKind, BitcoinLedgerKind, LedgerKind, SwapTypes},
-            ethereum,
+            identity,
             swap_protocols::ledger::{bitcoin, Ethereum},
         };
         let swap_types: SwapTypes = $swap_types;
@@ -51,8 +51,12 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BA = asset::Ether;
                     #[allow(dead_code)]
+                    type AI = identity::Bitcoin;
+                    #[allow(dead_code)]
+                    type BI = identity::Ethereum;
+                    #[allow(dead_code)]
                     type AcceptBody =
-                        crate::http_api::routes::rfc003::accept::OnlyRefund<ethereum::Address>;
+                        crate::http_api::routes::rfc003::accept::OnlyRefund<identity::Ethereum>;
 
                     _match_role!(role, $fn)
                 }
@@ -66,8 +70,12 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BA = asset::Ether;
                     #[allow(dead_code)]
+                    type AI = identity::Bitcoin;
+                    #[allow(dead_code)]
+                    type BI = identity::Ethereum;
+                    #[allow(dead_code)]
                     type AcceptBody =
-                        crate::http_api::routes::rfc003::accept::OnlyRefund<ethereum::Address>;
+                        crate::http_api::routes::rfc003::accept::OnlyRefund<identity::Ethereum>;
 
                     _match_role!(role, $fn)
                 }
@@ -81,8 +89,12 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BA = asset::Ether;
                     #[allow(dead_code)]
+                    type AI = identity::Bitcoin;
+                    #[allow(dead_code)]
+                    type BI = identity::Ethereum;
+                    #[allow(dead_code)]
                     type AcceptBody =
-                        crate::http_api::routes::rfc003::accept::OnlyRefund<ethereum::Address>;
+                        crate::http_api::routes::rfc003::accept::OnlyRefund<identity::Ethereum>;
 
                     _match_role!(role, $fn)
                 }
@@ -104,8 +116,12 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BA = asset::Erc20;
                     #[allow(dead_code)]
+                    type AI = identity::Bitcoin;
+                    #[allow(dead_code)]
+                    type BI = identity::Ethereum;
+                    #[allow(dead_code)]
                     type AcceptBody =
-                        crate::http_api::routes::rfc003::accept::OnlyRefund<ethereum::Address>;
+                        crate::http_api::routes::rfc003::accept::OnlyRefund<identity::Ethereum>;
 
                     _match_role!(role, $fn)
                 }
@@ -119,8 +135,12 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BA = asset::Erc20;
                     #[allow(dead_code)]
+                    type AI = identity::Bitcoin;
+                    #[allow(dead_code)]
+                    type BI = identity::Ethereum;
+                    #[allow(dead_code)]
                     type AcceptBody =
-                        crate::http_api::routes::rfc003::accept::OnlyRefund<ethereum::Address>;
+                        crate::http_api::routes::rfc003::accept::OnlyRefund<identity::Ethereum>;
 
                     _match_role!(role, $fn)
                 }
@@ -134,8 +154,12 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BA = asset::Erc20;
                     #[allow(dead_code)]
+                    type AI = identity::Bitcoin;
+                    #[allow(dead_code)]
+                    type BI = identity::Ethereum;
+                    #[allow(dead_code)]
                     type AcceptBody =
-                        crate::http_api::routes::rfc003::accept::OnlyRefund<ethereum::Address>;
+                        crate::http_api::routes::rfc003::accept::OnlyRefund<identity::Ethereum>;
 
                     _match_role!(role, $fn)
                 }
@@ -158,8 +182,12 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BA = asset::Bitcoin;
                     #[allow(dead_code)]
+                    type AI = identity::Ethereum;
+                    #[allow(dead_code)]
+                    type BI = identity::Bitcoin;
+                    #[allow(dead_code)]
                     type AcceptBody =
-                        crate::http_api::routes::rfc003::accept::OnlyRedeem<ethereum::Address>;
+                        crate::http_api::routes::rfc003::accept::OnlyRedeem<identity::Ethereum>;
 
                     _match_role!(role, $fn)
                 }
@@ -173,8 +201,12 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BA = asset::Bitcoin;
                     #[allow(dead_code)]
+                    type AI = identity::Ethereum;
+                    #[allow(dead_code)]
+                    type BI = identity::Bitcoin;
+                    #[allow(dead_code)]
                     type AcceptBody =
-                        crate::http_api::routes::rfc003::accept::OnlyRedeem<ethereum::Address>;
+                        crate::http_api::routes::rfc003::accept::OnlyRedeem<identity::Ethereum>;
 
                     _match_role!(role, $fn)
                 }
@@ -188,8 +220,12 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BA = asset::Bitcoin;
                     #[allow(dead_code)]
+                    type AI = identity::Ethereum;
+                    #[allow(dead_code)]
+                    type BI = identity::Bitcoin;
+                    #[allow(dead_code)]
                     type AcceptBody =
-                        crate::http_api::routes::rfc003::accept::OnlyRedeem<ethereum::Address>;
+                        crate::http_api::routes::rfc003::accept::OnlyRedeem<identity::Ethereum>;
 
                     _match_role!(role, $fn)
                 }
@@ -211,8 +247,12 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BA = asset::Bitcoin;
                     #[allow(dead_code)]
+                    type AI = identity::Ethereum;
+                    #[allow(dead_code)]
+                    type BI = identity::Bitcoin;
+                    #[allow(dead_code)]
                     type AcceptBody =
-                        crate::http_api::routes::rfc003::accept::OnlyRedeem<ethereum::Address>;
+                        crate::http_api::routes::rfc003::accept::OnlyRedeem<identity::Ethereum>;
 
                     _match_role!(role, $fn)
                 }
@@ -226,8 +266,12 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BA = asset::Bitcoin;
                     #[allow(dead_code)]
+                    type AI = identity::Ethereum;
+                    #[allow(dead_code)]
+                    type BI = identity::Bitcoin;
+                    #[allow(dead_code)]
                     type AcceptBody =
-                        crate::http_api::routes::rfc003::accept::OnlyRedeem<ethereum::Address>;
+                        crate::http_api::routes::rfc003::accept::OnlyRedeem<identity::Ethereum>;
 
                     _match_role!(role, $fn)
                 }
@@ -241,8 +285,12 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BA = asset::Bitcoin;
                     #[allow(dead_code)]
+                    type AI = identity::Ethereum;
+                    #[allow(dead_code)]
+                    type BI = identity::Bitcoin;
+                    #[allow(dead_code)]
                     type AcceptBody =
-                        crate::http_api::routes::rfc003::accept::OnlyRedeem<ethereum::Address>;
+                        crate::http_api::routes::rfc003::accept::OnlyRedeem<identity::Ethereum>;
 
                     _match_role!(role, $fn)
                 }

--- a/cnd/src/db/wrapper_types/mod.rs
+++ b/cnd/src/db/wrapper_types/mod.rs
@@ -1,4 +1,4 @@
-use crate::{asset, asset::Bitcoin, db::LedgerKind, ethereum, swap_protocols::ledger};
+use crate::{asset, asset::Bitcoin, db::LedgerKind, identity, swap_protocols::ledger};
 use std::{fmt, str::FromStr};
 
 pub mod custom_sql_types;
@@ -101,10 +101,10 @@ impl fmt::Display for Erc20Amount {
 /// Together with the `Text` sql type, this will store an ethereum address in
 /// hex encoding.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct EthereumAddress(ethereum::Address);
+pub struct EthereumAddress(identity::Ethereum);
 
 impl FromStr for EthereumAddress {
-    type Err = <ethereum::Address as FromStr>::Err;
+    type Err = <identity::Ethereum as FromStr>::Err;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         s.parse().map(EthereumAddress)
@@ -117,14 +117,14 @@ impl fmt::Display for EthereumAddress {
     }
 }
 
-impl From<EthereumAddress> for ethereum::Address {
+impl From<EthereumAddress> for identity::Ethereum {
     fn from(address: EthereumAddress) -> Self {
         address.0
     }
 }
 
-impl From<ethereum::Address> for EthereumAddress {
-    fn from(address: ethereum::Address) -> Self {
+impl From<identity::Ethereum> for EthereumAddress {
+    fn from(address: identity::Ethereum) -> Self {
         EthereumAddress(address)
     }
 }

--- a/cnd/src/http_api/action.rs
+++ b/cnd/src/http_api/action.rs
@@ -1,6 +1,7 @@
 use crate::{
     asset,
     http_api::{problem, Http, MissingQueryParameters, UnexpectedQueryParameters},
+    identity,
     swap_protocols::{
         actions::{
             bitcoin::{SendToAddress, SpendOutput},
@@ -57,7 +58,7 @@ pub enum ActionResponseBody {
         chain_id: ledger::ethereum::ChainId,
     },
     EthereumCallContract {
-        contract_address: crate::ethereum::Address,
+        contract_address: identity::Ethereum,
         #[serde(skip_serializing_if = "Option::is_none")]
         data: Option<crate::ethereum::Bytes>,
         gas_limit: crate::ethereum::U256,

--- a/cnd/src/http_api/mod.rs
+++ b/cnd/src/http_api/mod.rs
@@ -14,7 +14,7 @@ pub use self::{
 pub const PATH: &str = "swaps";
 
 use crate::{
-    asset, ethereum,
+    asset, identity,
     network::DialInformation,
     swap_protocols::{
         ledger::{self, ethereum::ChainId},
@@ -85,7 +85,7 @@ impl Serialize for Http<crate::ethereum::Transaction> {
     }
 }
 
-impl Serialize for Http<crate::bitcoin::PublicKey> {
+impl Serialize for Http<identity::Bitcoin> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -318,7 +318,7 @@ pub struct EtherAssetParams {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Erc20AssetParams {
     quantity: asset::Erc20Quantity,
-    token_contract: ethereum::Address,
+    token_contract: identity::Ethereum,
 }
 
 impl TryFrom<HttpLedgerParams> for HttpLedger {

--- a/cnd/src/http_api/routes/rfc003/accept.rs
+++ b/cnd/src/http_api/routes/rfc003/accept.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ethereum,
     http_api::action::ListRequiredFields,
+    identity,
     swap_protocols::{
         ledger::{bitcoin, Ethereum},
         rfc003::{
@@ -46,15 +46,13 @@ fn ethereum_bitcoin_accept_required_fields() -> Vec<siren::Field> {
     }]
 }
 
-impl IntoAcceptMessage<ethereum::Address, crate::bitcoin::PublicKey>
-    for OnlyRedeem<ethereum::Address>
-{
+impl IntoAcceptMessage<identity::Ethereum, identity::Bitcoin> for OnlyRedeem<identity::Ethereum> {
     fn into_accept_message(
         self,
         id: SwapId,
         secret_source: &dyn DeriveIdentities,
-    ) -> messages::Accept<ethereum::Address, crate::bitcoin::PublicKey> {
-        let beta_ledger_refund_identity = crate::bitcoin::PublicKey::from_secret_key(
+    ) -> messages::Accept<identity::Ethereum, identity::Bitcoin> {
+        let beta_ledger_refund_identity = identity::Bitcoin::from_secret_key(
             &*crate::SECP,
             &secret_source.derive_refund_identity(),
         );
@@ -99,15 +97,13 @@ fn bitcoin_ethereum_accept_required_fields() -> Vec<siren::Field> {
     }]
 }
 
-impl IntoAcceptMessage<crate::bitcoin::PublicKey, crate::ethereum::Address>
-    for OnlyRefund<ethereum::Address>
-{
+impl IntoAcceptMessage<identity::Bitcoin, identity::Ethereum> for OnlyRefund<identity::Ethereum> {
     fn into_accept_message(
         self,
         id: SwapId,
         secret_source: &dyn DeriveIdentities,
-    ) -> messages::Accept<crate::bitcoin::PublicKey, crate::ethereum::Address> {
-        let alpha_ledger_redeem_identity = crate::bitcoin::PublicKey::from_secret_key(
+    ) -> messages::Accept<identity::Bitcoin, identity::Ethereum> {
+        let alpha_ledger_redeem_identity = identity::Bitcoin::from_secret_key(
             &*crate::SECP,
             &secret_source.derive_redeem_identity(),
         );

--- a/cnd/src/http_api/routes/rfc003/handlers/action.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/action.rs
@@ -81,9 +81,11 @@ pub async fn handle_action(
                     )
                 })?;
 
-                let accepted =
-                    LoadAcceptedSwap::<AL, BL, AA, BA>::load_accepted_swap(&dependencies, &swap_id)
-                        .await?;
+                let accepted = LoadAcceptedSwap::<AL, BL, AA, BA, AI, BI>::load_accepted_swap(
+                    &dependencies,
+                    &swap_id,
+                )
+                .await?;
                 init_accepted_swap(&dependencies, accepted, types.role)?;
 
                 Ok(ActionResponseBody::None)

--- a/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
@@ -36,8 +36,10 @@ where
     BL: Ledger,
     AA: Ord + Send + Sync + 'static,
     BA: Ord + Send + Sync + 'static,
-    AI: Send + Sync + 'static + DeserializeOwned + Clone,
-    BI: Send + Sync + 'static + DeserializeOwned + Clone,
+    AI: Send + Sync + 'static,
+    BI: Send + Sync + 'static,
+    rfc003::messages::AcceptResponseBody<AI, BI>: DeserializeOwned,
+    Accept<AI, BI>: Copy,
     rfc003::Request<AL, BL, AA, BA, AI, BI>: TryInto<OutboundRequest> + Clone,
     <rfc003::Request<AL, BL, AA, BA, AI, BI> as TryInto<OutboundRequest>>::Error: Debug,
     Facade: LoadAcceptedSwap<AL, BL, AA, BA, AI, BI>

--- a/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
@@ -23,7 +23,7 @@ use libp2p_comit::frame::OutboundRequest;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{convert::TryInto, fmt::Debug, str::FromStr};
 
-async fn initiate_request<'de, AL, BL, AA, BA, AI, BI>(
+async fn initiate_request<AL, BL, AA, BA, AI, BI>(
     dependencies: Facade,
     id: SwapId,
     peer: DialInformation,

--- a/cnd/src/http_api/routes/rfc003/swap_state.rs
+++ b/cnd/src/http_api/routes/rfc003/swap_state.rs
@@ -50,13 +50,13 @@ pub enum SwapCommunicationState {
     Declined,
 }
 
-impl<AL, BL, AA, BA> From<rfc003::SwapCommunication<AL, BL, AA, BA>>
-    for SwapCommunication<AL::Identity, BL::Identity>
+impl<AL, BL, AA, BA, AI, BI> From<rfc003::SwapCommunication<AL, BL, AA, BA, AI, BI>>
+    for SwapCommunication<AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
 {
-    fn from(communication: rfc003::SwapCommunication<AL, BL, AA, BA>) -> Self {
+    fn from(communication: rfc003::SwapCommunication<AL, BL, AA, BA, AI, BI>) -> Self {
         use rfc003::SwapCommunication::*;
         match communication {
             Proposed { request } => Self {

--- a/cnd/src/http_api/routes/rfc003/swap_state.rs
+++ b/cnd/src/http_api/routes/rfc003/swap_state.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::type_repetition_in_bounds)]
 use crate::{
     http_api::{Http, SwapStatus},
-    swap_protocols::rfc003::{self, Ledger, SecretHash},
+    swap_protocols::rfc003::{self, SecretHash},
     timestamp::Timestamp,
 };
 use serde::Serialize;
@@ -52,9 +52,6 @@ pub enum SwapCommunicationState {
 
 impl<AL, BL, AA, BA, AI, BI> From<rfc003::SwapCommunication<AL, BL, AA, BA, AI, BI>>
     for SwapCommunication<AI, BI>
-where
-    AL: Ledger,
-    BL: Ledger,
 {
     fn from(communication: rfc003::SwapCommunication<AL, BL, AA, BA, AI, BI>) -> Self {
         use rfc003::SwapCommunication::*;

--- a/cnd/src/http_api/swap_resource.rs
+++ b/cnd/src/http_api/swap_resource.rs
@@ -49,7 +49,7 @@ pub enum SwapStatus {
     InternalFailure,
 }
 
-impl<AL, BL, AA, BA> From<rfc003::Request<AL, BL, AA, BA>> for SwapParameters
+impl<AL, BL, AA, BA, AI, BI> From<rfc003::Request<AL, BL, AA, BA, AI, BI>> for SwapParameters
 where
     HttpLedger: From<AL>,
     HttpLedger: From<BL>,
@@ -58,7 +58,7 @@ where
     AL: Ledger,
     BL: Ledger,
 {
-    fn from(request: rfc003::Request<AL, BL, AA, BA>) -> Self {
+    fn from(request: rfc003::Request<AL, BL, AA, BA, AI, BI>) -> Self {
         Self {
             alpha_ledger: HttpLedger::from(request.alpha_ledger),
             alpha_asset: HttpAsset::from(request.alpha_asset),
@@ -126,8 +126,8 @@ where
             counterparty: Http(swap.counterparty),
             state: match include_state {
                 IncludeState::Yes => Some(SwapState::<
-                    <AL as Ledger>::Identity,
-                    <BL as Ledger>::Identity,
+                    AI,
+                    BI,
                     <AL as Ledger>::HtlcLocation,
                     <BL as Ledger>::HtlcLocation,
                     <AL as Ledger>::Transaction,

--- a/cnd/src/http_api/swap_resource.rs
+++ b/cnd/src/http_api/swap_resource.rs
@@ -55,8 +55,6 @@ where
     HttpLedger: From<BL>,
     HttpAsset: From<AA>,
     HttpAsset: From<BA>,
-    AL: Ledger,
-    BL: Ledger,
 {
     fn from(request: rfc003::Request<AL, BL, AA, BA, AI, BI>) -> Self {
         Self {

--- a/cnd/src/init_swap.rs
+++ b/cnd/src/init_swap.rs
@@ -13,28 +13,30 @@ use crate::{
 };
 
 #[allow(clippy::cognitive_complexity)]
-pub fn init_accepted_swap<D, AL, BL, AA, BA>(
+pub fn init_accepted_swap<D, AL, BL, AA, BA, AI, BI>(
     dependencies: &D,
-    accepted: AcceptedSwap<AL, BL, AA, BA>,
+    accepted: AcceptedSwap<AL, BL, AA, BA, AI, BI>,
     role: Role,
 ) -> anyhow::Result<()>
 where
     D: StateStore
         + Clone
         + DeriveSwapSeed
-        + HtlcFunded<AL, AA>
-        + HtlcFunded<BL, BA>
-        + HtlcDeployed<AL, AA>
-        + HtlcDeployed<BL, BA>
-        + HtlcRedeemed<AL, AA>
-        + HtlcRedeemed<BL, BA>
-        + HtlcRefunded<AL, AA>
-        + HtlcRefunded<BL, BA>,
+        + HtlcFunded<AL, AA, AI>
+        + HtlcFunded<BL, BA, BI>
+        + HtlcDeployed<AL, AA, AI>
+        + HtlcDeployed<BL, BA, BI>
+        + HtlcRedeemed<AL, AA, AI>
+        + HtlcRedeemed<BL, BA, BI>
+        + HtlcRefunded<AL, AA, AI>
+        + HtlcRefunded<BL, BA, BI>,
     AL: Ledger,
     BL: Ledger,
     AA: Ord + Send + Sync + 'static,
     BA: Ord + Send + Sync + 'static,
-    Request<AL, BL, AA, BA>: Clone,
+    AI: Send + Sync + 'static + Clone,
+    BI: Send + Sync + 'static + Clone,
+    Request<AL, BL, AA, BA, AI, BI>: Clone,
 {
     let (request, accept, _) = &accepted;
 
@@ -44,22 +46,26 @@ where
 
     match role {
         Role::Alice => {
-            let state = alice::State::accepted(request.clone(), *accept, seed);
+            let state = alice::State::accepted(request.clone(), accept.clone(), seed);
             StateStore::insert(dependencies, id, state);
 
-            tokio::task::spawn(create_swap::<D, alice::State<AL, BL, AA, BA>>(
-                dependencies.clone(),
-                accepted,
-            ));
+            tokio::task::spawn(
+                create_swap::<D, alice::State<AL, BL, AA, BA, AI, BI>, AI, BI>(
+                    dependencies.clone(),
+                    accepted,
+                ),
+            );
         }
         Role::Bob => {
-            let state = bob::State::accepted(request.clone(), *accept, seed);
+            let state = bob::State::accepted(request.clone(), accept.clone(), seed);
             StateStore::insert(dependencies, id, state);
 
-            tokio::task::spawn(create_swap::<D, bob::State<AL, BL, AA, BA>>(
-                dependencies.clone(),
-                accepted,
-            ));
+            tokio::task::spawn(
+                create_swap::<D, bob::State<AL, BL, AA, BA, AI, BI>, AI, BI>(
+                    dependencies.clone(),
+                    accepted,
+                ),
+            );
         }
     };
 

--- a/cnd/src/init_swap.rs
+++ b/cnd/src/init_swap.rs
@@ -6,7 +6,7 @@ use crate::{
             alice, bob, create_swap,
             events::{HtlcDeployed, HtlcFunded, HtlcRedeemed, HtlcRefunded},
             state_store::StateStore,
-            Ledger, Request,
+            Accept, Ledger, Request,
         },
         Role,
     },
@@ -34,9 +34,10 @@ where
     BL: Ledger,
     AA: Ord + Send + Sync + 'static,
     BA: Ord + Send + Sync + 'static,
-    AI: Send + Sync + 'static + Clone,
-    BI: Send + Sync + 'static + Clone,
+    AI: Send + Sync + 'static,
+    BI: Send + Sync + 'static,
     Request<AL, BL, AA, BA, AI, BI>: Clone,
+    Accept<AI, BI>: Copy,
 {
     let (request, accept, _) = &accepted;
 
@@ -46,7 +47,7 @@ where
 
     match role {
         Role::Alice => {
-            let state = alice::State::accepted(request.clone(), accept.clone(), seed);
+            let state = alice::State::accepted(request.clone(), *accept, seed);
             StateStore::insert(dependencies, id, state);
 
             tokio::task::spawn(
@@ -57,7 +58,7 @@ where
             );
         }
         Role::Bob => {
-            let state = bob::State::accepted(request.clone(), accept.clone(), seed);
+            let state = bob::State::accepted(request.clone(), *accept, seed);
             StateStore::insert(dependencies, id, state);
 
             tokio::task::spawn(

--- a/cnd/src/load_swaps.rs
+++ b/cnd/src/load_swaps.rs
@@ -17,7 +17,8 @@ pub async fn load_swaps_from_database(facade: Facade) -> anyhow::Result<()> {
 
         with_swap_types!(types, {
             let accepted =
-                LoadAcceptedSwap::<AL, BL, AA, BA>::load_accepted_swap(&facade, &swap_id).await;
+                LoadAcceptedSwap::<AL, BL, AA, BA, AI, BI>::load_accepted_swap(&facade, &swap_id)
+                    .await;
 
             match accepted {
                 Ok(accepted) => {

--- a/cnd/src/network/mod.rs
+++ b/cnd/src/network/mod.rs
@@ -638,7 +638,7 @@ where
     AI: Send + 'static,
     BI: Send + 'static,
     DB: Save<Request<AL, BL, AA, BA, AI, BI>> + Save<Swap>,
-    Request<AL, BL, AA, BA, AI, BI>: Send + 'static + Clone,
+    Request<AL, BL, AA, BA, AI, BI>: Clone,
 {
     let id = swap_request.swap_id;
     let seed = seed.derive_swap_seed(id);

--- a/cnd/src/network/mod.rs
+++ b/cnd/src/network/mod.rs
@@ -43,6 +43,7 @@ use libp2p_comit::{
     handler::{ComitHandler, ProtocolInEvent, ProtocolOutEvent},
     BehaviourOutEvent, Comit, PendingInboundRequest,
 };
+use serde::de::DeserializeOwned;
 use std::{
     collections::{HashMap, HashSet},
     convert::TryInto,
@@ -622,20 +623,22 @@ async fn handle_request(
 }
 
 #[allow(clippy::type_complexity)]
-async fn insert_state_for_bob<AL, BL, AA, BA, DB>(
+async fn insert_state_for_bob<AL, BL, AA, BA, AI, BI, DB>(
     db: DB,
     seed: RootSeed,
     state_store: Arc<InMemoryStateStore>,
     counterparty: PeerId,
-    swap_request: Request<AL, BL, AA, BA>,
+    swap_request: Request<AL, BL, AA, BA, AI, BI>,
 ) -> anyhow::Result<()>
 where
     AL: Ledger,
     BL: Ledger,
     AA: Send + 'static,
     BA: Send + 'static,
-    DB: Save<Request<AL, BL, AA, BA>> + Save<Swap>,
-    Request<AL, BL, AA, BA>: Clone,
+    AI: Send + 'static,
+    BI: Send + 'static,
+    DB: Save<Request<AL, BL, AA, BA, AI, BI>> + Save<Swap>,
+    Request<AL, BL, AA, BA, AI, BI>: Send + 'static + Clone,
 {
     let id = swap_request.swap_id;
     let seed = seed.derive_swap_seed(id);
@@ -719,30 +722,32 @@ impl PendingRequestFor for Swarm {
 /// Send swap request to connected peer.
 #[async_trait]
 pub trait SendRequest {
-    async fn send_request<AL, BL, AA, BA>(
+    async fn send_request<AL, BL, AA, BA, AI, BI>(
         &self,
         peer_identity: DialInformation,
-        request: rfc003::Request<AL, BL, AA, BA>,
-    ) -> Result<rfc003::Response<AL, BL>, RequestError>
+        request: rfc003::Request<AL, BL, AA, BA, AI, BI>,
+    ) -> Result<rfc003::Response<AI, BI>, RequestError>
     where
         AL: Ledger,
         BL: Ledger,
-        rfc003::Request<AL, BL, AA, BA>: TryInto<OutboundRequest> + Send + 'static,
-        <rfc003::Request<AL, BL, AA, BA> as TryInto<OutboundRequest>>::Error: Debug;
+        rfc003::messages::AcceptResponseBody<AI, BI>: DeserializeOwned,
+        rfc003::Request<AL, BL, AA, BA, AI, BI>: TryInto<OutboundRequest> + Send + 'static + Clone,
+        <rfc003::Request<AL, BL, AA, BA, AI, BI> as TryInto<OutboundRequest>>::Error: Debug;
 }
 
 #[async_trait]
 impl SendRequest for Swarm {
-    async fn send_request<AL, BL, AA, BA>(
+    async fn send_request<AL, BL, AA, BA, AI, BI>(
         &self,
         dial_information: DialInformation,
-        request: rfc003::Request<AL, BL, AA, BA>,
-    ) -> Result<rfc003::Response<AL, BL>, RequestError>
+        request: rfc003::Request<AL, BL, AA, BA, AI, BI>,
+    ) -> Result<rfc003::Response<AI, BI>, RequestError>
     where
         AL: Ledger,
         BL: Ledger,
-        rfc003::Request<AL, BL, AA, BA>: TryInto<OutboundRequest> + Send + 'static,
-        <rfc003::Request<AL, BL, AA, BA> as TryInto<OutboundRequest>>::Error: Debug,
+        rfc003::messages::AcceptResponseBody<AI, BI>: DeserializeOwned,
+        rfc003::Request<AL, BL, AA, BA, AI, BI>: TryInto<OutboundRequest> + Send + 'static + Clone,
+        <rfc003::Request<AL, BL, AA, BA, AI, BI> as TryInto<OutboundRequest>>::Error: Debug,
     {
         let id = request.swap_id;
         let request = request
@@ -780,10 +785,9 @@ impl SendRequest for Swarm {
 
                 match decision {
                     Some(Decision::Accepted) => {
-                        match serde_json::from_value::<
-                            rfc003::messages::AcceptResponseBody<AL::Identity, BL::Identity>,
-                        >(response.body().clone())
-                        {
+                        match serde_json::from_value::<rfc003::messages::AcceptResponseBody<AI, BI>>(
+                            response.body().clone(),
+                        ) {
                             Ok(body) => Ok(Ok(rfc003::Accept {
                                 swap_id: id,
                                 beta_ledger_refund_identity: body.beta_ledger_refund_identity,
@@ -851,20 +855,20 @@ impl NetworkBehaviourEventProcess<libp2p::mdns::MdnsEvent> for ComitNode {
     fn inject_event(&mut self, _event: libp2p::mdns::MdnsEvent) {}
 }
 
-fn rfc003_swap_request<AL, BL, AA, BA>(
+fn rfc003_swap_request<AL, BL, AA, BA, AI, BI>(
     id: SwapId,
     alpha_ledger: AL,
     beta_ledger: BL,
     alpha_asset: AA,
     beta_asset: BA,
     hash_function: HashFunction,
-    body: rfc003::messages::RequestBody<AL::Identity, BL::Identity>,
-) -> rfc003::Request<AL, BL, AA, BA>
+    body: rfc003::messages::RequestBody<AI, BI>,
+) -> rfc003::Request<AL, BL, AA, BA, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
 {
-    rfc003::Request::<AL, BL, AA, BA> {
+    rfc003::Request::<AL, BL, AA, BA, AI, BI> {
         swap_id: id,
         alpha_asset,
         beta_asset,

--- a/cnd/src/network/mod.rs
+++ b/cnd/src/network/mod.rs
@@ -728,8 +728,6 @@ pub trait SendRequest {
         request: rfc003::Request<AL, BL, AA, BA, AI, BI>,
     ) -> Result<rfc003::Response<AI, BI>, RequestError>
     where
-        AL: Ledger,
-        BL: Ledger,
         rfc003::messages::AcceptResponseBody<AI, BI>: DeserializeOwned,
         rfc003::Request<AL, BL, AA, BA, AI, BI>: TryInto<OutboundRequest> + Send + 'static + Clone,
         <rfc003::Request<AL, BL, AA, BA, AI, BI> as TryInto<OutboundRequest>>::Error: Debug;
@@ -743,8 +741,6 @@ impl SendRequest for Swarm {
         request: rfc003::Request<AL, BL, AA, BA, AI, BI>,
     ) -> Result<rfc003::Response<AI, BI>, RequestError>
     where
-        AL: Ledger,
-        BL: Ledger,
         rfc003::messages::AcceptResponseBody<AI, BI>: DeserializeOwned,
         rfc003::Request<AL, BL, AA, BA, AI, BI>: TryInto<OutboundRequest> + Send + 'static + Clone,
         <rfc003::Request<AL, BL, AA, BA, AI, BI> as TryInto<OutboundRequest>>::Error: Debug,
@@ -863,12 +859,8 @@ fn rfc003_swap_request<AL, BL, AA, BA, AI, BI>(
     beta_asset: BA,
     hash_function: HashFunction,
     body: rfc003::messages::RequestBody<AI, BI>,
-) -> rfc003::Request<AL, BL, AA, BA, AI, BI>
-where
-    AL: Ledger,
-    BL: Ledger,
-{
-    rfc003::Request::<AL, BL, AA, BA, AI, BI> {
+) -> rfc003::Request<AL, BL, AA, BA, AI, BI> {
+    rfc003::Request {
         swap_id: id,
         alpha_asset,
         beta_asset,

--- a/cnd/src/quickcheck.rs
+++ b/cnd/src/quickcheck.rs
@@ -7,7 +7,7 @@ use crate::{
     swap_protocols::{
         ledger,
         ledger::{bitcoin, ethereum::ChainId},
-        rfc003::{Accept, Ledger, Request, SecretHash},
+        rfc003::{Accept, Request, SecretHash},
         HashFunction, Role, SwapId,
     },
     timestamp::Timestamp,
@@ -239,10 +239,6 @@ impl Arbitrary for Quickcheck<ledger::Ethereum> {
 
 impl<AL, BL, AA, BA, AI, BI> Arbitrary for Quickcheck<Request<AL, BL, AA, BA, AI, BI>>
 where
-    AL: Ledger,
-    BL: Ledger,
-    AI: Copy,
-    BI: Copy,
     Quickcheck<AL>: Arbitrary,
     Quickcheck<BL>: Arbitrary,
     Quickcheck<AA>: Arbitrary,
@@ -254,13 +250,13 @@ where
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         Quickcheck(Request {
             swap_id: *Quickcheck::<SwapId>::arbitrary(g),
-            alpha_ledger: *Quickcheck::<AL>::arbitrary(g),
-            beta_ledger: *Quickcheck::<BL>::arbitrary(g),
+            alpha_ledger: Quickcheck::<AL>::arbitrary(g).0,
+            beta_ledger: Quickcheck::<BL>::arbitrary(g).0,
             alpha_asset: Quickcheck::<AA>::arbitrary(g).0,
             beta_asset: Quickcheck::<BA>::arbitrary(g).0,
             hash_function: *Quickcheck::<HashFunction>::arbitrary(g),
-            alpha_ledger_refund_identity: *Quickcheck::<AI>::arbitrary(g),
-            beta_ledger_redeem_identity: *Quickcheck::<BI>::arbitrary(g),
+            alpha_ledger_refund_identity: Quickcheck::<AI>::arbitrary(g).0,
+            beta_ledger_redeem_identity: Quickcheck::<BI>::arbitrary(g).0,
             alpha_expiry: *Quickcheck::<Timestamp>::arbitrary(g),
             beta_expiry: *Quickcheck::<Timestamp>::arbitrary(g),
             secret_hash: *Quickcheck::<SecretHash>::arbitrary(g),

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -18,7 +18,7 @@ use crate::{
                 Refunded,
             },
             state_store::{self, InMemoryStateStore, StateStore},
-            ActorState, Ledger,
+            ActorState,
         },
         SwapId,
     },
@@ -88,8 +88,6 @@ impl SendRequest for Facade {
         request: rfc003::Request<AL, BL, AA, BA, AI, BI>,
     ) -> Result<rfc003::Response<AI, BI>, RequestError>
     where
-        AL: Ledger,
-        BL: Ledger,
         rfc003::messages::AcceptResponseBody<AI, BI>: DeserializeOwned,
         rfc003::Request<AL, BL, AA, BA, AI, BI>: TryInto<OutboundRequest> + Send + 'static + Clone,
         <rfc003::Request<AL, BL, AA, BA, AI, BI> as TryInto<OutboundRequest>>::Error: Debug,
@@ -101,8 +99,6 @@ impl SendRequest for Facade {
 #[async_trait]
 impl<AL, BL, AA, BA, AI, BI> LoadAcceptedSwap<AL, BL, AA, BA, AI, BI> for Facade
 where
-    AL: Ledger,
-    BL: Ledger,
     Sqlite: LoadAcceptedSwap<AL, BL, AA, BA, AI, BI>,
     AcceptedSwap<AL, BL, AA, BA, AI, BI>: Send + 'static,
 {

--- a/cnd/src/swap_protocols/rfc003/actions/bitcoin.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/bitcoin.rs
@@ -1,5 +1,5 @@
 use crate::{
-    asset,
+    asset, identity,
     swap_protocols::{
         actions::bitcoin::{SendToAddress, SpendOutput},
         ledger,
@@ -13,14 +13,14 @@ use crate::{
 use ::bitcoin::{Amount, OutPoint, Transaction};
 use blockchain_contracts::bitcoin::{rfc003::bitcoin_htlc::BitcoinHtlc, witness::PrimedInput};
 
-impl<B> FundAction<B, asset::Bitcoin> for (B, asset::Bitcoin)
+impl<B> FundAction<B, asset::Bitcoin, identity::Bitcoin> for (B, asset::Bitcoin, identity::Bitcoin)
 where
     B: ledger::Bitcoin + ledger::bitcoin::Network,
 {
     type FundActionOutput = SendToAddress;
 
     fn fund_action(
-        htlc_params: HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        htlc_params: HtlcParams<'_, B, asset::Bitcoin, identity::Bitcoin>,
     ) -> Self::FundActionOutput {
         let to = htlc_params.compute_address();
 
@@ -32,14 +32,15 @@ where
     }
 }
 
-impl<B> RefundAction<B, asset::Bitcoin> for (B, asset::Bitcoin)
+impl<B> RefundAction<B, asset::Bitcoin, identity::Bitcoin>
+    for (B, asset::Bitcoin, identity::Bitcoin)
 where
     B: ledger::Bitcoin + ledger::bitcoin::Network,
 {
     type RefundActionOutput = SpendOutput;
 
     fn refund_action(
-        htlc_params: HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        htlc_params: HtlcParams<'_, B, asset::Bitcoin, identity::Bitcoin>,
         htlc_location: OutPoint,
         secret_source: &dyn DeriveIdentities,
         fund_transaction: &Transaction,
@@ -57,14 +58,15 @@ where
     }
 }
 
-impl<B> RedeemAction<B, asset::Bitcoin> for (B, asset::Bitcoin)
+impl<B> RedeemAction<B, asset::Bitcoin, identity::Bitcoin>
+    for (B, asset::Bitcoin, identity::Bitcoin)
 where
     B: ledger::Bitcoin + ledger::bitcoin::Network,
 {
     type RedeemActionOutput = SpendOutput;
 
     fn redeem_action(
-        htlc_params: HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        htlc_params: HtlcParams<'_, B, asset::Bitcoin, identity::Bitcoin>,
         htlc_location: OutPoint,
         secret_source: &dyn DeriveIdentities,
         secret: Secret,

--- a/cnd/src/swap_protocols/rfc003/actions/bitcoin.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/bitcoin.rs
@@ -13,7 +13,7 @@ use crate::{
 use ::bitcoin::{Amount, OutPoint, Transaction};
 use blockchain_contracts::bitcoin::{rfc003::bitcoin_htlc::BitcoinHtlc, witness::PrimedInput};
 
-impl<B> FundAction<B, asset::Bitcoin, identity::Bitcoin> for (B, asset::Bitcoin, identity::Bitcoin)
+impl<B> FundAction<B, asset::Bitcoin, identity::Bitcoin> for (B, asset::Bitcoin)
 where
     B: ledger::Bitcoin + ledger::bitcoin::Network,
 {
@@ -32,8 +32,7 @@ where
     }
 }
 
-impl<B> RefundAction<B, asset::Bitcoin, identity::Bitcoin>
-    for (B, asset::Bitcoin, identity::Bitcoin)
+impl<B> RefundAction<B, asset::Bitcoin, identity::Bitcoin> for (B, asset::Bitcoin)
 where
     B: ledger::Bitcoin + ledger::bitcoin::Network,
 {
@@ -58,8 +57,7 @@ where
     }
 }
 
-impl<B> RedeemAction<B, asset::Bitcoin, identity::Bitcoin>
-    for (B, asset::Bitcoin, identity::Bitcoin)
+impl<B> RedeemAction<B, asset::Bitcoin, identity::Bitcoin> for (B, asset::Bitcoin)
 where
     B: ledger::Bitcoin + ledger::bitcoin::Network,
 {

--- a/cnd/src/swap_protocols/rfc003/actions/erc20.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/erc20.rs
@@ -1,6 +1,7 @@
 use crate::{
     asset,
     ethereum::Bytes,
+    identity,
     swap_protocols::{
         actions::ethereum::{CallContract, DeployContract},
         ledger::{ethereum::ChainId, Ethereum},
@@ -11,7 +12,7 @@ use crate::{
 use blockchain_contracts::ethereum::rfc003::erc20_htlc::Erc20Htlc;
 
 pub fn deploy_action(
-    htlc_params: HtlcParams<'_, Ethereum, asset::Erc20, crate::ethereum::Address>,
+    htlc_params: HtlcParams<'_, Ethereum, asset::Erc20, identity::Ethereum>,
 ) -> DeployContract {
     let chain_id = htlc_params.ledger.chain_id;
     let htlc = Erc20Htlc::from(htlc_params);
@@ -26,9 +27,9 @@ pub fn deploy_action(
 }
 
 pub fn fund_action(
-    htlc_params: HtlcParams<'_, Ethereum, asset::Erc20, crate::ethereum::Address>,
-    to_erc20_contract: crate::ethereum::Address,
-    beta_htlc_location: crate::ethereum::Address,
+    htlc_params: HtlcParams<'_, Ethereum, asset::Erc20, identity::Ethereum>,
+    to_erc20_contract: identity::Ethereum,
+    beta_htlc_location: identity::Ethereum,
 ) -> CallContract {
     let chain_id = htlc_params.ledger.chain_id;
     let gas_limit = Erc20Htlc::fund_tx_gas_limit();
@@ -51,7 +52,7 @@ pub fn fund_action(
 pub fn refund_action(
     chain_id: ChainId,
     expiry: Timestamp,
-    beta_htlc_location: crate::ethereum::Address,
+    beta_htlc_location: identity::Ethereum,
 ) -> CallContract {
     let data = Bytes::default();
     let gas_limit = Erc20Htlc::refund_tx_gas_limit();
@@ -66,7 +67,7 @@ pub fn refund_action(
 }
 
 pub fn redeem_action(
-    alpha_htlc_location: crate::ethereum::Address,
+    alpha_htlc_location: identity::Ethereum,
     secret: Secret,
     chain_id: ChainId,
 ) -> CallContract {

--- a/cnd/src/swap_protocols/rfc003/actions/ether.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/ether.rs
@@ -14,11 +14,13 @@ use crate::{
 };
 use blockchain_contracts::ethereum::rfc003::ether_htlc::EtherHtlc;
 
-impl FundAction<Ethereum, asset::Ether> for (Ethereum, asset::Ether) {
+impl FundAction<Ethereum, asset::Ether, identity::Ethereum>
+    for (Ethereum, asset::Ether, identity::Ethereum)
+{
     type FundActionOutput = DeployContract;
 
     fn fund_action(
-        htlc_params: HtlcParams<'_, Ethereum, asset::Ether, crate::ethereum::Address>,
+        htlc_params: HtlcParams<'_, Ethereum, asset::Ether, identity::Ethereum>,
     ) -> Self::FundActionOutput {
         let htlc = EtherHtlc::from(htlc_params.clone());
         let gas_limit = EtherHtlc::deploy_tx_gas_limit();
@@ -31,11 +33,13 @@ impl FundAction<Ethereum, asset::Ether> for (Ethereum, asset::Ether) {
         }
     }
 }
-impl RefundAction<Ethereum, asset::Ether> for (Ethereum, asset::Ether) {
+impl RefundAction<Ethereum, asset::Ether, identity::Ethereum>
+    for (Ethereum, asset::Ether, identity::Ethereum)
+{
     type RefundActionOutput = CallContract;
 
     fn refund_action(
-        htlc_params: HtlcParams<'_, Ethereum, asset::Ether, crate::ethereum::Address>,
+        htlc_params: HtlcParams<'_, Ethereum, asset::Ether, identity::Ethereum>,
         htlc_location: identity::Ethereum,
         _secret_source: &dyn DeriveIdentities,
         _fund_transaction: &Transaction,
@@ -51,11 +55,13 @@ impl RefundAction<Ethereum, asset::Ether> for (Ethereum, asset::Ether) {
         }
     }
 }
-impl RedeemAction<Ethereum, asset::Ether> for (Ethereum, asset::Ether) {
+impl RedeemAction<Ethereum, asset::Ether, identity::Ethereum>
+    for (Ethereum, asset::Ether, identity::Ethereum)
+{
     type RedeemActionOutput = CallContract;
 
     fn redeem_action(
-        htlc_params: HtlcParams<'_, Ethereum, asset::Ether, crate::ethereum::Address>,
+        htlc_params: HtlcParams<'_, Ethereum, asset::Ether, identity::Ethereum>,
         htlc_location: identity::Ethereum,
         _secret_source: &dyn DeriveIdentities,
         secret: Secret,

--- a/cnd/src/swap_protocols/rfc003/actions/ether.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/ether.rs
@@ -14,9 +14,7 @@ use crate::{
 };
 use blockchain_contracts::ethereum::rfc003::ether_htlc::EtherHtlc;
 
-impl FundAction<Ethereum, asset::Ether, identity::Ethereum>
-    for (Ethereum, asset::Ether, identity::Ethereum)
-{
+impl FundAction<Ethereum, asset::Ether, identity::Ethereum> for (Ethereum, asset::Ether) {
     type FundActionOutput = DeployContract;
 
     fn fund_action(
@@ -33,9 +31,7 @@ impl FundAction<Ethereum, asset::Ether, identity::Ethereum>
         }
     }
 }
-impl RefundAction<Ethereum, asset::Ether, identity::Ethereum>
-    for (Ethereum, asset::Ether, identity::Ethereum)
-{
+impl RefundAction<Ethereum, asset::Ether, identity::Ethereum> for (Ethereum, asset::Ether) {
     type RefundActionOutput = CallContract;
 
     fn refund_action(
@@ -55,9 +51,7 @@ impl RefundAction<Ethereum, asset::Ether, identity::Ethereum>
         }
     }
 }
-impl RedeemAction<Ethereum, asset::Ether, identity::Ethereum>
-    for (Ethereum, asset::Ether, identity::Ethereum)
-{
+impl RedeemAction<Ethereum, asset::Ether, identity::Ethereum> for (Ethereum, asset::Ether) {
     type RedeemActionOutput = CallContract;
 
     fn redeem_action(

--- a/cnd/src/swap_protocols/rfc003/actions/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/mod.rs
@@ -21,10 +21,7 @@ pub enum Action<Accept, Decline, Deploy, Fund, Redeem, Refund> {
     Refund(Refund),
 }
 
-pub trait FundAction<L, A, I>
-where
-    L: Ledger,
-{
+pub trait FundAction<L, A, I> {
     type FundActionOutput;
 
     fn fund_action(htlc_params: HtlcParams<'_, L, A, I>) -> Self::FundActionOutput;

--- a/cnd/src/swap_protocols/rfc003/actions/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/mod.rs
@@ -21,37 +21,37 @@ pub enum Action<Accept, Decline, Deploy, Fund, Redeem, Refund> {
     Refund(Refund),
 }
 
-pub trait FundAction<L, A>
+pub trait FundAction<L, A, I>
 where
     L: Ledger,
 {
     type FundActionOutput;
 
-    fn fund_action(htlc_params: HtlcParams<'_, L, A, L::Identity>) -> Self::FundActionOutput;
+    fn fund_action(htlc_params: HtlcParams<'_, L, A, I>) -> Self::FundActionOutput;
 }
 
-pub trait RefundAction<L, A>
+pub trait RefundAction<L, A, I>
 where
     L: Ledger,
 {
     type RefundActionOutput;
 
     fn refund_action(
-        htlc_params: HtlcParams<'_, L, A, L::Identity>,
+        htlc_params: HtlcParams<'_, L, A, I>,
         htlc_location: L::HtlcLocation,
         secret_source: &dyn DeriveIdentities,
         fund_transaction: &L::Transaction,
     ) -> Self::RefundActionOutput;
 }
 
-pub trait RedeemAction<L, A>
+pub trait RedeemAction<L, A, I>
 where
     L: Ledger,
 {
     type RedeemActionOutput;
 
     fn redeem_action(
-        htlc_params: HtlcParams<'_, L, A, L::Identity>,
+        htlc_params: HtlcParams<'_, L, A, I>,
         htlc_location: L::HtlcLocation,
         secret_source: &dyn DeriveIdentities,
         secret: Secret,

--- a/cnd/src/swap_protocols/rfc003/alice/actions/erc20.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/actions/erc20.rs
@@ -17,7 +17,7 @@ use std::convert::Infallible;
 impl<BL, BA, BI> Actions for alice::State<Ethereum, BL, asset::Erc20, BA, identity::Ethereum, BI>
 where
     BL: Ledger,
-    (BL, BA, BI): RedeemAction<BL, BA, BI>,
+    (BL, BA): RedeemAction<BL, BA, BI>,
 {
     #[allow(clippy::type_complexity)]
     type ActionKind = Action<
@@ -25,7 +25,7 @@ where
         Decline<Ethereum, BL>,
         ethereum::DeployContract,
         ethereum::CallContract,
-        <(BL, BA, BI) as RedeemAction<BL, BA, BI>>::RedeemActionOutput,
+        <(BL, BA) as RedeemAction<BL, BA, BI>>::RedeemActionOutput,
         ethereum::CallContract,
     >;
 
@@ -60,7 +60,7 @@ where
         };
 
         if let Funded { htlc_location, .. } = beta_state {
-            actions.push(Action::Redeem(<(BL, BA, BI)>::redeem_action(
+            actions.push(Action::Redeem(<(BL, BA)>::redeem_action(
                 HtlcParams::new_beta_params(request, response),
                 htlc_location.clone(),
                 &self.secret_source, // Derive identities with this.
@@ -74,16 +74,16 @@ where
 impl<AL, AA, AI> Actions for alice::State<AL, Ethereum, AA, asset::Erc20, AI, identity::Ethereum>
 where
     AL: Ledger,
-    (AL, AA, AI): FundAction<AL, AA, AI> + RefundAction<AL, AA, AI>,
+    (AL, AA): FundAction<AL, AA, AI> + RefundAction<AL, AA, AI>,
 {
     #[allow(clippy::type_complexity)]
     type ActionKind = Action<
         Accept<AL, Ethereum>,
         Decline<AL, Ethereum>,
         Infallible,
-        <(AL, AA, AI) as FundAction<AL, AA, AI>>::FundActionOutput,
+        <(AL, AA) as FundAction<AL, AA, AI>>::FundActionOutput,
         ethereum::CallContract,
-        <(AL, AA, AI) as RefundAction<AL, AA, AI>>::RefundActionOutput,
+        <(AL, AA) as RefundAction<AL, AA, AI>>::RefundActionOutput,
     >;
 
     fn actions(&self) -> Vec<Self::ActionKind> {
@@ -100,14 +100,14 @@ where
         use self::LedgerState::*;
 
         let mut actions = match alpha_state {
-            NotDeployed => vec![Action::Fund(<(AL, AA, AI)>::fund_action(
+            NotDeployed => vec![Action::Fund(<(AL, AA)>::fund_action(
                 HtlcParams::new_alpha_params(request, response),
             ))],
             Funded {
                 htlc_location,
                 fund_transaction,
                 ..
-            } => vec![Action::Refund(<(AL, AA, AI)>::refund_action(
+            } => vec![Action::Refund(<(AL, AA)>::refund_action(
                 HtlcParams::new_alpha_params(request, response),
                 htlc_location.clone(),
                 &self.secret_source,

--- a/cnd/src/swap_protocols/rfc003/alice/actions/generic_impl.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/actions/generic_impl.rs
@@ -13,17 +13,17 @@ impl<AL, BL, AA, BA, AI, BI> Actions for alice::State<AL, BL, AA, BA, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
-    (AL, AA, AI): FundAction<AL, AA, AI> + RefundAction<AL, AA, AI>,
-    (BL, BA, BI): RedeemAction<BL, BA, BI>,
+    (AL, AA): FundAction<AL, AA, AI> + RefundAction<AL, AA, AI>,
+    (BL, BA): RedeemAction<BL, BA, BI>,
 {
     #[allow(clippy::type_complexity)]
     type ActionKind = Action<
         Accept<AL, BL>,
         Decline<BL, BL>,
         Infallible,
-        <(AL, AA, AI) as FundAction<AL, AA, AI>>::FundActionOutput,
-        <(BL, BA, BI) as RedeemAction<BL, BA, BI>>::RedeemActionOutput,
-        <(AL, AA, AI) as RefundAction<AL, AA, AI>>::RefundActionOutput,
+        <(AL, AA) as FundAction<AL, AA, AI>>::FundActionOutput,
+        <(BL, BA) as RedeemAction<BL, BA, BI>>::RedeemActionOutput,
+        <(AL, AA) as RefundAction<AL, AA, AI>>::RefundActionOutput,
     >;
 
     fn actions(&self) -> Vec<Self::ActionKind> {
@@ -39,14 +39,14 @@ where
 
         use self::LedgerState::*;
         let mut actions = match alpha_state {
-            NotDeployed => vec![Action::Fund(<(AL, AA, AI)>::fund_action(
+            NotDeployed => vec![Action::Fund(<(AL, AA)>::fund_action(
                 HtlcParams::new_alpha_params(request, response),
             ))],
             IncorrectlyFunded {
                 htlc_location,
                 fund_transaction,
                 ..
-            } => vec![Action::Refund(<(AL, AA, AI)>::refund_action(
+            } => vec![Action::Refund(<(AL, AA)>::refund_action(
                 HtlcParams::new_alpha_params(request, response),
                 htlc_location.clone(),
                 &self.secret_source,
@@ -56,7 +56,7 @@ where
                 htlc_location,
                 fund_transaction,
                 ..
-            } => vec![Action::Refund(<(AL, AA, AI)>::refund_action(
+            } => vec![Action::Refund(<(AL, AA)>::refund_action(
                 HtlcParams::new_alpha_params(request, response),
                 htlc_location.clone(),
                 &self.secret_source,
@@ -66,7 +66,7 @@ where
         };
 
         if let Funded { htlc_location, .. } = beta_state {
-            actions.push(Action::Redeem(<(BL, BA, BI)>::redeem_action(
+            actions.push(Action::Redeem(<(BL, BA)>::redeem_action(
                 HtlcParams::new_beta_params(request, response),
                 htlc_location.clone(),
                 &self.secret_source, // Derive identities with this.

--- a/cnd/src/swap_protocols/rfc003/alice/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/mod.rs
@@ -12,12 +12,12 @@ use derivative::Derivative;
 
 #[derive(Clone, Derivative)]
 #[derivative(Debug, PartialEq)]
-pub struct State<AL, BL, AA, BA>
+pub struct State<AL, BL, AA, BA, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
 {
-    pub swap_communication: SwapCommunication<AL, BL, AA, BA>,
+    pub swap_communication: SwapCommunication<AL, BL, AA, BA, AI, BI>,
     pub alpha_ledger_state: LedgerState<AL::HtlcLocation, AL::Transaction, AA>,
     pub beta_ledger_state: LedgerState<BL::HtlcLocation, BL::Transaction, BA>,
     #[derivative(Debug = "ignore", PartialEq = "ignore")]
@@ -25,12 +25,15 @@ where
     pub failed: bool,
 }
 
-impl<AL, BL, AA, BA> State<AL, BL, AA, BA>
+impl<AL, BL, AA, BA, AI, BI> State<AL, BL, AA, BA, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
 {
-    pub fn proposed(request: messages::Request<AL, BL, AA, BA>, secret_source: SwapSeed) -> Self {
+    pub fn proposed(
+        request: messages::Request<AL, BL, AA, BA, AI, BI>,
+        secret_source: SwapSeed,
+    ) -> Self {
         Self {
             swap_communication: SwapCommunication::Proposed { request },
             alpha_ledger_state: LedgerState::NotDeployed,
@@ -41,8 +44,8 @@ where
     }
 
     pub fn accepted(
-        request: messages::Request<AL, BL, AA, BA>,
-        response: messages::Accept<AL::Identity, BL::Identity>,
+        request: messages::Request<AL, BL, AA, BA, AI, BI>,
+        response: messages::Accept<AI, BI>,
         secret_source: SwapSeed,
     ) -> Self {
         Self {
@@ -55,7 +58,7 @@ where
     }
 
     pub fn declined(
-        request: messages::Request<AL, BL, AA, BA>,
+        request: messages::Request<AL, BL, AA, BA, AI, BI>,
         response: messages::Decline,
         secret_source: SwapSeed,
     ) -> Self {
@@ -68,17 +71,19 @@ where
         }
     }
 
-    pub fn request(&self) -> &messages::Request<AL, BL, AA, BA> {
+    pub fn request(&self) -> &messages::Request<AL, BL, AA, BA, AI, BI> {
         self.swap_communication.request()
     }
 }
 
-impl<AL, BL, AA, BA> ActorState for State<AL, BL, AA, BA>
+impl<AL, BL, AA, BA, AI, BI> ActorState for State<AL, BL, AA, BA, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
     AA: 'static,
     BA: 'static,
+    AI: 'static,
+    BI: 'static,
 {
     type AL = AL;
     type BL = BL;

--- a/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
@@ -3,6 +3,7 @@ use crate::{
     btsieve::bitcoin::{
         watch_for_created_outpoint, watch_for_spent_outpoint, BitcoindConnector, Cache,
     },
+    identity,
     swap_protocols::{
         ledger::bitcoin,
         rfc003::{
@@ -19,13 +20,13 @@ use chrono::NaiveDateTime;
 use tracing_futures::Instrument;
 
 #[async_trait::async_trait]
-impl<B> HtlcFunded<B, asset::Bitcoin> for Cache<BitcoindConnector>
+impl<B> HtlcFunded<B, asset::Bitcoin, identity::Bitcoin> for Cache<BitcoindConnector>
 where
     B: bitcoin::Bitcoin + bitcoin::Network,
 {
     async fn htlc_funded(
         &self,
-        _htlc_params: &HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        _htlc_params: &HtlcParams<'_, B, asset::Bitcoin, identity::Bitcoin>,
         htlc_deployment: &Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>,
         _start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Funded<::bitcoin::Transaction, asset::Bitcoin>> {
@@ -41,13 +42,13 @@ where
 }
 
 #[async_trait::async_trait]
-impl<B> HtlcDeployed<B, asset::Bitcoin> for Cache<BitcoindConnector>
+impl<B> HtlcDeployed<B, asset::Bitcoin, identity::Bitcoin> for Cache<BitcoindConnector>
 where
     B: bitcoin::Bitcoin + bitcoin::Network,
 {
     async fn htlc_deployed(
         &self,
-        htlc_params: &HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        htlc_params: &HtlcParams<'_, B, asset::Bitcoin, identity::Bitcoin>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>> {
         let connector = self.clone();
@@ -65,13 +66,13 @@ where
 }
 
 #[async_trait::async_trait]
-impl<B> HtlcRedeemed<B, asset::Bitcoin> for Cache<BitcoindConnector>
+impl<B> HtlcRedeemed<B, asset::Bitcoin, identity::Bitcoin> for Cache<BitcoindConnector>
 where
     B: bitcoin::Bitcoin + bitcoin::Network,
 {
     async fn htlc_redeemed(
         &self,
-        htlc_params: &HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        htlc_params: &HtlcParams<'_, B, asset::Bitcoin, identity::Bitcoin>,
         htlc_deployment: &Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<::bitcoin::Transaction>> {
@@ -95,13 +96,13 @@ where
 }
 
 #[async_trait::async_trait]
-impl<B> HtlcRefunded<B, asset::Bitcoin> for Cache<BitcoindConnector>
+impl<B> HtlcRefunded<B, asset::Bitcoin, identity::Bitcoin> for Cache<BitcoindConnector>
 where
     B: bitcoin::Bitcoin + bitcoin::Network,
 {
     async fn htlc_refunded(
         &self,
-        _htlc_params: &HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>,
+        _htlc_params: &HtlcParams<'_, B, asset::Bitcoin, identity::Bitcoin>,
         htlc_deployment: &Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<::bitcoin::Transaction>> {

--- a/cnd/src/swap_protocols/rfc003/bitcoin/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bitcoin/mod.rs
@@ -1,9 +1,12 @@
 mod extract_secret;
 mod htlc_events;
 
-use crate::swap_protocols::{
-    ledger,
-    rfc003::{create_swap::HtlcParams, Ledger},
+use crate::{
+    asset, identity,
+    swap_protocols::{
+        ledger,
+        rfc003::{create_swap::HtlcParams, Ledger},
+    },
 };
 use ::bitcoin::{
     hashes::{hash160, Hash},
@@ -12,22 +15,20 @@ use ::bitcoin::{
 use blockchain_contracts::bitcoin::rfc003::bitcoin_htlc::BitcoinHtlc;
 
 pub use self::htlc_events::*;
-use crate::{asset, bitcoin::PublicKey};
 
 impl<B> Ledger for B
 where
     B: ledger::Bitcoin,
 {
     type HtlcLocation = OutPoint;
-    type Identity = PublicKey;
     type Transaction = Transaction;
 }
 
-impl<B> From<HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>> for BitcoinHtlc
+impl<B> From<HtlcParams<'_, B, asset::Bitcoin, identity::Bitcoin>> for BitcoinHtlc
 where
     B: ledger::Bitcoin,
 {
-    fn from(htlc_params: HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>) -> Self {
+    fn from(htlc_params: HtlcParams<'_, B, asset::Bitcoin, identity::Bitcoin>) -> Self {
         let refund_public_key = ::bitcoin::PublicKey::from(*htlc_params.refund_identity);
         let redeem_public_key = ::bitcoin::PublicKey::from(*htlc_params.redeem_identity);
 
@@ -43,7 +44,7 @@ where
     }
 }
 
-impl<B> HtlcParams<'_, B, asset::Bitcoin, crate::bitcoin::PublicKey>
+impl<B> HtlcParams<'_, B, asset::Bitcoin, identity::Bitcoin>
 where
     B: ledger::Bitcoin + ledger::bitcoin::Network,
 {

--- a/cnd/src/swap_protocols/rfc003/bob/actions/erc20.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/actions/erc20.rs
@@ -1,5 +1,6 @@
 use crate::{
     asset::{self},
+    identity,
     swap_protocols::{
         actions::{ethereum, Actions},
         ledger::Ethereum,
@@ -13,10 +14,10 @@ use crate::{
 };
 use std::convert::Infallible;
 
-impl<AL, AA> Actions for bob::State<AL, Ethereum, AA, asset::Erc20>
+impl<AL, AA, AI> Actions for bob::State<AL, Ethereum, AA, asset::Erc20, AI, identity::Ethereum>
 where
     AL: Ledger,
-    (AL, AA): RedeemAction<AL, AA>,
+    (AL, AA, AI): RedeemAction<AL, AA, AI>,
 {
     #[allow(clippy::type_complexity)]
     type ActionKind = Action<
@@ -24,7 +25,7 @@ where
         Decline<AL, Ethereum>,
         ethereum::DeployContract,
         ethereum::CallContract,
-        <(AL, AA) as RedeemAction<AL, AA>>::RedeemActionOutput,
+        <(AL, AA, AI) as RedeemAction<AL, AA, AI>>::RedeemActionOutput,
         ethereum::CallContract,
     >;
 
@@ -50,7 +51,7 @@ where
 
         let mut actions = match (alpha_state, beta_state) {
             (Funded { htlc_location, .. }, Redeemed { secret, .. }) => {
-                vec![Action::Redeem(<(AL, AA)>::redeem_action(
+                vec![Action::Redeem(<(AL, AA, AI)>::redeem_action(
                     HtlcParams::new_alpha_params(request, response),
                     htlc_location.clone(),
                     &*self.secret_source, // Derive identities with this.
@@ -82,19 +83,19 @@ where
     }
 }
 
-impl<BL, BA> Actions for bob::State<Ethereum, BL, asset::Erc20, BA>
+impl<BL, BA, BI> Actions for bob::State<Ethereum, BL, asset::Erc20, BA, identity::Ethereum, BI>
 where
     BL: Ledger,
-    (BL, BA): FundAction<BL, BA> + RefundAction<BL, BA>,
+    (BL, BA, BI): FundAction<BL, BA, BI> + RefundAction<BL, BA, BI>,
 {
     #[allow(clippy::type_complexity)]
     type ActionKind = Action<
         Accept<Ethereum, BL>,
         Decline<Ethereum, BL>,
         Infallible,
-        <(BL, BA) as FundAction<BL, BA>>::FundActionOutput,
+        <(BL, BA, BI) as FundAction<BL, BA, BI>>::FundActionOutput,
         ethereum::CallContract,
-        <(BL, BA) as RefundAction<BL, BA>>::RefundActionOutput,
+        <(BL, BA, BI) as RefundAction<BL, BA, BI>>::RefundActionOutput,
     >;
 
     fn actions(&self) -> Vec<Self::ActionKind> {
@@ -120,7 +121,7 @@ where
             (Funded { htlc_location, .. }, Redeemed { secret, .. }) => vec![Action::Redeem(
                 erc20::redeem_action(*htlc_location, *secret, request.alpha_ledger.chain_id),
             )],
-            (Funded { .. }, NotDeployed) => vec![Action::Fund(<(BL, BA)>::fund_action(
+            (Funded { .. }, NotDeployed) => vec![Action::Fund(<(BL, BA, BI)>::fund_action(
                 HtlcParams::new_beta_params(request, response),
             ))],
             _ => vec![],
@@ -132,7 +133,7 @@ where
             ..
         } = beta_state
         {
-            actions.push(Action::Refund(<(BL, BA)>::refund_action(
+            actions.push(Action::Refund(<(BL, BA, BI)>::refund_action(
                 HtlcParams::new_beta_params(request, response),
                 htlc_location.clone(),
                 &*self.secret_source,

--- a/cnd/src/swap_protocols/rfc003/bob/actions/erc20.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/actions/erc20.rs
@@ -17,7 +17,7 @@ use std::convert::Infallible;
 impl<AL, AA, AI> Actions for bob::State<AL, Ethereum, AA, asset::Erc20, AI, identity::Ethereum>
 where
     AL: Ledger,
-    (AL, AA, AI): RedeemAction<AL, AA, AI>,
+    (AL, AA): RedeemAction<AL, AA, AI>,
 {
     #[allow(clippy::type_complexity)]
     type ActionKind = Action<
@@ -25,7 +25,7 @@ where
         Decline<AL, Ethereum>,
         ethereum::DeployContract,
         ethereum::CallContract,
-        <(AL, AA, AI) as RedeemAction<AL, AA, AI>>::RedeemActionOutput,
+        <(AL, AA) as RedeemAction<AL, AA, AI>>::RedeemActionOutput,
         ethereum::CallContract,
     >;
 
@@ -51,7 +51,7 @@ where
 
         let mut actions = match (alpha_state, beta_state) {
             (Funded { htlc_location, .. }, Redeemed { secret, .. }) => {
-                vec![Action::Redeem(<(AL, AA, AI)>::redeem_action(
+                vec![Action::Redeem(<(AL, AA)>::redeem_action(
                     HtlcParams::new_alpha_params(request, response),
                     htlc_location.clone(),
                     &*self.secret_source, // Derive identities with this.
@@ -86,16 +86,16 @@ where
 impl<BL, BA, BI> Actions for bob::State<Ethereum, BL, asset::Erc20, BA, identity::Ethereum, BI>
 where
     BL: Ledger,
-    (BL, BA, BI): FundAction<BL, BA, BI> + RefundAction<BL, BA, BI>,
+    (BL, BA): FundAction<BL, BA, BI> + RefundAction<BL, BA, BI>,
 {
     #[allow(clippy::type_complexity)]
     type ActionKind = Action<
         Accept<Ethereum, BL>,
         Decline<Ethereum, BL>,
         Infallible,
-        <(BL, BA, BI) as FundAction<BL, BA, BI>>::FundActionOutput,
+        <(BL, BA) as FundAction<BL, BA, BI>>::FundActionOutput,
         ethereum::CallContract,
-        <(BL, BA, BI) as RefundAction<BL, BA, BI>>::RefundActionOutput,
+        <(BL, BA) as RefundAction<BL, BA, BI>>::RefundActionOutput,
     >;
 
     fn actions(&self) -> Vec<Self::ActionKind> {
@@ -121,7 +121,7 @@ where
             (Funded { htlc_location, .. }, Redeemed { secret, .. }) => vec![Action::Redeem(
                 erc20::redeem_action(*htlc_location, *secret, request.alpha_ledger.chain_id),
             )],
-            (Funded { .. }, NotDeployed) => vec![Action::Fund(<(BL, BA, BI)>::fund_action(
+            (Funded { .. }, NotDeployed) => vec![Action::Fund(<(BL, BA)>::fund_action(
                 HtlcParams::new_beta_params(request, response),
             ))],
             _ => vec![],
@@ -133,7 +133,7 @@ where
             ..
         } = beta_state
         {
-            actions.push(Action::Refund(<(BL, BA, BI)>::refund_action(
+            actions.push(Action::Refund(<(BL, BA)>::refund_action(
                 HtlcParams::new_beta_params(request, response),
                 htlc_location.clone(),
                 &*self.secret_source,

--- a/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
@@ -9,21 +9,21 @@ use crate::swap_protocols::{
 };
 use std::convert::Infallible;
 
-impl<AL, BL, AA, BA> Actions for bob::State<AL, BL, AA, BA>
+impl<AL, BL, AA, BA, AI, BI> Actions for bob::State<AL, BL, AA, BA, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
-    (BL, BA): FundAction<BL, BA> + RefundAction<BL, BA>,
-    (AL, AA): RedeemAction<AL, AA>,
+    (BL, BA, BI): FundAction<BL, BA, BI> + RefundAction<BL, BA, BI>,
+    (AL, AA, AI): RedeemAction<AL, AA, AI>,
 {
     #[allow(clippy::type_complexity)]
     type ActionKind = Action<
         Accept<AL, BL>,
         Decline<AL, BL>,
         Infallible,
-        <(BL, BA) as FundAction<BL, BA>>::FundActionOutput,
-        <(AL, AA) as RedeemAction<AL, AA>>::RedeemActionOutput,
-        <(BL, BA) as RefundAction<BL, BA>>::RefundActionOutput,
+        <(BL, BA, BI) as FundAction<BL, BA, BI>>::FundActionOutput,
+        <(AL, AA, AI) as RedeemAction<AL, AA, AI>>::RedeemActionOutput,
+        <(BL, BA, BI) as RefundAction<BL, BA, BI>>::RefundActionOutput,
     >;
 
     fn actions(&self) -> Vec<Self::ActionKind> {
@@ -47,7 +47,7 @@ where
         use self::LedgerState::*;
         let mut actions = match (alpha_state, beta_state) {
             (Funded { htlc_location, .. }, Redeemed { secret, .. }) => {
-                vec![Action::Redeem(<(AL, AA)>::redeem_action(
+                vec![Action::Redeem(<(AL, AA, AI)>::redeem_action(
                     HtlcParams::new_alpha_params(request, response),
                     htlc_location.clone(),
                     &*self.secret_source, // Derive identities with this.
@@ -55,7 +55,7 @@ where
                                            * action. */
                 ))]
             }
-            (Funded { .. }, NotDeployed) => vec![Action::Fund(<(BL, BA)>::fund_action(
+            (Funded { .. }, NotDeployed) => vec![Action::Fund(<(BL, BA, BI)>::fund_action(
                 HtlcParams::new_beta_params(request, response),
             ))],
             _ => vec![],
@@ -72,7 +72,7 @@ where
             ..
         } = beta_state
         {
-            actions.push(Action::Refund(<(BL, BA)>::refund_action(
+            actions.push(Action::Refund(<(BL, BA, BI)>::refund_action(
                 HtlcParams::new_beta_params(request, response),
                 htlc_location.clone(),
                 &*self.secret_source,

--- a/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
@@ -13,17 +13,17 @@ impl<AL, BL, AA, BA, AI, BI> Actions for bob::State<AL, BL, AA, BA, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
-    (BL, BA, BI): FundAction<BL, BA, BI> + RefundAction<BL, BA, BI>,
-    (AL, AA, AI): RedeemAction<AL, AA, AI>,
+    (BL, BA): FundAction<BL, BA, BI> + RefundAction<BL, BA, BI>,
+    (AL, AA): RedeemAction<AL, AA, AI>,
 {
     #[allow(clippy::type_complexity)]
     type ActionKind = Action<
         Accept<AL, BL>,
         Decline<AL, BL>,
         Infallible,
-        <(BL, BA, BI) as FundAction<BL, BA, BI>>::FundActionOutput,
-        <(AL, AA, AI) as RedeemAction<AL, AA, AI>>::RedeemActionOutput,
-        <(BL, BA, BI) as RefundAction<BL, BA, BI>>::RefundActionOutput,
+        <(BL, BA) as FundAction<BL, BA, BI>>::FundActionOutput,
+        <(AL, AA) as RedeemAction<AL, AA, AI>>::RedeemActionOutput,
+        <(BL, BA) as RefundAction<BL, BA, BI>>::RefundActionOutput,
     >;
 
     fn actions(&self) -> Vec<Self::ActionKind> {
@@ -47,7 +47,7 @@ where
         use self::LedgerState::*;
         let mut actions = match (alpha_state, beta_state) {
             (Funded { htlc_location, .. }, Redeemed { secret, .. }) => {
-                vec![Action::Redeem(<(AL, AA, AI)>::redeem_action(
+                vec![Action::Redeem(<(AL, AA)>::redeem_action(
                     HtlcParams::new_alpha_params(request, response),
                     htlc_location.clone(),
                     &*self.secret_source, // Derive identities with this.
@@ -55,7 +55,7 @@ where
                                            * action. */
                 ))]
             }
-            (Funded { .. }, NotDeployed) => vec![Action::Fund(<(BL, BA, BI)>::fund_action(
+            (Funded { .. }, NotDeployed) => vec![Action::Fund(<(BL, BA)>::fund_action(
                 HtlcParams::new_beta_params(request, response),
             ))],
             _ => vec![],
@@ -72,7 +72,7 @@ where
             ..
         } = beta_state
         {
-            actions.push(Action::Refund(<(BL, BA, BI)>::refund_action(
+            actions.push(Action::Refund(<(BL, BA)>::refund_action(
                 HtlcParams::new_beta_params(request, response),
                 htlc_location.clone(),
                 &*self.secret_source,

--- a/cnd/src/swap_protocols/rfc003/bob/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/mod.rs
@@ -1,19 +1,11 @@
 pub mod actions;
 
 use crate::swap_protocols::rfc003::{
-    self, ledger::Ledger, ledger_state::LedgerState, messages::Request, Accept, ActorState,
-    Decline, DeriveIdentities, SwapCommunication,
+    ledger::Ledger, ledger_state::LedgerState, messages::Request, Accept, ActorState, Decline,
+    DeriveIdentities, SwapCommunication,
 };
 use derivative::Derivative;
-use futures::sync::oneshot;
-use std::sync::{Arc, Mutex};
-
-#[allow(type_alias_bounds)]
-pub type ResponseSender<AL, BL>
-where
-    AL: Ledger,
-    BL: Ledger,
-= Arc<Mutex<Option<oneshot::Sender<rfc003::Response<AL, BL>>>>>;
+use std::sync::Arc;
 
 #[derive(Clone, Derivative)]
 #[derivative(Debug)]

--- a/cnd/src/swap_protocols/rfc003/bob/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/mod.rs
@@ -17,12 +17,12 @@ where
 
 #[derive(Clone, Derivative)]
 #[derivative(Debug)]
-pub struct State<AL, BL, AA, BA>
+pub struct State<AL, BL, AA, BA, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
 {
-    pub swap_communication: SwapCommunication<AL, BL, AA, BA>,
+    pub swap_communication: SwapCommunication<AL, BL, AA, BA, AI, BI>,
     pub alpha_ledger_state: LedgerState<AL::HtlcLocation, AL::Transaction, AA>,
     pub beta_ledger_state: LedgerState<BL::HtlcLocation, BL::Transaction, BA>,
     #[derivative(Debug = "ignore")]
@@ -30,13 +30,13 @@ where
     pub failed: bool, // Gets set on any error during the execution of a swap.
 }
 
-impl<AL, BL, AA, BA> State<AL, BL, AA, BA>
+impl<AL, BL, AA, BA, AI, BI> State<AL, BL, AA, BA, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
 {
     pub fn proposed(
-        request: Request<AL, BL, AA, BA>,
+        request: Request<AL, BL, AA, BA, AI, BI>,
         secret_source: impl DeriveIdentities,
     ) -> Self {
         Self {
@@ -49,8 +49,8 @@ where
     }
 
     pub fn accepted(
-        request: Request<AL, BL, AA, BA>,
-        response: Accept<AL::Identity, BL::Identity>,
+        request: Request<AL, BL, AA, BA, AI, BI>,
+        response: Accept<AI, BI>,
         secret_source: impl DeriveIdentities,
     ) -> Self {
         Self {
@@ -63,7 +63,7 @@ where
     }
 
     pub fn declined(
-        request: Request<AL, BL, AA, BA>,
+        request: Request<AL, BL, AA, BA, AI, BI>,
         response: Decline,
         secret_source: impl DeriveIdentities,
     ) -> Self {
@@ -76,7 +76,7 @@ where
         }
     }
 
-    pub fn request(&self) -> &Request<AL, BL, AA, BA> {
+    pub fn request(&self) -> &Request<AL, BL, AA, BA, AI, BI> {
         match &self.swap_communication {
             SwapCommunication::Accepted { request, .. }
             | SwapCommunication::Proposed { request, .. }
@@ -85,12 +85,14 @@ where
     }
 }
 
-impl<AL, BL, AA, BA> ActorState for State<AL, BL, AA, BA>
+impl<AL, BL, AA, BA, AI, BI> ActorState for State<AL, BL, AA, BA, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
     AA: 'static,
     BA: 'static,
+    AI: 'static,
+    BI: 'static,
 {
     type AL = AL;
     type BL = BL;

--- a/cnd/src/swap_protocols/rfc003/create_swap.rs
+++ b/cnd/src/swap_protocols/rfc003/create_swap.rs
@@ -207,17 +207,11 @@ pub struct HtlcParams<'a, L, A, I> {
     pub secret_hash: SecretHash,
 }
 
-impl<'a, L, A, I> HtlcParams<'a, L, A, I>
-where
-    L: Ledger,
-{
+impl<'a, L, A, I> HtlcParams<'a, L, A, I> {
     pub fn new_alpha_params<BL, BA, BI>(
         request: &'a rfc003::Request<L, BL, A, BA, I, BI>,
         accept_response: &'a rfc003::Accept<I, BI>,
-    ) -> Self
-    where
-        BL: Ledger,
-    {
+    ) -> Self {
         HtlcParams {
             asset: &request.alpha_asset,
             ledger: &request.alpha_ledger,
@@ -231,10 +225,7 @@ where
     pub fn new_beta_params<AL, AA, AI>(
         request: &'a rfc003::Request<AL, L, AA, A, AI, I>,
         accept_response: &'a rfc003::Accept<AI, I>,
-    ) -> Self
-    where
-        AL: Ledger,
-    {
+    ) -> Self {
         HtlcParams {
             asset: &request.beta_asset,
             ledger: &request.beta_ledger,
@@ -247,11 +238,7 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct OngoingSwap<AL, BL, AA, BA, AI, BI>
-where
-    AL: Ledger,
-    BL: Ledger,
-{
+pub struct OngoingSwap<AL, BL, AA, BA, AI, BI> {
     pub alpha_ledger: AL,
     pub beta_ledger: BL,
     pub alpha_asset: AA,
@@ -266,11 +253,7 @@ where
     pub secret_hash: SecretHash,
 }
 
-impl<AL, BL, AA, BA, AI, BI> OngoingSwap<AL, BL, AA, BA, AI, BI>
-where
-    AL: Ledger,
-    BL: Ledger,
-{
+impl<AL, BL, AA, BA, AI, BI> OngoingSwap<AL, BL, AA, BA, AI, BI> {
     pub fn new(request: Request<AL, BL, AA, BA, AI, BI>, accept: Accept<AI, BI>) -> Self {
         OngoingSwap {
             alpha_ledger: request.alpha_ledger,

--- a/cnd/src/swap_protocols/rfc003/ethereum/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/ethereum/htlc_events.rs
@@ -3,7 +3,8 @@ use crate::{
     btsieve::ethereum::{
         watch_for_contract_creation, watch_for_event, Cache, Event, Topic, Web3Connector,
     },
-    ethereum::{Address, Transaction, H256, U256},
+    ethereum::{Transaction, H256, U256},
+    identity,
     swap_protocols::{
         ledger::Ethereum,
         rfc003::{
@@ -27,11 +28,11 @@ lazy_static::lazy_static! {
 }
 
 #[async_trait::async_trait]
-impl HtlcFunded<Ethereum, Ether> for Cache<Web3Connector> {
+impl HtlcFunded<Ethereum, Ether, identity::Ethereum> for Cache<Web3Connector> {
     async fn htlc_funded(
         &self,
-        _htlc_params: &HtlcParams<'_, Ethereum, Ether, Address>,
-        deploy_transaction: &Deployed<Transaction, Address>,
+        _htlc_params: &HtlcParams<'_, Ethereum, Ether, identity::Ethereum>,
+        deploy_transaction: &Deployed<Transaction, identity::Ethereum>,
         _start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Funded<Transaction, Ether>> {
         Ok(Funded {
@@ -42,12 +43,12 @@ impl HtlcFunded<Ethereum, Ether> for Cache<Web3Connector> {
 }
 
 #[async_trait::async_trait]
-impl HtlcDeployed<Ethereum, Ether> for Cache<Web3Connector> {
+impl HtlcDeployed<Ethereum, Ether, identity::Ethereum> for Cache<Web3Connector> {
     async fn htlc_deployed(
         &self,
-        htlc_params: &HtlcParams<'_, Ethereum, Ether, Address>,
+        htlc_params: &HtlcParams<'_, Ethereum, Ether, identity::Ethereum>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Deployed<Transaction, Address>> {
+    ) -> anyhow::Result<Deployed<Transaction, identity::Ethereum>> {
         let connector = self.clone();
         let (transaction, location) =
             watch_for_contract_creation(connector, start_of_swap, htlc_params.bytecode())
@@ -62,11 +63,11 @@ impl HtlcDeployed<Ethereum, Ether> for Cache<Web3Connector> {
 }
 
 #[async_trait::async_trait]
-impl HtlcRedeemed<Ethereum, Ether> for Cache<Web3Connector> {
+impl HtlcRedeemed<Ethereum, Ether, identity::Ethereum> for Cache<Web3Connector> {
     async fn htlc_redeemed(
         &self,
-        _htlc_params: &HtlcParams<'_, Ethereum, Ether, Address>,
-        htlc_deployment: &Deployed<Transaction, Address>,
+        _htlc_params: &HtlcParams<'_, Ethereum, Ether, identity::Ethereum>,
+        htlc_deployment: &Deployed<Transaction, identity::Ethereum>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<Transaction>> {
         let connector = self.clone();
@@ -91,11 +92,11 @@ impl HtlcRedeemed<Ethereum, Ether> for Cache<Web3Connector> {
 }
 
 #[async_trait::async_trait]
-impl HtlcRefunded<Ethereum, Ether> for Cache<Web3Connector> {
+impl HtlcRefunded<Ethereum, Ether, identity::Ethereum> for Cache<Web3Connector> {
     async fn htlc_refunded(
         &self,
-        _htlc_params: &HtlcParams<'_, Ethereum, Ether, Address>,
-        htlc_deployment: &Deployed<Transaction, Address>,
+        _htlc_params: &HtlcParams<'_, Ethereum, Ether, identity::Ethereum>,
+        htlc_deployment: &Deployed<Transaction, identity::Ethereum>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<Transaction>> {
         let connector = self.clone();
@@ -113,11 +114,11 @@ impl HtlcRefunded<Ethereum, Ether> for Cache<Web3Connector> {
 }
 
 #[async_trait::async_trait]
-impl HtlcFunded<Ethereum, Erc20> for Cache<Web3Connector> {
+impl HtlcFunded<Ethereum, Erc20, identity::Ethereum> for Cache<Web3Connector> {
     async fn htlc_funded(
         &self,
-        htlc_params: &HtlcParams<'_, Ethereum, Erc20, Address>,
-        htlc_deployment: &Deployed<Transaction, Address>,
+        htlc_params: &HtlcParams<'_, Ethereum, Erc20, identity::Ethereum>,
+        htlc_deployment: &Deployed<Transaction, identity::Ethereum>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Funded<Transaction, Erc20>> {
         let connector = self.clone();
@@ -143,12 +144,12 @@ impl HtlcFunded<Ethereum, Erc20> for Cache<Web3Connector> {
 }
 
 #[async_trait::async_trait]
-impl HtlcDeployed<Ethereum, Erc20> for Cache<Web3Connector> {
+impl HtlcDeployed<Ethereum, Erc20, identity::Ethereum> for Cache<Web3Connector> {
     async fn htlc_deployed(
         &self,
-        htlc_params: &HtlcParams<'_, Ethereum, Erc20, Address>,
+        htlc_params: &HtlcParams<'_, Ethereum, Erc20, identity::Ethereum>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Deployed<Transaction, Address>> {
+    ) -> anyhow::Result<Deployed<Transaction, identity::Ethereum>> {
         let connector = self.clone();
 
         let (transaction, location) =
@@ -164,11 +165,11 @@ impl HtlcDeployed<Ethereum, Erc20> for Cache<Web3Connector> {
 }
 
 #[async_trait::async_trait]
-impl HtlcRedeemed<Ethereum, Erc20> for Cache<Web3Connector> {
+impl HtlcRedeemed<Ethereum, Erc20, identity::Ethereum> for Cache<Web3Connector> {
     async fn htlc_redeemed(
         &self,
-        _htlc_params: &HtlcParams<'_, Ethereum, Erc20, Address>,
-        htlc_deployment: &Deployed<Transaction, Address>,
+        _htlc_params: &HtlcParams<'_, Ethereum, Erc20, identity::Ethereum>,
+        htlc_deployment: &Deployed<Transaction, identity::Ethereum>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<Transaction>> {
         let connector = self.clone();
@@ -193,11 +194,11 @@ impl HtlcRedeemed<Ethereum, Erc20> for Cache<Web3Connector> {
 }
 
 #[async_trait::async_trait]
-impl HtlcRefunded<Ethereum, Erc20> for Cache<Web3Connector> {
+impl HtlcRefunded<Ethereum, Erc20, identity::Ethereum> for Cache<Web3Connector> {
     async fn htlc_refunded(
         &self,
-        _htlc_params: &HtlcParams<'_, Ethereum, Erc20, Address>,
-        htlc_deployment: &Deployed<Transaction, Address>,
+        _htlc_params: &HtlcParams<'_, Ethereum, Erc20, identity::Ethereum>,
+        htlc_deployment: &Deployed<Transaction, identity::Ethereum>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<Transaction>> {
         let connector = self.clone();

--- a/cnd/src/swap_protocols/rfc003/ethereum/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/ethereum/mod.rs
@@ -42,7 +42,6 @@ impl From<Seconds> for Duration {
 
 impl Ledger for Ethereum {
     type HtlcLocation = Address;
-    type Identity = Address;
     type Transaction = Transaction;
 }
 

--- a/cnd/src/swap_protocols/rfc003/events/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/events/mod.rs
@@ -30,51 +30,51 @@ pub struct Refunded<T> {
 }
 
 #[async_trait::async_trait]
-pub trait HtlcFunded<L, A>: Send + Sync + Sized + 'static
+pub trait HtlcFunded<L, A, I>: Send + Sync + Sized + 'static
 where
     L: Ledger,
 {
     async fn htlc_funded(
         &self,
-        htlc_params: &HtlcParams<'_, L, A, L::Identity>,
+        htlc_params: &HtlcParams<'_, L, A, I>,
         htlc_deployment: &Deployed<L::Transaction, L::HtlcLocation>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Funded<L::Transaction, A>>;
 }
 
 #[async_trait::async_trait]
-pub trait HtlcDeployed<L, A>: Send + Sync + Sized + 'static
+pub trait HtlcDeployed<L, A, I>: Send + Sync + Sized + 'static
 where
     L: Ledger,
 {
     async fn htlc_deployed(
         &self,
-        htlc_params: &HtlcParams<'_, L, A, L::Identity>,
+        htlc_params: &HtlcParams<'_, L, A, I>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Deployed<L::Transaction, L::HtlcLocation>>;
 }
 
 #[async_trait::async_trait]
-pub trait HtlcRedeemed<L, A>: Send + Sync + Sized + 'static
+pub trait HtlcRedeemed<L, A, I>: Send + Sync + Sized + 'static
 where
     L: Ledger,
 {
     async fn htlc_redeemed(
         &self,
-        htlc_params: &HtlcParams<'_, L, A, L::Identity>,
+        htlc_params: &HtlcParams<'_, L, A, I>,
         htlc_deployment: &Deployed<L::Transaction, L::HtlcLocation>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<L::Transaction>>;
 }
 
 #[async_trait::async_trait]
-pub trait HtlcRefunded<L, A>: Send + Sync + Sized + 'static
+pub trait HtlcRefunded<L, A, I>: Send + Sync + Sized + 'static
 where
     L: Ledger,
 {
     async fn htlc_refunded(
         &self,
-        htlc_params: &HtlcParams<'_, L, A, L::Identity>,
+        htlc_params: &HtlcParams<'_, L, A, I>,
         htlc_deployment: &Deployed<L::Transaction, L::HtlcLocation>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<L::Transaction>>;

--- a/cnd/src/swap_protocols/rfc003/ledger.rs
+++ b/cnd/src/swap_protocols/rfc003/ledger.rs
@@ -5,17 +5,6 @@ pub trait Ledger:
     Clone + Copy + Debug + Send + Sync + 'static + PartialEq + Eq + Hash + Sized
 {
     type HtlcLocation: PartialEq + Debug + Clone + DeserializeOwned + Serialize + Send + Sync;
-    type Identity: Clone
-        + Copy
-        + Debug
-        + Send
-        + Sync
-        + PartialEq
-        + Eq
-        + Hash
-        + 'static
-        + Serialize
-        + DeserializeOwned;
     type Transaction: Debug
         + Clone
         + DeserializeOwned

--- a/cnd/src/swap_protocols/rfc003/messages.rs
+++ b/cnd/src/swap_protocols/rfc003/messages.rs
@@ -6,7 +6,7 @@ use crate::{
     libp2p_comit_ext::ToHeader,
     swap_protocols::{
         ledger::{bitcoin, Ethereum},
-        rfc003::{DeriveIdentities, Ledger, SecretHash},
+        rfc003::{DeriveIdentities, SecretHash},
         HashFunction, SwapId, SwapProtocol,
     },
     timestamp::Timestamp,
@@ -21,11 +21,7 @@ use std::convert::TryFrom;
 /// This does _not_ represent the actual network message, that is why it also
 /// does not implement Serialize.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Request<AL, BL, AA, BA, AI, BI>
-where
-    AL: Ledger,
-    BL: Ledger,
-{
+pub struct Request<AL, BL, AA, BA, AI, BI> {
     pub swap_id: SwapId,
     pub alpha_ledger: AL,
     pub beta_ledger: BL,
@@ -598,11 +594,7 @@ pub struct RequestBody<AI, BI> {
     pub secret_hash: SecretHash,
 }
 
-impl<AL, BL, AA, BA, AI, BI> From<Request<AL, BL, AA, BA, AI, BI>> for RequestBody<AI, BI>
-where
-    AL: Ledger,
-    BL: Ledger,
-{
+impl<AL, BL, AA, BA, AI, BI> From<Request<AL, BL, AA, BA, AI, BI>> for RequestBody<AI, BI> {
     fn from(request: Request<AL, BL, AA, BA, AI, BI>) -> Self {
         RequestBody {
             alpha_ledger_refund_identity: request.alpha_ledger_refund_identity,

--- a/cnd/src/swap_protocols/rfc003/messages.rs
+++ b/cnd/src/swap_protocols/rfc003/messages.rs
@@ -2,7 +2,7 @@ use crate::{
     asset::{self, AssetKind},
     bitcoin::PublicKey,
     comit_api::LedgerKind,
-    ethereum::Address,
+    identity,
     libp2p_comit_ext::ToHeader,
     swap_protocols::{
         ledger::{bitcoin, Ethereum},
@@ -21,7 +21,7 @@ use std::convert::TryFrom;
 /// This does _not_ represent the actual network message, that is why it also
 /// does not implement Serialize.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Request<AL, BL, AA, BA>
+pub struct Request<AL, BL, AA, BA, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
@@ -32,22 +32,39 @@ where
     pub alpha_asset: AA,
     pub beta_asset: BA,
     pub hash_function: HashFunction,
-    pub alpha_ledger_refund_identity: AL::Identity,
-    pub beta_ledger_redeem_identity: BL::Identity,
+    pub alpha_ledger_refund_identity: AI,
+    pub beta_ledger_redeem_identity: BI,
     pub alpha_expiry: Timestamp,
     pub beta_expiry: Timestamp,
     pub secret_hash: SecretHash,
 }
 
-impl TryFrom<Request<bitcoin::Mainnet, Ethereum, asset::Bitcoin, asset::Ether>>
-    for OutboundRequest
+impl
+    TryFrom<
+        Request<
+            bitcoin::Mainnet,
+            Ethereum,
+            asset::Bitcoin,
+            asset::Ether,
+            identity::Bitcoin,
+            identity::Ethereum,
+        >,
+    > for OutboundRequest
 {
     type Error = anyhow::Error;
 
     fn try_from(
-        request: Request<bitcoin::Mainnet, Ethereum, asset::Bitcoin, asset::Ether>,
+        request: Request<
+            bitcoin::Mainnet,
+            Ethereum,
+            asset::Bitcoin,
+            asset::Ether,
+            identity::Bitcoin,
+            identity::Ethereum,
+        >,
     ) -> anyhow::Result<Self> {
-        let request_body: RequestBody<PublicKey, Address> = RequestBody::from(request.clone());
+        let request_body: RequestBody<identity::Bitcoin, identity::Ethereum> =
+            RequestBody::from(request.clone());
         let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
 
         let alpha_ledger = LedgerKind::BitcoinMainnet.to_header()?;
@@ -66,15 +83,32 @@ impl TryFrom<Request<bitcoin::Mainnet, Ethereum, asset::Bitcoin, asset::Ether>>
     }
 }
 
-impl TryFrom<Request<bitcoin::Testnet, Ethereum, asset::Bitcoin, asset::Ether>>
-    for OutboundRequest
+impl
+    TryFrom<
+        Request<
+            bitcoin::Testnet,
+            Ethereum,
+            asset::Bitcoin,
+            asset::Ether,
+            identity::Bitcoin,
+            identity::Ethereum,
+        >,
+    > for OutboundRequest
 {
     type Error = anyhow::Error;
 
     fn try_from(
-        request: Request<bitcoin::Testnet, Ethereum, asset::Bitcoin, asset::Ether>,
+        request: Request<
+            bitcoin::Testnet,
+            Ethereum,
+            asset::Bitcoin,
+            asset::Ether,
+            identity::Bitcoin,
+            identity::Ethereum,
+        >,
     ) -> anyhow::Result<Self> {
-        let request_body: RequestBody<PublicKey, Address> = RequestBody::from(request.clone());
+        let request_body: RequestBody<PublicKey, identity::Ethereum> =
+            RequestBody::from(request.clone());
         let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
 
         let alpha_ledger = LedgerKind::BitcoinTestnet.to_header()?;
@@ -93,15 +127,32 @@ impl TryFrom<Request<bitcoin::Testnet, Ethereum, asset::Bitcoin, asset::Ether>>
     }
 }
 
-impl TryFrom<Request<bitcoin::Regtest, Ethereum, asset::Bitcoin, asset::Ether>>
-    for OutboundRequest
+impl
+    TryFrom<
+        Request<
+            bitcoin::Regtest,
+            Ethereum,
+            asset::Bitcoin,
+            asset::Ether,
+            identity::Bitcoin,
+            identity::Ethereum,
+        >,
+    > for OutboundRequest
 {
     type Error = anyhow::Error;
 
     fn try_from(
-        request: Request<bitcoin::Regtest, Ethereum, asset::Bitcoin, asset::Ether>,
+        request: Request<
+            bitcoin::Regtest,
+            Ethereum,
+            asset::Bitcoin,
+            asset::Ether,
+            identity::Bitcoin,
+            identity::Ethereum,
+        >,
     ) -> anyhow::Result<Self> {
-        let request_body: RequestBody<PublicKey, Address> = RequestBody::from(request.clone());
+        let request_body: RequestBody<PublicKey, identity::Ethereum> =
+            RequestBody::from(request.clone());
         let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
 
         let alpha_ledger = LedgerKind::BitcoinRegtest.to_header()?;
@@ -120,15 +171,32 @@ impl TryFrom<Request<bitcoin::Regtest, Ethereum, asset::Bitcoin, asset::Ether>>
     }
 }
 
-impl TryFrom<Request<bitcoin::Mainnet, Ethereum, asset::Bitcoin, asset::Erc20>>
-    for OutboundRequest
+impl
+    TryFrom<
+        Request<
+            bitcoin::Mainnet,
+            Ethereum,
+            asset::Bitcoin,
+            asset::Erc20,
+            identity::Bitcoin,
+            identity::Ethereum,
+        >,
+    > for OutboundRequest
 {
     type Error = anyhow::Error;
 
     fn try_from(
-        request: Request<bitcoin::Mainnet, Ethereum, asset::Bitcoin, asset::Erc20>,
+        request: Request<
+            bitcoin::Mainnet,
+            Ethereum,
+            asset::Bitcoin,
+            asset::Erc20,
+            identity::Bitcoin,
+            identity::Ethereum,
+        >,
     ) -> anyhow::Result<Self> {
-        let request_body: RequestBody<PublicKey, Address> = RequestBody::from(request.clone());
+        let request_body: RequestBody<PublicKey, identity::Ethereum> =
+            RequestBody::from(request.clone());
         let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
 
         let alpha_ledger = LedgerKind::BitcoinMainnet.to_header()?;
@@ -147,15 +215,32 @@ impl TryFrom<Request<bitcoin::Mainnet, Ethereum, asset::Bitcoin, asset::Erc20>>
     }
 }
 
-impl TryFrom<Request<bitcoin::Testnet, Ethereum, asset::Bitcoin, asset::Erc20>>
-    for OutboundRequest
+impl
+    TryFrom<
+        Request<
+            bitcoin::Testnet,
+            Ethereum,
+            asset::Bitcoin,
+            asset::Erc20,
+            identity::Bitcoin,
+            identity::Ethereum,
+        >,
+    > for OutboundRequest
 {
     type Error = anyhow::Error;
 
     fn try_from(
-        request: Request<bitcoin::Testnet, Ethereum, asset::Bitcoin, asset::Erc20>,
+        request: Request<
+            bitcoin::Testnet,
+            Ethereum,
+            asset::Bitcoin,
+            asset::Erc20,
+            identity::Bitcoin,
+            identity::Ethereum,
+        >,
     ) -> anyhow::Result<Self> {
-        let request_body: RequestBody<PublicKey, Address> = RequestBody::from(request.clone());
+        let request_body: RequestBody<PublicKey, identity::Ethereum> =
+            RequestBody::from(request.clone());
         let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
 
         let alpha_ledger = LedgerKind::BitcoinTestnet.to_header()?;
@@ -174,15 +259,32 @@ impl TryFrom<Request<bitcoin::Testnet, Ethereum, asset::Bitcoin, asset::Erc20>>
     }
 }
 
-impl TryFrom<Request<bitcoin::Regtest, Ethereum, asset::Bitcoin, asset::Erc20>>
-    for OutboundRequest
+impl
+    TryFrom<
+        Request<
+            bitcoin::Regtest,
+            Ethereum,
+            asset::Bitcoin,
+            asset::Erc20,
+            identity::Bitcoin,
+            identity::Ethereum,
+        >,
+    > for OutboundRequest
 {
     type Error = anyhow::Error;
 
     fn try_from(
-        request: Request<bitcoin::Regtest, Ethereum, asset::Bitcoin, asset::Erc20>,
+        request: Request<
+            bitcoin::Regtest,
+            Ethereum,
+            asset::Bitcoin,
+            asset::Erc20,
+            identity::Bitcoin,
+            identity::Ethereum,
+        >,
     ) -> anyhow::Result<Self> {
-        let request_body: RequestBody<PublicKey, Address> = RequestBody::from(request.clone());
+        let request_body: RequestBody<PublicKey, identity::Ethereum> =
+            RequestBody::from(request.clone());
         let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
 
         let alpha_ledger = LedgerKind::BitcoinRegtest.to_header()?;
@@ -201,15 +303,32 @@ impl TryFrom<Request<bitcoin::Regtest, Ethereum, asset::Bitcoin, asset::Erc20>>
     }
 }
 
-impl TryFrom<Request<Ethereum, bitcoin::Mainnet, asset::Ether, asset::Bitcoin>>
-    for OutboundRequest
+impl
+    TryFrom<
+        Request<
+            Ethereum,
+            bitcoin::Mainnet,
+            asset::Ether,
+            asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
+        >,
+    > for OutboundRequest
 {
     type Error = anyhow::Error;
 
     fn try_from(
-        request: Request<Ethereum, bitcoin::Mainnet, asset::Ether, asset::Bitcoin>,
+        request: Request<
+            Ethereum,
+            bitcoin::Mainnet,
+            asset::Ether,
+            asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
+        >,
     ) -> anyhow::Result<Self> {
-        let request_body: RequestBody<Address, PublicKey> = RequestBody::from(request.clone());
+        let request_body: RequestBody<identity::Ethereum, PublicKey> =
+            RequestBody::from(request.clone());
         let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
 
         let alpha_ledger = LedgerKind::Ethereum(request.alpha_ledger).to_header()?;
@@ -228,15 +347,32 @@ impl TryFrom<Request<Ethereum, bitcoin::Mainnet, asset::Ether, asset::Bitcoin>>
     }
 }
 
-impl TryFrom<Request<Ethereum, bitcoin::Testnet, asset::Ether, asset::Bitcoin>>
-    for OutboundRequest
+impl
+    TryFrom<
+        Request<
+            Ethereum,
+            bitcoin::Testnet,
+            asset::Ether,
+            asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
+        >,
+    > for OutboundRequest
 {
     type Error = anyhow::Error;
 
     fn try_from(
-        request: Request<Ethereum, bitcoin::Testnet, asset::Ether, asset::Bitcoin>,
+        request: Request<
+            Ethereum,
+            bitcoin::Testnet,
+            asset::Ether,
+            asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
+        >,
     ) -> anyhow::Result<Self> {
-        let request_body: RequestBody<Address, PublicKey> = RequestBody::from(request.clone());
+        let request_body: RequestBody<identity::Ethereum, PublicKey> =
+            RequestBody::from(request.clone());
         let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
 
         let alpha_ledger = LedgerKind::Ethereum(request.alpha_ledger).to_header()?;
@@ -255,15 +391,32 @@ impl TryFrom<Request<Ethereum, bitcoin::Testnet, asset::Ether, asset::Bitcoin>>
     }
 }
 
-impl TryFrom<Request<Ethereum, bitcoin::Regtest, asset::Ether, asset::Bitcoin>>
-    for OutboundRequest
+impl
+    TryFrom<
+        Request<
+            Ethereum,
+            bitcoin::Regtest,
+            asset::Ether,
+            asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
+        >,
+    > for OutboundRequest
 {
     type Error = anyhow::Error;
 
     fn try_from(
-        request: Request<Ethereum, bitcoin::Regtest, asset::Ether, asset::Bitcoin>,
+        request: Request<
+            Ethereum,
+            bitcoin::Regtest,
+            asset::Ether,
+            asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
+        >,
     ) -> anyhow::Result<Self> {
-        let request_body: RequestBody<Address, PublicKey> = RequestBody::from(request.clone());
+        let request_body: RequestBody<identity::Ethereum, PublicKey> =
+            RequestBody::from(request.clone());
         let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
 
         let alpha_ledger = LedgerKind::Ethereum(request.alpha_ledger).to_header()?;
@@ -282,15 +435,32 @@ impl TryFrom<Request<Ethereum, bitcoin::Regtest, asset::Ether, asset::Bitcoin>>
     }
 }
 
-impl TryFrom<Request<Ethereum, bitcoin::Mainnet, asset::Erc20, asset::Bitcoin>>
-    for OutboundRequest
+impl
+    TryFrom<
+        Request<
+            Ethereum,
+            bitcoin::Mainnet,
+            asset::Erc20,
+            asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
+        >,
+    > for OutboundRequest
 {
     type Error = anyhow::Error;
 
     fn try_from(
-        request: Request<Ethereum, bitcoin::Mainnet, asset::Erc20, asset::Bitcoin>,
+        request: Request<
+            Ethereum,
+            bitcoin::Mainnet,
+            asset::Erc20,
+            asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
+        >,
     ) -> anyhow::Result<Self> {
-        let request_body: RequestBody<Address, PublicKey> = RequestBody::from(request.clone());
+        let request_body: RequestBody<identity::Ethereum, PublicKey> =
+            RequestBody::from(request.clone());
         let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
 
         let alpha_ledger = LedgerKind::Ethereum(request.alpha_ledger).to_header()?;
@@ -309,15 +479,32 @@ impl TryFrom<Request<Ethereum, bitcoin::Mainnet, asset::Erc20, asset::Bitcoin>>
     }
 }
 
-impl TryFrom<Request<Ethereum, bitcoin::Testnet, asset::Erc20, asset::Bitcoin>>
-    for OutboundRequest
+impl
+    TryFrom<
+        Request<
+            Ethereum,
+            bitcoin::Testnet,
+            asset::Erc20,
+            asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
+        >,
+    > for OutboundRequest
 {
     type Error = anyhow::Error;
 
     fn try_from(
-        request: Request<Ethereum, bitcoin::Testnet, asset::Erc20, asset::Bitcoin>,
+        request: Request<
+            Ethereum,
+            bitcoin::Testnet,
+            asset::Erc20,
+            asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
+        >,
     ) -> anyhow::Result<Self> {
-        let request_body: RequestBody<Address, PublicKey> = RequestBody::from(request.clone());
+        let request_body: RequestBody<identity::Ethereum, PublicKey> =
+            RequestBody::from(request.clone());
         let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
 
         let alpha_ledger = LedgerKind::Ethereum(request.alpha_ledger).to_header()?;
@@ -336,15 +523,32 @@ impl TryFrom<Request<Ethereum, bitcoin::Testnet, asset::Erc20, asset::Bitcoin>>
     }
 }
 
-impl TryFrom<Request<Ethereum, bitcoin::Regtest, asset::Erc20, asset::Bitcoin>>
-    for OutboundRequest
+impl
+    TryFrom<
+        Request<
+            Ethereum,
+            bitcoin::Regtest,
+            asset::Erc20,
+            asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
+        >,
+    > for OutboundRequest
 {
     type Error = anyhow::Error;
 
     fn try_from(
-        request: Request<Ethereum, bitcoin::Regtest, asset::Erc20, asset::Bitcoin>,
+        request: Request<
+            Ethereum,
+            bitcoin::Regtest,
+            asset::Erc20,
+            asset::Bitcoin,
+            identity::Ethereum,
+            identity::Bitcoin,
+        >,
     ) -> anyhow::Result<Self> {
-        let request_body: RequestBody<Address, PublicKey> = RequestBody::from(request.clone());
+        let request_body: RequestBody<identity::Ethereum, PublicKey> =
+            RequestBody::from(request.clone());
         let protocol = SwapProtocol::Rfc003(request.hash_function).to_header()?;
 
         let alpha_ledger = LedgerKind::Ethereum(request.alpha_ledger).to_header()?;
@@ -394,12 +598,12 @@ pub struct RequestBody<AI, BI> {
     pub secret_hash: SecretHash,
 }
 
-impl<AL, BL, AA, BA> From<Request<AL, BL, AA, BA>> for RequestBody<AL::Identity, BL::Identity>
+impl<AL, BL, AA, BA, AI, BI> From<Request<AL, BL, AA, BA, AI, BI>> for RequestBody<AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
 {
-    fn from(request: Request<AL, BL, AA, BA>) -> Self {
+    fn from(request: Request<AL, BL, AA, BA, AI, BI>) -> Self {
         RequestBody {
             alpha_ledger_refund_identity: request.alpha_ledger_refund_identity,
             beta_ledger_redeem_identity: request.beta_ledger_redeem_identity,

--- a/cnd/src/swap_protocols/rfc003/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/mod.rs
@@ -30,34 +30,33 @@ use crate::seed::SwapSeed;
 use ::bitcoin::secp256k1::SecretKey;
 
 /// Swap request response as received from peer node acting as Bob.
-pub type Response<AL, BL> =
-    Result<Accept<<AL as Ledger>::Identity, <BL as Ledger>::Identity>, Decline>;
+pub type Response<AI, BI> = Result<Accept<AI, BI>, Decline>;
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum SwapCommunication<AL, BL, AA, BA>
+pub enum SwapCommunication<AL, BL, AA, BA, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
 {
     Proposed {
-        request: Request<AL, BL, AA, BA>,
+        request: Request<AL, BL, AA, BA, AI, BI>,
     },
     Accepted {
-        request: Request<AL, BL, AA, BA>,
-        response: Accept<AL::Identity, BL::Identity>,
+        request: Request<AL, BL, AA, BA, AI, BI>,
+        response: Accept<AI, BI>,
     },
     Declined {
-        request: Request<AL, BL, AA, BA>,
+        request: Request<AL, BL, AA, BA, AI, BI>,
         response: Decline,
     },
 }
 
-impl<AL, BL, AA, BA> SwapCommunication<AL, BL, AA, BA>
+impl<AL, BL, AA, BA, AI, BI> SwapCommunication<AL, BL, AA, BA, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
 {
-    pub fn request(&self) -> &Request<AL, BL, AA, BA> {
+    pub fn request(&self) -> &Request<AL, BL, AA, BA, AI, BI> {
         match self {
             SwapCommunication::Accepted { request, .. } => request,
             SwapCommunication::Proposed { request } => request,

--- a/cnd/src/swap_protocols/rfc003/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/mod.rs
@@ -33,11 +33,7 @@ use ::bitcoin::secp256k1::SecretKey;
 pub type Response<AI, BI> = Result<Accept<AI, BI>, Decline>;
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum SwapCommunication<AL, BL, AA, BA, AI, BI>
-where
-    AL: Ledger,
-    BL: Ledger,
-{
+pub enum SwapCommunication<AL, BL, AA, BA, AI, BI> {
     Proposed {
         request: Request<AL, BL, AA, BA, AI, BI>,
     },
@@ -51,11 +47,7 @@ where
     },
 }
 
-impl<AL, BL, AA, BA, AI, BI> SwapCommunication<AL, BL, AA, BA, AI, BI>
-where
-    AL: Ledger,
-    BL: Ledger,
-{
+impl<AL, BL, AA, BA, AI, BI> SwapCommunication<AL, BL, AA, BA, AI, BI> {
     pub fn request(&self) -> &Request<AL, BL, AA, BA, AI, BI> {
         match self {
             SwapCommunication::Accepted { request, .. } => request,

--- a/cnd/src/swap_protocols/rfc003/state_store.rs
+++ b/cnd/src/swap_protocols/rfc003/state_store.rs
@@ -148,6 +148,7 @@ mod tests {
         asset,
         asset::ethereum::FromWei,
         ethereum::Address,
+        identity,
         seed::{DeriveSwapSeed, RootSeed},
         swap_protocols::{
             ledger::{bitcoin, Ethereum},
@@ -191,14 +192,24 @@ mod tests {
         let secret_source = seed.derive_swap_seed(id);
         let state = alice::State::accepted(request, accept, secret_source);
 
-        state_store
-            .insert::<alice::State<bitcoin::Regtest, Ethereum, asset::Bitcoin, asset::Ether>>(
-                id,
-                state.clone(),
-            );
+        state_store.insert::<alice::State<
+            bitcoin::Regtest,
+            Ethereum,
+            asset::Bitcoin,
+            asset::Ether,
+            identity::Bitcoin,
+            identity::Ethereum,
+        >>(id, state.clone());
 
         let res = state_store
-            .get::<alice::State<bitcoin::Regtest, Ethereum, asset::Bitcoin, asset::Ether>>(&id)
+            .get::<alice::State<
+                bitcoin::Regtest,
+                Ethereum,
+                asset::Bitcoin,
+                asset::Ether,
+                identity::Bitcoin,
+                identity::Ethereum,
+            >>(&id)
             .unwrap();
         assert_that(&res).contains_value(&state);
     }


### PR DESCRIPTION
In an effort to remove the `Ledger` trait first remove the associated type `Identity`.  While doing this use the new `identity` modules.

Replace useages of `crate::ethereum::Address` with `identity::Ethereum`.  We have to be a bit more careful with `PublicKey` because we have a wrapper by the same name.

Works towards: #2081 