### PR TITLE
Replaced web3 types without own ones #1938

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993f74b4c99c1908d156b8d2e0fb6277736b0ecbd833982fd1241d39b2766a6"
+
+[[package]]
 name = "blake2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +398,12 @@ name = "bumpalo"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
+
+[[package]]
+name = "byte-slice-cast"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
 
 [[package]]
 name = "byte-tools"
@@ -527,13 +539,15 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "directories",
- "ethbloom",
+ "ethbloom 0.6.4",
  "fern",
+ "fixed-hash 0.5.2",
  "futures 0.1.29",
  "futures 0.3.4",
  "genawaiter",
  "hex 0.4.2",
  "http-api-problem",
+ "impl-serde 0.3.0",
  "impl-template",
  "lazy_static",
  "libp2p",
@@ -545,6 +559,7 @@ dependencies = [
  "num 0.2.1",
  "paste",
  "pem",
+ "primitive-types",
  "quickcheck",
  "rand 0.7.3",
  "regex",
@@ -777,16 +792,13 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.15.0"
+version = "0.99.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"
+checksum = "a806e96c59a76a5ba6e18735b6cf833344671e61e7863f2edb5c518ea2cac95c"
 dependencies = [
- "lazy_static",
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "regex",
- "rustc_version",
- "syn 0.15.44",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.15",
 ]
 
 [[package]]
@@ -917,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "8.0.1"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebdeeea85a6d217b9fcc862906d7e283c047e04114165c433756baf5dce00a6c"
+checksum = "965126c64662832991f5a748893577630b558e47fa94e7f35aefcd20d737cef7"
 dependencies = [
  "error-chain",
  "ethereum-types",
@@ -937,24 +949,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3932e82d64d347a045208924002930dc105a138995ccdc1479d0f05f0359f17c"
 dependencies = [
  "crunchy",
- "fixed-hash",
+ "fixed-hash 0.3.2",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.2.3",
+ "tiny-keccak 1.5.0",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cfe1c169414b709cf28aa30c74060bdb830a03a8ba473314d079ac79d80a5f"
+dependencies = [
+ "crunchy",
+ "fixed-hash 0.5.2",
+ "impl-rlp",
+ "impl-serde 0.2.3",
  "tiny-keccak 1.5.0",
 ]
 
 [[package]]
 name = "ethereum-types"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d1bc682337e2c5ec98930853674dd2b4bd5d0d246933a9e98e5280f7c76c5f"
+checksum = "ba744248e3553a393143d5ebb68939fc3a4ec0c22a269682535f5ffe7fed728c"
 dependencies = [
- "ethbloom",
- "fixed-hash",
+ "ethbloom 0.8.1",
+ "fixed-hash 0.5.2",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.2.3",
  "primitive-types",
- "uint 0.7.1",
+ "uint",
 ]
 
 [[package]]
@@ -986,6 +1011,18 @@ dependencies = [
  "rand 0.5.6",
  "rustc-hex",
  "static_assertions 0.2.5",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3367952ceb191f4ab95dd5685dc163ac539e36202f9fcfd0cb22f9f9c542fefc"
+dependencies = [
+ "byteorder 1.3.4",
+ "rand 0.7.3",
+ "rustc-hex",
+ "static_assertions 1.1.0",
 ]
 
 [[package]]
@@ -1597,11 +1634,11 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.2.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2050d823639fbeae26b2b5ba09aca8907793117324858070ade0673c49f793b"
+checksum = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
 dependencies = [
- "parity-codec",
+ "parity-scale-codec",
 ]
 
 [[package]]
@@ -1618,6 +1655,15 @@ name = "impl-serde"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58e3cae7e99c7ff5a995da2cf78dd0a5383740eda71d98cf7b1910c301ac69b8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bbe9ea9b182f0fb1cabbd61f4ff9b7b7b9197955e95a7e4c27de5055eb29ff8"
 dependencies = [
  "serde",
 ]
@@ -1696,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "11.0.0"
+version = "14.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b83fdc5e0218128d0d270f2f2e7a5ea716f3240c8518a58bc89e6716ba8581"
+checksum = "fe3b688648f1ef5d5072229e2d672ecb92cbff7d1c79bcf3fd5898f3f3df0970"
 dependencies = [
  "futures 0.1.29",
  "log 0.4.8",
@@ -1962,7 +2008,7 @@ dependencies = [
  "rand 0.7.3",
  "sha2",
  "smallvec 1.2.0",
- "uint 0.8.2",
+ "uint",
  "unsigned-varint",
  "void",
  "wasm-timer",
@@ -2230,15 +2276,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed946d4529956a20f2d63ebe1b69996d5a2137c91913fe3ebbeff957f5bca7ff"
-dependencies = [
- "scopeguard",
 ]
 
 [[package]]
@@ -2675,16 +2712,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-codec"
-version = "3.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b9df1283109f542d8852cd6b30e9341acc2137481eb6157d2e62af68b0afec9"
-dependencies = [
- "arrayvec 0.4.12",
- "serde",
-]
-
-[[package]]
 name = "parity-multiaddr"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2718,6 +2745,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "parity-scale-codec"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f747c06d9f3b2ad387ac881b9667298c81b1243aa9833f086e05996937c35507"
+dependencies = [
+ "arrayvec 0.5.1",
+ "bitvec",
+ "byte-slice-cast",
+ "serde",
+]
+
+[[package]]
 name = "parity-send-wrapper"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2725,22 +2764,11 @@ checksum = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
 
 [[package]]
 name = "parking_lot"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"
-dependencies = [
- "lock_api 0.2.0",
- "parking_lot_core 0.5.0",
- "rustc_version",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
- "lock_api 0.3.3",
+ "lock_api",
  "parking_lot_core 0.6.2",
  "rustc_version",
 ]
@@ -2751,24 +2779,8 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
 dependencies = [
- "lock_api 0.3.3",
+ "lock_api",
  "parking_lot_core 0.7.0",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb88cb1cb3790baa6776844f968fea3be44956cf184fa1be5a03341f5491278c"
-dependencies = [
- "cfg-if",
- "cloudabi",
- "libc",
- "rand 0.6.5",
- "redox_syscall",
- "rustc_version",
- "smallvec 0.6.13",
- "winapi 0.3.8",
 ]
 
 [[package]]
@@ -2901,15 +2913,15 @@ checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "primitive-types"
-version = "0.3.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2288eb2a39386c4bc817974cc413afe173010dc80e470fcb1e9a35580869f024"
+checksum = "e4336f4f5d5524fa60bcbd6fe626f9223d8142a50e7053e979acdf0da41ab975"
 dependencies = [
- "fixed-hash",
+ "fixed-hash 0.5.2",
  "impl-codec",
  "impl-rlp",
- "impl-serde",
- "uint 0.7.1",
+ "impl-serde 0.3.0",
+ "uint",
 ]
 
 [[package]]
@@ -3109,44 +3121,15 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.7",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
- "rand_chacha 0.2.1",
+ "rand_chacha",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.3.1",
+ "rand_hc",
 ]
 
 [[package]]
@@ -3185,73 +3168,11 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -4478,18 +4399,6 @@ checksum = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 
 [[package]]
 name = "uint"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2143cded94692b156c356508d92888acc824db5bffc0b4089732264c6fcf86d4"
-dependencies = [
- "byteorder 1.3.4",
- "crunchy",
- "heapsize",
- "rustc-hex",
-]
-
-[[package]]
-name = "uint"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75a4cdd7b87b28840dba13c483b9a88ee6bbf16ba5c951ee1ecfcf723078e0d"
@@ -4817,12 +4726,12 @@ dependencies = [
 
 [[package]]
 name = "web3"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076f34ed252d74a8521e3b013254b1a39f94a98f23aae7cfc85cda6e7b395664"
+checksum = "a0631c83208cf420eeb2ed9b6cb2d5fc853aa76a43619ccec2a3d52d741f1261"
 dependencies = [
- "arrayvec 0.4.12",
- "base64 0.10.1",
+ "arrayvec 0.5.1",
+ "base64 0.11.0",
  "derive_more",
  "ethabi",
  "ethereum-types",
@@ -4830,13 +4739,13 @@ dependencies = [
  "hyper 0.12.35",
  "jsonrpc-core",
  "log 0.4.8",
- "parking_lot 0.8.0",
+ "parking_lot 0.10.0",
  "rustc-hex",
  "serde",
  "serde_json",
  "tokio-core",
  "tokio-timer 0.1.2",
- "url 1.7.2",
+ "url 2.1.1",
 ]
 
 [[package]]

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -20,12 +20,14 @@ diesel_migrations = "1.4.0"
 directories = "2.0"
 ethbloom = "0.6.4"
 fern = { version = "0.5", features = ["colored"] }
+fixed-hash = { version = "0.5", default-features = false }
 futures = { version = "0.1" }
 futures-core = { version = "0.3", features = ["compat", "async-await"], default-features = false, package = "futures" }
 genawaiter = "0.99"
 hex = "0.4"
 http-api-problem = { version = "0.15", features = ["with_warp"] }
 impl-template = "1.0.0-alpha"
+impl-serde = { version = "0.3.0", default-features = false }
 lazy_static = "1"
 libp2p = { version = "0.16" }
 libp2p-comit = { path = "../libp2p-comit" }
@@ -35,6 +37,7 @@ lru = "0.4.3"
 num = "0.2"
 paste = "0.1"
 pem = "0.7"
+primitive-types = { version = "0.6", features = ["serde"] }
 rand = "0.7"
 reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }
 serde = { version = "1", features = ["derive"] }
@@ -59,7 +62,6 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 void = "1.0.2"
 warp = { version = "0.2", default-features = false }
-web3 = { version = "0.8", default-features = false, features = ["http"] }
 
 [dev-dependencies]
 base64 = "0.11"
@@ -71,3 +73,4 @@ serde_urlencoded = "0.6"
 spectral = { version = "0.6", default-features = false }
 tempfile = "3.1.0"
 testcontainers = "0.8"
+web3 = { version = "0.10", default-features = false, features = ["http"] }

--- a/cnd/src/btsieve/ethereum/mod.rs
+++ b/cnd/src/btsieve/ethereum/mod.rs
@@ -4,12 +4,11 @@ mod web3_connector;
 pub use self::{cache::Cache, web3_connector::Web3Connector};
 use crate::{
     btsieve::{BlockByHash, LatestBlock, Predates, ReceiptByHash},
-    ethereum::{Address, Bytes, IsStatusOk, Log, Transaction, TransactionReceipt, H256, U256},
+    ethereum::{Address, Bytes, IsStatusOk, Log, Transaction, TransactionReceipt, H256, U256, Input},
     Never,
 };
 use anyhow;
 use chrono::NaiveDateTime;
-use ethbloom::Input;
 use futures_core::compat::Future01CompatExt;
 use genawaiter::{
     sync::{Co, Gen},
@@ -18,7 +17,7 @@ use genawaiter::{
 use std::collections::HashSet;
 
 type Hash = H256;
-type Block = crate::ethereum::Block<Transaction>;
+type Block = crate::ethereum::Block;
 
 pub async fn watch_for_contract_creation<C>(
     blockchain_connector: C,
@@ -370,23 +369,23 @@ pub struct Topic(pub H256);
 /// ```rust, ignore
 /// 
 /// Event {
-///     address: "0xe46FB33e4DB653De84cB0E0E8b810A6c4cD39d59",
-///     topics: [
-///         None,
-///         Some("0x000000000000000000000000e46fb33e4db653de84cb0e0e8b810a6c4cd39d59"),
+/// 	address: "0xe46FB33e4DB653De84cB0E0E8b810A6c4cD39d59",
+/// 	topics: [
+/// 	    None,
+/// 	    Some("0x000000000000000000000000e46fb33e4db653de84cb0e0e8b810a6c4cd39d59"),
 ///         None,
 ///     ],
 /// }
 ///
 /// Log: {
-///     address: "0xe46FB33e4DB653De84cB0E0E8b810A6c4cD39d59",
-///     data: "0x123",
-///     topics: [
-///         "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-///         "0x000000000000000000000000e46fb33e4db653de84cb0e0e8b810a6c4cd39d59",
-///         "0x000000000000000000000000d51ecee7414c4445534f74208538683702cbb3e4",
-///     ]
-///     ...  // Other data omitted
+/// 	address: "0xe46FB33e4DB653De84cB0E0E8b810A6c4cD39d59",
+/// 	data: "0x123",
+/// 	topics: [
+/// 	    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+/// 	    "0x000000000000000000000000e46fb33e4db653de84cb0e0e8b810a6c4cd39d59",
+/// 	    "0x000000000000000000000000d51ecee7414c4445534f74208538683702cbb3e4",
+/// 	]
+/// 	...  // Other data omitted
 /// }
 /// ```
 #[derive(Clone, Default, Eq, PartialEq, serde::Serialize, serdebug::SerDebug)]

--- a/cnd/src/btsieve/ethereum/web3_connector.rs
+++ b/cnd/src/btsieve/ethereum/web3_connector.rs
@@ -1,7 +1,7 @@
 use crate::{
     btsieve::{BlockByHash, LatestBlock, ReceiptByHash},
-    ethereum::{BlockId, BlockNumber},
-    transaction,
+    ethereum::{BlockNumber},
+    transaction
 };
 use anyhow::Context;
 use futures::Future;
@@ -26,7 +26,7 @@ impl Web3Connector {
 }
 
 impl LatestBlock for Web3Connector {
-    type Block = Option<crate::ethereum::Block<transaction::Ethereum>>;
+    type Block = Option<crate::ethereum::Block>;
     type BlockHash = crate::ethereum::H256;
 
     fn latest_block(
@@ -37,7 +37,7 @@ impl LatestBlock for Web3Connector {
 
         let future = async move {
             let request = JsonRpcRequest::new("eth_getBlockByNumber", vec![
-                serialize(BlockId::Number(BlockNumber::Latest))?,
+                serialize(BlockNumber::Latest)?,
                 serialize(true)?,
             ]);
 
@@ -46,7 +46,7 @@ impl LatestBlock for Web3Connector {
                 .json(&request)
                 .send()
                 .await?
-                .json::<JsonRpcResponse<crate::ethereum::Block<transaction::Ethereum>>>()
+                .json::<JsonRpcResponse<crate::ethereum::Block>>()
                 .await?;
 
             let block = match response {
@@ -102,7 +102,7 @@ enum JsonRpcResponse<T> {
 }
 
 impl BlockByHash for Web3Connector {
-    type Block = Option<crate::ethereum::Block<transaction::Ethereum>>;
+    type Block = Option<crate::ethereum::Block>;
     type BlockHash = crate::ethereum::H256;
 
     fn block_by_hash(
@@ -123,7 +123,7 @@ impl BlockByHash for Web3Connector {
                 .json(&request)
                 .send()
                 .await?
-                .json::<JsonRpcResponse<crate::ethereum::Block<transaction::Ethereum>>>()
+                .json::<JsonRpcResponse<crate::ethereum::Block>>()
                 .await?;
 
             let block = match response {

--- a/cnd/src/ethereum/mod.rs
+++ b/cnd/src/ethereum/mod.rs
@@ -1,10 +1,63 @@
 #![warn(unused_extern_crates, missing_debug_implementations, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 
-pub use web3::types::{
-    Address, Block, BlockId, BlockNumber, Bytes, Log, Transaction, TransactionReceipt,
-    TransactionRequest, H160, H2048, H256, U128, U256,
+pub use primitive_types::{
+    H160, H256, U128, U256
 };
+
+pub use ethbloom::{Bloom as H2048, Input};
+
+use fixed_hash::*;
+use impl_serde::impl_fixed_hash_serde;
+
+use hex::{FromHex, ToHex};
+use serde::de::{Error, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+
+pub type Index = U128;
+pub type Address = H160;
+
+construct_fixed_hash! {
+    pub struct H64(8);
+}
+impl_fixed_hash_serde!(H64, 8);
+
+/// "Receipt" of an executed transaction: details of its execution.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TransactionReceipt {
+    /// Transaction hash.
+    #[serde(rename = "transactionHash")]
+    pub transaction_hash: H256,
+    /// Index within the block.
+    #[serde(rename = "transactionIndex")]
+    pub transaction_index: Index,
+    /// Hash of the block this transaction was included within.
+    #[serde(rename = "blockHash")]
+    pub block_hash: Option<H256>,
+    /// Number of the block this transaction was included within.
+    #[serde(rename = "blockNumber")]
+    pub block_number: Option<U256>,
+    /// Cumulative gas used within the block after this was executed.
+    #[serde(rename = "cumulativeGasUsed")]
+    pub cumulative_gas_used: U256,
+    /// Gas used by this transaction alone.
+    ///
+    /// Gas used is `None` if the the client is running in light client mode.
+    #[serde(rename = "gasUsed")]
+    pub gas_used: Option<U256>,
+    /// Contract address created, or `None` if not a deployment.
+    #[serde(rename = "contractAddress")]
+    pub contract_address: Option<H160>,
+    /// Logs generated within this transaction.
+    pub logs: Vec<Log>,
+    /// Status: either 1 (success) or 0 (failure).
+    pub status: Option<U256>,
+    /// Logs bloom
+    #[serde(rename = "logsBloom")]
+    pub logs_bloom: H2048,
+}
+
 
 pub trait IsStatusOk {
     fn is_status_ok(&self) -> bool;
@@ -14,5 +67,207 @@ impl IsStatusOk for TransactionReceipt {
     fn is_status_ok(&self) -> bool {
         const TRANSACTION_STATUS_OK: u32 = 1;
         self.status == Some(TRANSACTION_STATUS_OK.into())
+    }
+}
+
+/// Description of a Transaction, pending or in the chain.
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
+pub struct Transaction {
+    /// Hash
+    pub hash: H256,
+    /// Nonce
+    pub nonce: U256,
+    /// Block hash. None when pending.
+    #[serde(rename = "blockHash")]
+    pub block_hash: Option<H256>,
+    /// Block number. None when pending.
+    #[serde(rename = "blockNumber")]
+    pub block_number: Option<U256>,
+    /// Transaction Index. None when pending.
+    #[serde(rename = "transactionIndex")]
+    pub transaction_index: Option<Index>,
+    /// Sender
+    pub from: H160,
+    /// Recipient (None when contract creation)
+    pub to: Option<H160>,
+    /// Transfered value
+    pub value: U256,
+    /// Gas Price
+    #[serde(rename = "gasPrice")]
+    pub gas_price: U256,
+    /// Gas amount
+    pub gas: U256,
+    /// Input data
+    pub input: Bytes,
+}
+
+/// A log produced by a transaction.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Log {
+    /// H160
+    pub address: H160,
+    /// Topics
+    pub topics: Vec<H256>,
+    /// Data
+    pub data: Bytes,
+    /// Block Hash
+    #[serde(rename = "blockHash")]
+    pub block_hash: Option<H256>,
+    /// Block Number
+    #[serde(rename = "blockNumber")]
+    pub block_number: Option<U256>,
+    /// Transaction Hash
+    #[serde(rename = "transactionHash")]
+    pub transaction_hash: Option<H256>,
+    /// Transaction Index
+    #[serde(rename = "transactionIndex")]
+    pub transaction_index: Option<U256>,
+    /// Log Index in Block
+    #[serde(rename = "logIndex")]
+    pub log_index: Option<U256>,
+    /// Log Index in Transaction
+    #[serde(rename = "transactionLogIndex")]
+    pub transaction_log_index: Option<u64>,
+    /// Log Type
+    #[serde(rename = "logType")]
+    pub log_type: Option<String>,
+    /// Removed
+    pub removed: Option<bool>,
+}
+
+/// The block returned from RPC calls.
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
+pub struct Block {
+    /// Hash of the block
+    pub hash: Option<H256>,
+    /// Hash of the parent
+    #[serde(rename = "parentHash")]
+    pub parent_hash: H256,
+    /// Hash of the uncles
+    #[serde(rename = "sha3Uncles")]
+    pub uncles_hash: H256,
+    /// Miner/author's address.
+    #[serde(rename = "miner")]
+    pub author: H160,
+    /// State root hash
+    #[serde(rename = "stateRoot")]
+    pub state_root: H256,
+    /// Transactions root hash
+    #[serde(rename = "transactionsRoot")]
+    pub transactions_root: H256,
+    /// Transactions receipts root hash
+    #[serde(rename = "receiptsRoot")]
+    pub receipts_root: H256,
+    /// Block number. None if pending.
+    pub number: Option<U128>,
+    /// Gas Used
+    #[serde(rename = "gasUsed")]
+    pub gas_used: U256,
+    /// Gas Limit
+    #[serde(rename = "gasLimit")]
+    pub gas_limit: U256,
+    /// Extra data
+    #[serde(rename = "extraData")]
+    pub extra_data: Bytes,
+    /// Logs bloom
+    #[serde(rename = "logsBloom")]
+    pub logs_bloom: H2048,
+    /// Timestamp
+    pub timestamp: U256,
+    /// Difficulty
+    pub difficulty: U256,
+    /// Total difficulty
+    #[serde(rename = "totalDifficulty")]
+    pub total_difficulty: U256,
+    /// Seal fields
+    #[serde(default, rename = "sealFields")]
+    pub seal_fields: Vec<Bytes>,
+    /// Uncles' hashes
+    pub uncles: Vec<H256>,
+    /// Transactions
+    pub transactions: Vec<Transaction>,
+    /// Size in bytes
+    pub size: Option<U256>,
+    /// Mix Hash
+    #[serde(rename = "mixHash")]
+    pub mix_hash: Option<H256>,
+    /// Nonce
+    pub nonce: Option<H64>,
+}
+
+/// Block Number
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BlockNumber {
+    Latest
+}
+
+impl Serialize for BlockNumber {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+    {
+        match *self {
+            BlockNumber::Latest => serializer.serialize_str("latest"),
+        }
+    }
+}
+
+/// Raw bytes wrapper
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Bytes(pub Vec<u8>);
+
+impl<T: Into<Vec<u8>>> From<T> for Bytes {
+    fn from(data: T) -> Self {
+        Bytes(data.into())
+    }
+}
+
+impl Serialize for Bytes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+    {
+        let mut serialized = "0x".to_owned();
+        serialized.push_str(self.0.encode_hex::<String>().as_ref());
+        serializer.serialize_str(serialized.as_ref())
+    }
+}
+
+impl<'a> Deserialize<'a> for Bytes {
+    fn deserialize<D>(deserializer: D) -> Result<Bytes, D::Error>
+        where
+            D: Deserializer<'a>,
+    {
+        deserializer.deserialize_identifier(BytesVisitor)
+    }
+}
+
+struct BytesVisitor;
+
+impl<'a> Visitor<'a> for BytesVisitor {
+    type Value = Bytes;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "a 0x-prefixed hex-encoded vector of bytes")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: Error,
+    {
+        if value.len() >= 2 && &value[0..2] == "0x" && value.len() & 1 == 0 {
+            Ok(Bytes(
+                FromHex::from_hex(&value[2..]).map_err(|_| Error::custom("invalid hex"))?,
+            ))
+        } else {
+            Err(Error::custom("invalid format"))
+        }
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+        where
+            E: Error,
+    {
+        self.visit_str(value.as_ref())
     }
 }

--- a/cnd/tests/ethereum_go_back_into_the_past.rs
+++ b/cnd/tests/ethereum_go_back_into_the_past.rs
@@ -9,7 +9,7 @@ use ethereum_helper::EthereumConnectorMock;
 
 #[tokio::test]
 async fn find_transaction_go_back_into_the_past() {
-    let block1_with_transaction: Block<Transaction> = include_json_test_data!(
+    let block1_with_transaction: Block = include_json_test_data!(
         "./test_data/ethereum/find_transaction_go_back_into_the_past/block1_with_transaction.json"
     );
     let want_transaction: Transaction = include_json_test_data!(

--- a/cnd/tests/ethereum_helper/connector_mock.rs
+++ b/cnd/tests/ethereum_helper/connector_mock.rs
@@ -1,6 +1,6 @@
 use cnd::{
     btsieve::{BlockByHash, LatestBlock, ReceiptByHash},
-    ethereum::{Block, Transaction, TransactionReceipt, H256},
+    ethereum::{Block, TransactionReceipt, H256},
 };
 use futures::{future::IntoFuture, Future};
 use std::{
@@ -10,8 +10,8 @@ use std::{
 
 #[derive(Clone)]
 pub struct EthereumConnectorMock {
-    all_blocks: HashMap<H256, Block<Transaction>>,
-    latest_blocks: Vec<Block<Transaction>>,
+    all_blocks: HashMap<H256, Block>,
+    latest_blocks: Vec<Block>,
     receipts: HashMap<H256, TransactionReceipt>,
     latest_time_return_block: Instant,
     current_latest_block_index: usize,
@@ -19,8 +19,8 @@ pub struct EthereumConnectorMock {
 
 impl EthereumConnectorMock {
     pub fn new(
-        latest_blocks: impl IntoIterator<Item = Block<Transaction>>,
-        all_blocks: impl IntoIterator<Item = Block<Transaction>>,
+        latest_blocks: impl IntoIterator<Item = Block>,
+        all_blocks: impl IntoIterator<Item = Block>,
         receipts: Vec<(H256, TransactionReceipt)>,
     ) -> Self {
         let all_blocks = all_blocks
@@ -43,7 +43,7 @@ impl EthereumConnectorMock {
 }
 
 impl LatestBlock for EthereumConnectorMock {
-    type Block = Option<Block<Transaction>>;
+    type Block = Option<Block>;
     type BlockHash = H256;
 
     fn latest_block(
@@ -69,7 +69,7 @@ impl LatestBlock for EthereumConnectorMock {
 }
 
 impl BlockByHash for EthereumConnectorMock {
-    type Block = Option<Block<Transaction>>;
+    type Block = Option<Block>;
     type BlockHash = H256;
 
     fn block_by_hash(

--- a/cnd/tests/ethereum_missed_previous_latest_block.rs
+++ b/cnd/tests/ethereum_missed_previous_latest_block.rs
@@ -40,7 +40,7 @@ async fn find_transaction_missed_previous_latest_block_single_block_gap() {
         ],
         vec![(want_transaction.hash, want_receipt.clone())],
     );
-    let block2: Block<Transaction> = include_json_test_data!(
+    let block2: Block = include_json_test_data!(
         "./test_data/ethereum/find_transaction_missed_previous_latest_block/block2.json"
     );
     let start_of_swap = NaiveDateTime::from_timestamp(block2.timestamp.as_u32() as i64, 0);
@@ -94,7 +94,7 @@ async fn find_transaction_missed_previous_latest_block_two_block_gap() {
         ],
         vec![(want_transaction.hash, want_receipt.clone())],
     );
-    let block2: Block<Transaction> = include_json_test_data!(
+    let block2: Block = include_json_test_data!(
         "./test_data/ethereum/find_transaction_missed_previous_latest_block/block2.json"
     );
     let start_of_swap = NaiveDateTime::from_timestamp(block2.timestamp.as_u32() as i64, 0);

--- a/cnd/tests/ethereum_transaction_matching_smoke_test.rs
+++ b/cnd/tests/ethereum_transaction_matching_smoke_test.rs
@@ -1,7 +1,7 @@
 use chrono::offset::Utc;
 use cnd::{
     btsieve::ethereum::{matching_transaction_and_receipt, Web3Connector},
-    ethereum::{TransactionRequest, U256},
+    ethereum::{U256},
 };
 use futures_core::compat::Future01CompatExt;
 use reqwest::Url;
@@ -10,6 +10,7 @@ use testcontainers::*;
 use web3::{
     transports::{EventLoopHandle, Http},
     Web3,
+    types::TransactionRequest
 };
 
 /// A very basic e2e test that verifies that we glued all our code together


### PR DESCRIPTION
Moved the web3 dependency to dev-dependencies and created copies of
those types in the ethereum module.

Fixes #1938.