### PR TITLE
Make StateStore trait generic over the state and events

### DIFF
--- a/cnd/src/http_api/routes/index/handlers/get_swaps.rs
+++ b/cnd/src/http_api/routes/index/handlers/get_swaps.rs
@@ -11,7 +11,7 @@ pub async fn handle_get_swaps(dependencies: Facade) -> anyhow::Result<siren::Ent
         let types = dependencies.determine_types(&swap.swap_id).await?;
 
         let sub_entity = build_rfc003_siren_entity(
-            &dependencies,
+            dependencies.state_store.as_ref(),
             swap,
             types,
             IncludeState::No,

--- a/cnd/src/http_api/routes/rfc003/handlers/get_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/get_swap.rs
@@ -8,5 +8,11 @@ pub async fn handle_get_swap(dependencies: Facade, id: SwapId) -> anyhow::Result
     let swap = Retrieve::get(&dependencies, &id).await?;
     let types = dependencies.determine_types(&id).await?;
 
-    build_rfc003_siren_entity(&dependencies, swap, types, IncludeState::Yes, OnFail::Error)
+    build_rfc003_siren_entity(
+        dependencies.state_store.as_ref(),
+        swap,
+        types,
+        IncludeState::Yes,
+        OnFail::Error,
+    )
 }

--- a/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
@@ -9,10 +9,11 @@ use crate::{
     swap_protocols::{
         rfc003::{
             self, alice,
+            create_swap::SwapEvent,
             events::{HtlcDeployed, HtlcFunded, HtlcRedeemed, HtlcRefunded},
-            state_store::StateStore,
             Accept, Decline, DeriveIdentities, DeriveSecret, Request, SecretHash,
         },
+        state_store::StateStore,
         Facade, HashFunction, Role, SwapId,
     },
     timestamp::Timestamp,
@@ -67,7 +68,7 @@ where
 
     let state =
         alice::State::<_, _, _, _, AH, BH, _, _, AT, BT>::proposed(swap_request.clone(), seed);
-    StateStore::insert(&dependencies, id, state);
+    StateStore::<_, SwapEvent<AA, BA, AH, BH, AT, BT>>::insert(&dependencies, id, state);
 
     let future = {
         async move {
@@ -97,7 +98,11 @@ where
                         decline,
                         seed,
                     );
-                    StateStore::insert(&dependencies, id, state);
+                    StateStore::<_, SwapEvent<AA, BA, AH, BH, AT, BT>>::insert(
+                        &dependencies,
+                        id,
+                        state,
+                    );
                     Save::save(&dependencies, decline).await?;
                 }
             };
@@ -758,7 +763,7 @@ mod tests {
     use super::*;
     use crate::{
         network::DialInformation,
-        swap_protocols::{ledger, ledger::ethereum::ChainId},
+        swap_protocols::ledger::{self, ethereum::ChainId},
     };
     use spectral::prelude::*;
 

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -15,14 +15,17 @@
 use crate::cli::Options;
 use anyhow::Context;
 use cnd::{
-    btsieve::{bitcoin, bitcoin::BitcoindConnector, ethereum, ethereum::Web3Connector},
+    btsieve::{
+        bitcoin::{self, BitcoindConnector},
+        ethereum::{self, Web3Connector},
+    },
     config::{self, Settings},
     db::Sqlite,
     http_api::route_factory,
     load_swaps,
     network::Swarm,
     seed::RootSeed,
-    swap_protocols::{rfc003::state_store::InMemoryStateStore, Facade},
+    swap_protocols::{state_store::InMemoryStateStore, Facade},
 };
 use rand::rngs::OsRng;
 use std::{process, sync::Arc};

--- a/cnd/src/network/mod.rs
+++ b/cnd/src/network/mod.rs
@@ -4,7 +4,10 @@ pub use transport::ComitTransport;
 
 use crate::{
     asset::AssetKind,
-    btsieve::{bitcoin, bitcoin::BitcoindConnector, ethereum, ethereum::Web3Connector},
+    btsieve::{
+        bitcoin::{self, BitcoindConnector},
+        ethereum::{self, Web3Connector},
+    },
     comit_api::LedgerKind,
     config::Settings,
     db::{Save, Sqlite, Swap},
@@ -15,9 +18,10 @@ use crate::{
         ledger,
         rfc003::{
             self, bob,
+            create_swap::SwapEvent,
             messages::{Decision, DeclineResponseBody, Request, RequestBody, SwapDeclineReason},
-            state_store::{InMemoryStateStore, StateStore},
         },
+        state_store::{InMemoryStateStore, StateStore},
         HashFunction, Role, SwapId, SwapProtocol,
     },
     transaction,
@@ -40,8 +44,7 @@ use libp2p::{
 };
 use libp2p_comit::{
     frame::{OutboundRequest, Response, ValidatedInboundRequest},
-    handler,
-    handler::{ComitHandler, ProtocolInEvent, ProtocolOutEvent},
+    handler::{self, ComitHandler, ProtocolInEvent, ProtocolOutEvent},
     BehaviourOutEvent, Comit, PendingInboundRequest,
 };
 use serde::{de::DeserializeOwned, Serialize};
@@ -730,8 +733,8 @@ async fn insert_state_for_bob<AL, BL, AA, BA, AH, BH, AI, BI, AT, BT, DB>(
 where
     AL: Send + 'static,
     BL: Send + 'static,
-    AA: Send + 'static,
-    BA: Send + 'static,
+    AA: Ord + Send + 'static,
+    BA: Ord + Send + 'static,
     AH: Send + 'static,
     BH: Send + 'static,
     AI: Send + 'static,
@@ -740,6 +743,7 @@ where
     BT: Send + 'static,
     DB: Save<Request<AL, BL, AA, BA, AI, BI>> + Save<Swap>,
     Request<AL, BL, AA, BA, AI, BI>: Clone,
+    bob::State<AL, BL, AA, BA, AH, BH, AI, BI, AT, BT>: Clone + Sync,
 {
     let id = swap_request.swap_id;
     let seed = seed.derive_swap_seed(id);
@@ -749,7 +753,7 @@ where
 
     let state =
         bob::State::<_, _, _, _, AH, BH, _, _, AT, BT>::proposed(swap_request.clone(), seed);
-    state_store.insert(id, state);
+    StateStore::<_, SwapEvent<AA, BA, AH, BH, AT, BT>>::insert(state_store.as_ref(), id, state);
 
     Ok(())
 }

--- a/cnd/src/swap_protocols/mod.rs
+++ b/cnd/src/swap_protocols/mod.rs
@@ -2,6 +2,7 @@ pub mod actions;
 mod facade;
 pub mod ledger;
 pub mod rfc003;
+pub mod state_store;
 mod swap_id;
 
 pub use self::{facade::*, swap_id::*};

--- a/cnd/src/swap_protocols/rfc003/mod.rs
+++ b/cnd/src/swap_protocols/rfc003/mod.rs
@@ -6,7 +6,6 @@ pub mod ethereum;
 pub mod events;
 pub mod ledger_state;
 pub mod messages;
-pub mod state_store;
 
 pub mod actions;
 mod actor_state;


### PR DESCRIPTION
Pre-work towards re-modelling COMIT's core to account for `HAN` and `HErc20`.

The goal is to make it easier to split the state store into different ledgers (and eventually different single ledger protocols such as HAN and HErc20) in the near future.