### PR TITLE
Re-enable most of the disabled dependencies for dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,26 +10,12 @@ update_configs:
           update_type: "all"
           dependency_type: "direct"
     ignored_updates:
-      # as per https://github.com/comit-network/comit-rs/issues/1316
-      - match:
-          dependency_name: "primitive-types"
-      - match:
-          dependency_name: "rlp"
-      # we only depend on ethbloom to access certain types. our version needs to match whichever version web3 is transitively bringing in
-      - match:
-          dependency_name: "ethbloom"
       # we only depend on `libsqlite3-sys` directly to activate the "bundled" feature. the version we are using has to match the one that diesel is depending on, hence bumping it manually is pointless.
       - match:
           dependency_name: "libsqlite3-sys"
-      # this needs updating based on the libp2p version
-      - match:
-          dependency_name: "multistream-select"
-      # this needs updating based on the tokio_codec version
+      # this needs updating based on the futures_codec version
       - match:
           dependency_name: "bytes"
-      # until all our code is async/await ready, we cannot update tokio through dependabot
-      - match:
-          dependency_name: "tokio"
   - package_manager: "javascript"
     directory: "/api_tests"
     update_schedule: "daily"


### PR DESCRIPTION
We resolved most of the issues we had with dependencies forcing us to make extra entries in Cargo.toml. That caused failing dependency updates from dependabot.

We can now re-enable those entries :tada: