### PR TITLE
format code before committing

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
+make format
 make check_format
 


### PR DESCRIPTION
Having to manual run `make format` before every commit is a bit annoying. Added make format to the the pre commit git hook since we "need" to run it to pass CI tests anyway