### PR TITLE
Use modules for domain terms

### DIFF
--- a/cnd/src/btsieve/bitcoin/mod.rs
+++ b/cnd/src/btsieve/bitcoin/mod.rs
@@ -7,7 +7,10 @@ pub use self::{
     bitcoind_connector::BitcoindConnector, cache::Cache, transaction_ext::TransactionExt,
     transaction_pattern::TransactionPattern,
 };
-use crate::btsieve::{BlockByHash, LatestBlock, Predates};
+use crate::{
+    btsieve::{BlockByHash, LatestBlock, Predates},
+    transaction,
+};
 use bitcoin::{
     consensus::{encode::deserialize, Decodable},
     BitcoinHash,
@@ -21,7 +24,7 @@ pub async fn matching_transaction<C>(
     mut blockchain_connector: C,
     pattern: TransactionPattern,
     start_of_swap: NaiveDateTime,
-) -> anyhow::Result<bitcoin::Transaction>
+) -> anyhow::Result<transaction::Bitcoin>
 where
     C: LatestBlock<Block = bitcoin::Block>
         + BlockByHash<Block = bitcoin::Block, BlockHash = bitcoin::BlockHash>
@@ -131,7 +134,7 @@ where
 fn check_block_against_pattern<'b>(
     block: &'b bitcoin::Block,
     pattern: &TransactionPattern,
