### PR TITLE
Remove some noise from the e2e test declarations

### DIFF
--- a/api_tests/lib/actor_test.ts
+++ b/api_tests/lib/actor_test.ts
@@ -2,59 +2,68 @@ import { Actors } from "./actors";
 import { createActors } from "./create_actors";
 import JasmineSmacker from "smack-my-jasmine-up";
 import { timeout } from "./utils";
+import ProvidesCallback = jest.ProvidesCallback;
 
 /*
  * This test function will take care of instantiating the actors and tearing them down again
  * after the test, regardless if the test succeeded or failed.
  */
-async function nActorTest(
+function nActorTest(
     actorNames: ["alice", "bob", "charlie"] | ["alice", "bob"] | ["alice"],
     testFn: (actors: Actors) => Promise<void>
-) {
-    const name = JasmineSmacker.getCurrentTestName();
-    if (!name.match(/[A-z0-9\-]+/)) {
-        // We use the test name as a file name for the log and hence need to restrict it.
-        throw new Error(
-            `Testname '${name}' is invalid. Only A-z, 0-9 and dashes are allowed.`
-        );
-    }
-
-    const actors = await createActors(name, actorNames);
-
-    try {
-        await timeout(60_000, testFn(actors));
-    } catch (e) {
-        for (const actorName of actorNames) {
-            await actors.getActorByName(actorName).dumpState();
+): ProvidesCallback {
+    return async done => {
+        const name = JasmineSmacker.getCurrentTestName();
+        if (!name.match(/[A-z0-9\-]+/)) {
+            // We use the test name as a file name for the log and hence need to restrict it.
+            throw new Error(
+                `Testname '${name}' is invalid. Only A-z, 0-9 and dashes are allowed.`
+            );
         }
-        throw e;
-    } finally {
-        for (const actorName of actorNames) {
-            actors.getActorByName(actorName).stop();
+
+        const actors = await createActors(name, actorNames);
+
+        try {
+            await timeout(60_000, testFn(actors));
+        } catch (e) {
+            for (const actorName of actorNames) {
+                await actors.getActorByName(actorName).dumpState();
+            }
+            throw e;
+        } finally {
+            for (const actorName of actorNames) {
+                actors.getActorByName(actorName).stop();
+            }
         }
-    }
+
+        done();
+    };
 }
 
 /*
  * Instantiates a new e2e test based on three actors
  *
  */
-export async function threeActorTest(
+export function threeActorTest(
     testFn: (actors: Actors) => Promise<void>
-) {
-    await nActorTest(["alice", "bob", "charlie"], testFn);
+): ProvidesCallback {
+    return nActorTest(["alice", "bob", "charlie"], testFn);
 }
 
 /*
  * Instantiates a new e2e test based on two actors
  */
-export async function twoActorTest(testFn: (actors: Actors) => Promise<void>) {
-    await nActorTest(["alice", "bob"], testFn);
+export function twoActorTest(
+    testFn: (actors: Actors) => Promise<void>
+): ProvidesCallback {
+    return nActorTest(["alice", "bob"], testFn);
 }
 
 /*
  * Instantiates a new e2e test based on one actor
  */
-export async function oneActorTest(testFn: (actors: Actors) => Promise<void>) {
-    await nActorTest(["alice"], testFn);
+export function oneActorTest(
+    testFn: (actors: Actors) => Promise<void>
+): ProvidesCallback {
+    return nActorTest(["alice"], testFn);
 }

--- a/api_tests/tests/dry/lightning_routes.ts
+++ b/api_tests/tests/dry/lightning_routes.ts
@@ -9,8 +9,9 @@ import { oneActorTest } from "../../lib/actor_test";
 // Lightning routes                               //
 // ******************************************** //
 describe("Lightning routes tests", () => {
-    it("lightning-routes-post-eth-lnbtc-return-400", async function() {
-        await oneActorTest(async function({ alice }) {
+    it(
+        "lightning-routes-post-eth-lnbtc-return-400",
+        oneActorTest(async ({ alice }) => {
             const promise = alice.cnd.createHanEthereumEtherHalightLightningBitcoin();
             return expect(promise).to.eventually.be.rejected.then(error => {
                 expect(error).to.have.property(
@@ -18,11 +19,12 @@ describe("Lightning routes tests", () => {
                     "Request failed with status code 400"
                 );
             });
-        });
-    });
+        })
+    );
 
-    it("lightning-routes-post-erc20-lnbtc-return-400", async function() {
-        await oneActorTest(async function({ alice }) {
+    it(
+        "lightning-routes-post-erc20-lnbtc-return-400",
+        oneActorTest(async ({ alice }) => {
             const promise = alice.cnd.createHerc20EthereumErc20HalightLightningBitcoin();
             return expect(promise).to.eventually.be.rejected.then(error => {
                 expect(error).to.have.property(
@@ -30,11 +32,12 @@ describe("Lightning routes tests", () => {
                     "Request failed with status code 400"
                 );
             });
-        });
-    });
+        })
+    );
 
-    it("lightning-routes-post-lnbtc-eth-return-400", async function() {
-        await oneActorTest(async function({ alice }) {
+    it(
+        "lightning-routes-post-lnbtc-eth-return-400",
+        oneActorTest(async ({ alice }) => {
             const promise = alice.cnd.createHalightLightningBitcoinHanEthereumEther();
             return expect(promise).to.eventually.be.rejected.then(error => {
                 expect(error).to.have.property(
@@ -42,11 +45,12 @@ describe("Lightning routes tests", () => {
                     "Request failed with status code 400"
                 );
             });
-        });
-    });
+        })
+    );
 
-    it("lightning-routes-post-lnbtc-erc20-return-400", async function() {
-        await oneActorTest(async function({ alice }) {
+    it(
+        "lightning-routes-post-lnbtc-erc20-return-400",
+        oneActorTest(async ({ alice }) => {
             const promise = alice.cnd.createHalightLightningBitcoinHerc20EthereumErc20();
             return expect(promise).to.eventually.be.rejected.then(error => {
                 expect(error).to.have.property(
@@ -54,6 +58,6 @@ describe("Lightning routes tests", () => {
                     "Request failed with status code 400"
                 );
             });
-        });
-    });
+        })
+    );
 });

--- a/api_tests/tests/dry/multiple_peers.ts
+++ b/api_tests/tests/dry/multiple_peers.ts
@@ -25,8 +25,9 @@ function toMatch(swapDetail: SwapDetails): MatchInterface {
 // Multiple peers                               //
 // ******************************************** //
 describe("Multiple peers tests", () => {
-    it("alice-sends-swap-request-to-bob-and-charlie", async function() {
-        await threeActorTest(async function({ alice, bob, charlie }) {
+    it(
+        "alice-sends-swap-request-to-bob-and-charlie",
+        threeActorTest(async ({ alice, bob, charlie }) => {
             // Alice send swap request to Bob
             const aliceToBobSwapUrl = await alice.cnd.postSwap(
                 await createDefaultSwapRequest(bob)
@@ -72,6 +73,6 @@ describe("Multiple peers tests", () => {
                 toMatch(bobSwapDetails),
                 toMatch(charlieSwapDetails),
             ]);
-        });
-    });
+        })
+    );
 });

--- a/api_tests/tests/dry/peers_using_ip.ts
+++ b/api_tests/tests/dry/peers_using_ip.ts
@@ -30,17 +30,19 @@ async function assertPeersAvailable(alice: Actor, bob: Actor, message: string) {
 }
 
 describe("Peers using IP tests", () => {
-    it("alice-empty-peer-list", async function() {
-        await twoActorTest(async function({ alice }) {
+    it(
+        "alice-empty-peer-list",
+        twoActorTest(async ({ alice }) => {
             const res = await request(alice.cndHttpApiUrl()).get("/peers");
 
             expect(res.status).to.equal(200);
             expect(res.body.peers).to.be.empty;
-        });
-    });
+        })
+    );
 
-    it("alice-send-request-wrong-peer-id", async function() {
-        await threeActorTest(async function({ alice, bob, charlie }) {
+    it(
+        "alice-send-request-wrong-peer-id",
+        threeActorTest(async ({ alice, bob, charlie }) => {
             await assertNoPeersAvailable(
                 alice,
                 "[Alice] Should not yet see Bob's nor Charlie's peer id in her list of peers"
@@ -74,11 +76,12 @@ describe("Peers using IP tests", () => {
                 charlie,
                 "[Charlie] Should not see Alice's PeerID because there was no communication so far"
             );
-        });
-    });
+        })
+    );
 
-    it("alice-send-swap-request-to-charlie", async function() {
-        await threeActorTest(async function({ alice, bob, charlie }) {
+    it(
+        "alice-send-swap-request-to-charlie",
+        threeActorTest(async ({ alice, bob, charlie }) => {
             await assertNoPeersAvailable(
                 alice,
                 "[Alice] Should not yet see Bob's nor Charlie's peer id in her list of peers"
@@ -105,6 +108,6 @@ describe("Peers using IP tests", () => {
                 alice,
                 "[Charlie] Should see Alice's peer ID in his list of peers after receiving a swap request from Alice"
             );
-        });
-    });
+        })
+    );
 });

--- a/api_tests/tests/dry/rfc003_schema.ts
+++ b/api_tests/tests/dry/rfc003_schema.ts
@@ -36,15 +36,18 @@ async function assertValidSirenDocument(
 }
 
 describe("Rfc003 schema tests", () => {
-    it("get-all-swaps-is-valid-siren", async function() {
-        await twoActorTest(async function({ alice }) {
+    it(
+        "get-all-swaps-is-valid-siren",
+        twoActorTest(async ({ alice }) => {
             const res = await request(alice.cndHttpApiUrl()).get("/swaps");
 
             expect(res.body).to.be.jsonSchema(sirenJsonSchema);
-        });
-    });
-    it("get-single-swap-is-valid-siren", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+        })
+    );
+
+    it(
+        "get-single-swap-is-valid-siren",
+        twoActorTest(async ({ alice, bob }) => {
             // Alice send swap request to Bob
             await alice.cnd.postSwap(await createDefaultSwapRequest(bob));
 
@@ -70,11 +73,12 @@ describe("Rfc003 schema tests", () => {
                 bob,
                 "[Bob] Response for GET /swaps/rfc003/{} is a valid siren document and properties match the json schema"
             );
-        });
-    });
+        })
+    );
 
-    it("get-single-swap-contains-link-to-rfc", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "get-single-swap-contains-link-to-rfc",
+        twoActorTest(async ({ alice, bob }) => {
             // Alice send swap request to Bob
             await alice.cnd.postSwap(await createDefaultSwapRequest(bob));
 
@@ -95,8 +99,8 @@ describe("Rfc003 schema tests", () => {
                 href:
                     "https://github.com/comit-network/RFCs/blob/master/RFC-003-SWAP-Basic.adoc",
             });
-        });
-    });
+        })
+    );
 });
 
 // ******************************************** //
@@ -114,8 +118,9 @@ async function assertSwapsInProgress(actor: Actor, message: string) {
 }
 
 describe("Rfc003 schema swap reject tests", () => {
-    it("alice-can-make-default-swap-request", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "alice-can-make-default-swap-request",
+        twoActorTest(async ({ alice, bob }) => {
             // Alice should be able to send two swap requests to Bob
             const url1 = await alice.cnd.postSwap({
                 ...(await createDefaultSwapRequest(bob)),
@@ -146,11 +151,12 @@ describe("Rfc003 schema swap reject tests", () => {
                 bob,
                 "[Bob] Shows the swaps as IN_PROGRESS in /swaps"
             );
-        });
-    });
+        })
+    );
 
-    it("bob-can-decline-swap", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "bob-can-decline-swap",
+        twoActorTest(async ({ alice, bob }) => {
             // Alice should be able to send two swap requests to Bob
             const aliceReasonableSwap = await alice.cnd.postSwap({
                 ...(await createDefaultSwapRequest(bob)),
@@ -221,6 +227,6 @@ describe("Rfc003 schema swap reject tests", () => {
                     .status,
                 "[Alice] Should be in the SENT State for the other swap request"
             ).to.eq("SENT");
-        });
-    });
+        })
+    );
 });

--- a/api_tests/tests/dry/sanity.ts
+++ b/api_tests/tests/dry/sanity.ts
@@ -12,8 +12,9 @@ import * as sirenJsonSchema from "../../siren.schema.json";
 // ******************************************** //
 
 describe("Sanity - peers using IP", () => {
-    it("invalid-swap-yields-404", async function() {
-        await oneActorTest(async function({ alice }) {
+    it(
+        "invalid-swap-yields-404",
+        oneActorTest(async ({ alice }) => {
             const res = await request(alice.cndHttpApiUrl()).get(
                 "/swaps/rfc003/deadbeef-dead-beef-dead-deadbeefdead"
             );
@@ -23,21 +24,23 @@ describe("Sanity - peers using IP", () => {
                 "content-type",
                 "application/problem+json"
             );
-        });
-    });
+        })
+    );
 
-    it("empty-swap-list-after-startup", async function() {
-        await oneActorTest(async function({ alice }) {
+    it(
+        "empty-swap-list-after-startup",
+        oneActorTest(async ({ alice }) => {
             const res = await request(alice.cndHttpApiUrl()).get("/swaps");
 
             const body = res.body as Entity;
 
             expect(body.entities).to.have.lengthOf(0);
-        });
-    });
+        })
+    );
 
-    it("bad-request-for-invalid-swap-combination", async function() {
-        await oneActorTest(async function({ alice }) {
+    it(
+        "bad-request-for-invalid-swap-combination",
+        oneActorTest(async ({ alice }) => {
             const res = await request(alice.cndHttpApiUrl())
                 .post("/swaps/rfc003")
                 .send({
@@ -68,10 +71,12 @@ describe("Sanity - peers using IP", () => {
                 "application/problem+json"
             );
             expect(res.body.title).to.equal("Invalid body.");
-        });
-    });
-    it("returns-invalid-body-for-bad-json", async function() {
-        await oneActorTest(async function({ alice }) {
+        })
+    );
+
+    it(
+        "returns-invalid-body-for-bad-json",
+        oneActorTest(async ({ alice }) => {
             const res = await request(alice.cndHttpApiUrl())
                 .post("/swaps/rfc003")
                 .send({
@@ -84,36 +89,44 @@ describe("Sanity - peers using IP", () => {
                 "application/problem+json"
             );
             expect(res.body.title).to.equal("Invalid body.");
-        });
-    });
-    it("alice-has-empty-peer-list", async function() {
-        await oneActorTest(async function({ alice }) {
+        })
+    );
+
+    it(
+        "alice-has-empty-peer-list",
+        oneActorTest(async ({ alice }) => {
             const res = await request(alice.cndHttpApiUrl()).get("/peers");
 
             expect(res).to.have.status(200);
             expect(res.body.peers).to.have.length(0);
-        });
-    });
-    it("returns-listen-addresses-on-root-document", async function() {
-        await oneActorTest(async function({ alice }) {
+        })
+    );
+
+    it(
+        "returns-listen-addresses-on-root-document",
+        oneActorTest(async ({ alice }) => {
             const res = await request(alice.cndHttpApiUrl()).get("/");
 
             expect(res.body.id).to.be.a("string");
             expect(res.body.listen_addresses).to.be.an("array");
             // At least 2 ipv4 addresses, lookup and external interface
             expect(res.body.listen_addresses.length).to.be.greaterThan(1);
-        });
-    });
-    it("can-fetch-root-document-as-siren", async function() {
-        await oneActorTest(async function({ alice }) {
+        })
+    );
+
+    it(
+        "can-fetch-root-document-as-siren",
+        oneActorTest(async ({ alice }) => {
             const res = await request(alice.cndHttpApiUrl()).get("/");
 
             expect(res).to.have.status(200);
             expect(res.body).to.be.jsonSchema(sirenJsonSchema);
-        });
-    });
-    it("returns-listen-addresses-on-root-document-as-siren", async function() {
-        await oneActorTest(async function({ alice }) {
+        })
+    );
+
+    it(
+        "returns-listen-addresses-on-root-document-as-siren",
+        oneActorTest(async ({ alice }) => {
             const res = await request(alice.cndHttpApiUrl())
                 .get("/")
                 .set("accept", "application/vnd.siren+json");
@@ -124,10 +137,12 @@ describe("Sanity - peers using IP", () => {
             expect(
                 res.body.properties.listen_addresses.length
             ).to.be.greaterThan(1);
-        });
-    });
-    it("returns-links-to-create-swap-endpoints-on-root-document-as-siren", async function() {
-        await oneActorTest(async function({ alice }) {
+        })
+    );
+
+    it(
+        "returns-links-to-create-swap-endpoints-on-root-document-as-siren",
+        oneActorTest(async ({ alice }) => {
             const res = await request(alice.cndHttpApiUrl())
                 .get("/")
                 .set("accept", "application/vnd.siren+json");
@@ -162,6 +177,6 @@ describe("Sanity - peers using IP", () => {
                 class: ["swaps", "rfc003"],
                 href: "/swaps/rfc003",
             });
-        });
-    });
+        })
+    );
 });

--- a/api_tests/tests/e2e/bitcoin_ethereum.ts
+++ b/api_tests/tests/e2e/bitcoin_ethereum.ts
@@ -13,8 +13,9 @@ import { LedgerKind } from "../../lib/ledgers/ledger";
 // Lightning Sanity Test                        //
 // ******************************************** //
 describe("E2E: Sanity - LND Alice pays Bob", () => {
-    it.skip("sanity-lnd-alice-pays-bob", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it.skip(
+        "sanity-lnd-alice-pays-bob",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(
                 { ledger: LedgerKind.Lightning, asset: AssetKind.Bitcoin },
                 { ledger: LedgerKind.Bitcoin, asset: AssetKind.Bitcoin }
@@ -24,11 +25,12 @@ describe("E2E: Sanity - LND Alice pays Bob", () => {
             );
             await alice.lnPayInvoiceWithRequest(paymentRequest);
             await bob.lnAssertInvoiceSettled(rHash);
-        });
-    });
+        })
+    );
 
-    it.skip("sanity-lnd-alice-pays-bob-using-hold-invoice", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it.skip(
+        "sanity-lnd-alice-pays-bob-using-hold-invoice",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(
                 { ledger: LedgerKind.Lightning, asset: AssetKind.Bitcoin },
                 { ledger: LedgerKind.Bitcoin, asset: AssetKind.Bitcoin }
@@ -57,8 +59,8 @@ describe("E2E: Sanity - LND Alice pays Bob", () => {
             expect(pay.paymentPreimage.toString("hex")).equals(secret);
 
             await bob.lnAssertInvoiceSettled(secretHash);
-        });
-    });
+        })
+    );
 });
 
 // ******************************************** //
@@ -66,8 +68,9 @@ describe("E2E: Sanity - LND Alice pays Bob", () => {
 // Ethereum/ether Beta Ledger/Beta Asset        //
 // ******************************************** //
 describe("E2E: Bitcoin/bitcoin - Ethereum/ether", () => {
-    it("rfc003-btc-eth-alice-redeems-bob-redeems", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-btc-eth-alice-redeems-bob-redeems",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Bitcoin, AssetKind.Ether);
             await bob.accept();
 
@@ -79,15 +82,16 @@ describe("E2E: Bitcoin/bitcoin - Ethereum/ether", () => {
 
             await alice.assertSwapped();
             await bob.assertSwapped();
-        });
-    });
+        })
+    );
 
     // ************************ //
     // Refund test              //
     // ************************ //
 
-    it("rfc003-btc-eth-bob-refunds-alice-refunds", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-btc-eth-bob-refunds-alice-refunds",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Bitcoin, AssetKind.Ether);
             await bob.accept();
 
@@ -99,11 +103,12 @@ describe("E2E: Bitcoin/bitcoin - Ethereum/ether", () => {
 
             await bob.assertRefunded();
             await alice.assertRefunded();
-        });
-    });
+        })
+    );
 
-    it("rfc003-btc-eth-alice-refunds-bob-refunds", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-btc-eth-alice-refunds-bob-refunds",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Bitcoin, AssetKind.Ether);
             await bob.accept();
 
@@ -115,15 +120,16 @@ describe("E2E: Bitcoin/bitcoin - Ethereum/ether", () => {
 
             await alice.assertRefunded();
             await bob.assertRefunded();
-        });
-    });
+        })
+    );
 
     // ************************ //
     // Restart cnd test         //
     // ************************ //
 
-    it("rfc003-btc-eth-cnd-can-be-restarted", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-btc-eth-cnd-can-be-restarted",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Bitcoin, AssetKind.Ether);
             await bob.accept();
 
@@ -135,15 +141,16 @@ describe("E2E: Bitcoin/bitcoin - Ethereum/ether", () => {
 
             await alice.currentSwapIsAccepted();
             await bob.currentSwapIsAccepted();
-        });
-    });
+        })
+    );
 
     // ************************ //
     // Resume cnd test          //
     // ************************ //
 
-    it("rfc003-btc-eth-resume-alice-down-bob-funds", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-btc-eth-resume-alice-down-bob-funds",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Bitcoin, AssetKind.Ether);
             await bob.accept();
 
@@ -163,11 +170,12 @@ describe("E2E: Bitcoin/bitcoin - Ethereum/ether", () => {
 
             await alice.assertSwapped();
             await bob.assertSwapped();
-        });
-    });
+        })
+    );
 
