### PR TITLE
Remove libp2p-websocket and secp256k1 dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,18 +169,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce6977f57fa68da77ffe5542950d47e9c23d65f5bc7cb0a9f8700996913eec7"
-dependencies = [
- "futures 0.3.4",
- "rustls",
- "webpki",
- "webpki-roots 0.17.0",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,15 +210,6 @@ checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 dependencies = [
  "byteorder 1.3.4",
  "safemem",
-]
-
-[[package]]
-name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder 1.3.4",
 ]
 
 [[package]]
@@ -948,7 +927,6 @@ dependencies = [
  "cfg-if",
  "crc32fast",
  "libc",
- "libz-sys",
  "miniz_oxide",
 ]
 
@@ -1642,7 +1620,6 @@ dependencies = [
  "libp2p-tcp",
  "libp2p-uds",
  "libp2p-wasm-ext",
- "libp2p-websocket",
  "libp2p-yamux",
  "parity-multiaddr",
  "parity-multihash",
@@ -2011,27 +1988,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-websocket"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5351ca9eea122081c1c0f9323164d2918cac29b5a6bfe5054d4ba8ec9447cf42"
-dependencies = [
- "async-tls",
- "bytes 0.5.4",
- "either",
- "futures 0.3.4",
- "libp2p-core",
- "log 0.4.8",
- "quicksink",
- "rustls",
- "rw-stream-sink",
- "soketto",
- "url 2.1.1",
- "webpki",
- "webpki-roots 0.18.0",
-]
-
-[[package]]
 name = "libp2p-yamux"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,18 +2023,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6457c70bbff456d9fe49deaba35ec47c3e598bf8d7950ff0575ceb7a8a6ad1"
 dependencies = [
  "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
-dependencies = [
- "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -3146,19 +3090,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
-dependencies = [
- "base64 0.10.1",
- "log 0.4.8",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3233,16 +3164,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sct"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "secp256k1"
@@ -3393,12 +3314,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
-
-[[package]]
 name = "sha2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3482,26 +3397,6 @@ dependencies = [
  "sha2",
  "subtle 2.2.2",
  "x25519-dalek",
-]
-
-[[package]]
-name = "soketto"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9dab3f95c9ebdf3a88268c19af668f637a3c5039c2c56ff2d40b1b2d64a25b"
-dependencies = [
- "base64 0.11.0",
- "bytes 0.5.4",
- "flate2",
- "futures 0.3.4",
- "http",
- "httparse",
- "log 0.4.8",
- "rand 0.7.3",
- "sha1",
- "smallvec 1.2.0",
- "static_assertions 1.1.0",
- "thiserror",
 ]
 
 [[package]]
@@ -4286,34 +4181,6 @@ dependencies = [
  "sourcefile",
  "wasm-bindgen",
  "wasm-bindgen-webidl",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f50e1972865d6b1adb54167d1c8ed48606004c2c9d0ea5f1eeb34d95e863ef"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a262ae37dd9d60f60dd473d1158f9fbebf110ba7b6a5051c8160460f6043718b"
-dependencies = [
- "webpki",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cd5736df7f12a964a5067a12c62fa38e1bd8080aff1f80bc29be7c80d19ab4"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -26,7 +26,7 @@ hex = "0.4"
 http-api-problem = { version = "0.15", features = ["with_warp"] }
 impl-template = "1.0.0-alpha"
 lazy_static = "1"
-libp2p = { version = "0.16" }
+libp2p = { version = "0.16", default-features = false }
 libp2p-comit = { path = "../libp2p-comit" }
 libsqlite3-sys = { version = ">=0.8.0, <0.13.0", features = ["bundled"] }
 log = { version = "0.4", features = ["serde"] }

--- a/libp2p-comit/Cargo.toml
+++ b/libp2p-comit/Cargo.toml
@@ -10,7 +10,7 @@ bytes = "0.5"
 derivative = "1"
 futures = { version = "0.3", features = ["alloc", "io-compat"] }
 futures_codec = "0.4"
-libp2p = "0.16"
+libp2p = { version = "0.16", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 strum_macros = "0.18"


### PR DESCRIPTION
We don't use these features and they bring in unmaintained dependencies:

https://github.com/comit-network/comit-rs/issues/2189