### PR TITLE
Replaced web3 types without own ones #1938

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,7 @@ dependencies = [
  "num 0.2.1",
  "paste",
  "pem",
+ "primitive-types",
  "quickcheck",
  "rand 0.7.3",
  "regex",

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -35,6 +35,7 @@ lru = "0.4.3"
 num = "0.2"
 paste = "0.1"
 pem = "0.7"
+primitive-types = { version = "0.3.0", features = ["serde"] }
 rand = "0.7"
 reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }
 serde = { version = "1", features = ["derive"] }
@@ -59,7 +60,6 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 void = "1.0.2"
 warp = { version = "0.2", default-features = false }
-web3 = { version = "0.8", default-features = false, features = ["http"] }
 
 [dev-dependencies]
 base64 = "0.11"
@@ -71,3 +71,4 @@ serde_urlencoded = "0.6"
 spectral = { version = "0.6", default-features = false }
 tempfile = "3.1.0"
 testcontainers = "0.8"
+web3 = { version = "0.8", default-features = false, features = ["http"] }

--- a/cnd/src/btsieve/ethereum/mod.rs
+++ b/cnd/src/btsieve/ethereum/mod.rs
@@ -4,12 +4,13 @@ mod web3_connector;
 pub use self::{cache::Cache, web3_connector::Web3Connector};
 use crate::{
     btsieve::{BlockByHash, LatestBlock, Predates, ReceiptByHash},
-    ethereum::{Address, Bytes, IsStatusOk, Log, Transaction, TransactionReceipt, H256, U256},
+    ethereum::{
+        Address, Bytes, Input, IsStatusOk, Log, Transaction, TransactionReceipt, H256, U256,
+    },
     Never,
 };
 use anyhow;
 use chrono::NaiveDateTime;
