### PR TITLE
Remove HtlcLocation from Ledger trait

### DIFF
--- a/cnd/src/db/with_swap_types.rs
+++ b/cnd/src/db/with_swap_types.rs
@@ -9,12 +9,12 @@ macro_rules! _match_role {
         match $role {
             Role::Alice => {
                 #[allow(dead_code)]
-                type ROLE = alice::State<AL, BL, AA, BA, AI, BI>;
+                type ROLE = alice::State<AL, BL, AA, BA, AH, BH, AI, BI>;
                 $fn
             }
             Role::Bob => {
                 #[allow(dead_code)]
-                type ROLE = bob::State<AL, BL, AA, BA, AI, BI>;
+                type ROLE = bob::State<AL, BL, AA, BA, AH, BH, AI, BI>;
                 $fn
             }
         }
@@ -27,7 +27,7 @@ macro_rules! with_swap_types {
         use crate::{
             asset,
             db::{AssetKind, BitcoinLedgerKind, LedgerKind, SwapTypes},
-            identity,
+            htlc_location, identity,
             swap_protocols::ledger::{bitcoin, Ethereum},
         };
         let swap_types: SwapTypes = $swap_types;
@@ -55,6 +55,10 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BI = identity::Ethereum;
                     #[allow(dead_code)]
+                    type AH = htlc_location::Bitcoin;
+                    #[allow(dead_code)]
+                    type BH = htlc_location::Ethereum;
+                    #[allow(dead_code)]
                     type AcceptBody =
                         crate::http_api::routes::rfc003::accept::OnlyRefund<identity::Ethereum>;
 
@@ -74,6 +78,10 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BI = identity::Ethereum;
                     #[allow(dead_code)]
+                    type AH = htlc_location::Bitcoin;
+                    #[allow(dead_code)]
+                    type BH = htlc_location::Ethereum;
+                    #[allow(dead_code)]
                     type AcceptBody =
                         crate::http_api::routes::rfc003::accept::OnlyRefund<identity::Ethereum>;
 
@@ -92,6 +100,10 @@ macro_rules! with_swap_types {
                     type AI = identity::Bitcoin;
                     #[allow(dead_code)]
                     type BI = identity::Ethereum;
+                    #[allow(dead_code)]
+                    type AH = htlc_location::Bitcoin;
+                    #[allow(dead_code)]
+                    type BH = htlc_location::Ethereum;
                     #[allow(dead_code)]
                     type AcceptBody =
                         crate::http_api::routes::rfc003::accept::OnlyRefund<identity::Ethereum>;
@@ -120,6 +132,10 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BI = identity::Ethereum;
                     #[allow(dead_code)]
+                    type AH = htlc_location::Bitcoin;
+                    #[allow(dead_code)]
+                    type BH = htlc_location::Ethereum;
+                    #[allow(dead_code)]
                     type AcceptBody =
                         crate::http_api::routes::rfc003::accept::OnlyRefund<identity::Ethereum>;
 
@@ -139,6 +155,10 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BI = identity::Ethereum;
                     #[allow(dead_code)]
+                    type AH = htlc_location::Bitcoin;
+                    #[allow(dead_code)]
+                    type BH = htlc_location::Ethereum;
+                    #[allow(dead_code)]
                     type AcceptBody =
                         crate::http_api::routes::rfc003::accept::OnlyRefund<identity::Ethereum>;
 
@@ -157,6 +177,10 @@ macro_rules! with_swap_types {
                     type AI = identity::Bitcoin;
                     #[allow(dead_code)]
                     type BI = identity::Ethereum;
+                    #[allow(dead_code)]
+                    type AH = htlc_location::Bitcoin;
+                    #[allow(dead_code)]
+                    type BH = htlc_location::Ethereum;
                     #[allow(dead_code)]
                     type AcceptBody =
                         crate::http_api::routes::rfc003::accept::OnlyRefund<identity::Ethereum>;
@@ -186,6 +210,10 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BI = identity::Bitcoin;
                     #[allow(dead_code)]
+                    type AH = htlc_location::Ethereum;
+                    #[allow(dead_code)]
+                    type BH = htlc_location::Bitcoin;
+                    #[allow(dead_code)]
                     type AcceptBody =
                         crate::http_api::routes::rfc003::accept::OnlyRedeem<identity::Ethereum>;
 
@@ -205,6 +233,10 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BI = identity::Bitcoin;
                     #[allow(dead_code)]
+                    type AH = htlc_location::Ethereum;
+                    #[allow(dead_code)]
+                    type BH = htlc_location::Bitcoin;
+                    #[allow(dead_code)]
                     type AcceptBody =
                         crate::http_api::routes::rfc003::accept::OnlyRedeem<identity::Ethereum>;
 
@@ -223,6 +255,10 @@ macro_rules! with_swap_types {
                     type AI = identity::Ethereum;
                     #[allow(dead_code)]
                     type BI = identity::Bitcoin;
+                    #[allow(dead_code)]
+                    type AH = htlc_location::Ethereum;
+                    #[allow(dead_code)]
+                    type BH = htlc_location::Bitcoin;
                     #[allow(dead_code)]
                     type AcceptBody =
                         crate::http_api::routes::rfc003::accept::OnlyRedeem<identity::Ethereum>;
@@ -251,6 +287,10 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BI = identity::Bitcoin;
                     #[allow(dead_code)]
+                    type AH = htlc_location::Ethereum;
+                    #[allow(dead_code)]
+                    type BH = htlc_location::Bitcoin;
+                    #[allow(dead_code)]
                     type AcceptBody =
                         crate::http_api::routes::rfc003::accept::OnlyRedeem<identity::Ethereum>;
 
@@ -270,6 +310,10 @@ macro_rules! with_swap_types {
                     #[allow(dead_code)]
                     type BI = identity::Bitcoin;
                     #[allow(dead_code)]
+                    type AH = htlc_location::Ethereum;
+                    #[allow(dead_code)]
+                    type BH = htlc_location::Bitcoin;
+                    #[allow(dead_code)]
                     type AcceptBody =
                         crate::http_api::routes::rfc003::accept::OnlyRedeem<identity::Ethereum>;
 
@@ -288,6 +332,10 @@ macro_rules! with_swap_types {
                     type AI = identity::Ethereum;
                     #[allow(dead_code)]
                     type BI = identity::Bitcoin;
+                    #[allow(dead_code)]
+                    type AH = htlc_location::Ethereum;
+                    #[allow(dead_code)]
+                    type BH = htlc_location::Bitcoin;
                     #[allow(dead_code)]
                     type AcceptBody =
                         crate::http_api::routes::rfc003::accept::OnlyRedeem<identity::Ethereum>;

--- a/cnd/src/http_api/routes/rfc003/handlers/action.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/action.rs
@@ -86,7 +86,11 @@ pub async fn handle_action(
                     &swap_id,
                 )
                 .await?;
-                init_accepted_swap(&dependencies, accepted, types.role)?;
+                init_accepted_swap::<_, _, _, _, _, AH, BH, _, _>(
+                    &dependencies,
+                    accepted,
+                    types.role,
+                )?;
 
                 Ok(ActionResponseBody::None)
             }
@@ -119,7 +123,11 @@ pub async fn handle_action(
 
                 let swap_request = state.request();
                 let seed = dependencies.derive_swap_seed(swap_id);
-                let state = State::declined(swap_request.clone(), decline_message, seed);
+                let state = State::<AL, BL, AA, BA, AH, BH, AI, BI>::declined(
+                    swap_request.clone(),
+                    decline_message,
+                    seed,
+                );
                 StateStore::insert(&dependencies, swap_id, state);
 
                 Ok(ActionResponseBody::None)

--- a/cnd/src/http_api/routes/rfc003/swap_state.rs
+++ b/cnd/src/http_api/routes/rfc003/swap_state.rs
@@ -7,10 +7,10 @@ use crate::{
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
-#[serde(bound = "Http<AI>: Serialize, Http<BI>: Serialize,\
-             Http<AH>: Serialize, Http<BH>: Serialize,\
-             Http<AT>: Serialize, Http<BT>: Serialize")]
-pub struct SwapState<AI, BI, AH, BH, AT, BT> {
+#[serde(bound = "Http<AH>: Serialize, Http<BH>: Serialize,\
+                 Http<AI>: Serialize, Http<BI>: Serialize,\
+                 Http<AT>: Serialize, Http<BT>: Serialize")]
+pub struct SwapState<AH, BH, AI, BI, AT, BT> {
     pub communication: SwapCommunication<AI, BI>,
     pub alpha_ledger: LedgerState<AH, AT>,
     pub beta_ledger: LedgerState<BH, BT>,
@@ -90,11 +90,11 @@ impl<AL, BL, AA, BA, AI, BI> From<rfc003::SwapCommunication<AL, BL, AA, BA, AI, 
     }
 }
 
-impl<H, T, A> From<rfc003::LedgerState<H, T, A>> for LedgerState<H, T>
+impl<H, T, A> From<rfc003::LedgerState<A, H, T>> for LedgerState<H, T>
 where
-    rfc003::LedgerState<H, T, A>: Clone,
+    rfc003::LedgerState<A, H, T>: Clone,
 {
-    fn from(ledger_state: rfc003::LedgerState<H, T, A>) -> Self {
+    fn from(ledger_state: rfc003::LedgerState<A, H, T>) -> Self {
         use self::rfc003::LedgerState::*;
         let status = ledger_state.clone().into();
         match ledger_state {

--- a/cnd/src/http_api/swap_resource.rs
+++ b/cnd/src/http_api/swap_resource.rs
@@ -124,10 +124,10 @@ where
             counterparty: Http(swap.counterparty),
             state: match include_state {
                 IncludeState::Yes => Some(SwapState::<
+                    AH,
+                    BH,
                     AI,
                     BI,
-                    <AL as Ledger>::HtlcLocation,
-                    <BL as Ledger>::HtlcLocation,
                     <AL as Ledger>::Transaction,
                     <BL as Ledger>::Transaction,
                 > {

--- a/cnd/src/load_swaps.rs
+++ b/cnd/src/load_swaps.rs
@@ -22,7 +22,9 @@ pub async fn load_swaps_from_database(facade: Facade) -> anyhow::Result<()> {
 
             match accepted {
                 Ok(accepted) => {
-                    init_accepted_swap(&facade, accepted, types.role)?;
+                    init_accepted_swap::<_, _, _, _, _, AH, BH, _, _>(
+                        &facade, accepted, types.role,
+                    )?;
                 }
                 Err(e) => tracing::error!("failed to load swap: {}, continuing ...", e),
             };

--- a/cnd/src/network/mod.rs
+++ b/cnd/src/network/mod.rs
@@ -8,6 +8,7 @@ use crate::{
     comit_api::LedgerKind,
     config::Settings,
     db::{Save, Sqlite, Swap},
+    htlc_location,
     libp2p_comit_ext::{FromHeader, ToHeader},
     seed::{DeriveSwapSeed, RootSeed},
     swap_protocols::{
@@ -29,7 +30,7 @@ use futures_core::{
 };
 use libp2p::{
     core::either::{EitherError, EitherOutput},
-    identity::{self, ed25519},
+    identity::{ed25519, Keypair},
     mdns::Mdns,
     swarm::{
         protocols_handler::DummyProtocolsHandler, ExpandedSwarm, IntoProtocolsHandlerSelect,
@@ -130,10 +131,10 @@ impl Swarm {
     }
 }
 
-fn derive_key_pair(seed: &RootSeed) -> identity::Keypair {
+fn derive_key_pair(seed: &RootSeed) -> Keypair {
     let bytes = seed.sha256_with_seed(&[b"NODE_ID"]);
     let key = ed25519::SecretKey::from_bytes(bytes).expect("we always pass 32 bytes");
-    identity::Keypair::Ed25519(key.into())
+    Keypair::Ed25519(key.into())
 }
 
 #[derive(NetworkBehaviour)]
@@ -280,12 +281,18 @@ async fn handle_request(
                                 hash_function,
                                 body!(request.take_body_as()),
                             );
-                            insert_state_for_bob(
-                                db.clone(),
-                                seed,
-                                state_store.clone(),
-                                counterparty,
-                                request,
+                            insert_state_for_bob::<
+                                _,
+                                _,
+                                _,
+                                _,
+                                htlc_location::Bitcoin,
+                                htlc_location::Ethereum,
+                                _,
+                                _,
+                                _,
+                            >(
+                                db.clone(), seed, state_store.clone(), counterparty, request
                             )
                             .await
                             .expect("Could not save state to db");
@@ -306,12 +313,18 @@ async fn handle_request(
                                 hash_function,
                                 body!(request.take_body_as()),
                             );
-                            insert_state_for_bob(
-                                db.clone(),
-                                seed,
-                                state_store.clone(),
-                                counterparty,
-                                request,
+                            insert_state_for_bob::<
+                                _,
+                                _,
+                                _,
+                                _,
+                                htlc_location::Bitcoin,
+                                htlc_location::Ethereum,
+                                _,
+                                _,
+                                _,
+                            >(
+                                db.clone(), seed, state_store.clone(), counterparty, request
                             )
                             .await
                             .expect("Could not save state to db");
@@ -332,12 +345,18 @@ async fn handle_request(
                                 hash_function,
                                 body!(request.take_body_as()),
                             );
-                            insert_state_for_bob(
-                                db.clone(),
-                                seed,
-                                state_store.clone(),
-                                counterparty,
-                                request,
+                            insert_state_for_bob::<
+                                _,
+                                _,
+                                _,
+                                _,
+                                htlc_location::Bitcoin,
+                                htlc_location::Ethereum,
+                                _,
+                                _,
+                                _,
+                            >(
+                                db.clone(), seed, state_store.clone(), counterparty, request
                             )
                             .await
                             .expect("Could not save state to db");
@@ -358,12 +377,18 @@ async fn handle_request(
                                 hash_function,
                                 body!(request.take_body_as()),
                             );
-                            insert_state_for_bob(
-                                db.clone(),
-                                seed,
-                                state_store.clone(),
-                                counterparty,
-                                request,
+                            insert_state_for_bob::<
+                                _,
+                                _,
+                                _,
+                                _,
+                                htlc_location::Ethereum,
+                                htlc_location::Bitcoin,
+                                _,
+                                _,
+                                _,
+                            >(
+                                db.clone(), seed, state_store.clone(), counterparty, request
                             )
                             .await
                             .expect("Could not save state to db");
@@ -384,12 +409,18 @@ async fn handle_request(
                                 hash_function,
                                 body!(request.take_body_as()),
                             );
-                            insert_state_for_bob(
-                                db.clone(),
-                                seed,
-                                state_store.clone(),
-                                counterparty,
-                                request,
+                            insert_state_for_bob::<
+                                _,
+                                _,
+                                _,
+                                _,
+                                htlc_location::Ethereum,
+                                htlc_location::Bitcoin,
+                                _,
+                                _,
+                                _,
+                            >(
+                                db.clone(), seed, state_store.clone(), counterparty, request
                             )
                             .await
                             .expect("Could not save state to db");
@@ -410,12 +441,18 @@ async fn handle_request(
                                 hash_function,
                                 body!(request.take_body_as()),
                             );
-                            insert_state_for_bob(
-                                db.clone(),
-                                seed,
-                                state_store.clone(),
-                                counterparty,
-                                request,
+                            insert_state_for_bob::<
+                                _,
+                                _,
+                                _,
+                                _,
+                                htlc_location::Ethereum,
+                                htlc_location::Bitcoin,
+                                _,
+                                _,
+                                _,
+                            >(
+                                db.clone(), seed, state_store.clone(), counterparty, request
                             )
                             .await
                             .expect("Could not save state to db");
@@ -436,12 +473,18 @@ async fn handle_request(
                                 hash_function,
                                 body!(request.take_body_as()),
                             );
-                            insert_state_for_bob(
-                                db.clone(),
-                                seed,
-                                state_store.clone(),
-                                counterparty,
-                                request,
+                            insert_state_for_bob::<
+                                _,
+                                _,
+                                _,
+                                _,
+                                htlc_location::Bitcoin,
+                                htlc_location::Ethereum,
+                                _,
+                                _,
+                                _,
+                            >(
+                                db.clone(), seed, state_store.clone(), counterparty, request
                             )
                             .await
                             .expect("Could not save state to db");
@@ -463,12 +506,18 @@ async fn handle_request(
                                 hash_function,
                                 body!(request.take_body_as()),
                             );
-                            insert_state_for_bob(
-                                db.clone(),
-                                seed,
-                                state_store.clone(),
-                                counterparty,
-                                request,
+                            insert_state_for_bob::<
+                                _,
+                                _,
+                                _,
+                                _,
+                                htlc_location::Bitcoin,
+                                htlc_location::Ethereum,
+                                _,
+                                _,
+                                _,
+                            >(
+                                db.clone(), seed, state_store.clone(), counterparty, request
                             )
                             .await
                             .expect("Could not save state to db");
@@ -490,12 +539,18 @@ async fn handle_request(
                                 hash_function,
                                 body!(request.take_body_as()),
                             );
-                            insert_state_for_bob(
-                                db.clone(),
-                                seed,
-                                state_store.clone(),
-                                counterparty,
-                                request,
+                            insert_state_for_bob::<
+                                _,
+                                _,
+                                _,
+                                _,
+                                htlc_location::Ethereum,
+                                htlc_location::Bitcoin,
+                                _,
+                                _,
+                                _,
+                            >(
+                                db.clone(), seed, state_store.clone(), counterparty, request
                             )
                             .await
                             .expect("Could not save state to db");
@@ -517,12 +572,18 @@ async fn handle_request(
                                 hash_function,
                                 body!(request.take_body_as()),
                             );
-                            insert_state_for_bob(
-                                db.clone(),
-                                seed,
-                                state_store.clone(),
-                                counterparty,
-                                request,
+                            insert_state_for_bob::<
+                                _,
+                                _,
+                                _,
+                                _,
+                                htlc_location::Ethereum,
+                                htlc_location::Bitcoin,
+                                _,
+                                _,
+                                _,
+                            >(
+                                db.clone(), seed, state_store.clone(), counterparty, request
                             )
                             .await
                             .expect("Could not save state to db");
@@ -543,12 +604,18 @@ async fn handle_request(
                                 hash_function,
                                 body!(request.take_body_as()),
                             );
-                            insert_state_for_bob(
-                                db.clone(),
-                                seed,
-                                state_store.clone(),
-                                counterparty,
-                                request,
+                            insert_state_for_bob::<
+                                _,
+                                _,
+                                _,
+                                _,
+                                htlc_location::Ethereum,
+                                htlc_location::Bitcoin,
+                                _,
+                                _,
+                                _,
+                            >(
+                                db.clone(), seed, state_store.clone(), counterparty, request
                             )
                             .await
                             .expect("Could not save state to db");
@@ -569,12 +636,18 @@ async fn handle_request(
                                 hash_function,
                                 body!(request.take_body_as()),
                             );
-                            insert_state_for_bob(
-                                db.clone(),
-                                seed,
-                                state_store.clone(),
-                                counterparty,
-                                request,
+                            insert_state_for_bob::<
+                                _,
+                                _,
+                                _,
+                                _,
+                                htlc_location::Ethereum,
+                                htlc_location::Bitcoin,
+                                _,
+                                _,
+                                _,
+                            >(
+                                db.clone(), seed, state_store.clone(), counterparty, request
                             )
                             .await
                             .expect("Could not save state to db");
@@ -623,7 +696,7 @@ async fn handle_request(
 }
 
 #[allow(clippy::type_complexity)]
-async fn insert_state_for_bob<AL, BL, AA, BA, AI, BI, DB>(
+async fn insert_state_for_bob<AL, BL, AA, BA, AH, BH, AI, BI, DB>(
     db: DB,
     seed: RootSeed,
     state_store: Arc<InMemoryStateStore>,
@@ -637,6 +710,8 @@ where
     BA: Send + 'static,
     AI: Send + 'static,
     BI: Send + 'static,
+    AH: Send + 'static,
+    BH: Send + 'static,
     DB: Save<Request<AL, BL, AA, BA, AI, BI>> + Save<Swap>,
     Request<AL, BL, AA, BA, AI, BI>: Clone,
 {
@@ -646,7 +721,7 @@ where
     Save::save(&db, Swap::new(id, Role::Bob, counterparty)).await?;
     Save::save(&db, swap_request.clone()).await?;
 
-    let state = bob::State::proposed(swap_request.clone(), seed);
+    let state = bob::State::<_, _, _, _, AH, BH, _, _>::proposed(swap_request.clone(), seed);
     state_store.insert(id, state);
 
     Ok(())

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -12,7 +12,7 @@ use crate::{
         ledger::{bitcoin, Ethereum},
         rfc003::{
             self,
-            create_swap::{HtlcParams, SwapEventOnLedger},
+            create_swap::{HtlcParams, ReplacementSwapEventOnLedger},
             events::{
                 Deployed, Funded, HtlcDeployed, HtlcFunded, HtlcRedeemed, HtlcRefunded, Redeemed,
                 Refunded,
@@ -68,18 +68,8 @@ impl StateStore for Facade {
         self.state_store.get(key)
     }
 
-    fn update<A>(
-        &self,
-        key: &SwapId,
-        update: SwapEventOnLedger<
-            <A as ActorState>::AL,
-            <A as ActorState>::BL,
-            A::AA,
-            A::BA,
-            A::AH,
-            A::BH,
-        >,
-    ) where
+    fn update<A>(&self, key: &SwapId, update: ReplacementSwapEventOnLedger<A>)
+    where
         A: ActorState,
         A::AA: Ord,
         A::BA: Ord,

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -71,7 +71,14 @@ impl StateStore for Facade {
     fn update<A>(
         &self,
         key: &SwapId,
-        update: SwapEventOnLedger<<A as ActorState>::AL, <A as ActorState>::BL, A::AA, A::BA>,
+        update: SwapEventOnLedger<
+            <A as ActorState>::AL,
+            <A as ActorState>::BL,
+            A::AA,
+            A::BA,
+            A::AH,
+            A::BH,
+        >,
     ) where
         A: ActorState,
         A::AA: Ord,
@@ -128,15 +135,16 @@ impl
     HtlcFunded<
         ((bitcoin::Mainnet, bitcoin::Testnet, bitcoin::Regtest)),
         asset::Bitcoin,
+        htlc_location::Bitcoin,
         identity::Bitcoin,
     > for Facade
 {
     async fn htlc_funded(
         &self,
         htlc_params: &HtlcParams<__TYPE0__, asset::Bitcoin, identity::Bitcoin>,
-        htlc_deployment: &Deployed<transaction::Bitcoin, htlc_location::Bitcoin>,
+        htlc_deployment: &Deployed<htlc_location::Bitcoin, transaction::Bitcoin>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Funded<transaction::Bitcoin, asset::Bitcoin>> {
+    ) -> anyhow::Result<Funded<asset::Bitcoin, transaction::Bitcoin>> {
         self.bitcoin_connector
             .htlc_funded(htlc_params, htlc_deployment, start_of_swap)
             .await
@@ -149,6 +157,7 @@ impl
     HtlcDeployed<
         ((bitcoin::Mainnet, bitcoin::Testnet, bitcoin::Regtest)),
         asset::Bitcoin,
+        htlc_location::Bitcoin,
         identity::Bitcoin,
     > for Facade
 {
@@ -156,7 +165,7 @@ impl
         &self,
         htlc_params: &HtlcParams<__TYPE0__, asset::Bitcoin, identity::Bitcoin>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Deployed<transaction::Bitcoin, htlc_location::Bitcoin>> {
+    ) -> anyhow::Result<Deployed<htlc_location::Bitcoin, transaction::Bitcoin>> {
         self.bitcoin_connector
             .htlc_deployed(htlc_params, start_of_swap)
             .await
@@ -169,13 +178,14 @@ impl
     HtlcRedeemed<
         ((bitcoin::Mainnet, bitcoin::Testnet, bitcoin::Regtest)),
         asset::Bitcoin,
+        htlc_location::Bitcoin,
         identity::Bitcoin,
     > for Facade
 {
     async fn htlc_redeemed(
         &self,
         htlc_params: &HtlcParams<__TYPE0__, asset::Bitcoin, identity::Bitcoin>,
-        htlc_deployment: &Deployed<transaction::Bitcoin, htlc_location::Bitcoin>,
+        htlc_deployment: &Deployed<htlc_location::Bitcoin, transaction::Bitcoin>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<transaction::Bitcoin>> {
         self.bitcoin_connector
@@ -190,13 +200,14 @@ impl
     HtlcRefunded<
         ((bitcoin::Mainnet, bitcoin::Testnet, bitcoin::Regtest)),
         asset::Bitcoin,
+        htlc_location::Bitcoin,
         identity::Bitcoin,
     > for Facade
 {
     async fn htlc_refunded(
         &self,
         htlc_params: &HtlcParams<__TYPE0__, asset::Bitcoin, identity::Bitcoin>,
-        htlc_deployment: &Deployed<transaction::Bitcoin, htlc_location::Bitcoin>,
+        htlc_deployment: &Deployed<htlc_location::Bitcoin, transaction::Bitcoin>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<transaction::Bitcoin>> {
         self.bitcoin_connector
@@ -207,13 +218,20 @@ impl
 
 #[impl_template]
 #[async_trait::async_trait]
-impl HtlcFunded<Ethereum, ((asset::Ether, asset::Erc20)), identity::Ethereum> for Facade {
+impl
+    HtlcFunded<
+        Ethereum,
+        ((asset::Ether, asset::Erc20)),
+        htlc_location::Ethereum,
+        identity::Ethereum,
+    > for Facade
+{
     async fn htlc_funded(
         &self,
         htlc_params: &HtlcParams<Ethereum, __TYPE0__, identity::Ethereum>,
-        htlc_deployment: &Deployed<transaction::Ethereum, identity::Ethereum>,
+        htlc_deployment: &Deployed<htlc_location::Ethereum, transaction::Ethereum>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Funded<transaction::Ethereum, __TYPE0__>> {
+    ) -> anyhow::Result<Funded<__TYPE0__, transaction::Ethereum>> {
         self.ethereum_connector
             .htlc_funded(htlc_params, htlc_deployment, start_of_swap)
             .await
@@ -222,12 +240,19 @@ impl HtlcFunded<Ethereum, ((asset::Ether, asset::Erc20)), identity::Ethereum> fo
 
 #[impl_template]
 #[async_trait::async_trait]
-impl HtlcDeployed<Ethereum, ((asset::Ether, asset::Erc20)), identity::Ethereum> for Facade {
+impl
+    HtlcDeployed<
+        Ethereum,
+        ((asset::Ether, asset::Erc20)),
+        htlc_location::Ethereum,
+        identity::Ethereum,
+    > for Facade
+{
     async fn htlc_deployed(
         &self,
         htlc_params: &HtlcParams<Ethereum, __TYPE0__, identity::Ethereum>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Deployed<transaction::Ethereum, identity::Ethereum>> {
+    ) -> anyhow::Result<Deployed<htlc_location::Ethereum, transaction::Ethereum>> {
         self.ethereum_connector
             .htlc_deployed(htlc_params, start_of_swap)
             .await
@@ -236,11 +261,18 @@ impl HtlcDeployed<Ethereum, ((asset::Ether, asset::Erc20)), identity::Ethereum> 
 
 #[impl_template]
 #[async_trait::async_trait]
-impl HtlcRedeemed<Ethereum, ((asset::Ether, asset::Erc20)), identity::Ethereum> for Facade {
+impl
+    HtlcRedeemed<
+        Ethereum,
+        ((asset::Ether, asset::Erc20)),
+        htlc_location::Ethereum,
+        identity::Ethereum,
+    > for Facade
+{
     async fn htlc_redeemed(
         &self,
         htlc_params: &HtlcParams<Ethereum, __TYPE0__, identity::Ethereum>,
-        htlc_deployment: &Deployed<transaction::Ethereum, identity::Ethereum>,
+        htlc_deployment: &Deployed<htlc_location::Ethereum, transaction::Ethereum>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<transaction::Ethereum>> {
         self.ethereum_connector
@@ -251,11 +283,18 @@ impl HtlcRedeemed<Ethereum, ((asset::Ether, asset::Erc20)), identity::Ethereum> 
 
 #[impl_template]
 #[async_trait::async_trait]
-impl HtlcRefunded<Ethereum, ((asset::Ether, asset::Erc20)), identity::Ethereum> for Facade {
+impl
+    HtlcRefunded<
+        Ethereum,
+        ((asset::Ether, asset::Erc20)),
+        htlc_location::Ethereum,
+        identity::Ethereum,
+    > for Facade
+{
     async fn htlc_refunded(
         &self,
         htlc_params: &HtlcParams<Ethereum, __TYPE0__, identity::Ethereum>,
-        htlc_deployment: &Deployed<transaction::Ethereum, identity::Ethereum>,
+        htlc_deployment: &Deployed<htlc_location::Ethereum, transaction::Ethereum>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<transaction::Ethereum>> {
         self.ethereum_connector

--- a/cnd/src/swap_protocols/rfc003/actions/erc20.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/erc20.rs
@@ -1,7 +1,7 @@
 use crate::{
     asset,
     ethereum::Bytes,
-    identity,
+    htlc_location, identity,
     swap_protocols::{
         actions::ethereum::{CallContract, DeployContract},
         ledger::{ethereum::ChainId, Ethereum},
@@ -29,7 +29,7 @@ pub fn deploy_action(
 pub fn fund_action(
     htlc_params: HtlcParams<Ethereum, asset::Erc20, identity::Ethereum>,
     to_erc20_contract: identity::Ethereum,
-    beta_htlc_location: identity::Ethereum,
+    beta_htlc_location: htlc_location::Ethereum,
 ) -> CallContract {
     let chain_id = htlc_params.ledger.chain_id;
     let gas_limit = Erc20Htlc::fund_tx_gas_limit();
@@ -50,7 +50,7 @@ pub fn fund_action(
 pub fn refund_action(
     chain_id: ChainId,
     expiry: Timestamp,
-    beta_htlc_location: identity::Ethereum,
+    beta_htlc_location: htlc_location::Ethereum,
 ) -> CallContract {
     let data = Bytes::default();
     let gas_limit = Erc20Htlc::refund_tx_gas_limit();
@@ -65,7 +65,7 @@ pub fn refund_action(
 }
 
 pub fn redeem_action(
-    alpha_htlc_location: identity::Ethereum,
+    alpha_htlc_location: htlc_location::Ethereum,
     secret: Secret,
     chain_id: ChainId,
 ) -> CallContract {

--- a/cnd/src/swap_protocols/rfc003/actions/ether.rs
+++ b/cnd/src/swap_protocols/rfc003/actions/ether.rs
@@ -1,7 +1,7 @@
 use crate::{
     asset,
     ethereum::{Bytes, Transaction},
-    identity,
+    htlc_location, identity,
     swap_protocols::{
         actions::ethereum::{CallContract, DeployContract},
         ledger::Ethereum,
@@ -33,7 +33,7 @@ impl FundAction for (Ethereum, asset::Ether) {
 
 impl RefundAction for (Ethereum, asset::Ether) {
     type HtlcParams = HtlcParams<Ethereum, asset::Ether, identity::Ethereum>;
-    type HtlcLocation = identity::Ethereum;
+    type HtlcLocation = htlc_location::Ethereum;
     type FundTransaction = Transaction;
     type Output = CallContract;
 
@@ -57,7 +57,7 @@ impl RefundAction for (Ethereum, asset::Ether) {
 
 impl RedeemAction for (Ethereum, asset::Ether) {
     type HtlcParams = HtlcParams<Ethereum, asset::Ether, identity::Ethereum>;
-    type HtlcLocation = identity::Ethereum;
+    type HtlcLocation = htlc_location::Ethereum;
     type Output = CallContract;
 
     fn redeem_action(

--- a/cnd/src/swap_protocols/rfc003/actor_state.rs
+++ b/cnd/src/swap_protocols/rfc003/actor_state.rs
@@ -5,24 +5,18 @@ pub trait ActorState: 'static {
     type BL: Ledger;
     type AA;
     type BA;
+    type AH;
+    type BH;
 
     fn expected_alpha_asset(&self) -> &Self::AA;
     fn expected_beta_asset(&self) -> &Self::BA;
 
     fn alpha_ledger_mut(
         &mut self,
-    ) -> &mut LedgerState<
-        <Self::AL as Ledger>::HtlcLocation,
-        <Self::AL as Ledger>::Transaction,
-        Self::AA,
-    >;
+    ) -> &mut LedgerState<Self::AA, Self::AH, <Self::AL as Ledger>::Transaction>;
     fn beta_ledger_mut(
         &mut self,
-    ) -> &mut LedgerState<
-        <Self::BL as Ledger>::HtlcLocation,
-        <Self::BL as Ledger>::Transaction,
-        Self::BA,
-    >;
+    ) -> &mut LedgerState<Self::BA, Self::BH, <Self::BL as Ledger>::Transaction>;
 
     /// Returns true if the current swap failed at some stage.
     fn swap_failed(&self) -> bool;

--- a/cnd/src/swap_protocols/rfc003/alice/actions/generic_impl.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/actions/generic_impl.rs
@@ -9,21 +9,23 @@ use crate::swap_protocols::{
 };
 use std::convert::Infallible;
 
-impl<AL, BL, AA, BA, AI, BI> Actions for alice::State<AL, BL, AA, BA, AI, BI>
+impl<AL, BL, AA, BA, AH, BH, AI, BI> Actions for alice::State<AL, BL, AA, BA, AH, BH, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
     AA: Clone,
-    AI: Clone,
     BA: Clone,
+    AH: Clone,
+    BH: Clone,
+    AI: Clone,
     BI: Clone,
     (AL, AA): FundAction<HtlcParams = HtlcParams<AL, AA, AI>>
         + RefundAction<
             HtlcParams = HtlcParams<AL, AA, AI>,
-            HtlcLocation = AL::HtlcLocation,
+            HtlcLocation = AH,
             FundTransaction = AL::Transaction,
         >,
-    (BL, BA): RedeemAction<HtlcParams = HtlcParams<BL, BA, BI>, HtlcLocation = BL::HtlcLocation>,
+    (BL, BA): RedeemAction<HtlcParams = HtlcParams<BL, BA, BI>, HtlcLocation = BH>,
 {
     #[allow(clippy::type_complexity)]
     type ActionKind = Action<

--- a/cnd/src/swap_protocols/rfc003/alice/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/alice/mod.rs
@@ -12,20 +12,20 @@ use derivative::Derivative;
 
 #[derive(Clone, Derivative)]
 #[derivative(Debug, PartialEq)]
-pub struct State<AL, BL, AA, BA, AI, BI>
+pub struct State<AL, BL, AA, BA, AH, BH, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
 {
     pub swap_communication: SwapCommunication<AL, BL, AA, BA, AI, BI>,
-    pub alpha_ledger_state: LedgerState<AL::HtlcLocation, AL::Transaction, AA>,
-    pub beta_ledger_state: LedgerState<BL::HtlcLocation, BL::Transaction, BA>,
+    pub alpha_ledger_state: LedgerState<AA, AH, AL::Transaction>,
+    pub beta_ledger_state: LedgerState<BA, BH, BL::Transaction>,
     #[derivative(Debug = "ignore", PartialEq = "ignore")]
     pub secret_source: SwapSeed, // Used to derive identities and also to generate the secret.
     pub failed: bool,
 }
 
-impl<AL, BL, AA, BA, AI, BI> State<AL, BL, AA, BA, AI, BI>
+impl<AL, BL, AA, BA, AH, BH, AI, BI> State<AL, BL, AA, BA, AH, BH, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
@@ -76,7 +76,7 @@ where
     }
 }
 
-impl<AL, BL, AA, BA, AI, BI> ActorState for State<AL, BL, AA, BA, AI, BI>
+impl<AL, BL, AA, BA, AH, BH, AI, BI> ActorState for State<AL, BL, AA, BA, AH, BH, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
@@ -84,11 +84,15 @@ where
     BA: 'static,
     AI: 'static,
     BI: 'static,
+    AH: 'static,
+    BH: 'static,
 {
     type AL = AL;
     type BL = BL;
     type AA = AA;
     type BA = BA;
+    type AH = AH;
+    type BH = BH;
 
     fn expected_alpha_asset(&self) -> &Self::AA {
         &self.swap_communication.request().alpha_asset
@@ -98,11 +102,11 @@ where
         &self.swap_communication.request().beta_asset
     }
 
-    fn alpha_ledger_mut(&mut self) -> &mut LedgerState<AL::HtlcLocation, AL::Transaction, AA> {
+    fn alpha_ledger_mut(&mut self) -> &mut LedgerState<AA, AH, AL::Transaction> {
         &mut self.alpha_ledger_state
     }
 
-    fn beta_ledger_mut(&mut self) -> &mut LedgerState<BL::HtlcLocation, BL::Transaction, BA> {
+    fn beta_ledger_mut(&mut self) -> &mut LedgerState<BA, BH, BL::Transaction> {
         &mut self.beta_ledger_state
     }
 

--- a/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
@@ -21,16 +21,17 @@ use anyhow::Context;
 use chrono::NaiveDateTime;
 
 #[async_trait::async_trait]
-impl<B> HtlcFunded<B, asset::Bitcoin, identity::Bitcoin> for Cache<BitcoindConnector>
+impl<B> HtlcFunded<B, asset::Bitcoin, htlc_location::Bitcoin, identity::Bitcoin>
+    for Cache<BitcoindConnector>
 where
     B: bitcoin::Bitcoin + bitcoin::Network,
 {
     async fn htlc_funded(
         &self,
         _htlc_params: &HtlcParams<B, asset::Bitcoin, identity::Bitcoin>,
-        htlc_deployment: &Deployed<transaction::Bitcoin, htlc_location::Bitcoin>,
+        htlc_deployment: &Deployed<htlc_location::Bitcoin, transaction::Bitcoin>,
         _start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Funded<transaction::Bitcoin, asset::Bitcoin>> {
+    ) -> anyhow::Result<Funded<asset::Bitcoin, transaction::Bitcoin>> {
         let tx = &htlc_deployment.transaction;
         let asset =
             asset::Bitcoin::from_sat(tx.output[htlc_deployment.location.vout as usize].value);
@@ -43,7 +44,8 @@ where
 }
 
 #[async_trait::async_trait]
-impl<B> HtlcDeployed<B, asset::Bitcoin, identity::Bitcoin> for Cache<BitcoindConnector>
+impl<B> HtlcDeployed<B, asset::Bitcoin, htlc_location::Bitcoin, identity::Bitcoin>
+    for Cache<BitcoindConnector>
 where
     B: bitcoin::Bitcoin + bitcoin::Network,
 {
@@ -51,7 +53,7 @@ where
         &self,
         htlc_params: &HtlcParams<B, asset::Bitcoin, identity::Bitcoin>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Deployed<transaction::Bitcoin, htlc_location::Bitcoin>> {
+    ) -> anyhow::Result<Deployed<htlc_location::Bitcoin, transaction::Bitcoin>> {
         let connector = self.clone();
         let pattern = TransactionPattern {
             to_address: Some(htlc_params.compute_address()),
@@ -78,14 +80,15 @@ where
 }
 
 #[async_trait::async_trait]
-impl<B> HtlcRedeemed<B, asset::Bitcoin, identity::Bitcoin> for Cache<BitcoindConnector>
+impl<B> HtlcRedeemed<B, asset::Bitcoin, htlc_location::Bitcoin, identity::Bitcoin>
+    for Cache<BitcoindConnector>
 where
     B: bitcoin::Bitcoin + bitcoin::Network,
 {
     async fn htlc_redeemed(
         &self,
         htlc_params: &HtlcParams<B, asset::Bitcoin, identity::Bitcoin>,
-        htlc_deployment: &Deployed<transaction::Bitcoin, htlc_location::Bitcoin>,
+        htlc_deployment: &Deployed<htlc_location::Bitcoin, transaction::Bitcoin>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<transaction::Bitcoin>> {
         let connector = self.clone();
@@ -109,14 +112,15 @@ where
 }
 
 #[async_trait::async_trait]
-impl<B> HtlcRefunded<B, asset::Bitcoin, identity::Bitcoin> for Cache<BitcoindConnector>
+impl<B> HtlcRefunded<B, asset::Bitcoin, htlc_location::Bitcoin, identity::Bitcoin>
+    for Cache<BitcoindConnector>
 where
     B: bitcoin::Bitcoin + bitcoin::Network,
 {
     async fn htlc_refunded(
         &self,
         _htlc_params: &HtlcParams<B, asset::Bitcoin, identity::Bitcoin>,
-        htlc_deployment: &Deployed<transaction::Bitcoin, htlc_location::Bitcoin>,
+        htlc_deployment: &Deployed<htlc_location::Bitcoin, transaction::Bitcoin>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<transaction::Bitcoin>> {
         let connector = self.clone();

--- a/cnd/src/swap_protocols/rfc003/bitcoin/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bitcoin/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use ::bitcoin::{
     hashes::{hash160, Hash},
-    Address, OutPoint, Transaction,
+    Address, Transaction,
 };
 use blockchain_contracts::bitcoin::rfc003::bitcoin_htlc::BitcoinHtlc;
 
@@ -20,7 +20,6 @@ impl<B> Ledger for B
 where
     B: ledger::Bitcoin,
 {
-    type HtlcLocation = OutPoint;
     type Transaction = Transaction;
 }
 

--- a/cnd/src/swap_protocols/rfc003/bob/actions/erc20.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/actions/erc20.rs
@@ -1,6 +1,6 @@
 use crate::{
     asset::{self},
-    identity,
+    htlc_location, identity,
     swap_protocols::{
         actions::{ethereum, Actions},
         ledger::Ethereum,
@@ -14,12 +14,23 @@ use crate::{
 };
 use std::convert::Infallible;
 
-impl<AL, AA, AI> Actions for bob::State<AL, Ethereum, AA, asset::Erc20, AI, identity::Ethereum>
+impl<AL, AA, AI, AH> Actions
+    for bob::State<
+        AL,
+        Ethereum,
+        AA,
+        asset::Erc20,
+        AH,
+        htlc_location::Ethereum,
+        AI,
+        identity::Ethereum,
+    >
 where
     AL: Ledger,
     AA: Clone,
+    AH: Clone,
     AI: Clone,
-    (AL, AA): RedeemAction<HtlcParams = HtlcParams<AL, AA, AI>, HtlcLocation = AL::HtlcLocation>,
+    (AL, AA): RedeemAction<HtlcParams = HtlcParams<AL, AA, AI>, HtlcLocation = AH>,
 {
     #[allow(clippy::type_complexity)]
     type ActionKind = Action<
@@ -85,15 +96,26 @@ where
     }
 }
 
-impl<BL, BA, BI> Actions for bob::State<Ethereum, BL, asset::Erc20, BA, identity::Ethereum, BI>
+impl<BL, BA, BI, BH> Actions
+    for bob::State<
+        Ethereum,
+        BL,
+        asset::Erc20,
+        BA,
+        htlc_location::Ethereum,
+        BH,
+        identity::Ethereum,
+        BI,
+    >
 where
     BL: Ledger,
     BA: Clone,
+    BH: Clone,
     BI: Clone,
     (BL, BA): FundAction<HtlcParams = HtlcParams<BL, BA, BI>>
         + RefundAction<
             HtlcParams = HtlcParams<BL, BA, BI>,
-            HtlcLocation = BL::HtlcLocation,
+            HtlcLocation = BH,
             FundTransaction = BL::Transaction,
         >,
 {

--- a/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/actions/generic_impl.rs
@@ -9,21 +9,23 @@ use crate::swap_protocols::{
 };
 use std::convert::Infallible;
 
-impl<AL, BL, AA, BA, AI, BI> Actions for bob::State<AL, BL, AA, BA, AI, BI>
+impl<AL, BL, AA, BA, AH, BH, AI, BI> Actions for bob::State<AL, BL, AA, BA, AH, BH, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
     AA: Clone,
     BA: Clone,
+    AH: Clone,
+    BH: Clone,
     AI: Clone,
     BI: Clone,
     (BL, BA): FundAction<HtlcParams = HtlcParams<BL, BA, BI>>
         + RefundAction<
             HtlcParams = HtlcParams<BL, BA, BI>,
-            HtlcLocation = BL::HtlcLocation,
+            HtlcLocation = BH,
             FundTransaction = BL::Transaction,
         >,
-    (AL, AA): RedeemAction<HtlcParams = HtlcParams<AL, AA, AI>, HtlcLocation = AL::HtlcLocation>,
+    (AL, AA): RedeemAction<HtlcParams = HtlcParams<AL, AA, AI>, HtlcLocation = AH>,
 {
     #[allow(clippy::type_complexity)]
     type ActionKind = Action<

--- a/cnd/src/swap_protocols/rfc003/bob/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/bob/mod.rs
@@ -9,20 +9,20 @@ use std::sync::Arc;
 
 #[derive(Clone, Derivative)]
 #[derivative(Debug)]
-pub struct State<AL, BL, AA, BA, AI, BI>
+pub struct State<AL, BL, AA, BA, AH, BH, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
 {
     pub swap_communication: SwapCommunication<AL, BL, AA, BA, AI, BI>,
-    pub alpha_ledger_state: LedgerState<AL::HtlcLocation, AL::Transaction, AA>,
-    pub beta_ledger_state: LedgerState<BL::HtlcLocation, BL::Transaction, BA>,
+    pub alpha_ledger_state: LedgerState<AA, AH, AL::Transaction>,
+    pub beta_ledger_state: LedgerState<BA, BH, BL::Transaction>,
     #[derivative(Debug = "ignore")]
     pub secret_source: Arc<dyn DeriveIdentities>,
     pub failed: bool, // Gets set on any error during the execution of a swap.
 }
 
-impl<AL, BL, AA, BA, AI, BI> State<AL, BL, AA, BA, AI, BI>
+impl<AL, BL, AA, BA, AH, BH, AI, BI> State<AL, BL, AA, BA, AH, BH, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
@@ -77,7 +77,7 @@ where
     }
 }
 
-impl<AL, BL, AA, BA, AI, BI> ActorState for State<AL, BL, AA, BA, AI, BI>
+impl<AL, BL, AA, BA, AH, BH, AI, BI> ActorState for State<AL, BL, AA, BA, AH, BH, AI, BI>
 where
     AL: Ledger,
     BL: Ledger,
@@ -85,11 +85,15 @@ where
     BA: 'static,
     AI: 'static,
     BI: 'static,
+    AH: 'static,
+    BH: 'static,
 {
     type AL = AL;
     type BL = BL;
     type AA = AA;
     type BA = BA;
+    type AH = AH;
+    type BH = BH;
 
     fn expected_alpha_asset(&self) -> &Self::AA {
         &self.swap_communication.request().alpha_asset
@@ -99,11 +103,11 @@ where
         &self.swap_communication.request().beta_asset
     }
 
-    fn alpha_ledger_mut(&mut self) -> &mut LedgerState<AL::HtlcLocation, AL::Transaction, AA> {
+    fn alpha_ledger_mut(&mut self) -> &mut LedgerState<AA, AH, AL::Transaction> {
         &mut self.alpha_ledger_state
     }
 
-    fn beta_ledger_mut(&mut self) -> &mut LedgerState<BL::HtlcLocation, BL::Transaction, BA> {
+    fn beta_ledger_mut(&mut self) -> &mut LedgerState<BA, BH, BL::Transaction> {
         &mut self.beta_ledger_state
     }
 

--- a/cnd/src/swap_protocols/rfc003/create_swap.rs
+++ b/cnd/src/swap_protocols/rfc003/create_swap.rs
@@ -38,19 +38,21 @@ pub async fn create_swap<D, A, AI, BI>(
     accepted: AcceptedSwap<A::AL, A::BL, A::AA, A::BA, AI, BI>,
 ) where
     D: StateStore
-        + HtlcFunded<A::AL, A::AA, AI>
-        + HtlcFunded<A::BL, A::BA, BI>
-        + HtlcDeployed<A::AL, A::AA, AI>
-        + HtlcDeployed<A::BL, A::BA, BI>
-        + HtlcRedeemed<A::AL, A::AA, AI>
-        + HtlcRedeemed<A::BL, A::BA, BI>
-        + HtlcRefunded<A::AL, A::AA, AI>
-        + HtlcRefunded<A::BL, A::BA, BI>
+        + HtlcFunded<A::AL, A::AA, A::AH, AI>
+        + HtlcFunded<A::BL, A::BA, A::BH, BI>
+        + HtlcDeployed<A::AL, A::AA, A::AH, AI>
+        + HtlcDeployed<A::BL, A::BA, A::BH, BI>
+        + HtlcRedeemed<A::AL, A::AA, A::AH, AI>
+        + HtlcRedeemed<A::BL, A::BA, A::BH, BI>
+        + HtlcRefunded<A::AL, A::AA, A::AH, AI>
+        + HtlcRefunded<A::BL, A::BA, A::BH, BI>
         + Clone,
-    A::AA: Ord + Clone,
-    A::BA: Ord + Clone,
     A::AL: Clone,
     A::BL: Clone,
+    A::AA: Ord + Clone,
+    A::BA: Ord + Clone,
+    A::AH: Clone,
+    A::BH: Clone,
     AI: Clone,
     BI: Clone,
     A: ActorState,
@@ -66,13 +68,13 @@ pub async fn create_swap<D, A, AI, BI>(
         let dependencies = dependencies.clone();
         |co| async move {
             future::try_join(
-                watch_alpha_ledger::<_, A::AL, A::BL, _, _, AI, BI>(
+                watch_alpha_ledger::<_, A::AL, A::BL, A::AA, A::BA, A::AH, A::BH, AI, BI>(
                     &dependencies,
                     &co,
                     swap.alpha_htlc_params(),
                     at,
                 ),
-                watch_beta_ledger::<_, A::AL, A::BL, _, _, AI, BI>(
+                watch_beta_ledger::<_, A::AL, A::BL, A::AA, A::BA, A::AH, A::BH, AI, BI>(
                     &dependencies,
                     &co,
                     swap.beta_htlc_params(),
@@ -108,19 +110,20 @@ pub async fn create_swap<D, A, AI, BI>(
 /// Returns a future that waits for events on alpha ledger to happen.
 ///
 /// Each event is yielded through the controller handle (co) of the coroutine.
-async fn watch_alpha_ledger<D, AL, BL, AA, BA, AI, BI>(
+async fn watch_alpha_ledger<D, AL, BL, AA, BA, AH, BH, AI, BI>(
     dependencies: &D,
-    co: &Co<SwapEventOnLedger<AL, BL, AA, BA>>,
+    co: &Co<SwapEventOnLedger<AL, BL, AA, BA, AH, BH>>,
     htlc_params: HtlcParams<AL, AA, AI>,
     start_of_swap: NaiveDateTime,
 ) -> anyhow::Result<()>
 where
     AL: Ledger,
     BL: Ledger,
-    D: HtlcFunded<AL, AA, AI>
-        + HtlcDeployed<AL, AA, AI>
-        + HtlcRedeemed<AL, AA, AI>
-        + HtlcRefunded<AL, AA, AI>,
+    D: HtlcFunded<AL, AA, AH, AI>
+        + HtlcDeployed<AL, AA, AH, AI>
+        + HtlcRedeemed<AL, AA, AH, AI>
+        + HtlcRefunded<AL, AA, AH, AI>,
+    Deployed<AH, AL::Transaction>: Clone,
 {
     let deployed = dependencies
         .htlc_deployed(&htlc_params, start_of_swap)
@@ -156,19 +159,20 @@ where
 /// Returns a future that waits for events on beta ledger to happen.
 ///
 /// Each event is yielded through the controller handle (co) of the coroutine.
-async fn watch_beta_ledger<D, AL, BL, AA, BA, AI, BI>(
+async fn watch_beta_ledger<D, AL, BL, AA, BA, AH, BH, AI, BI>(
     dependencies: &D,
-    co: &Co<SwapEventOnLedger<AL, BL, AA, BA>>,
+    co: &Co<SwapEventOnLedger<AL, BL, AA, BA, AH, BH>>,
     htlc_params: HtlcParams<BL, BA, BI>,
     start_of_swap: NaiveDateTime,
 ) -> anyhow::Result<()>
 where
     AL: Ledger,
     BL: Ledger,
-    D: HtlcFunded<BL, BA, BI>
-        + HtlcDeployed<BL, BA, BI>
-        + HtlcRedeemed<BL, BA, BI>
-        + HtlcRefunded<BL, BA, BI>,
+    D: HtlcFunded<BL, BA, BH, BI>
+        + HtlcDeployed<BL, BA, BH, BI>
+        + HtlcRedeemed<BL, BA, BH, BI>
+        + HtlcRefunded<BL, BA, BH, BI>,
+    Deployed<BH, BL::Transaction>: Clone,
 {
     let deployed = dependencies
         .htlc_deployed(&htlc_params, start_of_swap)
@@ -317,24 +321,18 @@ where
     }
 }
 
-pub type SwapEventOnLedger<AL, BL, AA, BA> = SwapEvent<
-    <AL as Ledger>::HtlcLocation,
-    <AL as Ledger>::Transaction,
-    <BL as Ledger>::HtlcLocation,
-    <BL as Ledger>::Transaction,
-    AA,
-    BA,
->;
+pub type SwapEventOnLedger<AL, BL, AA, BA, AH, BH> =
+    SwapEvent<AA, BA, AH, BH, <AL as Ledger>::Transaction, <BL as Ledger>::Transaction>;
 
 #[derive(Debug, Clone, PartialEq, strum_macros::Display)]
-pub enum SwapEvent<AH, AT, BH, BT, AA, BA> {
-    AlphaDeployed(Deployed<AT, AH>),
-    AlphaFunded(Funded<AT, AA>),
+pub enum SwapEvent<AA, BA, AH, BH, AT, BT> {
+    AlphaDeployed(Deployed<AH, AT>),
+    AlphaFunded(Funded<AA, AT>),
     AlphaRedeemed(Redeemed<AT>),
     AlphaRefunded(Refunded<AT>),
 
-    BetaDeployed(Deployed<BT, BH>),
-    BetaFunded(Funded<BT, BA>),
+    BetaDeployed(Deployed<BH, BT>),
+    BetaFunded(Funded<BA, BT>),
     BetaRedeemed(Redeemed<BT>),
     BetaRefunded(Refunded<BT>),
 }
@@ -342,20 +340,20 @@ pub enum SwapEvent<AH, AT, BH, BT, AA, BA> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{asset, ethereum, htlc_location, identity, transaction};
+    use crate::{asset, htlc_location, transaction};
 
     #[test]
     fn swap_event_should_render_to_nice_string() {
         let event = SwapEvent::<
-            htlc_location::Bitcoin,
-            transaction::Bitcoin,
-            identity::Ethereum,
-            transaction::Ethereum,
             asset::Bitcoin,
             asset::Ether,
+            htlc_location::Bitcoin,
+            htlc_location::Ethereum,
+            transaction::Bitcoin,
+            transaction::Ethereum,
         >::BetaDeployed(Deployed {
-            transaction: ethereum::Transaction::default(),
-            location: identity::Ethereum::default(),
+            location: htlc_location::Ethereum::default(),
+            transaction: transaction::Ethereum::default(),
         });
 
         let formatted = format!("{}", event);

--- a/cnd/src/swap_protocols/rfc003/create_swap.rs
+++ b/cnd/src/swap_protocols/rfc003/create_swap.rs
@@ -324,6 +324,16 @@ where
 pub type SwapEventOnLedger<AL, BL, AA, BA, AH, BH> =
     SwapEvent<AA, BA, AH, BH, <AL as Ledger>::Transaction, <BL as Ledger>::Transaction>;
 
+// Needed to satisfy clippy, this goes away once Ledger::Transaction is gone.
+pub type ReplacementSwapEventOnLedger<A> = SwapEvent<
+    <A as ActorState>::AA,
+    <A as ActorState>::BA,
+    <A as ActorState>::AH,
+    <A as ActorState>::BH,
+    <<A as ActorState>::AL as Ledger>::Transaction,
+    <<A as ActorState>::BL as Ledger>::Transaction,
+>;
+
 #[derive(Debug, Clone, PartialEq, strum_macros::Display)]
 pub enum SwapEvent<AA, BA, AH, BH, AT, BT> {
     AlphaDeployed(Deployed<AH, AT>),

--- a/cnd/src/swap_protocols/rfc003/ethereum/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/ethereum/mod.rs
@@ -2,7 +2,7 @@ pub mod htlc_events;
 
 use crate::{
     asset,
-    ethereum::{Address, Bytes, Transaction},
+    ethereum::{Bytes, Transaction},
     identity,
     swap_protocols::{
         ledger::Ethereum,
@@ -42,7 +42,6 @@ impl From<Seconds> for Duration {
 }
 
 impl Ledger for Ethereum {
-    type HtlcLocation = Address;
     type Transaction = Transaction;
 }
 

--- a/cnd/src/swap_protocols/rfc003/events/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/events/mod.rs
@@ -7,9 +7,9 @@ use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
-pub struct Funded<T, A> {
-    pub transaction: T,
+pub struct Funded<A, T> {
     pub asset: A,
+    pub transaction: T,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -19,9 +19,9 @@ pub struct Redeemed<T> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
-pub struct Deployed<T, H> {
-    pub transaction: T,
+pub struct Deployed<H, T> {
     pub location: H,
+    pub transaction: T,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -30,20 +30,20 @@ pub struct Refunded<T> {
 }
 
 #[async_trait::async_trait]
-pub trait HtlcFunded<L, A, I>: Send + Sync + Sized + 'static
+pub trait HtlcFunded<L, A, H, I>: Send + Sync + Sized + 'static
 where
     L: Ledger,
 {
     async fn htlc_funded(
         &self,
         htlc_params: &HtlcParams<L, A, I>,
-        htlc_deployment: &Deployed<L::Transaction, L::HtlcLocation>,
+        htlc_deployment: &Deployed<H, L::Transaction>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Funded<L::Transaction, A>>;
+    ) -> anyhow::Result<Funded<A, L::Transaction>>;
 }
 
 #[async_trait::async_trait]
-pub trait HtlcDeployed<L, A, I>: Send + Sync + Sized + 'static
+pub trait HtlcDeployed<L, A, H, I>: Send + Sync + Sized + 'static
 where
     L: Ledger,
 {
@@ -51,31 +51,31 @@ where
         &self,
         htlc_params: &HtlcParams<L, A, I>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Deployed<L::Transaction, L::HtlcLocation>>;
+    ) -> anyhow::Result<Deployed<H, L::Transaction>>;
 }
 
 #[async_trait::async_trait]
-pub trait HtlcRedeemed<L, A, I>: Send + Sync + Sized + 'static
+pub trait HtlcRedeemed<L, A, H, I>: Send + Sync + Sized + 'static
 where
     L: Ledger,
 {
     async fn htlc_redeemed(
         &self,
         htlc_params: &HtlcParams<L, A, I>,
-        htlc_deployment: &Deployed<L::Transaction, L::HtlcLocation>,
+        htlc_deployment: &Deployed<H, L::Transaction>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<L::Transaction>>;
 }
 
 #[async_trait::async_trait]
-pub trait HtlcRefunded<L, A, I>: Send + Sync + Sized + 'static
+pub trait HtlcRefunded<L, A, H, I>: Send + Sync + Sized + 'static
 where
     L: Ledger,
 {
     async fn htlc_refunded(
         &self,
         htlc_params: &HtlcParams<L, A, I>,
-        htlc_deployment: &Deployed<L::Transaction, L::HtlcLocation>,
+        htlc_deployment: &Deployed<H, L::Transaction>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<L::Transaction>>;
 }

--- a/cnd/src/swap_protocols/rfc003/ledger.rs
+++ b/cnd/src/swap_protocols/rfc003/ledger.rs
@@ -4,7 +4,6 @@ use std::{fmt::Debug, hash::Hash};
 pub trait Ledger:
     Clone + Copy + Debug + Send + Sync + 'static + PartialEq + Eq + Hash + Sized
 {
-    type HtlcLocation: PartialEq + Debug + Clone + DeserializeOwned + Serialize + Send + Sync;
     type Transaction: Debug
         + Clone
         + DeserializeOwned

--- a/cnd/src/swap_protocols/rfc003/ledger_state.rs
+++ b/cnd/src/swap_protocols/rfc003/ledger_state.rs
@@ -11,7 +11,7 @@ use strum_macros::EnumDiscriminants;
     derive(Serialize, Display),
     serde(rename_all = "SCREAMING_SNAKE_CASE")
 )]
-pub enum LedgerState<H, T, A> {
+pub enum LedgerState<A, H, T> {
     NotDeployed,
     Deployed {
         htlc_location: H,
@@ -46,8 +46,8 @@ pub enum LedgerState<H, T, A> {
     },
 }
 
-impl<T, H, A> LedgerState<H, T, A> {
-    pub fn transition_to_deployed(&mut self, deployed: Deployed<T, H>) {
+impl<A, H, T> LedgerState<A, H, T> {
+    pub fn transition_to_deployed(&mut self, deployed: Deployed<H, T>) {
         let Deployed {
             transaction,
             location,
@@ -64,7 +64,7 @@ impl<T, H, A> LedgerState<H, T, A> {
         }
     }
 
-    pub fn transition_to_funded(&mut self, funded: Funded<T, A>) {
+    pub fn transition_to_funded(&mut self, funded: Funded<A, T>) {
         let Funded { transaction, asset } = funded;
 
         match std::mem::replace(self, LedgerState::NotDeployed) {
@@ -83,7 +83,7 @@ impl<T, H, A> LedgerState<H, T, A> {
         }
     }
 
-    pub fn transition_to_incorrectly_funded(&mut self, funded: Funded<T, A>) {
+    pub fn transition_to_incorrectly_funded(&mut self, funded: Funded<A, T>) {
         let Funded { transaction, asset } = funded;
 
         match std::mem::replace(self, LedgerState::NotDeployed) {

--- a/cnd/src/swap_protocols/rfc003/state_store.rs
+++ b/cnd/src/swap_protocols/rfc003/state_store.rs
@@ -22,12 +22,12 @@ pub trait StateStore: Send + Sync + 'static {
         &self,
         key: &SwapId,
         update: SwapEvent<
-            <<A as ActorState>::AL as Ledger>::HtlcLocation,
-            <<A as ActorState>::AL as Ledger>::Transaction,
-            <<A as ActorState>::BL as Ledger>::HtlcLocation,
-            <<A as ActorState>::BL as Ledger>::Transaction,
             A::AA,
             A::BA,
+            A::AH,
+            A::BH,
+            <<A as ActorState>::AL as Ledger>::Transaction,
+            <<A as ActorState>::BL as Ledger>::Transaction,
         >,
     ) where
         A: ActorState,
@@ -68,12 +68,12 @@ impl StateStore for InMemoryStateStore {
         &self,
         key: &SwapId,
         event: SwapEvent<
-            <<A as ActorState>::AL as Ledger>::HtlcLocation,
-            <<A as ActorState>::AL as Ledger>::Transaction,
-            <<A as ActorState>::BL as Ledger>::HtlcLocation,
-            <<A as ActorState>::BL as Ledger>::Transaction,
             A::AA,
             A::BA,
+            A::AH,
+            A::BH,
+            <<A as ActorState>::AL as Ledger>::Transaction,
+            <<A as ActorState>::BL as Ledger>::Transaction,
         >,
     ) where
         A: ActorState,

--- a/cnd/src/swap_protocols/rfc003/state_store.rs
+++ b/cnd/src/swap_protocols/rfc003/state_store.rs
@@ -148,7 +148,7 @@ mod tests {
         asset,
         asset::ethereum::FromWei,
         ethereum::Address,
-        identity,
+        htlc_location, identity,
         seed::{DeriveSwapSeed, RootSeed},
         swap_protocols::{
             ledger::{bitcoin, Ethereum},
@@ -197,6 +197,8 @@ mod tests {
             Ethereum,
             asset::Bitcoin,
             asset::Ether,
+            htlc_location::Bitcoin,
+            htlc_location::Ethereum,
             identity::Bitcoin,
             identity::Ethereum,
         >>(id, state.clone());
@@ -207,6 +209,8 @@ mod tests {
                 Ethereum,
                 asset::Bitcoin,
                 asset::Ether,
+                htlc_location::Bitcoin,
+                htlc_location::Ethereum,
                 identity::Bitcoin,
                 identity::Ethereum,
             >>(&id)


### PR DESCRIPTION
Remove the HtlcLocation associated type from Ledger trait.

In preparation for removing the `Ledger` trait remove the `HtlcLocation` trait bound from `Ledger` trait.  This PR is split into 3 patches.

- Patch 1 does the bulk of the work (also implements idea presented in [comment below](https://github.com/comit-network/comit-rs/pull/2128#pullrequestreview-367521434))
- Patch 2 adds a type alias that is WIP i.e., will be removed once we remove `Transaction` from `Ledger`.  Kept separate because its a bit ugly.
- Patch 3 Removes the actual associated type i.e., this patch is a very small diff that explains why we do everything in patch 1.

Please see commit messages on each patch for more details, thanks.

Works towards: https://github.com/comit-network/comit-rs/issues/2081