### PR TITLE
Don't clone blockchain connectors

### DIFF
--- a/cnd/src/btsieve/bitcoin/cache.rs
+++ b/cnd/src/btsieve/bitcoin/cache.rs
@@ -27,15 +27,14 @@ impl<C> Cache<C> {
 #[async_trait]
 impl<C> LatestBlock for Cache<C>
 where
-    C: LatestBlock<Block = Block> + Clone,
+    C: LatestBlock<Block = Block>,
 {
     type Block = Block;
 
-    async fn latest_block(&mut self) -> anyhow::Result<Self::Block> {
+    async fn latest_block(&self) -> anyhow::Result<Self::Block> {
         let cache = Arc::clone(&self.block_cache);
-        let mut connector = self.connector.clone();
 
-        let block = connector.latest_block().await?;
+        let block = self.connector.latest_block().await?;
 
         let block_hash = block.bitcoin_hash();
         let mut guard = cache.lock().await;
@@ -50,13 +49,12 @@ where
 #[async_trait]
 impl<C> BlockByHash for Cache<C>
 where
-    C: BlockByHash<Block = Block, BlockHash = Hash> + Clone,
+    C: BlockByHash<Block = Block, BlockHash = Hash>,
 {
     type Block = Block;
     type BlockHash = BlockHash;
 
-    async fn block_by_hash(&mut self, block_hash: Self::BlockHash) -> anyhow::Result<Self::Block> {
-        let mut connector = self.connector.clone();
+    async fn block_by_hash(&self, block_hash: Self::BlockHash) -> anyhow::Result<Self::Block> {
         let cache = Arc::clone(&self.block_cache);
 
         if let Some(block) = cache.lock().await.get(&block_hash) {
@@ -64,7 +62,7 @@ where
             return Ok(block.clone());
         }
 
-        let block = connector.block_by_hash(block_hash.clone()).await?;
+        let block = self.connector.block_by_hash(block_hash.clone()).await?;
         tracing::trace!("Fetched block from connector: {:x}", block_hash);
 
         // We dropped the lock so at this stage the block may have been inserted by

--- a/cnd/src/btsieve/bitcoin/mod.rs
+++ b/cnd/src/btsieve/bitcoin/mod.rs
@@ -103,7 +103,7 @@ where
     S: Fn(&bitcoin::Transaction) -> Option<M>,
 {
     let mut block_generator =
-        Gen::new({ |co| async move { find_relevant_blocks(connector, &co, start_of_swap).await } });
+        Gen::new({ |co| async { find_relevant_blocks(connector, co, start_of_swap).await } });
 
     loop {
         match block_generator.async_resume().await {

--- a/cnd/src/btsieve/ethereum/cache.rs
+++ b/cnd/src/btsieve/ethereum/cache.rs
@@ -44,15 +44,14 @@ impl<C> Cache<C> {
 #[async_trait]
 impl<C> LatestBlock for Cache<C>
 where
-    C: LatestBlock<Block = Block> + Clone,
+    C: LatestBlock<Block = Block>,
 {
     type Block = Block;
 
-    async fn latest_block(&mut self) -> anyhow::Result<Self::Block> {
+    async fn latest_block(&self) -> anyhow::Result<Self::Block> {
         let cache = self.block_cache.clone();
-        let mut connector = self.connector.clone();
 
-        let block = connector.latest_block().await?;
+        let block = self.connector.latest_block().await?;
 
         let block_hash = block.hash.expect("no blocks without hash");
         let mut guard = cache.lock().await;
@@ -67,13 +66,12 @@ where
 #[async_trait]
 impl<C> BlockByHash for Cache<C>
 where
-    C: BlockByHash<Block = Block, BlockHash = Hash> + Clone,
+    C: BlockByHash<Block = Block, BlockHash = Hash>,
 {
     type Block = Block;
     type BlockHash = Hash;
 
-    async fn block_by_hash(&mut self, block_hash: Self::BlockHash) -> anyhow::Result<Self::Block> {
-        let mut connector = self.connector.clone();
+    async fn block_by_hash(&self, block_hash: Self::BlockHash) -> anyhow::Result<Self::Block> {
         let cache = Arc::clone(&self.block_cache);
 
         if let Some(block) = cache.lock().await.get(&block_hash) {
@@ -81,7 +79,7 @@ where
             return Ok(block.clone());
         }
 
-        let block = connector.block_by_hash(block_hash.clone()).await?;
+        let block = self.connector.block_by_hash(block_hash.clone()).await?;
         tracing::trace!("Fetched block from connector: {:x}", block_hash);
 
         // We dropped the lock so at this stage the block may have been inserted by
@@ -96,10 +94,9 @@ where
 #[async_trait]
 impl<C> ReceiptByHash for Cache<C>
 where
-    C: ReceiptByHash + Clone,
+    C: ReceiptByHash,
 {
     async fn receipt_by_hash(&self, transaction_hash: Hash) -> anyhow::Result<TransactionReceipt> {
-        let connector = self.connector.clone();
         let cache = Arc::clone(&self.receipt_cache);
 
         if let Some(receipt) = cache.lock().await.get(&transaction_hash) {
@@ -107,7 +104,10 @@ where
             return Ok(receipt.clone());
         }
 
-        let receipt = connector.receipt_by_hash(transaction_hash.clone()).await?;
+        let receipt = self
+            .connector
+            .receipt_by_hash(transaction_hash.clone())
+            .await?;
 
         tracing::trace!("Fetched receipt from connector: {:x}", transaction_hash);
 

--- a/cnd/src/btsieve/ethereum/mod.rs
+++ b/cnd/src/btsieve/ethereum/mod.rs
@@ -115,7 +115,7 @@ where
     F: Fn(&Transaction) -> bool,
 {
     let mut block_generator =
-        Gen::new({ |co| async move { find_relevant_blocks(connector, &co, start_of_swap).await } });
+        Gen::new({ |co| async { find_relevant_blocks(connector, co, start_of_swap).await } });
 
     loop {
         match block_generator.async_resume().await {
@@ -157,7 +157,7 @@ where
     F: Fn(TransactionReceipt) -> Option<Log>,
 {
     let mut block_generator =
-        Gen::new({ |co| async move { find_relevant_blocks(connector, &co, start_of_swap).await } });
+        Gen::new({ |co| async { find_relevant_blocks(connector, co, start_of_swap).await } });
 
     loop {
         match block_generator.async_resume().await {

--- a/cnd/src/btsieve/ethereum/mod.rs
+++ b/cnd/src/btsieve/ethereum/mod.rs
@@ -35,15 +35,12 @@ impl PreviousBlockHash<Hash> for Block {
 }
 
 pub async fn watch_for_contract_creation<C>(
-    blockchain_connector: C,
+    blockchain_connector: &C,
     start_of_swap: NaiveDateTime,
     bytecode: Bytes,
 ) -> anyhow::Result<(Transaction, Address)>
 where
-    C: LatestBlock<Block = Block>
-        + BlockByHash<Block = Block, BlockHash = Hash>
-        + ReceiptByHash
-        + Clone,
+    C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
 {
     let (transaction, receipt) =
         matching_transaction_and_receipt(blockchain_connector, start_of_swap, |transaction| {
@@ -60,18 +57,15 @@ where
 }
 
 pub async fn watch_for_event<C>(
-    blockchain_connector: C,
+    blockchain_connector: &C,
     start_of_swap: NaiveDateTime,
     event: Event,
 ) -> anyhow::Result<(Transaction, Log)>
 where
-    C: LatestBlock<Block = Block>
-        + BlockByHash<Block = Block, BlockHash = Hash>
-        + ReceiptByHash
-        + Clone,
+    C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
 {
     matching_transaction_and_log(
-        blockchain_connector.clone(),
+        blockchain_connector,
         start_of_swap,
         event.topics.clone(),
         |receipt| find_log_for_event_in_receipt(&event, receipt),
@@ -80,7 +74,10 @@ where
 }
 
 /// Fetch receipt from connector using transaction hash.
-async fn fetch_receipt<C>(blockchain_connector: C, hash: Hash) -> anyhow::Result<TransactionReceipt>
+async fn fetch_receipt<C>(
+    blockchain_connector: &C,
+    hash: Hash,
+) -> anyhow::Result<TransactionReceipt>
 where
     C: ReceiptByHash,
 {
@@ -109,28 +106,23 @@ fn find_log_for_event_in_receipt(event: &Event, receipt: TransactionReceipt) -> 
 }
 
 pub async fn matching_transaction_and_receipt<C, F>(
-    connector: C,
+    connector: &C,
     start_of_swap: NaiveDateTime,
     matcher: F,
 ) -> anyhow::Result<(Transaction, TransactionReceipt)>
 where
-    C: LatestBlock<Block = Block>
-        + BlockByHash<Block = Block, BlockHash = Hash>
-        + ReceiptByHash
-        + Clone,
+    C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
     F: Fn(&Transaction) -> bool,
 {
-    let mut block_generator = Gen::new({
-        let connector = connector.clone();
-        |co| async move { find_relevant_blocks(connector, &co, start_of_swap).await }
-    });
+    let mut block_generator =
+        Gen::new({ |co| async move { find_relevant_blocks(connector, &co, start_of_swap).await } });
 
     loop {
         match block_generator.async_resume().await {
             GeneratorState::Yielded(block) => {
                 for transaction in block.transactions.into_iter() {
                     if matcher(&transaction) {
-                        let receipt = fetch_receipt(connector.clone(), transaction.hash).await?;
+                        let receipt = fetch_receipt(connector, transaction.hash).await?;
                         if !receipt.is_status_ok() {
                             // This can be caused by a failed attempt to complete an action,
                             // for example, sending a transaction with low gas.
@@ -155,22 +147,17 @@ where
 }
 
 async fn matching_transaction_and_log<C, F>(
-    connector: C,
+    connector: &C,
     start_of_swap: NaiveDateTime,
     topics: Vec<Option<Topic>>,
     matcher: F,
 ) -> anyhow::Result<(Transaction, Log)>
 where
-    C: LatestBlock<Block = Block>
-        + BlockByHash<Block = Block, BlockHash = Hash>
-        + ReceiptByHash
-        + Clone,
+    C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
     F: Fn(TransactionReceipt) -> Option<Log>,
 {
-    let mut block_generator = Gen::new({
-        let connector = connector.clone();
-        |co| async move { find_relevant_blocks(connector, &co, start_of_swap).await }
-    });
+    let mut block_generator =
+        Gen::new({ |co| async move { find_relevant_blocks(connector, &co, start_of_swap).await } });
 
     loop {
         match block_generator.async_resume().await {
@@ -200,7 +187,7 @@ where
                     block_hash,
                 );
                 for transaction in block.transactions.into_iter() {
-                    let receipt = fetch_receipt(connector.clone(), transaction.hash).await?;
+                    let receipt = fetch_receipt(connector, transaction.hash).await?;
                     let status_is_ok = receipt.is_status_ok();
                     if let Some(log) = matcher(receipt) {
                         if !status_is_ok {

--- a/cnd/src/btsieve/ethereum/web3_connector.rs
+++ b/cnd/src/btsieve/ethereum/web3_connector.rs
@@ -4,17 +4,16 @@ use crate::{
     jsonrpc,
 };
 use async_trait::async_trait;
-use std::sync::Arc;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Web3Connector {
-    client: Arc<jsonrpc::Client>,
+    client: jsonrpc::Client,
 }
 
 impl Web3Connector {
     pub fn new(node_url: reqwest::Url) -> Self {
         Self {
-            client: Arc::new(jsonrpc::Client::new(node_url)),
+            client: jsonrpc::Client::new(node_url),
         }
     }
 }
@@ -23,7 +22,7 @@ impl Web3Connector {
 impl LatestBlock for Web3Connector {
     type Block = crate::ethereum::Block;
 
-    async fn latest_block(&mut self) -> anyhow::Result<Self::Block> {
+    async fn latest_block(&self) -> anyhow::Result<Self::Block> {
         let block: Self::Block = self
             .client
             .send(jsonrpc::Request::new("eth_getBlockByNumber", vec![
@@ -46,7 +45,7 @@ impl BlockByHash for Web3Connector {
     type Block = crate::ethereum::Block;
     type BlockHash = crate::ethereum::H256;
 
-    async fn block_by_hash(&mut self, block_hash: Self::BlockHash) -> anyhow::Result<Self::Block> {
+    async fn block_by_hash(&self, block_hash: Self::BlockHash) -> anyhow::Result<Self::Block> {
         let block = self
             .client
             .send(jsonrpc::Request::new("eth_getBlockByHash", vec![

--- a/cnd/src/btsieve/mod.rs
+++ b/cnd/src/btsieve/mod.rs
@@ -49,7 +49,7 @@ pub trait PreviousBlockHash<H> {
 /// It yields those blocks as part of the process.
 pub async fn find_relevant_blocks<C, B, H>(
     connector: &C,
-    co: &Co<B>,
+    co: Co<B>,
     start_of_swap: NaiveDateTime,
 ) -> anyhow::Result<Never>
 where
@@ -61,7 +61,7 @@ where
 
     // Look back in time until we get a block that predates start_of_swap.
     let mut seen_blocks =
-        walk_back_until(predates_start_of_swap(start_of_swap), connector, co, block).await?;
+        walk_back_until(predates_start_of_swap(start_of_swap), connector, &co, block).await?;
 
     // Look forward in time, but keep going back for missed blocks
     loop {
@@ -70,7 +70,7 @@ where
         let missed_blocks = walk_back_until(
             seen_block_or_predates_start_of_swap(&seen_blocks, start_of_swap),
             connector,
-            co,
+            &co,
             block,
         )
         .await?;

--- a/cnd/src/btsieve/mod.rs
+++ b/cnd/src/btsieve/mod.rs
@@ -14,7 +14,7 @@ use std::{collections::HashSet, hash::Hash};
 pub trait LatestBlock: Send + Sync + 'static {
     type Block;
 
-    async fn latest_block(&mut self) -> anyhow::Result<Self::Block>;
+    async fn latest_block(&self) -> anyhow::Result<Self::Block>;
 }
 
 #[async_trait]
@@ -22,7 +22,7 @@ pub trait BlockByHash: Send + Sync + 'static {
     type Block;
     type BlockHash;
 
-    async fn block_by_hash(&mut self, block_hash: Self::BlockHash) -> anyhow::Result<Self::Block>;
+    async fn block_by_hash(&self, block_hash: Self::BlockHash) -> anyhow::Result<Self::Block>;
 }
 
 /// Checks if a given block predates a certain timestamp.
@@ -48,25 +48,20 @@ pub trait PreviousBlockHash<H> {
 ///
 /// It yields those blocks as part of the process.
 pub async fn find_relevant_blocks<C, B, H>(
-    mut connector: C,
+    connector: &C,
     co: &Co<B>,
     start_of_swap: NaiveDateTime,
 ) -> anyhow::Result<Never>
 where
-    C: LatestBlock<Block = B> + BlockByHash<Block = B, BlockHash = H> + Clone,
+    C: LatestBlock<Block = B> + BlockByHash<Block = B, BlockHash = H>,
     B: Predates + BlockHash<H> + PreviousBlockHash<H> + Clone,
     H: Eq + Hash + Copy,
 {
     let block = connector.latest_block().await?;
 
     // Look back in time until we get a block that predates start_of_swap.
-    let mut seen_blocks = walk_back_until(
-        predates_start_of_swap(start_of_swap),
-        connector.clone(),
-        co,
-        block,
-    )
-    .await?;
+    let mut seen_blocks =
+        walk_back_until(predates_start_of_swap(start_of_swap), connector, co, block).await?;
 
     // Look forward in time, but keep going back for missed blocks
     loop {
@@ -74,7 +69,7 @@ where
 
         let missed_blocks = walk_back_until(
             seen_block_or_predates_start_of_swap(&seen_blocks, start_of_swap),
-            connector.clone(),
+            connector,
             co,
             block,
         )
@@ -94,19 +89,18 @@ where
 /// This function returns the block-hashes of all visited blocks.
 async fn walk_back_until<C, P, B, H>(
     stop_condition: P,
-    connector: C,
+    connector: &C,
     co: &Co<B>,
     block: B,
 ) -> anyhow::Result<HashSet<H>>
 where
-    C: BlockByHash<Block = B, BlockHash = H> + Clone,
+    C: BlockByHash<Block = B, BlockHash = H>,
     P: Fn(&B) -> anyhow::Result<bool>,
     B: BlockHash<H> + PreviousBlockHash<H> + Clone,
     H: Eq + Hash + Copy,
 {
     let mut seen_blocks: HashSet<H> = HashSet::new();
     let mut blockhash = block.block_hash();
-    let mut connector = connector.clone();
 
     co.yield_(block.clone()).await;
     seen_blocks.insert(blockhash);

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -60,19 +60,19 @@ fn main() -> anyhow::Result<()> {
     const BITCOIN_BLOCK_CACHE_CAPACITY: usize = 144;
     let bitcoin_connector = {
         let config::Bitcoin { network, bitcoind } = settings.clone().bitcoin;
-        bitcoin::Cache::new(
+        Arc::new(bitcoin::Cache::new(
             BitcoindConnector::new(bitcoind.node_url, network)?,
             BITCOIN_BLOCK_CACHE_CAPACITY,
-        )
+        ))
     };
 
     const ETHEREUM_BLOCK_CACHE_CAPACITY: usize = 720;
     const ETHEREUM_RECEIPT_CACHE_CAPACITY: usize = 720;
-    let ethereum_connector = ethereum::Cache::new(
+    let ethereum_connector = Arc::new(ethereum::Cache::new(
         Web3Connector::new(settings.clone().ethereum.parity.node_url),
         ETHEREUM_BLOCK_CACHE_CAPACITY,
         ETHEREUM_RECEIPT_CACHE_CAPACITY,
-    );
+    ));
 
     let state_store = Arc::new(InMemoryStateStore::default());
 
@@ -82,16 +82,16 @@ fn main() -> anyhow::Result<()> {
         &settings,
         seed,
         &mut runtime,
-        &bitcoin_connector,
-        &ethereum_connector,
-        &state_store,
+        Arc::clone(&bitcoin_connector),
+        Arc::clone(&ethereum_connector),
+        Arc::clone(&state_store),
         &database,
     )?;
 
     let deps = Facade {
         bitcoin_connector,
         ethereum_connector,
-        state_store: Arc::clone(&state_store),
+        state_store,
         seed,
         swarm,
         db: database,

--- a/cnd/src/network/mod.rs
+++ b/cnd/src/network/mod.rs
@@ -80,9 +80,9 @@ impl Swarm {
         settings: &Settings,
         seed: RootSeed,
         runtime: &mut Runtime,
-        bitcoin_connector: &bitcoin::Cache<BitcoindConnector>,
-        ethereum_connector: &ethereum::Cache<Web3Connector>,
-        state_store: &Arc<InMemoryStateStore>,
+        bitcoin_connector: Arc<bitcoin::Cache<BitcoindConnector>>,
+        ethereum_connector: Arc<ethereum::Cache<Web3Connector>>,
+        state_store: Arc<InMemoryStateStore>,
         database: &Sqlite,
     ) -> anyhow::Result<Self> {
         let local_key_pair = derive_key_pair(&seed);
@@ -91,9 +91,9 @@ impl Swarm {
 
         let transport = transport::build_comit_transport(local_key_pair)?;
         let behaviour = ComitNode::new(
-            bitcoin_connector.clone(),
-            ethereum_connector.clone(),
-            Arc::clone(&state_store),
+            bitcoin_connector,
+            ethereum_connector,
+            state_store,
             seed,
             database.clone(),
             runtime.handle().clone(),
@@ -157,9 +157,9 @@ pub struct ComitNode {
     mdns: Mdns,
 
     #[behaviour(ignore)]
-    pub bitcoin_connector: bitcoin::Cache<BitcoindConnector>,
+    pub bitcoin_connector: Arc<bitcoin::Cache<BitcoindConnector>>,
     #[behaviour(ignore)]
-    pub ethereum_connector: ethereum::Cache<Web3Connector>,
+    pub ethereum_connector: Arc<ethereum::Cache<Web3Connector>>,
     #[behaviour(ignore)]
     pub state_store: Arc<InMemoryStateStore>,
     #[behaviour(ignore)]
@@ -206,8 +206,8 @@ pub struct Reason {
 
 impl ComitNode {
     pub fn new(
-        bitcoin_connector: bitcoin::Cache<BitcoindConnector>,
-        ethereum_connector: ethereum::Cache<Web3Connector>,
+        bitcoin_connector: Arc<bitcoin::Cache<BitcoindConnector>>,
+        ethereum_connector: Arc<ethereum::Cache<Web3Connector>>,
         state_store: Arc<InMemoryStateStore>,
         seed: RootSeed,
         db: Sqlite,

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -45,8 +45,8 @@ use std::{convert::TryInto, fmt::Debug, sync::Arc};
 #[delegate(Retrieve, target = "db")]
 #[delegate(DetermineTypes, target = "db")]
 pub struct Facade {
-    pub bitcoin_connector: btsieve::bitcoin::Cache<BitcoindConnector>,
-    pub ethereum_connector: ethereum::Cache<Web3Connector>,
+    pub bitcoin_connector: Arc<btsieve::bitcoin::Cache<BitcoindConnector>>,
+    pub ethereum_connector: Arc<ethereum::Cache<Web3Connector>>,
     pub state_store: Arc<InMemoryStateStore>,
     pub seed: RootSeed,
     pub swarm: Swarm,

--- a/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
@@ -56,10 +56,8 @@ where
         htlc_params: &HtlcParams<B, asset::Bitcoin, identity::Bitcoin>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Deployed<htlc_location::Bitcoin, transaction::Bitcoin>> {
-        let connector = self.clone();
-
         let (transaction, location) =
-            watch_for_created_outpoint(connector, start_of_swap, htlc_params.compute_address())
+            watch_for_created_outpoint(self, start_of_swap, htlc_params.compute_address())
                 .instrument(tracing::info_span!("htlc_deployed"))
                 .await?;
 
@@ -83,12 +81,10 @@ where
         htlc_deployment: &Deployed<htlc_location::Bitcoin, transaction::Bitcoin>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<transaction::Bitcoin>> {
-        let connector = self.clone();
-
         let (transaction, _) =
-            watch_for_spent_outpoint(connector, start_of_swap, htlc_deployment.location, vec![
-                vec![1u8],
-            ])
+            watch_for_spent_outpoint(self, start_of_swap, htlc_deployment.location, vec![vec![
+                1u8,
+            ]])
             .instrument(tracing::info_span!("htlc_redeemed"))
             .await?;
 
@@ -115,14 +111,10 @@ where
         htlc_deployment: &Deployed<htlc_location::Bitcoin, transaction::Bitcoin>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<transaction::Bitcoin>> {
-        let connector = self.clone();
-
         let (transaction, _) =
-            watch_for_spent_outpoint(connector, start_of_swap, htlc_deployment.location, vec![
-                vec![],
-            ])
-            .instrument(tracing::info_span!("htlc_refunded"))
-            .await?;
+            watch_for_spent_outpoint(self, start_of_swap, htlc_deployment.location, vec![vec![]])
+                .instrument(tracing::info_span!("htlc_refunded"))
+                .await?;
 
         Ok(Refunded { transaction })
     }

--- a/cnd/src/swap_protocols/rfc003/create_swap.rs
+++ b/cnd/src/swap_protocols/rfc003/create_swap.rs
@@ -44,8 +44,7 @@ pub async fn create_alpha_watcher<D, A, AI, BI>(
         + HtlcRedeemed<A::AL, A::AA, A::AH, AI, A::AT>
         + HtlcRedeemed<A::BL, A::BA, A::BH, BI, A::BT>
         + HtlcRefunded<A::AL, A::AA, A::AH, AI, A::AT>
-        + HtlcRefunded<A::BL, A::BA, A::BH, BI, A::BT>
-        + Clone,
+        + HtlcRefunded<A::BL, A::BA, A::BH, BI, A::BT>,
     A::AL: Clone,
     A::BL: Clone,
     A::AA: Ord + Clone,
@@ -66,11 +65,10 @@ pub async fn create_alpha_watcher<D, A, AI, BI>(
 
     // construct a generator that watches alpha and beta ledger concurrently
     let mut generator = Gen::new({
-        let dependencies = dependencies.clone();
-        |co| async move {
+        |co| async {
             watch_alpha_ledger::<_, A::AL, A::BL, A::AA, A::BA, A::AH, A::BH, AI, BI, A::AT, A::BT>(
                 &dependencies,
-                &co,
+                co,
                 swap.alpha_htlc_params(),
                 at,
             )
@@ -123,8 +121,7 @@ pub async fn create_beta_watcher<D, A, AI, BI>(
         + HtlcRedeemed<A::AL, A::AA, A::AH, AI, A::AT>
         + HtlcRedeemed<A::BL, A::BA, A::BH, BI, A::BT>
         + HtlcRefunded<A::AL, A::AA, A::AH, AI, A::AT>
-        + HtlcRefunded<A::BL, A::BA, A::BH, BI, A::BT>
-        + Clone,
+        + HtlcRefunded<A::BL, A::BA, A::BH, BI, A::BT>,
     A::AL: Clone,
     A::BL: Clone,
     A::AA: Ord + Clone,
@@ -145,11 +142,10 @@ pub async fn create_beta_watcher<D, A, AI, BI>(
 
     // construct a generator that watches alpha and beta ledger concurrently
     let mut generator = Gen::new({
-        let dependencies = dependencies.clone();
-        |co| async move {
+        |co| async {
             watch_beta_ledger::<_, A::AL, A::BL, A::AA, A::BA, A::AH, A::BH, AI, BI, A::AT, A::BT>(
                 &dependencies,
-                &co,
+                co,
                 swap.beta_htlc_params(),
                 at,
             )
@@ -184,7 +180,7 @@ pub async fn create_beta_watcher<D, A, AI, BI>(
 /// Each event is yielded through the controller handle (co) of the coroutine.
 async fn watch_alpha_ledger<D, AL, BL, AA, BA, AH, BH, AI, BI, AT, BT>(
     dependencies: &D,
-    co: &Co<SwapEvent<AA, BA, AH, BH, AT, BT>>,
+    co: Co<SwapEvent<AA, BA, AH, BH, AT, BT>>,
     htlc_params: HtlcParams<AL, AA, AI>,
     start_of_swap: NaiveDateTime,
 ) -> anyhow::Result<()>
@@ -233,7 +229,7 @@ where
 /// Each event is yielded through the controller handle (co) of the coroutine.
 async fn watch_beta_ledger<D, AL, BL, AA, BA, AH, BH, AI, BI, AT, BT>(
     dependencies: &D,
-    co: &Co<SwapEvent<AA, BA, AH, BH, AT, BT>>,
+    co: Co<SwapEvent<AA, BA, AH, BH, AT, BT>>,
     htlc_params: HtlcParams<BL, BA, BI>,
     start_of_swap: NaiveDateTime,
 ) -> anyhow::Result<()>

--- a/cnd/src/swap_protocols/rfc003/ethereum/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/ethereum/htlc_events.rs
@@ -67,9 +67,8 @@ impl
         htlc_params: &HtlcParams<Ethereum, asset::Ether, identity::Ethereum>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Deployed<htlc_location::Ethereum, transaction::Ethereum>> {
-        let connector = self.clone();
         let (transaction, location) =
-            watch_for_contract_creation(connector, start_of_swap, htlc_params.bytecode())
+            watch_for_contract_creation(self, start_of_swap, htlc_params.bytecode())
                 .instrument(tracing::info_span!("htlc_deployed"))
                 .await?;
 
@@ -96,13 +95,12 @@ impl
         htlc_deployment: &Deployed<htlc_location::Ethereum, transaction::Ethereum>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<transaction::Ethereum>> {
-        let connector = self.clone();
         let event = Event {
             address: htlc_deployment.location,
             topics: vec![Some(Topic(*REDEEM_LOG_MSG))],
         };
 
-        let (transaction, log) = watch_for_event(connector, start_of_swap, event)
+        let (transaction, log) = watch_for_event(self, start_of_swap, event)
             .instrument(tracing::info_span!("htlc_redeemed"))
             .await?;
 
@@ -133,13 +131,12 @@ impl
         htlc_deployment: &Deployed<htlc_location::Ethereum, transaction::Ethereum>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<transaction::Ethereum>> {
-        let connector = self.clone();
         let event = Event {
             address: htlc_deployment.location,
             topics: vec![Some(Topic(*REFUND_LOG_MSG))],
         };
 
-        let (transaction, _) = watch_for_event(connector, start_of_swap, event)
+        let (transaction, _) = watch_for_event(self, start_of_swap, event)
             .instrument(tracing::info_span!("htlc_refunded"))
             .await?;
 
@@ -163,8 +160,6 @@ impl
         htlc_deployment: &Deployed<htlc_location::Ethereum, transaction::Ethereum>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Funded<asset::Erc20, transaction::Ethereum>> {
-        let connector = self.clone();
-
         let event = Event {
             address: htlc_params.asset.token_contract,
             topics: vec![
@@ -174,7 +169,7 @@ impl
             ],
         };
 
-        let (transaction, log) = watch_for_event(connector, start_of_swap, event)
+        let (transaction, log) = watch_for_event(self, start_of_swap, event)
             .instrument(tracing::info_span!("htlc_funded"))
             .await?;
 
@@ -200,10 +195,8 @@ impl
         htlc_params: &HtlcParams<Ethereum, asset::Erc20, identity::Ethereum>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Deployed<htlc_location::Ethereum, transaction::Ethereum>> {
-        let connector = self.clone();
-
         let (transaction, location) =
-            watch_for_contract_creation(connector, start_of_swap, htlc_params.clone().bytecode())
+            watch_for_contract_creation(self, start_of_swap, htlc_params.clone().bytecode())
                 .instrument(tracing::info_span!("htlc_deployed"))
                 .await?;
 
@@ -230,13 +223,12 @@ impl
         htlc_deployment: &Deployed<htlc_location::Ethereum, transaction::Ethereum>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<transaction::Ethereum>> {
-        let connector = self.clone();
         let event = Event {
             address: htlc_deployment.location,
             topics: vec![Some(Topic(*REDEEM_LOG_MSG))],
         };
 
-        let (transaction, log) = watch_for_event(connector, start_of_swap, event)
+        let (transaction, log) = watch_for_event(self, start_of_swap, event)
             .instrument(tracing::info_span!("htlc_redeemed"))
             .await?;
 
@@ -267,13 +259,12 @@ impl
         htlc_deployment: &Deployed<htlc_location::Ethereum, transaction::Ethereum>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<transaction::Ethereum>> {
-        let connector = self.clone();
         let event = Event {
             address: htlc_deployment.location,
             topics: vec![Some(Topic(*REFUND_LOG_MSG))],
         };
 
-        let (transaction, _) = watch_for_event(connector, start_of_swap, event)
+        let (transaction, _) = watch_for_event(self, start_of_swap, event)
             .instrument(tracing::info_span!("htlc_refunded"))
             .await?;
 

--- a/cnd/tests/bitcoin_go_back_into_the_past.rs
+++ b/cnd/tests/bitcoin_go_back_into_the_past.rs
@@ -29,7 +29,7 @@ async fn find_transaction_go_back_into_the_past() {
     let start_of_swap =
         NaiveDateTime::from_timestamp(block1_with_transaction.header.time as i64, 0);
     let (expected_transaction, _out_point) = watch_for_created_outpoint(
-        connector,
+        &connector,
         start_of_swap,
         Address::from_str(
             include_str!("test_data/bitcoin/find_transaction_go_back_into_the_past/address").trim(),

--- a/cnd/tests/bitcoin_missed_previous_latest_block.rs
+++ b/cnd/tests/bitcoin_missed_previous_latest_block.rs
@@ -31,7 +31,7 @@ async fn find_transaction_missed_previous_latest_block() {
     // first one
     let start_of_swap = NaiveDateTime::from_timestamp((block1.header.time as i64) + 1, 0);
     let (expected_transaction, _out_point) = watch_for_created_outpoint(
-        connector,
+        &connector,
         start_of_swap,
         Address::from_str(
             include_str!("test_data/bitcoin/find_transaction_missed_previous_latest_block/address")
@@ -78,7 +78,7 @@ async fn find_transaction_missed_previous_latest_block_with_big_gap() {
     // first one
     let start_of_swap = NaiveDateTime::from_timestamp((block1.header.time as i64) + 1, 0);
     let (expected_transaction, _out_point) = watch_for_created_outpoint(
-        connector,
+        &connector,
         start_of_swap,
         Address::from_str(
             include_str!(
@@ -116,7 +116,7 @@ async fn find_transaction_if_blockchain_reorganisation() {
 
     let start_of_swap = Utc::now().naive_local();
     let (expected_transaction, _out_point) = watch_for_created_outpoint(
-        connector,
+        &connector,
         start_of_swap,
         Address::from_str(
             include_str!("test_data/bitcoin/find_transaction_if_blockchain_reorganisation/address")
@@ -154,7 +154,7 @@ async fn find_transaction_if_blockchain_reorganisation_with_long_chain() {
     );
 
     let start_of_swap = Utc::now().naive_local();
-    let (expected_transaction, _out_point) = watch_for_created_outpoint(connector, start_of_swap, Address::from_str(
+    let (expected_transaction, _out_point) = watch_for_created_outpoint(&connector, start_of_swap, Address::from_str(
         include_str!(
             "test_data/bitcoin/find_transaction_if_blockchain_reorganisation_with_long_chain/address"
         ).trim()

--- a/cnd/tests/bitcoin_transaction_pattern_e2e.rs
+++ b/cnd/tests/bitcoin_transaction_pattern_e2e.rs
@@ -62,7 +62,7 @@ async fn bitcoin_transaction_pattern_e2e_test() {
         .expect("failed to send money to address");
 
     let (funding_transaction, _out_point) =
-        watch_for_created_outpoint(connector, start_of_swap, target_address)
+        watch_for_created_outpoint(&connector, start_of_swap, target_address)
             .await
             .unwrap();
 

--- a/cnd/tests/ethereum_go_back_into_the_past.rs
+++ b/cnd/tests/ethereum_go_back_into_the_past.rs
@@ -49,7 +49,7 @@ async fn find_transaction_go_back_into_the_past() {
         NaiveDateTime::from_timestamp(block1_with_transaction.timestamp.low_u32() as i64, 0);
 
     let (got_transaction, got_receipt) =
-        matching_transaction_and_receipt(connector, start_of_swap, {
+        matching_transaction_and_receipt(&connector, start_of_swap, {
             |transaction| transaction.to == want_transaction.to
         })
         .await

--- a/cnd/tests/ethereum_missed_previous_latest_block.rs
+++ b/cnd/tests/ethereum_missed_previous_latest_block.rs
@@ -46,7 +46,7 @@ async fn find_transaction_missed_previous_latest_block_single_block_gap() {
     let start_of_swap = NaiveDateTime::from_timestamp(block2.timestamp.as_u32() as i64, 0);
 
     let (got_transaction, got_receipt) =
-        matching_transaction_and_receipt(connector, start_of_swap, {
+        matching_transaction_and_receipt(&connector, start_of_swap, {
             |transaction| transaction.to == want_transaction.to
         })
         .await
@@ -100,7 +100,7 @@ async fn find_transaction_missed_previous_latest_block_two_block_gap() {
     let start_of_swap = NaiveDateTime::from_timestamp(block2.timestamp.as_u32() as i64, 0);
 
     let (got_transaction, got_receipt) =
-        matching_transaction_and_receipt(connector, start_of_swap, {
+        matching_transaction_and_receipt(&connector, start_of_swap, {
             |transaction| transaction.to == want_transaction.to
         })
         .await

--- a/cnd/tests/ethereum_transaction_matching_smoke_test.rs
+++ b/cnd/tests/ethereum_transaction_matching_smoke_test.rs
@@ -55,7 +55,7 @@ async fn ethereum_transaction_matching_smoke_test() {
 
     let (matched_transaction, _receipt) = tokio::time::timeout(
         Duration::from_secs(5),
-        matching_transaction_and_receipt(connector, start_of_swap, |transaction| {
+        matching_transaction_and_receipt(&connector, start_of_swap, |transaction| {
             transaction.to == Some(target_address)
         }),
     )


### PR DESCRIPTION
Initially, we thought it was a good idea to make the traits BlockByHash and LatestBlock take &mut self. It turns out that we don't need this functionality for anything other than the tests and it actually forces us to clone the connector in many places.

Removing the mutable reference to self allows us to stop cloning the connector and simply pass references into all the functions.