### PR TITLE
Remove category from log message

### DIFF
--- a/api_tests/src/dry_test_environment.ts
+++ b/api_tests/src/dry_test_environment.ts
@@ -56,6 +56,10 @@ export default class DryTestEnvironment extends NodeEnvironment {
                     base: logDir,
                     property: "categoryName",
                     extension: ".log",
+                    layout: {
+                        type: "pattern",
+                        pattern: "%d %5.10p: %m",
+                    },
                 },
             },
             categories: {

--- a/api_tests/src/e2e_test_environment.ts
+++ b/api_tests/src/e2e_test_environment.ts
@@ -74,6 +74,10 @@ export default class E2ETestEnvironment extends NodeEnvironment {
                     base: logDir,
                     property: "categoryName",
                     extension: ".log",
+                    layout: {
+                        type: "pattern",
+                        pattern: "%d %5.10p: %m",
+                    },
                 },
             },
             categories: {


### PR DESCRIPTION
With the multiFile appender approach, every category is a different file. We don't need to print the category again the log files.