### PR TITLE
Make config validation function generic and condense error handling

### DIFF
--- a/cnd/src/btsieve/bitcoin/mod.rs
+++ b/cnd/src/btsieve/bitcoin/mod.rs
@@ -2,7 +2,7 @@ mod bitcoind_connector;
 mod cache;
 
 pub use self::{
-    bitcoind_connector::{chain_info, BitcoindConnector, ChainInfo},
+    bitcoind_connector::{BitcoindConnector, ChainInfo},
     cache::Cache,
 };
 use crate::btsieve::{

--- a/cnd/src/btsieve/ethereum/mod.rs
+++ b/cnd/src/btsieve/ethereum/mod.rs
@@ -3,7 +3,7 @@ mod web3_connector;
 
 pub use self::{
     cache::Cache,
-    web3_connector::{net_version, Web3Connector},
+    web3_connector::{Web3Connector},
 };
 use crate::{
     btsieve::{

--- a/cnd/src/config/validation.rs
+++ b/cnd/src/config/validation.rs
@@ -1,56 +1,32 @@
-use crate::swap_protocols::ledger::ethereum::ChainId;
-use bitcoin::Network;
 use thiserror::Error;
-
-use crate::btsieve::{
-    bitcoin::{chain_info, BitcoindConnector},
-    ethereum::{net_version, Web3Connector},
-};
+use std::fmt::Debug;
+use async_trait::async_trait;
 
 #[derive(Error, Debug)]
-pub enum ConfigValidationError<T: std::fmt::Debug> {
+pub enum Error<T: Debug> {
     #[error("Connected network does not match network specified in settings (expected {connected_network:?}, got {specified_network:?})")]
-    ConnectedNetworkDoesNotMatchSpecified {
+    Validation {
         connected_network: T,
         specified_network: T,
     },
 }
-
-#[derive(Debug)]
-pub enum NetworkValidationResult<T> {
-    Valid,
-    Invalid {
-        connected_network: T,
-        specified_network: T,
-    },
-}
-
-pub async fn validate_ethereum_chain_id(
-    connection: &Web3Connector,
-    specified: ChainId,
-) -> Result<NetworkValidationResult<ChainId>, anyhow::Error> {
-    let actual = net_version(connection).await?;
+pub async fn validate_blockchain_config<C, S>(connector: &C, specified: S) -> anyhow::Result<()>
+    where
+        C: FetchNetworkId<S>,
+        S: PartialEq + Debug + Send + Sync + 'static,
+{
+    let actual = connector.network_id().await?;
     if actual == specified {
-        Ok(NetworkValidationResult::Valid)
+        Ok(())
     } else {
-        Ok(NetworkValidationResult::Invalid {
+        Err(anyhow::Error::from(Error::Validation {
             connected_network: actual,
             specified_network: specified,
-        })
+        }))
     }
 }
 
-pub async fn validate_bitcoin_network(
-    connection: &BitcoindConnector,
-    specified: Network,
-) -> Result<NetworkValidationResult<Network>, anyhow::Error> {
-    let actual = chain_info(connection).await?;
-    if actual.chain == specified {
-        Ok(NetworkValidationResult::Valid)
-    } else {
-        Ok(NetworkValidationResult::Invalid {
-            connected_network: actual.chain,
-            specified_network: specified,
-        })
-    }
+#[async_trait]
+pub trait FetchNetworkId<S>: Send + Sync + 'static {
+    async fn network_id(&self) -> anyhow::Result<S>;
 }


### PR DESCRIPTION
The Ethereum and Bitcoin node config validation functions were
replaced with a generic one. A trait was added to provide a
cleaner API to the caller and reduce the amount of imports
required to call the the validation function in main. Error
handling was condensed and cnd will crash if a unspecified error
occurs when trying to contact the blockchain node to validate
the config.