-    it("rfc003-btc-eth-resume-alice-down-bob-redeems", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-btc-eth-resume-alice-down-bob-redeems",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Bitcoin, AssetKind.Ether);
             await bob.accept();
 
@@ -187,11 +195,12 @@ describe("E2E: Bitcoin/bitcoin - Ethereum/ether", () => {
 
             await alice.assertSwapped();
             await bob.assertSwapped();
-        });
-    });
+        })
+    );
 
-    it("rfc003-btc-eth-resume-bob-down-alice-funds", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-btc-eth-resume-bob-down-alice-funds",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Bitcoin, AssetKind.Ether);
             await bob.accept();
 
@@ -215,11 +224,12 @@ describe("E2E: Bitcoin/bitcoin - Ethereum/ether", () => {
 
             await alice.assertSwapped();
             await bob.assertSwapped();
-        });
-    });
+        })
+    );
 
-    it("rfc003-btc-eth-resume-bob-down-alice-redeems", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-btc-eth-resume-bob-down-alice-redeems",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Bitcoin, AssetKind.Ether);
             await bob.accept();
 
@@ -240,15 +250,16 @@ describe("E2E: Bitcoin/bitcoin - Ethereum/ether", () => {
 
             await alice.assertSwapped();
             await bob.assertSwapped();
-        });
-    });
+        })
+    );
 
     // ************************ //
     // Underfunding test        //
     // ************************ //
 
