### PR TITLE
Ensure that bitcoind binds to the custom ports

### DIFF
--- a/api_tests/lib/ledgers/bitcoind_instance.ts
+++ b/api_tests/lib/ledgers/bitcoind_instance.ts
@@ -118,14 +118,16 @@ export class BitcoindInstance implements BitcoinInstance {
         const output = `regtest=1
 server=1
 printtoconsole=1
-bind=0.0.0.0:${this.p2pPort}
-rpcbind=0.0.0.0:${this.rpcPort}
 rpcallowip=0.0.0.0/0
 nodebug=1
 rest=1
 acceptnonstdtxn=0
 zmqpubrawblock=tcp://127.0.0.1:${this.zmqPubRawBlockPort}
 zmqpubrawtx=tcp://127.0.0.1:${this.zmqPubRawTxPort}
+
+[regtest]
+bind=0.0.0.0:${this.p2pPort}
+rpcbind=0.0.0.0:${this.rpcPort}
 `;
         const config = path.join(dataDir, "bitcoin.conf");
         await writeFileAsync(config, output);


### PR DESCRIPTION
bitcoind was shutting down on my machine as it was trying and failing to bind to the default ports:


```
2020-03-16T01:40:38Z Binding RPC on address :: port 18443 failed.
2020-03-16T01:40:38Z Binding RPC on address 0.0.0.0 port 18443 failed.
2020-03-16T01:40:38Z Unable to bind any endpoint for RPC server
2020-03-16T01:40:38Z Error: Unable to start HTTP server. See debug log for details.
2020-03-16T01:40:38Z Shutdown: In progress...
2020-03-16T01:40:38Z scheduler thread interrupt
2020-03-16T01:40:38Z Shutdown: done
```

```
2020-03-16T01:40:38Z Warning: Config setting for -bind only applied on regtest network when in [regtest] section.
2020-03-16T01:40:38Z Warning: Config setting for -rpcbind only applied on regtest network when in [regtest] section.
```