-use ethbloom::Input;
 use futures_core::compat::Future01CompatExt;
 use genawaiter::{
     sync::{Co, Gen},
@@ -18,7 +19,7 @@ use genawaiter::{
 use std::collections::HashSet;
 
 type Hash = H256;
-type Block = crate::ethereum::Block<Transaction>;
+type Block = crate::ethereum::Block;
 
 pub async fn watch_for_contract_creation<C>(
     blockchain_connector: C,

--- a/cnd/src/btsieve/ethereum/web3_connector.rs
+++ b/cnd/src/btsieve/ethereum/web3_connector.rs
@@ -1,7 +1,6 @@
 use crate::{
     btsieve::{BlockByHash, LatestBlock, ReceiptByHash},
-    ethereum::{BlockId, BlockNumber},
-    transaction,
+    ethereum::BlockNumber,
 };
 use anyhow::Context;
 use futures::Future;
@@ -26,7 +25,7 @@ impl Web3Connector {
 }
 
 impl LatestBlock for Web3Connector {
-    type Block = Option<crate::ethereum::Block<transaction::Ethereum>>;
+    type Block = Option<crate::ethereum::Block>;
     type BlockHash = crate::ethereum::H256;
 
     fn latest_block(
@@ -37,7 +36,7 @@ impl LatestBlock for Web3Connector {
 
         let future = async move {
             let request = JsonRpcRequest::new("eth_getBlockByNumber", vec![
-                serialize(BlockId::Number(BlockNumber::Latest))?,
+                serialize(BlockNumber::Latest)?,
                 serialize(true)?,
             ]);
 
@@ -46,7 +45,7 @@ impl LatestBlock for Web3Connector {
                 .json(&request)
                 .send()
                 .await?
-                .json::<JsonRpcResponse<crate::ethereum::Block<transaction::Ethereum>>>()
+                .json::<JsonRpcResponse<crate::ethereum::Block>>()
                 .await?;
 
             let block = match response {
@@ -102,7 +101,7 @@ enum JsonRpcResponse<T> {
 }
 
 impl BlockByHash for Web3Connector {
-    type Block = Option<crate::ethereum::Block<transaction::Ethereum>>;
+    type Block = Option<crate::ethereum::Block>;
     type BlockHash = crate::ethereum::H256;
 
     fn block_by_hash(
@@ -123,7 +122,7 @@ impl BlockByHash for Web3Connector {
                 .json(&request)
                 .send()
                 .await?
-                .json::<JsonRpcResponse<crate::ethereum::Block<transaction::Ethereum>>>()
+                .json::<JsonRpcResponse<crate::ethereum::Block>>()
                 .await?;
 
             let block = match response {

--- a/cnd/src/ethereum/hex_serde/mod.rs
+++ b/cnd/src/ethereum/hex_serde/mod.rs
@@ -1,0 +1,47 @@
+use hex::{FromHex, FromHexError};
+use serde::{de, de::Visitor, Deserializer};
+use std::{fmt, marker::PhantomData};
+
+/// A deserializer for 0x prefixed hex-strings
+pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: FromHex<Error = FromHexError>,
+{
+    struct HexVisitor<T>(PhantomData<T>);
+
+    impl<'de, T> Visitor<'de> for HexVisitor<T>
+    where
+        T: FromHex<Error = FromHexError>,
+    {
+        type Value = T;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(formatter, "a 0x-prefixed hex-string")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<T, E>
+        where
+            E: de::Error,
+        {
+            if v.len() >= 2 && &v[0..2] == "0x" {
+                T::from_hex(&v[2..]).map_err(|e| match e {
+                    FromHexError::InvalidHexCharacter { c, index } => E::invalid_value(
+                        de::Unexpected::Char(c),
+                        &format!("Unexpected character {:?} as position {}", c, index).as_str(),
+                    ),
+                    FromHexError::InvalidStringLength => {
+                        E::invalid_length(v.len(), &"Unexpected length of hex string")
+                    }
+                    FromHexError::OddLength => {
+                        E::invalid_length(v.len(), &"Odd length of hex string")
+                    }
+                })
+            } else {
+                Err(serde::de::Error::custom("invalid format"))
+            }
+        }
+    }
+
+    deserializer.deserialize_str(HexVisitor(PhantomData))
+}

--- a/cnd/src/ethereum/mod.rs
+++ b/cnd/src/ethereum/mod.rs
@@ -1,10 +1,59 @@
 #![warn(unused_extern_crates, missing_debug_implementations, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 
-pub use web3::types::{
-    Address, Block, BlockId, BlockNumber, Bytes, Log, Transaction, TransactionReceipt,
-    TransactionRequest, H160, H2048, H256, U128, U256,
+pub use primitive_types::{H160, H256, U128, U256};
+
+pub use ethbloom::{Bloom as H2048, Input};
+
+use hex::{FromHex, ToHex};
+use serde::{
+    de::{Error, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
 };
+use std::fmt;
+
+mod hex_serde;
+
+pub type Index = U128;
+pub type Address = H160;
+
+#[derive(Debug, Default, Copy, Clone, PartialEq, Deserialize)]
+pub struct H64(#[serde(with = "hex_serde")] [u8; 8]);
+
+/// "Receipt" of an executed transaction: details of its execution.
+#[derive(Debug, Default, Clone, PartialEq, Deserialize)]
+pub struct TransactionReceipt {
+    /// Transaction hash.
+    #[serde(rename = "transactionHash")]
+    pub transaction_hash: H256,
+    /// Index within the block.
+    #[serde(rename = "transactionIndex")]
+    pub transaction_index: Index,
+    /// Hash of the block this transaction was included within.
+    #[serde(rename = "blockHash")]
+    pub block_hash: H256,
+    /// Number of the block this transaction was included within.
+    #[serde(rename = "blockNumber")]
+    pub block_number: U256,
+    /// Cumulative gas used within the block after this was executed.
+    #[serde(rename = "cumulativeGasUsed")]
+    pub cumulative_gas_used: U256,
+    /// Gas used by this transaction alone.
+    ///
+    /// Gas used is `None` if the the client is running in light client mode.
+    #[serde(rename = "gasUsed")]
+    pub gas_used: U256,
+    /// Contract address created, or `None` if not a deployment.
+    #[serde(rename = "contractAddress")]
+    pub contract_address: Option<H160>,
+    /// Logs generated within this transaction.
+    pub logs: Vec<Log>,
+    /// Status: either 1 (success) or 0 (failure).
+    pub status: U256,
+    /// Logs bloom
+    #[serde(rename = "logsBloom")]
+    pub logs_bloom: H2048,
+}
 
 pub trait IsStatusOk {
     fn is_status_ok(&self) -> bool;
@@ -13,6 +62,224 @@ pub trait IsStatusOk {
 impl IsStatusOk for TransactionReceipt {
     fn is_status_ok(&self) -> bool {
         const TRANSACTION_STATUS_OK: u32 = 1;
-        self.status == Some(TRANSACTION_STATUS_OK.into())
+        self.status == TRANSACTION_STATUS_OK.into()
+    }
+}
+
+/// Description of a Transaction, pending or in the chain.
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
+pub struct Transaction {
+    /// Hash
+    pub hash: H256,
+    /// Nonce
+    pub nonce: U256,
+    /// Block hash. None when pending.
+    #[serde(rename = "blockHash")]
+    pub block_hash: H256,
+    /// Block number. None when pending.
+    #[serde(rename = "blockNumber")]
+    pub block_number: U256,
+    /// Transaction Index. None when pending.
+    #[serde(rename = "transactionIndex")]
+    pub transaction_index: Index,
+    /// Sender
+    pub from: H160,
+    /// Recipient (None when contract creation)
+    pub to: Option<H160>,
+    /// Transfered value
+    pub value: U256,
+    /// Gas Price
+    #[serde(rename = "gasPrice")]
+    pub gas_price: U256,
+    /// Gas amount
+    pub gas: U256,
+    /// Input data
+    pub input: Bytes,
+}
+
+/// A log produced by a transaction.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct Log {
+    /// H160
+    pub address: H160,
+    /// Topics
+    pub topics: Vec<H256>,
+    /// Data
+    pub data: Bytes,
+    /// Block Hash
+    #[serde(rename = "blockHash")]
+    pub block_hash: Option<H256>,
+    /// Block Number
+    #[serde(rename = "blockNumber")]
+    pub block_number: Option<U256>,
+    /// Transaction Hash
+    #[serde(rename = "transactionHash")]
+    pub transaction_hash: Option<H256>,
+    /// Transaction Index
+    #[serde(rename = "transactionIndex")]
+    pub transaction_index: Option<U256>,
+}
+
+/// The block returned from RPC calls.
+#[derive(Debug, Default, Clone, PartialEq, Deserialize)]
+pub struct Block {
+    /// Hash of the block
+    pub hash: Option<H256>,
+    /// Hash of the parent
+    #[serde(rename = "parentHash")]
+    pub parent_hash: H256,
+    /// Hash of the uncles
+    #[serde(rename = "sha3Uncles")]
+    pub uncles_hash: H256,
+    /// Miner/author's address.
+    #[serde(rename = "miner")]
+    pub author: H160,
+    /// State root hash
+    #[serde(rename = "stateRoot")]
+    pub state_root: H256,
+    /// Transactions root hash
+    #[serde(rename = "transactionsRoot")]
+    pub transactions_root: H256,
+    /// Transactions receipts root hash
+    #[serde(rename = "receiptsRoot")]
+    pub receipts_root: H256,
+    /// Block number. None if pending.
+    pub number: Option<U128>,
+    /// Gas Used
+    #[serde(rename = "gasUsed")]
+    pub gas_used: U256,
+    /// Gas Limit
+    #[serde(rename = "gasLimit")]
+    pub gas_limit: U256,
+    /// Extra data
+    #[serde(rename = "extraData")]
+    pub extra_data: Bytes,
+    /// Logs bloom
+    #[serde(rename = "logsBloom")]
+    pub logs_bloom: H2048,
+    /// Timestamp
+    pub timestamp: U256,
+    /// Difficulty
+    pub difficulty: U256,
+    /// Total difficulty
+    #[serde(rename = "totalDifficulty")]
+    pub total_difficulty: U256,
+    /// Seal fields
+    #[serde(default, rename = "sealFields")]
+    pub seal_fields: Vec<Bytes>,
+    /// Uncles' hashes
+    pub uncles: Vec<H256>,
+    /// Transactions
+    pub transactions: Vec<Transaction>,
+    /// Size in bytes
+    pub size: Option<U256>,
+    /// Mix Hash
+    #[serde(rename = "mixHash")]
+    pub mix_hash: Option<H256>,
+    /// Nonce
+    pub nonce: Option<H64>,
+}
+
+/// Used to specify a block. Can currently only specify the latest block but
+/// other variants can be added as required
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BlockNumber {
+    Latest,
+}
+
+impl Serialize for BlockNumber {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match *self {
+            BlockNumber::Latest => serializer.serialize_str("latest"),
+        }
+    }
+}
+
+/// Raw bytes wrapper
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Bytes(pub Vec<u8>);
+
+impl<T: Into<Vec<u8>>> From<T> for Bytes {
+    fn from(data: T) -> Self {
+        Bytes(data.into())
+    }
+}
+
+impl Serialize for Bytes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serialized = "0x".to_owned();
+        serialized.push_str(self.0.encode_hex::<String>().as_ref());
+        serializer.serialize_str(serialized.as_ref())
+    }
+}
+
+impl<'a> Deserialize<'a> for Bytes {
+    fn deserialize<D>(deserializer: D) -> Result<Bytes, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        deserializer.deserialize_identifier(BytesVisitor)
+    }
+}
+
+struct BytesVisitor;
+
+impl<'a> Visitor<'a> for BytesVisitor {
+    type Value = Bytes;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "a 0x-prefixed hex-encoded vector of bytes")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        if value.len() >= 2 && &value[0..2] == "0x" && value.len() & 1 == 0 {
+            Ok(Bytes(
+                FromHex::from_hex(&value[2..]).map_err(|_| Error::custom("invalid hex"))?,
+            ))
+        } else {
+            Err(Error::custom("invalid format"))
+        }
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        self.visit_str(value.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Log;
+    #[test]
+    fn deserialise_log() {
+        let json = r#"
+            {
+                "address": "0xc5549e335b2786520f4c5d706c76c9ee69d0a028",
+                "blockHash": "0x3ae3b6ffb04204f52dee42000e8b971c0f7c2b4aa8dd9455e41a30ee4b31e8a9",
+                "blockNumber": "0x856ca0",
+                "data": "0x0000000000000000000000000000000000000000000000000000000ba43b7400",
+                "logIndex": "0x81",
+                "removed": false,
+                "topics": [
+                    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                    "0x000000000000000000000000fb303a1fba5b4804863131145bc27256d3ab6692",
+                    "0x000000000000000000000000d50fb7d948426633ec126aeea140ce4dd0979682"
+                ],
+                "transactionHash": "0x5ffd218c617f76c73aa49ee636027440b58eb022778c5e75794563c0d60fcb88",
+                "transactionIndex": "0x93"
+            }"#;
+
+        let _: Log = serde_json::from_str(json).unwrap();
     }
 }

--- a/cnd/src/quickcheck.rs
+++ b/cnd/src/quickcheck.rs
@@ -192,10 +192,9 @@ impl Arbitrary for Quickcheck<transaction::Ethereum> {
         Quickcheck(transaction::Ethereum {
             hash: *Quickcheck::<crate::ethereum::H256>::arbitrary(g),
             nonce: *Quickcheck::<crate::ethereum::U256>::arbitrary(g),
-            block_hash: Option::<Quickcheck<crate::ethereum::H256>>::arbitrary(g).map(|i| i.0),
-            block_number: Option::<Quickcheck<crate::ethereum::U256>>::arbitrary(g).map(|i| i.0),
-            transaction_index: Option::<Quickcheck<crate::ethereum::U128>>::arbitrary(g)
-                .map(|i| i.0),
+            block_hash: *Quickcheck::<crate::ethereum::H256>::arbitrary(g),
+            block_number: *Quickcheck::<crate::ethereum::U256>::arbitrary(g),
+            transaction_index: *Quickcheck::<crate::ethereum::U128>::arbitrary(g),
             from: *Quickcheck::<crate::ethereum::H160>::arbitrary(g),
             to: Option::<Quickcheck<crate::ethereum::H160>>::arbitrary(g).map(|i| i.0),
             value: *Quickcheck::<crate::ethereum::U256>::arbitrary(g),

--- a/cnd/tests/ethereum_go_back_into_the_past.rs
+++ b/cnd/tests/ethereum_go_back_into_the_past.rs
@@ -9,7 +9,7 @@ use ethereum_helper::EthereumConnectorMock;
 
 #[tokio::test]
 async fn find_transaction_go_back_into_the_past() {
-    let block1_with_transaction: Block<Transaction> = include_json_test_data!(
+    let block1_with_transaction: Block = include_json_test_data!(
         "./test_data/ethereum/find_transaction_go_back_into_the_past/block1_with_transaction.json"
     );
     let want_transaction: Transaction = include_json_test_data!(

--- a/cnd/tests/ethereum_helper/connector_mock.rs
+++ b/cnd/tests/ethereum_helper/connector_mock.rs
@@ -1,6 +1,6 @@
 use cnd::{
     btsieve::{BlockByHash, LatestBlock, ReceiptByHash},
-    ethereum::{Block, Transaction, TransactionReceipt, H256},
+    ethereum::{Block, TransactionReceipt, H256},
 };
 use futures::{future::IntoFuture, Future};
 use std::{
@@ -10,8 +10,8 @@ use std::{
 
 #[derive(Clone)]
 pub struct EthereumConnectorMock {
-    all_blocks: HashMap<H256, Block<Transaction>>,
-    latest_blocks: Vec<Block<Transaction>>,
+    all_blocks: HashMap<H256, Block>,
+    latest_blocks: Vec<Block>,
     receipts: HashMap<H256, TransactionReceipt>,
     latest_time_return_block: Instant,
     current_latest_block_index: usize,
@@ -19,8 +19,8 @@ pub struct EthereumConnectorMock {
 
 impl EthereumConnectorMock {
     pub fn new(
-        latest_blocks: impl IntoIterator<Item = Block<Transaction>>,
-        all_blocks: impl IntoIterator<Item = Block<Transaction>>,
+        latest_blocks: impl IntoIterator<Item = Block>,
+        all_blocks: impl IntoIterator<Item = Block>,
         receipts: Vec<(H256, TransactionReceipt)>,
     ) -> Self {
         let all_blocks = all_blocks
@@ -43,7 +43,7 @@ impl EthereumConnectorMock {
 }
 
 impl LatestBlock for EthereumConnectorMock {
-    type Block = Option<Block<Transaction>>;
+    type Block = Option<Block>;
     type BlockHash = H256;
 
     fn latest_block(
@@ -69,7 +69,7 @@ impl LatestBlock for EthereumConnectorMock {
 }
 
 impl BlockByHash for EthereumConnectorMock {
-    type Block = Option<Block<Transaction>>;
+    type Block = Option<Block>;
     type BlockHash = H256;
 
     fn block_by_hash(

--- a/cnd/tests/ethereum_missed_previous_latest_block.rs
+++ b/cnd/tests/ethereum_missed_previous_latest_block.rs
@@ -40,7 +40,7 @@ async fn find_transaction_missed_previous_latest_block_single_block_gap() {
         ],
         vec![(want_transaction.hash, want_receipt.clone())],
     );
-    let block2: Block<Transaction> = include_json_test_data!(
+    let block2: Block = include_json_test_data!(
         "./test_data/ethereum/find_transaction_missed_previous_latest_block/block2.json"
     );
     let start_of_swap = NaiveDateTime::from_timestamp(block2.timestamp.as_u32() as i64, 0);
@@ -94,7 +94,7 @@ async fn find_transaction_missed_previous_latest_block_two_block_gap() {
         ],
         vec![(want_transaction.hash, want_receipt.clone())],
     );
-    let block2: Block<Transaction> = include_json_test_data!(
+    let block2: Block = include_json_test_data!(
         "./test_data/ethereum/find_transaction_missed_previous_latest_block/block2.json"
     );
     let start_of_swap = NaiveDateTime::from_timestamp(block2.timestamp.as_u32() as i64, 0);

--- a/cnd/tests/ethereum_transaction_matching_smoke_test.rs
+++ b/cnd/tests/ethereum_transaction_matching_smoke_test.rs
@@ -1,7 +1,7 @@
 use chrono::offset::Utc;
 use cnd::{
     btsieve::ethereum::{matching_transaction_and_receipt, Web3Connector},
-    ethereum::{TransactionRequest, U256},
+    ethereum::U256,
 };
 use futures_core::compat::Future01CompatExt;
 use reqwest::Url;
@@ -9,6 +9,7 @@ use std::time::Duration;
 use testcontainers::*;
 use web3::{
     transports::{EventLoopHandle, Http},
+    types::TransactionRequest,
     Web3,
 };
 


### PR DESCRIPTION
Moved the web3 dependency to dev-dependencies and created copies of
those types in the ethereum module

I tried to remove the ethbloom and primitive type dependencies as well but it will require a fair bit of work to replace H256, ethbloom, H160, U128, U256.