-    it("rfc003-btc-eth-alice-underfunds-bob-aborts", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-btc-eth-alice-underfunds-bob-aborts",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Bitcoin, AssetKind.Ether);
             await bob.accept();
 
@@ -263,11 +274,12 @@ describe("E2E: Bitcoin/bitcoin - Ethereum/ether", () => {
             await alice.assertRefunded();
 
             await bob.assertBetaNotDeployed();
-        });
-    });
+        })
+    );
 
-    it("rfc003-btc-eth-bob-underfunds-both-refund", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-btc-eth-bob-underfunds-both-refund",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Bitcoin, AssetKind.Ether);
             await bob.accept();
             await alice.fund();
@@ -284,15 +296,16 @@ describe("E2E: Bitcoin/bitcoin - Ethereum/ether", () => {
             await bob.assertRefunded();
             await alice.refund();
             await alice.assertRefunded();
-        });
-    });
+        })
+    );
 
     // ************************ //
     // Overfund test            //
     // ************************ //
 
-    it("rfc003-btc-eth-alice-overfunds-bob-aborts", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-btc-eth-alice-overfunds-bob-aborts",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Bitcoin, AssetKind.Ether);
             await bob.accept();
 
@@ -307,11 +320,12 @@ describe("E2E: Bitcoin/bitcoin - Ethereum/ether", () => {
             await alice.assertRefunded();
 
             await bob.assertBetaNotDeployed();
-        });
-    });
+        })
+    );
 
