### PR TITLE
Properly wait for cnds to start up and accept requests

### DIFF
--- a/api_tests/lib/cnd/cnd_instance.ts
+++ b/api_tests/lib/cnd/cnd_instance.ts
@@ -5,7 +5,7 @@ import tempWrite from "temp-write";
 import { promisify } from "util";
 import { CndConfigFile, E2ETestActorConfig } from "../config";
 import { LedgerConfig } from "../ledgers/ledger_runner";
-import { HarnessGlobal } from "../utils";
+import { HarnessGlobal, sleep } from "../utils";
 import path from "path";
 import { LogReader } from "../ledgers/log_reader";
 
@@ -77,6 +77,9 @@ export class CndInstance {
 
         const logReader = new LogReader(logFile);
         await logReader.waitForLogMessage("Starting HTTP server on");
+
+        // we emit the log _before_ we start the http server, let's make sure it actually starts up
+        await sleep(1000);
     }
 
     public stop() {

--- a/api_tests/lib/cnd/cnd_instance.ts
+++ b/api_tests/lib/cnd/cnd_instance.ts
@@ -5,7 +5,9 @@ import tempWrite from "temp-write";
 import { promisify } from "util";
 import { CndConfigFile, E2ETestActorConfig } from "../config";
 import { LedgerConfig } from "../ledgers/ledger_runner";
-import { HarnessGlobal, sleep } from "../utils";
+import { HarnessGlobal } from "../utils";
+import path from "path";
+import { LogReader } from "../ledgers/log_reader";
 
 declare var global: HarnessGlobal;
 
@@ -44,18 +46,17 @@ export class CndInstance {
             "config.toml"
         );
 
+        const logFile = path.join(
+            this.logDir,
+            `cnd-${this.actorConfig.name}.log`
+        );
+
         this.process = spawn(bin, ["--config", configFile], {
             cwd: this.projectRoot,
             stdio: [
                 "ignore", // stdin
-                await openAsync(
-                    this.logDir + "/cnd-" + this.actorConfig.name + ".log",
-                    "w"
-                ), // stdout
-                await openAsync(
-                    this.logDir + "/cnd-" + this.actorConfig.name + ".log",
-                    "w"
-                ), // stderr
+                await openAsync(logFile, "w"), // stdout
+                await openAsync(logFile, "w"), // stderr
             ],
         });
 
@@ -74,7 +75,8 @@ export class CndInstance {
             }
         });
 
-        await sleep(1000); // allow the nodes to start up
+        const logReader = new LogReader(logFile);
+        await logReader.waitForLogMessage("Starting HTTP server on");
     }
 
     public stop() {


### PR DESCRIPTION
Found this while debugging #2132. 

It is not fully going to solve it but help resilience of the test suite in general.