### PR TITLE
Config validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Added
+- Added a step during initialisation to test whether the chain/network id's of the Ethereum/Bitcoin nodes that cnd has connected to matches the chain/network id's specified in the config. Cnd will abort if the config and the actual chain/network id does not match. Cnd will log a warning if it cannot make a request to the nodes.
 
+### Changed
 - **Breaking config changes**: cnd config has changed. Bitcoin and Ethereum has 2 optional fields specifically for the connector (i.e. bitcoind and parity). If provided, the network (for bitcoin) and chain_id (for ethereum) are mandatory. If the url was not provided, a default aiming at localhost will be derived. If no connectors were provided, defaults will be provided. For a full example config run: `cnd --dump-config`.
 
 ## 0.6.0 - 2020-02-13

--- a/cnd/src/btsieve/bitcoin/mod.rs
+++ b/cnd/src/btsieve/bitcoin/mod.rs
@@ -1,9 +1,14 @@
 mod bitcoind_connector;
 mod cache;
 
-pub use self::{bitcoind_connector::BitcoindConnector, cache::Cache};
-use crate::btsieve::{
-    find_relevant_blocks, BlockByHash, BlockHash, LatestBlock, Predates, PreviousBlockHash,
+pub use self::{
+    bitcoind_connector::{chain_info, BitcoindConnector, ChainInfo},
+    cache::Cache,
+};
+use crate::{
+    btsieve::{
+        find_relevant_blocks, BlockByHash, BlockHash, LatestBlock, Predates, PreviousBlockHash,
+    },
 };
 use bitcoin::{
     blockdata::script::Instruction,

--- a/cnd/src/btsieve/ethereum/mod.rs
+++ b/cnd/src/btsieve/ethereum/mod.rs
@@ -1,7 +1,10 @@
 mod cache;
 mod web3_connector;
 
-pub use self::{cache::Cache, web3_connector::Web3Connector};
+pub use self::{
+    cache::Cache,
+    web3_connector::{net_version, Web3Connector},
+};
 use crate::{
     btsieve::{
         find_relevant_blocks, BlockByHash, BlockHash, LatestBlock, Predates, PreviousBlockHash,

--- a/cnd/src/btsieve/ethereum/web3_connector.rs
+++ b/cnd/src/btsieve/ethereum/web3_connector.rs
@@ -3,6 +3,7 @@ use crate::{
     ethereum::{TransactionReceipt, H256},
     jsonrpc,
 };
+use crate::swap_protocols::ledger::ethereum::ChainId;
 use async_trait::async_trait;
 
 #[derive(Debug)]
@@ -74,4 +75,17 @@ impl ReceiptByHash for Web3Connector {
 
         Ok(receipt)
     }
+}
+
+pub async fn net_version(conn: &Web3Connector) -> Result<crate::swap_protocols::ledger::ethereum::ChainId, anyhow::Error> {
+    let empty_params: Vec<()> = vec![];
+
+    let chain_id: ChainId = conn
+        .client
+        .send::<Vec<()>, crate::swap_protocols::ledger::ethereum::ChainId>(jsonrpc::Request::new("net_version", empty_params))
+        .await?;
+
+    tracing::debug!("Fetched net_version from web3: {:?}", chain_id);
+
+    Ok(chain_id)
 }

--- a/cnd/src/config/mod.rs
+++ b/cnd/src/config/mod.rs
@@ -1,6 +1,7 @@
 pub mod file;
 mod serde_bitcoin_network;
 pub mod settings;
+pub mod validation;
 
 use crate::swap_protocols::ledger::ethereum;
 use libp2p::Multiaddr;

--- a/cnd/src/config/validation.rs
+++ b/cnd/src/config/validation.rs
@@ -1,0 +1,50 @@
+use crate::swap_protocols::ledger::ethereum::ChainId;
+use bitcoin::Network;
+use thiserror::Error;
+
+use crate::btsieve::{
+    bitcoin::{chain_info, BitcoindConnector},
+    ethereum::{net_version, Web3Connector},
+};
+
+#[derive(Error, Debug)]
+pub enum ConfigValidationError<T: std::fmt::Debug> {
+    #[error("Connected network does not match network specified in settings (expected {connected_network:?}, got {specified_network:?})")]
+    ConnectedNetworkDoesNotMatchSpecified {
+        connected_network: T,
+        specified_network: T,
+    }
+}
+
+#[derive(Debug)]
+pub enum NetworkValidationResult<T> {
+    Valid,
+    Invalid {
+        connected_network: T,
+        specified_network: T,
+    }
+}
+
+pub async fn validate_ethereum_chain_id(connection: &Web3Connector, specified: ChainId) -> Result<NetworkValidationResult<ChainId>, anyhow::Error> {
+    let actual = net_version(connection).await?;
+    if actual == specified {
+        Ok(NetworkValidationResult::Valid)
+    } else {
+        Ok(NetworkValidationResult::Invalid {
+            connected_network: actual,
+            specified_network: specified,
+        })
+    }
+}
+
+pub async fn validate_bitcoin_network(connection: &BitcoindConnector, specified: Network) -> Result<NetworkValidationResult<Network>, anyhow::Error>  {
+    let actual = chain_info(connection).await?;
+    if actual.chain == specified {
+        Ok(NetworkValidationResult::Valid)
+    } else {
+        Ok(NetworkValidationResult::Invalid {
+            connected_network: actual.chain,
+            specified_network: specified,
+        })
+    }
+}

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -19,7 +19,11 @@ use cnd::{
         bitcoin::{self, BitcoindConnector},
         ethereum::{self, Web3Connector},
     },
-    config::{self, Settings},
+    config::{
+        self,
+        validation::{NetworkValidationResult, ConfigValidationError, validate_bitcoin_network, validate_ethereum_chain_id},
+        Settings,
+    },
     db::Sqlite,
     http_api::route_factory,
     load_swaps,
@@ -69,6 +73,11 @@ fn main() -> anyhow::Result<()> {
         ))
     };
 
+    match runtime.block_on(validate_bitcoin_network(&bitcoin_connector.connector, settings.bitcoin.network)) {
+        Ok(result) => handle_invalid_network_validation(result)?,
+        Err(err) =>  tracing::warn!("Failed to connect to Bitcoin node while validating config: {}", err),
+    };
+
     const ETHEREUM_BLOCK_CACHE_CAPACITY: usize = 720;
     const ETHEREUM_RECEIPT_CACHE_CAPACITY: usize = 720;
     let ethereum_connector = Arc::new(ethereum::Cache::new(
@@ -76,6 +85,11 @@ fn main() -> anyhow::Result<()> {
         ETHEREUM_BLOCK_CACHE_CAPACITY,
         ETHEREUM_RECEIPT_CACHE_CAPACITY,
     ));
+
+    match runtime.block_on(validate_ethereum_chain_id(&ethereum_connector.connector, settings.ethereum.chain_id)) {
+        Ok(result) => handle_invalid_network_validation(result)?,
+        Err(err) => tracing::warn!("Failed to connect to Ethereum node while validating config: {}", err),
+    };
 
     let state_store = Arc::new(InMemoryStateStore::default());
 
@@ -161,4 +175,14 @@ fn dump_config(settings: Settings) -> anyhow::Result<()> {
     let serialized = toml::to_string(&file)?;
     println!("{}", serialized);
     Ok(())
+}
+
+/// Throws an error if the connected connected blockchain network is invalid
+fn handle_invalid_network_validation<T: std::fmt::Debug>(validation: NetworkValidationResult<T>) -> anyhow::Result<(), ConfigValidationError<T>> {
+    match validation {
+        NetworkValidationResult::Invalid { connected_network: connected, specified_network: specified } => {
+            Err(ConfigValidationError::ConnectedNetworkDoesNotMatchSpecified { connected_network: connected, specified_network: specified })
+        },
+        NetworkValidationResult::Valid => Ok(())
+    }
 }


### PR DESCRIPTION
This PR checks to see if the bitcoin node network id and ethereum node chain id matches the id's specified in the config file. The check is performed at at startup. A warning is logged if the request to retrieve the id fails. Cnd will abort if the check finds that the actual id does not match the specified id.

Closes #2088.