-    it("rfc003-btc-eth-bob-overfunds-both-refund", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-btc-eth-bob-overfunds-both-refund",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Bitcoin, AssetKind.Ether);
             await bob.accept();
             await alice.fund();
@@ -328,8 +342,8 @@ describe("E2E: Bitcoin/bitcoin - Ethereum/ether", () => {
             await bob.assertRefunded();
             await alice.refund();
             await alice.assertRefunded();
-        });
-    });
+        })
+    );
 });
 
 // ******************************************** //
@@ -337,8 +351,9 @@ describe("E2E: Bitcoin/bitcoin - Ethereum/ether", () => {
 // Bitcoin/bitcoin Beta Ledger/Beta Asset       //
 // ******************************************** //
 describe("E2E: Ethereum/ether - Bitcoin/bitcoin", () => {
-    it("rfc003-eth-btc-alice-redeems-bob-redeems", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-eth-btc-alice-redeems-bob-redeems",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Ether, AssetKind.Bitcoin);
             await bob.accept();
 
@@ -350,15 +365,16 @@ describe("E2E: Ethereum/ether - Bitcoin/bitcoin", () => {
 
             await alice.assertSwapped();
             await bob.assertSwapped();
-        });
-    });
+        })
+    );
 
     // ************************ //
     // Ignore Failed ETH TX     //
     // ************************ //
 
