### PR TITLE
Remove non-functional mergify rule

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -32,15 +32,6 @@ pull_request_rules:
     actions:
       comment:
         message: "bors r+"
-  - name: recreate dependabot PRs with merge conflicts
-    conditions:
-      - "status-success=ci/circleci: debug-build-test"
-      - "author=dependabot-preview[bot]"
-      - conflict
-      - label!=no-mergify
-    actions:
-      comment:
-        message: "@dependabot recreate"
   - name: Delete branch if the pull request is merged
     conditions:
       - merged


### PR DESCRIPTION
Dependabot doesn't allow to recreate PRs from users that don't have write-access. Mergify doesn't have this so this always fails anyway. In addition, I checked with dependabot and it actually has a feature to automatically rebase on conflicts, which I now enabled.