-) -> Option<&'b bitcoin::Transaction> {
+) -> Option<&'b transaction::Bitcoin> {
     block.txdata.iter().find(|transaction| {
         let result = pattern.matches(transaction);
 
@@ -200,7 +203,7 @@ mod tests {
         let transaction = r#"02000000014135047eff77c95bce4955f630bc3e334690d31517176dbc23e9345493c48ecf000000004847304402200da78118d6970bca6f152a6ca81fa8c4dde856680eb6564edb329ce1808207c402203b3b4890dd203cc4c9361bbbeb7ebce70110d4b07f411208b2540b10373755ba01feffffff02644024180100000017a9142464790f3a3fddb132691fac9fd02549cdc09ff48700a3e1110000000017a914c40a2c4fd9dcad5e1694a41ca46d337eb59369d78765000000
 "#.to_owned();
 
-        let bytes = decode_response::<bitcoin::Transaction>(transaction);
+        let bytes = decode_response::<transaction::Bitcoin>(transaction);
 
         assert_that(&bytes).is_ok();
     }

--- a/cnd/src/btsieve/ethereum/web3_connector.rs
+++ b/cnd/src/btsieve/ethereum/web3_connector.rs
@@ -1,6 +1,7 @@
 use crate::{
     btsieve::{BlockByHash, LatestBlock, ReceiptByHash},
     ethereum::{BlockId, BlockNumber},
+    transaction,
 };
 use anyhow::Context;
 use futures::Future;
@@ -25,7 +26,7 @@ impl Web3Connector {
 }
 
 impl LatestBlock for Web3Connector {
-    type Block = Option<crate::ethereum::Block<crate::ethereum::Transaction>>;
+    type Block = Option<crate::ethereum::Block<transaction::Ethereum>>;
     type BlockHash = crate::ethereum::H256;
 
     fn latest_block(
@@ -45,7 +46,7 @@ impl LatestBlock for Web3Connector {
                 .json(&request)
                 .send()
                 .await?
-                .json::<JsonRpcResponse<crate::ethereum::Block<crate::ethereum::Transaction>>>()
+                .json::<JsonRpcResponse<crate::ethereum::Block<transaction::Ethereum>>>()
                 .await?;
 
             let block = match response {
@@ -101,7 +102,7 @@ enum JsonRpcResponse<T> {
 }
 
 impl BlockByHash for Web3Connector {
-    type Block = Option<crate::ethereum::Block<crate::ethereum::Transaction>>;
+    type Block = Option<crate::ethereum::Block<transaction::Ethereum>>;
     type BlockHash = crate::ethereum::H256;
 
     fn block_by_hash(
@@ -122,7 +123,7 @@ impl BlockByHash for Web3Connector {
                 .json(&request)
                 .send()
                 .await?
-                .json::<JsonRpcResponse<crate::ethereum::Block<crate::ethereum::Transaction>>>()
+                .json::<JsonRpcResponse<crate::ethereum::Block<transaction::Ethereum>>>()
                 .await?;
 
             let block = match response {

--- a/cnd/src/http_api/action.rs
+++ b/cnd/src/http_api/action.rs
@@ -10,6 +10,7 @@ use crate::{
         ledger, SwapId,
     },
     timestamp::Timestamp,
+    transaction,
 };
 use anyhow::Context;
 use blockchain_contracts::bitcoin::witness;
@@ -71,7 +72,7 @@ pub enum ActionResponseBody {
 
 impl ActionResponseBody {
     fn bitcoin_broadcast_signed_transaction(
-        transaction: &bitcoin::Transaction,
+        transaction: &transaction::Bitcoin,
         network: bitcoin::Network,
     ) -> Self {
         let min_median_block_time = if transaction.lock_time == 0 {

--- a/cnd/src/http_api/mod.rs
+++ b/cnd/src/http_api/mod.rs
@@ -14,12 +14,13 @@ pub use self::{
 pub const PATH: &str = "swaps";
 
 use crate::{
-    asset, identity,
+    asset, htlc_location, identity,
     network::DialInformation,
     swap_protocols::{
         ledger::{self, ethereum::ChainId},
         SwapId, SwapProtocol,
     },
+    transaction,
 };
 use libp2p::{Multiaddr, PeerId};
 use serde::{
@@ -67,7 +68,7 @@ impl<'de> Deserialize<'de> for Http<asset::Bitcoin> {
     }
 }
 
-impl Serialize for Http<bitcoin::Transaction> {
+impl Serialize for Http<transaction::Bitcoin> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -76,7 +77,7 @@ impl Serialize for Http<bitcoin::Transaction> {
     }
 }
 
-impl Serialize for Http<crate::ethereum::Transaction> {
+impl Serialize for Http<transaction::Ethereum> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -95,7 +96,7 @@ impl Serialize for Http<identity::Bitcoin> {
     }
 }
 
-impl_serialize_type_with_fields!(bitcoin::OutPoint { "txid" => txid, "vout" => vout });
+impl_serialize_type_with_fields!(htlc_location::Bitcoin { "txid" => txid, "vout" => vout });
 impl_serialize_http!(crate::ethereum::H160);
 impl_serialize_http!(SwapId);
 
@@ -500,6 +501,7 @@ mod tests {
             ledger::{bitcoin, ethereum, Ethereum},
             HashFunction, SwapId, SwapProtocol,
         },
+        transaction,
     };
     use ::bitcoin::{
         hashes::{hex::FromHex, sha256d},
@@ -583,7 +585,7 @@ mod tests {
 
     #[test]
     fn http_transaction_serializes_correctly_to_json() {
-        let bitcoin_tx = ::bitcoin::Transaction {
+        let bitcoin_tx = transaction::Bitcoin {
             version: 1,
             lock_time: 0,
             input: vec![TxIn {
@@ -594,9 +596,9 @@ mod tests {
             }],
             output: vec![],
         };
-        let ethereum_tx = crate::ethereum::Transaction {
+        let ethereum_tx = transaction::Ethereum {
             hash: H256::repeat_byte(1),
-            ..crate::ethereum::Transaction::default()
+            ..transaction::Ethereum::default()
         };
 
         let bitcoin_tx = Http(bitcoin_tx);

--- a/cnd/src/lib.rs
+++ b/cnd/src/lib.rs
@@ -69,6 +69,13 @@ pub mod transaction {
     pub use bitcoin::Transaction as Bitcoin;
 }
 
+/// Define domain specific terms using htlc_location module so that we can refer
+/// to things in an ergonomic fashion e.g., `htlc_location::Bitcoin`.
+pub mod htlc_location {
+    pub use crate::ethereum::Address as Ethereum;
+    pub use bitcoin::OutPoint as Bitcoin;
+}
+
 lazy_static::lazy_static! {
     pub static ref SECP: ::bitcoin::secp256k1::Secp256k1<::bitcoin::secp256k1::All> =
         ::bitcoin::secp256k1::Secp256k1::new();

--- a/cnd/src/quickcheck.rs
+++ b/cnd/src/quickcheck.rs
@@ -11,6 +11,7 @@ use crate::{
         HashFunction, Role, SwapId,
     },
     timestamp::Timestamp,
+    transaction,
 };
 use ::bitcoin::{
     hashes::{sha256d, Hash},
@@ -186,9 +187,9 @@ impl Arbitrary for Quickcheck<crate::ethereum::H256> {
     }
 }
 
-impl Arbitrary for Quickcheck<crate::ethereum::Transaction> {
+impl Arbitrary for Quickcheck<transaction::Ethereum> {
     fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
-        Quickcheck(crate::ethereum::Transaction {
+        Quickcheck(transaction::Ethereum {
             hash: *Quickcheck::<crate::ethereum::H256>::arbitrary(g),
             nonce: *Quickcheck::<crate::ethereum::U256>::arbitrary(g),
             block_hash: Option::<Quickcheck<crate::ethereum::H256>>::arbitrary(g).map(|i| i.0),

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -2,7 +2,7 @@ use crate::{
     asset::{self},
     btsieve::{self, bitcoin::BitcoindConnector, ethereum, ethereum::Web3Connector},
     db::{AcceptedSwap, DetermineTypes, LoadAcceptedSwap, Retrieve, Save, Sqlite, Swap, SwapTypes},
-    identity,
+    htlc_location, identity,
     network::{
         ComitPeers, DialInformation, ListenAddresses, LocalPeerId, PendingRequestFor, RequestError,
         SendRequest, Swarm,
@@ -22,6 +22,7 @@ use crate::{
         },
         SwapId,
     },
+    transaction,
 };
 use async_trait::async_trait;
 use chrono::NaiveDateTime;
@@ -133,9 +134,9 @@ impl
     async fn htlc_funded(
         &self,
         htlc_params: &HtlcParams<__TYPE0__, asset::Bitcoin, identity::Bitcoin>,
-        htlc_deployment: &Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>,
+        htlc_deployment: &Deployed<transaction::Bitcoin, htlc_location::Bitcoin>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Funded<::bitcoin::Transaction, asset::Bitcoin>> {
+    ) -> anyhow::Result<Funded<transaction::Bitcoin, asset::Bitcoin>> {
         self.bitcoin_connector
             .htlc_funded(htlc_params, htlc_deployment, start_of_swap)
             .await
@@ -155,7 +156,7 @@ impl
         &self,
         htlc_params: &HtlcParams<__TYPE0__, asset::Bitcoin, identity::Bitcoin>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>> {
+    ) -> anyhow::Result<Deployed<transaction::Bitcoin, htlc_location::Bitcoin>> {
         self.bitcoin_connector
             .htlc_deployed(htlc_params, start_of_swap)
             .await
@@ -174,9 +175,9 @@ impl
     async fn htlc_redeemed(
         &self,
         htlc_params: &HtlcParams<__TYPE0__, asset::Bitcoin, identity::Bitcoin>,
-        htlc_deployment: &Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>,
+        htlc_deployment: &Deployed<transaction::Bitcoin, htlc_location::Bitcoin>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Redeemed<::bitcoin::Transaction>> {
+    ) -> anyhow::Result<Redeemed<transaction::Bitcoin>> {
         self.bitcoin_connector
             .htlc_redeemed(htlc_params, htlc_deployment, start_of_swap)
             .await
@@ -195,9 +196,9 @@ impl
     async fn htlc_refunded(
         &self,
         htlc_params: &HtlcParams<__TYPE0__, asset::Bitcoin, identity::Bitcoin>,
-        htlc_deployment: &Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>,
+        htlc_deployment: &Deployed<transaction::Bitcoin, htlc_location::Bitcoin>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Refunded<::bitcoin::Transaction>> {
+    ) -> anyhow::Result<Refunded<transaction::Bitcoin>> {
         self.bitcoin_connector
             .htlc_refunded(htlc_params, htlc_deployment, start_of_swap)
             .await
@@ -210,9 +211,9 @@ impl HtlcFunded<Ethereum, ((asset::Ether, asset::Erc20)), identity::Ethereum> fo
     async fn htlc_funded(
         &self,
         htlc_params: &HtlcParams<Ethereum, __TYPE0__, identity::Ethereum>,
-        htlc_deployment: &Deployed<crate::ethereum::Transaction, identity::Ethereum>,
+        htlc_deployment: &Deployed<transaction::Ethereum, identity::Ethereum>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Funded<crate::ethereum::Transaction, __TYPE0__>> {
+    ) -> anyhow::Result<Funded<transaction::Ethereum, __TYPE0__>> {
         self.ethereum_connector
             .htlc_funded(htlc_params, htlc_deployment, start_of_swap)
             .await
@@ -226,7 +227,7 @@ impl HtlcDeployed<Ethereum, ((asset::Ether, asset::Erc20)), identity::Ethereum> 
         &self,
         htlc_params: &HtlcParams<Ethereum, __TYPE0__, identity::Ethereum>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Deployed<crate::ethereum::Transaction, identity::Ethereum>> {
+    ) -> anyhow::Result<Deployed<transaction::Ethereum, identity::Ethereum>> {
         self.ethereum_connector
             .htlc_deployed(htlc_params, start_of_swap)
             .await
@@ -239,9 +240,9 @@ impl HtlcRedeemed<Ethereum, ((asset::Ether, asset::Erc20)), identity::Ethereum> 
     async fn htlc_redeemed(
         &self,
         htlc_params: &HtlcParams<Ethereum, __TYPE0__, identity::Ethereum>,
-        htlc_deployment: &Deployed<crate::ethereum::Transaction, identity::Ethereum>,
+        htlc_deployment: &Deployed<transaction::Ethereum, identity::Ethereum>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Redeemed<crate::ethereum::Transaction>> {
+    ) -> anyhow::Result<Redeemed<transaction::Ethereum>> {
         self.ethereum_connector
             .htlc_redeemed(htlc_params, htlc_deployment, start_of_swap)
             .await
@@ -254,9 +255,9 @@ impl HtlcRefunded<Ethereum, ((asset::Ether, asset::Erc20)), identity::Ethereum> 
     async fn htlc_refunded(
         &self,
         htlc_params: &HtlcParams<Ethereum, __TYPE0__, identity::Ethereum>,
-        htlc_deployment: &Deployed<crate::ethereum::Transaction, identity::Ethereum>,
+        htlc_deployment: &Deployed<transaction::Ethereum, identity::Ethereum>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Refunded<crate::ethereum::Transaction>> {
+    ) -> anyhow::Result<Refunded<transaction::Ethereum>> {
         self.ethereum_connector
             .htlc_refunded(htlc_params, htlc_deployment, start_of_swap)
             .await

--- a/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
@@ -68,7 +68,7 @@ where
             .expect("Deployment transaction must contain outpoint described in pattern");
 
         Ok(Deployed {
-            location: ::bitcoin::OutPoint {
+            location: htlc_location::Bitcoin {
                 txid: transaction.txid(),
                 vout,
             },

--- a/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
@@ -3,7 +3,7 @@ use crate::{
     btsieve::bitcoin::{
         matching_transaction, BitcoindConnector, Cache, TransactionExt, TransactionPattern,
     },
-    identity,
+    htlc_location, identity,
     swap_protocols::{
         ledger::bitcoin,
         rfc003::{
@@ -15,8 +15,8 @@ use crate::{
             },
         },
     },
+    transaction,
 };
-use ::bitcoin::OutPoint;
 use anyhow::Context;
 use chrono::NaiveDateTime;
 
@@ -28,9 +28,9 @@ where
     async fn htlc_funded(
         &self,
         _htlc_params: &HtlcParams<B, asset::Bitcoin, identity::Bitcoin>,
-        htlc_deployment: &Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>,
+        htlc_deployment: &Deployed<transaction::Bitcoin, htlc_location::Bitcoin>,
         _start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Funded<::bitcoin::Transaction, asset::Bitcoin>> {
+    ) -> anyhow::Result<Funded<transaction::Bitcoin, asset::Bitcoin>> {
         let tx = &htlc_deployment.transaction;
         let asset =
             asset::Bitcoin::from_sat(tx.output[htlc_deployment.location.vout as usize].value);
@@ -51,7 +51,7 @@ where
         &self,
         htlc_params: &HtlcParams<B, asset::Bitcoin, identity::Bitcoin>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>> {
+    ) -> anyhow::Result<Deployed<transaction::Bitcoin, htlc_location::Bitcoin>> {
         let connector = self.clone();
         let pattern = TransactionPattern {
             to_address: Some(htlc_params.compute_address()),
@@ -68,7 +68,7 @@ where
             .expect("Deployment transaction must contain outpoint described in pattern");
 
         Ok(Deployed {
-            location: OutPoint {
+            location: ::bitcoin::OutPoint {
                 txid: transaction.txid(),
                 vout,
             },
@@ -85,9 +85,9 @@ where
     async fn htlc_redeemed(
         &self,
         htlc_params: &HtlcParams<B, asset::Bitcoin, identity::Bitcoin>,
-        htlc_deployment: &Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>,
+        htlc_deployment: &Deployed<transaction::Bitcoin, htlc_location::Bitcoin>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Redeemed<::bitcoin::Transaction>> {
+    ) -> anyhow::Result<Redeemed<transaction::Bitcoin>> {
         let connector = self.clone();
         let pattern = TransactionPattern {
             to_address: None,
@@ -116,9 +116,9 @@ where
     async fn htlc_refunded(
         &self,
         _htlc_params: &HtlcParams<B, asset::Bitcoin, identity::Bitcoin>,
-        htlc_deployment: &Deployed<::bitcoin::Transaction, ::bitcoin::OutPoint>,
+        htlc_deployment: &Deployed<transaction::Bitcoin, htlc_location::Bitcoin>,
         start_of_swap: NaiveDateTime,
-    ) -> anyhow::Result<Refunded<::bitcoin::Transaction>> {
+    ) -> anyhow::Result<Refunded<transaction::Bitcoin>> {
         let connector = self.clone();
         let pattern = TransactionPattern {
             to_address: None,

--- a/cnd/src/swap_protocols/rfc003/create_swap.rs
+++ b/cnd/src/swap_protocols/rfc003/create_swap.rs
@@ -342,15 +342,15 @@ pub enum SwapEvent<AH, AT, BH, BT, AA, BA> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{asset, ethereum, identity};
+    use crate::{asset, ethereum, htlc_location, identity, transaction};
 
     #[test]
     fn swap_event_should_render_to_nice_string() {
         let event = SwapEvent::<
-            ::bitcoin::OutPoint,
-            ::bitcoin::Transaction,
+            htlc_location::Bitcoin,
+            transaction::Bitcoin,
             identity::Ethereum,
-            crate::ethereum::Transaction,
+            transaction::Ethereum,
             asset::Bitcoin,
             asset::Ether,
         >::BetaDeployed(Deployed {

--- a/cnd/src/swap_protocols/rfc003/ethereum/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/ethereum/mod.rs
@@ -3,6 +3,7 @@ pub mod htlc_events;
 use crate::{
     asset,
     ethereum::{Address, Bytes, Transaction},
+    identity,
     swap_protocols::{
         ledger::Ethereum,
         rfc003::{create_swap::HtlcParams, Ledger},
@@ -45,8 +46,8 @@ impl Ledger for Ethereum {
     type Transaction = Transaction;
 }
 
-impl From<HtlcParams<Ethereum, asset::Ether, crate::ethereum::Address>> for EtherHtlc {
-    fn from(htlc_params: HtlcParams<Ethereum, asset::Ether, crate::ethereum::Address>) -> Self {
+impl From<HtlcParams<Ethereum, asset::Ether, identity::Ethereum>> for EtherHtlc {
+    fn from(htlc_params: HtlcParams<Ethereum, asset::Ether, identity::Ethereum>) -> Self {
         let refund_address = blockchain_contracts::ethereum::Address(htlc_params.refund_identity.0);
         let redeem_address = blockchain_contracts::ethereum::Address(htlc_params.redeem_identity.0);
 
@@ -59,14 +60,14 @@ impl From<HtlcParams<Ethereum, asset::Ether, crate::ethereum::Address>> for Ethe
     }
 }
 
-impl HtlcParams<Ethereum, asset::Ether, crate::ethereum::Address> {
+impl HtlcParams<Ethereum, asset::Ether, identity::Ethereum> {
     pub fn bytecode(&self) -> Bytes {
         EtherHtlc::from(self.clone()).into()
     }
 }
 
-impl From<HtlcParams<Ethereum, asset::Erc20, crate::ethereum::Address>> for Erc20Htlc {
-    fn from(htlc_params: HtlcParams<Ethereum, asset::Erc20, crate::ethereum::Address>) -> Self {
+impl From<HtlcParams<Ethereum, asset::Erc20, identity::Ethereum>> for Erc20Htlc {
+    fn from(htlc_params: HtlcParams<Ethereum, asset::Erc20, identity::Ethereum>) -> Self {
         let refund_address = blockchain_contracts::ethereum::Address(htlc_params.refund_identity.0);
         let redeem_address = blockchain_contracts::ethereum::Address(htlc_params.redeem_identity.0);
         let token_contract_address =
@@ -83,7 +84,7 @@ impl From<HtlcParams<Ethereum, asset::Erc20, crate::ethereum::Address>> for Erc2
     }
 }
 
-impl HtlcParams<Ethereum, asset::Erc20, crate::ethereum::Address> {
+impl HtlcParams<Ethereum, asset::Erc20, identity::Ethereum> {
     pub fn bytecode(self) -> Bytes {
         Erc20Htlc::from(self).into()
     }


### PR DESCRIPTION
Recently we added `identity::Bitcoin` and `transaction::Bitcoin`. Add `htlc_location::Bitcoin`.

Use these modules across the codebase.

Done while working on removing Ledger trait.