-    it("rfc003-eth-btc-alpha-deploy-fails", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-eth-btc-alpha-deploy-fails",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Ether, AssetKind.Bitcoin);
             await bob.accept();
 
@@ -368,15 +384,16 @@ describe("E2E: Ethereum/ether - Bitcoin/bitcoin", () => {
             await bob.assertAlphaNotDeployed();
             await bob.assertBetaNotDeployed();
             await alice.assertBetaNotDeployed();
-        });
-    });
+        })
+    );
 
     // ************************ //
     // Refund tests             //
     // ************************ //
 
-    it("rfc003-eth-btc-bob-refunds-alice-refunds", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-eth-btc-bob-refunds-alice-refunds",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Ether, AssetKind.Bitcoin);
             await bob.accept();
 
@@ -388,15 +405,16 @@ describe("E2E: Ethereum/ether - Bitcoin/bitcoin", () => {
 
             await bob.assertRefunded();
             await alice.assertRefunded();
-        });
-    });
+        })
+    );
 
     // ************************ //
     // Bitcoin High Fees        //
     // ************************ //
 
-    it("rfc003-eth-btc-alice-redeems-with-high-fee", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-eth-btc-alice-redeems-with-high-fee",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Ether, AssetKind.Bitcoin);
             await bob.accept();
 
@@ -406,8 +424,8 @@ describe("E2E: Ethereum/ether - Bitcoin/bitcoin", () => {
             const responsePromise = alice.redeemWithHighFee();
 
             return expect(responsePromise).to.be.rejected;
-        });
-    });
+        })
+    );
 });
 
 // ******************************************** //
