### PR TITLE
Fully qualified import for os specific imports

### DIFF
--- a/cnd/src/lib.rs
+++ b/cnd/src/lib.rs
@@ -50,7 +50,6 @@ pub mod swap_protocols;
 pub mod timestamp;
 
 use anyhow::Context;
-use directories::{ProjectDirs, UserDirs};
 use std::{
     env,
     path::{Path, PathBuf},
@@ -78,7 +77,8 @@ lazy_static::lazy_static! {
 // Windows: C:\Users\<user>\AppData\Roaming\comit\config\
 // OSX: /Users/<user>/Library/Preferences/comit/
 fn config_dir() -> Option<PathBuf> {
-    ProjectDirs::from("", "", "comit").map(|proj_dirs| proj_dirs.config_dir().to_path_buf())
+    directories::ProjectDirs::from("", "", "comit")
+        .map(|proj_dirs| proj_dirs.config_dir().to_path_buf())
 }
 
 pub fn default_config_path() -> anyhow::Result<PathBuf> {
@@ -91,20 +91,22 @@ pub fn default_config_path() -> anyhow::Result<PathBuf> {
 // Windows: C:\Users\<user>\AppData\Roaming\comit\
 // OSX: /Users/<user>/Library/Application Support/comit/
 pub fn data_dir() -> Option<PathBuf> {
-    ProjectDirs::from("", "", "comit").map(|proj_dirs| proj_dirs.data_dir().to_path_buf())
+    directories::ProjectDirs::from("", "", "comit")
+        .map(|proj_dirs| proj_dirs.data_dir().to_path_buf())
 }
 
 /// Returns `/Users/[username]/Library/Application Support/Lnd/`.
 /// exists.
 #[cfg(target_os = "macos")]
 pub fn lnd_default_dir() -> Option<PathBuf> {
-    ProjectDirs::from("", "", "Lnd").map(|proj_dirs| proj_dirs.data_dir().to_path_buf())
+    directories::ProjectDirs::from("", "", "Lnd")
+        .map(|proj_dirs| proj_dirs.data_dir().to_path_buf())
 }
 
 /// Returns `~/.lnd` if $HOME exists.
 #[cfg(target_os = "linux")]
 pub fn lnd_default_dir() -> Option<PathBuf> {
-    UserDirs::new().map(|d| d.home_dir().to_path_buf().join(".lnd"))
+    directories::UserDirs::new().map(|d| d.home_dir().to_path_buf().join(".lnd"))
 }
 
 /// Returns the directory used by lnd.


### PR DESCRIPTION
I had problems with Clippy because of

```
UserDirs::new().map(|d| d.home_dir().to_path_buf().join(".lnd"))
```

The `UserDirs` import is for Linux only and that causes Clippy to complain on Mac. 
Changed all directory imports to be fully qualified in this file.