### PR TITLE
Use new rustfmt toolchain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,8 +87,8 @@ commands:
           name:  "Install Rust"
           command: |
             curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $(< rust-toolchain) && source $HOME/.cargo/env
-            rustup install nightly-2019-07-31
-            rustup component add rustfmt --toolchain nightly-2019-07-31
+            rustup install nightly-2020-01-15
+            rustup component add rustfmt --toolchain nightly-2020-01-15
 
             # Define variables that need interpolation
             # As CircleCI starts a new shell for each `run` declaration, we need to export cargo home to $BASH_ENV
@@ -124,7 +124,7 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - rustup-{{ checksum "rust-toolchain" }}-nightly-2019-07-31
+            - rustup-{{ checksum "rust-toolchain" }}-nightly-2020-01-15
             # We don't want multiple toolchains to pile up in our cache, so only restore the ones we actually use.
       - restore_cache:
           keys:
@@ -142,7 +142,7 @@ commands:
       - save_cache:
           paths:
             - ~/.rustup
-          key: rustup-{{ checksum "rust-toolchain" }}-nightly-2019-07-31
+          key: rustup-{{ checksum "rust-toolchain" }}-nightly-2020-01-15
       - save_cache:
           paths:
             - ~/.cargo

--- a/cnd/src/btsieve/bitcoin/mod.rs
+++ b/cnd/src/btsieve/bitcoin/mod.rs
@@ -5,10 +5,8 @@ pub use self::{
     bitcoind_connector::{chain_info, BitcoindConnector, ChainInfo},
     cache::Cache,
 };
-use crate::{
-    btsieve::{
-        find_relevant_blocks, BlockByHash, BlockHash, LatestBlock, Predates, PreviousBlockHash,
-    },
+use crate::btsieve::{
+    find_relevant_blocks, BlockByHash, BlockHash, LatestBlock, Predates, PreviousBlockHash,
 };
 use bitcoin::{
     blockdata::script::Instruction,

--- a/cnd/src/btsieve/ethereum/web3_connector.rs
+++ b/cnd/src/btsieve/ethereum/web3_connector.rs
@@ -2,8 +2,8 @@ use crate::{
     btsieve::{ethereum::ReceiptByHash, BlockByHash, LatestBlock},
     ethereum::{TransactionReceipt, H256},
     jsonrpc,
+    swap_protocols::ledger::ethereum::ChainId,
 };
-use crate::swap_protocols::ledger::ethereum::ChainId;
 use async_trait::async_trait;
 
 #[derive(Debug)]
@@ -77,13 +77,17 @@ impl ReceiptByHash for Web3Connector {
     }
 }
 
-pub async fn net_version(conn: &Web3Connector) -> Result<crate::swap_protocols::ledger::ethereum::ChainId, anyhow::Error> {
+pub async fn net_version(
+    conn: &Web3Connector,
+) -> Result<crate::swap_protocols::ledger::ethereum::ChainId, anyhow::Error> {
     let empty_params: Vec<()> = vec![];
 
-    let chain_id: ChainId = conn
-        .client
-        .send::<Vec<()>, crate::swap_protocols::ledger::ethereum::ChainId>(jsonrpc::Request::new("net_version", empty_params))
-        .await?;
+    let chain_id: ChainId =
+        conn.client
+            .send::<Vec<()>, crate::swap_protocols::ledger::ethereum::ChainId>(
+                jsonrpc::Request::new("net_version", empty_params),
+            )
+            .await?;
 
     tracing::debug!("Fetched net_version from web3: {:?}", chain_id);
 

--- a/cnd/src/config/validation.rs
+++ b/cnd/src/config/validation.rs
@@ -13,7 +13,7 @@ pub enum ConfigValidationError<T: std::fmt::Debug> {
     ConnectedNetworkDoesNotMatchSpecified {
         connected_network: T,
         specified_network: T,
-    }
+    },
 }
 
 #[derive(Debug)]
@@ -22,10 +22,13 @@ pub enum NetworkValidationResult<T> {
     Invalid {
         connected_network: T,
         specified_network: T,
-    }
+    },
 }
 
-pub async fn validate_ethereum_chain_id(connection: &Web3Connector, specified: ChainId) -> Result<NetworkValidationResult<ChainId>, anyhow::Error> {
+pub async fn validate_ethereum_chain_id(
+    connection: &Web3Connector,
+    specified: ChainId,
+) -> Result<NetworkValidationResult<ChainId>, anyhow::Error> {
     let actual = net_version(connection).await?;
     if actual == specified {
         Ok(NetworkValidationResult::Valid)
@@ -37,7 +40,10 @@ pub async fn validate_ethereum_chain_id(connection: &Web3Connector, specified: C
     }
 }
 
-pub async fn validate_bitcoin_network(connection: &BitcoindConnector, specified: Network) -> Result<NetworkValidationResult<Network>, anyhow::Error>  {
+pub async fn validate_bitcoin_network(
+    connection: &BitcoindConnector,
+    specified: Network,
+) -> Result<NetworkValidationResult<Network>, anyhow::Error> {
     let actual = chain_info(connection).await?;
     if actual.chain == specified {
         Ok(NetworkValidationResult::Valid)


### PR DESCRIPTION
Run make format with the newly updated toolchain

Recently we updated the toolchain to 1.41.1, and also the nightly toolchain to `nightly-2020-01-15`.  CI is configured to run a different version of `rustfmt` so this got past CI.  However, this upgrade introduce a bunch of new formatting to our codebase.

- Run `make format`
- Configure CI to use the same nightly toolchain as the makefile