@@ -415,8 +433,9 @@ describe("E2E: Ethereum/ether - Bitcoin/bitcoin", () => {
 // Ethereum/erc20 Beta Ledger/Beta Asset        //
 // ******************************************** //
 describe("E2E: Bitcoin/bitcoin - Ethereum/erc20", () => {
-    it("rfc003-btc-eth-erc20-alice-redeems-bob-redeems", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-btc-eth-erc20-alice-redeems-bob-redeems",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Bitcoin, AssetKind.Erc20);
             await bob.accept();
 
@@ -429,11 +448,12 @@ describe("E2E: Bitcoin/bitcoin - Ethereum/erc20", () => {
 
             await alice.assertSwapped();
             await bob.assertSwapped();
-        });
-    });
+        })
+    );
 
-    it("rfc003-btc-eth-erc20-bob-refunds-alice-refunds", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-btc-eth-erc20-bob-refunds-alice-refunds",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Bitcoin, AssetKind.Erc20);
             await bob.accept();
 
@@ -446,8 +466,8 @@ describe("E2E: Bitcoin/bitcoin - Ethereum/erc20", () => {
 
             await alice.assertRefunded();
             await bob.assertRefunded();
-        });
-    });
+        })
+    );
 });
 
 // ******************************************** //
@@ -455,8 +475,9 @@ describe("E2E: Bitcoin/bitcoin - Ethereum/erc20", () => {
 // Bitcoin/bitcoin Beta Ledger/Beta Asset       //
 // ******************************************** //
 describe("E2E: Ethereum/erc20 - Bitcoin/bitcoin", () => {
-    it("rfc003-eth-erc20_btc-alice-redeems-bob-redeems", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-eth-erc20_btc-alice-redeems-bob-redeems",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Erc20, AssetKind.Bitcoin);
             await bob.accept();
 
@@ -469,11 +490,12 @@ describe("E2E: Ethereum/erc20 - Bitcoin/bitcoin", () => {
 
             await alice.assertSwapped();
             await bob.assertSwapped();
-        });
-    });
+        })
+    );
 
-    it("rfc003-eth-erc20_btc-bob-refunds-alice-refunds", async function() {
-        await twoActorTest(async function({ alice, bob }) {
+    it(
+        "rfc003-eth-erc20_btc-bob-refunds-alice-refunds",
+        twoActorTest(async ({ alice, bob }) => {
             await alice.sendRequest(AssetKind.Erc20, AssetKind.Bitcoin);
             await bob.accept();
 
@@ -486,6 +508,6 @@ describe("E2E: Ethereum/erc20 - Bitcoin/bitcoin", () => {
 
             await alice.assertRefunded();
             await bob.assertRefunded();
-        });
-    });
+        })
+    );
 });


### PR DESCRIPTION
We have several layers of function calls here that can be reduced.
Unfortunately, it does not reduce the indentation yet but I think
this is a step in the right direction. Anyway, we can remove a layer
of indirection that is unnecessary.