### PR TITLE
Upgrade node to version 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,9 +78,9 @@ commands:
             curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
             curl -sL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
             echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-            echo "deb https://deb.nodesource.com/node_10.x/ trusty main" | sudo tee /etc/apt/sources.list.d/node_10.list
+            echo "deb https://deb.nodesource.com/node_12.x/ trusty main" | sudo tee /etc/apt/sources.list.d/node_12.list
             sudo apt-get update
-            sudo apt-get install -y nodejs=10.* yarn
+            sudo apt-get install -y nodejs=12.* yarn
   install_rust:
     steps:
       - run:

--- a/api_tests/package.json
+++ b/api_tests/package.json
@@ -11,7 +11,7 @@
         "fix": "tslint --project . --fix && prettier --write '**/*.{ts,js,json,yml}'"
     },
     "engines": {
-        "node": "^10.14"
+        "node": "^12"
     },
     "author": "CoBloX Team",
     "license": "ISC",


### PR DESCRIPTION
@thomaseizinger found an issue describing incompatibility of the node version we are using on circleCI and jest: https://github.com/facebook/jest/issues/9453.

The tests are running locally. So let's upgrade circleCI as well. 