### PR TITLE
Add skeleton API function for controller/swarm interface

### DIFF
--- a/cnd/src/network/mod.rs
+++ b/cnd/src/network/mod.rs
@@ -136,6 +136,30 @@ impl Swarm {
             local_peer_id,
         })
     }
+
+    /// This is the API for Alice to call in order to execute the appropriate
+    /// communication protocols to announce a swap to Bob (i.e., to send the
+    /// known swap parameters and receive the remaining swap parameters) in
+    /// order to finalize this swap.
+    ///
+    /// `id` is an identifier use to access the database to get the known swap
+    /// parameters.
+    // Identifier type will be defined in ticket: https://github.com/comit-network/comit-rs/issues/2173
+    pub async fn finalize_announce_swap(&mut self, _id: String) -> anyhow::Result<()> {
+        // 1. Load parameters for the swap from the database and call down to
+        // the swarm to execute the required communication protocols.
+        //
+        // 2. Write the remaining parameters to the database (keyed by swap_id).
+        //
+        // 3. Spawn the swap using `swap_id` as an argument.  `spawn()` can then
+        // load the swap from the database and spawn it.
+
+        unimplemented!()
+    }
+
+    // On Bob's side, when an announce message is received execute the required
+    // communication protocols and write the finalized swap to the database.  Then
+    // spawn the same as is done for Alice.
 }
 
 struct SwarmWorker {


### PR DESCRIPTION
In order to be able to utilise the new communication protocol we need an interface between the controller and the swarm.

Add an API function that allows the controller (acting as Alice) to call the swarm (libp2p layer) and trigger execution of the new communication protocols (by calling through to the underlying swarm) in order to announce the created swap, send the known parameters, and receive the remaining required swap parameters back from Bob.

Fixes: #2170