### PR TITLE
Move type parameter in BlockHash and PreviousBlockHash to assoc. type

### DIFF
--- a/cnd/src/btsieve/bitcoin/mod.rs
+++ b/cnd/src/btsieve/bitcoin/mod.rs
@@ -17,13 +17,17 @@ use reqwest::{Client, Url};
 type Hash = bitcoin::BlockHash;
 type Block = bitcoin::Block;
 
-impl BlockHash<Hash> for Block {
+impl BlockHash for Block {
+    type BlockHash = Hash;
+
     fn block_hash(&self) -> Hash {
         self.bitcoin_hash()
     }
 }
 
-impl PreviousBlockHash<Hash> for Block {
+impl PreviousBlockHash for Block {
+    type BlockHash = Hash;
+
     fn previous_block_hash(&self) -> Hash {
         self.header.prev_blockhash
     }

--- a/cnd/src/btsieve/ethereum/mod.rs
+++ b/cnd/src/btsieve/ethereum/mod.rs
@@ -21,14 +21,18 @@ pub trait ReceiptByHash: Send + Sync + 'static {
     async fn receipt_by_hash(&self, transaction_hash: Hash) -> anyhow::Result<TransactionReceipt>;
 }
 
-impl BlockHash<Hash> for Block {
+impl BlockHash for Block {
+    type BlockHash = Hash;
+
     fn block_hash(&self) -> H256 {
         self.hash
             .expect("Connector returned latest block with null hash")
     }
 }
 
-impl PreviousBlockHash<Hash> for Block {
+impl PreviousBlockHash for Block {
+    type BlockHash = Hash;
+
     fn previous_block_hash(&self) -> H256 {
         self.parent_hash
     }


### PR DESCRIPTION
Type parameters are too powerful for what we need here. A single type will never have more than one BlockHash type, hence we can move those generics to the associated type level.