### PR TITLE
Make log statement about bitcoind exiting unambigous

### DIFF
--- a/api_tests/lib/ledgers/bitcoind_instance.ts
+++ b/api_tests/lib/ledgers/bitcoind_instance.ts
@@ -65,7 +65,7 @@ export class BitcoindInstance implements BitcoinInstance {
 
         this.process.on("exit", (code: number, signal: number) => {
             this.logger.info(
-                "binary exited with code",
+                "bitcoind exited with code",
                 code,
                 "after signal",
                 signal


### PR DESCRIPTION
We have one global logger for the whole test environment, hence we need to be explicit, which binary exited.