### PR TITLE
Swap digest: enum & nested structs

### DIFF
--- a/digest-macro-derive/src/lib.rs
+++ b/digest-macro-derive/src/lib.rs
@@ -33,13 +33,11 @@ fn impl_digest_macro(ast: &syn::DeriveInput) -> TokenStream {
 
             let gen = quote! {
                     impl ::digest::Digest for #name
-                        where #(#types: ::digest::FieldDigest),*
+                        where #(#types: ::digest::IntoDigestInput),*
                     {
                         fn digest(self) -> ::multihash::Multihash {
-                            use ::digest::FieldDigest;
-
                             let mut digests = vec![];
-                            #(digests.push(self.#idents.field_digest(#bytes.to_vec())););*
+                            #(digests.push(::digest::field_digest(self.#idents, #bytes.to_vec())););*
 
                             digests.sort();
 

--- a/digest-macro-derive/src/lib.rs
+++ b/digest-macro-derive/src/lib.rs
@@ -5,7 +5,7 @@ use proc_macro2::{Delimiter, Group, Punct, Spacing};
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{Attribute, Data, Fields, Lit, Meta};
 
-#[proc_macro_derive(DigestMacro, attributes(digest_bytes))]
+#[proc_macro_derive(DigestMacro, attributes(digest_prefix))]
 pub fn digest_macro_fn(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();
     impl_digest_macro(&ast)
@@ -94,20 +94,20 @@ impl ToTokens for Bytes {
 fn attr_to_bytes(attrs: &[Attribute]) -> Bytes {
     let attr = attrs
         .get(0)
-        .expect("digest_bytes attribute must be the only attribute present on all fields");
+        .expect("digest_prefix attribute must be the only attribute present on all fields");
     let meta = attr.parse_meta().expect("Attribute is malformed");
 
     if let Meta::NameValue(name_value) = meta {
-        if name_value.path.is_ident("digest_bytes") {
+        if name_value.path.is_ident("digest_prefix") {
             if let Lit::Str(lit_str) = name_value.lit {
                 let str = lit_str.value();
                 let bytes =
-                    ::hex::decode(&str).expect("digest_bytes value should be in hex format");
+                    ::hex::decode(&str).expect("digest_prefix value should be in hex format");
                 return Bytes(bytes);
             }
         }
     }
-    panic!("Only `digest_bytes = \"0102..0A\"` attributes are supported");
+    panic!("Only `digest_prefix = \"0102..0A\"` attributes are supported");
 }
 
 #[cfg(test)]

--- a/digest-macro-derive/src/lib.rs
+++ b/digest-macro-derive/src/lib.rs
@@ -5,7 +5,7 @@ use proc_macro2::{Delimiter, Group, Punct, Spacing};
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{Attribute, Data, Fields, Lit, Meta};
 
-#[proc_macro_derive(DigestMacro, attributes(digest_prefix))]
+#[proc_macro_derive(Digest, attributes(digest_prefix))]
 pub fn digest_macro_fn(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();
     impl_digest_macro(&ast)

--- a/digest-macro-derive/src/lib.rs
+++ b/digest-macro-derive/src/lib.rs
@@ -5,13 +5,13 @@ use proc_macro2::{Delimiter, Group, Punct, Spacing};
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{Attribute, Data, Fields, Lit, Meta};
 
-#[proc_macro_derive(RootDigestMacro, attributes(digest_bytes))]
-pub fn root_digest_macro_fn(input: TokenStream) -> TokenStream {
+#[proc_macro_derive(DigestMacro, attributes(digest_bytes))]
+pub fn digest_macro_fn(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();
-    impl_root_digest_macro(&ast)
+    impl_digest_macro(&ast)
 }
 
-fn impl_root_digest_macro(ast: &syn::DeriveInput) -> TokenStream {
+fn impl_digest_macro(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
 
     match &ast.data {
@@ -32,10 +32,10 @@ fn impl_root_digest_macro(ast: &syn::DeriveInput) -> TokenStream {
             };
 
             let gen = quote! {
-                    impl ::digest::RootDigest for #name
+                    impl ::digest::Digest for #name
                         where #(#types: ::digest::FieldDigest),*
                     {
-                        fn root_digest(self) -> Multihash {
+                        fn digest(self) -> Multihash {
                             let mut digests = vec![];
                             #(digests.push(self.#idents.field_digest(#bytes.to_vec())););*
 
@@ -61,9 +61,9 @@ fn impl_root_digest_macro(ast: &syn::DeriveInput) -> TokenStream {
                 .map(|variant| attr_to_bytes(&variant.attrs));
 
             let gen = quote! {
-                    impl ::digest::RootDigest for #name
+                    impl ::digest::Digest for #name
                     {
-                        fn root_digest(self) -> Multihash {
+                        fn digest(self) -> Multihash {
                             let bytes = match self {
                                 #(Self::#idents => #bytes.to_vec()),*
                             };

--- a/digest-macro-derive/src/lib.rs
+++ b/digest-macro-derive/src/lib.rs
@@ -35,7 +35,9 @@ fn impl_digest_macro(ast: &syn::DeriveInput) -> TokenStream {
                     impl ::digest::Digest for #name
                         where #(#types: ::digest::FieldDigest),*
                     {
-                        fn digest(self) -> Multihash {
+                        fn digest(self) -> ::multihash::Multihash {
+                            use ::digest::FieldDigest;
+
                             let mut digests = vec![];
                             #(digests.push(self.#idents.field_digest(#bytes.to_vec())););*
 
@@ -46,7 +48,7 @@ fn impl_digest_macro(ast: &syn::DeriveInput) -> TokenStream {
                                 res
                             });
 
-                            digest(&res)
+                            ::digest::digest(&res)
                         }
                     }
             };
@@ -86,7 +88,7 @@ fn impl_digest_macro(ast: &syn::DeriveInput) -> TokenStream {
             let gen = quote! {
                     impl ::digest::Digest for #name
                     {
-                        fn digest(self) -> Multihash {
+                        fn digest(self) -> ::multihash::Multihash {
                             let bytes = match self {
                                 #(Self::#unit_variant_idents => #unit_variant_bytes.to_vec()),*,
                                 #(Self::#tuple_variant_idents(data) => {
@@ -96,7 +98,7 @@ fn impl_digest_macro(ast: &syn::DeriveInput) -> TokenStream {
                                 }),*
                             };
 
-                            digest(&bytes)
+                            ::digest::digest(&bytes)
                         }
                     }
             };

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -16,6 +16,19 @@ pub trait FieldDigest {
     fn field_digest(self, prefix: Vec<u8>) -> Multihash;
 }
 
+impl<T> FieldDigest for T
+where
+    T: Digest,
+{
+    fn field_digest(self, prefix: Vec<u8>) -> Multihash {
+        let mut bytes = prefix;
+        let field_digest = self.digest();
+        bytes.append(&mut field_digest.into_bytes());
+
+        digest(&bytes)
+    }
+}
+
 impl FieldDigest for String {
     fn field_digest(self, prefix: Vec<u8>) -> Multihash {
         let mut bytes = prefix;

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -1,4 +1,4 @@
-pub use digest_macro_derive::RootDigestMacro;
+pub use digest_macro_derive::DigestMacro;
 pub use hex;
 
 pub use multihash;
@@ -8,8 +8,8 @@ pub fn digest(bytes: &[u8]) -> Multihash {
     multihash::Sha3_256::digest(bytes)
 }
 
-pub trait RootDigest {
-    fn root_digest(self) -> Multihash;
+pub trait Digest {
+    fn digest(self) -> Multihash;
 }
 
 pub trait FieldDigest {

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -1,3 +1,52 @@
+/// This crate brings two traits: `Digest` and `FieldDigest`
+///
+/// `Digest` should be implemented on data structures using the `Digest`
+/// derive macro.
+/// The attribute `digest_prefix` must be applied on each field. It plays the
+/// role of an identifier to ensure that fields with same data but different
+/// meaning do not result to the same digest.
+///
+/// Elementary data types should implement `IntoDigestInput`, this allows you to
+/// control how the data is transformed to a byte array.
+///
+/// ```
+/// use digest::{Digest, IntoDigestInput};
+///
+/// struct MyType(Vec<u8>);
+///
+/// impl IntoDigestInput for MyType {
+///     fn into_digest_input(self) -> Vec<u8> {
+///         self.0
+///     }
+/// }
+///
+/// #[derive(Digest)]
+/// struct MyStruct {
+///     #[digest_prefix = "00AA"]
+///     foo: MyType,
+///     #[digest_prefix = "1122"]
+///     bar: MyType,
+/// }
+/// ```
+///
+/// The digest algorithm goes as follow:
+/// 1. Compute `field_digest(prefix)` for all fields of the struct,
+/// 2. Lexically order the field digests,
+/// 3. Concatenate the result,
+/// 4. Hash the result.
+///
+/// The field digest algorithm goes as follow:
+/// For elementary types:
+///     1. Transform the data in a byte array (if there is
+///   any data) using `IntoDigestInput` trait,
+///     2. Concatenate prefix and the resulting byte array,
+///     3. Hash the result.
+/// For data structures:
+///     1. Calculate the root digest of the struct,
+///     2. Concatenate prefix and resulting root digest,
+///     3. Hash the result.
+///
+/// For unit variants of enums, only the prefix as input to the hash function.
 pub use digest_macro_derive::Digest;
 pub use hex;
 

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -13,12 +13,12 @@ pub trait Digest {
 }
 
 pub trait FieldDigest {
-    fn field_digest(self, suffix: Vec<u8>) -> Multihash;
+    fn field_digest(self, prefix: Vec<u8>) -> Multihash;
 }
 
 impl FieldDigest for String {
-    fn field_digest(self, suffix: Vec<u8>) -> Multihash {
-        let mut bytes = suffix;
+    fn field_digest(self, prefix: Vec<u8>) -> Multihash {
+        let mut bytes = prefix;
         // String::into_bytes return the bytes for UTF-8 encoding
         let mut value = self.into_bytes();
         bytes.append(&mut value);
@@ -28,8 +28,8 @@ impl FieldDigest for String {
 }
 
 impl FieldDigest for Vec<u8> {
-    fn field_digest(mut self, suffix: Vec<u8>) -> Multihash {
-        let mut bytes = suffix;
+    fn field_digest(mut self, prefix: Vec<u8>) -> Multihash {
+        let mut bytes = prefix;
         bytes.append(&mut self);
 
         digest(&self)

--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -1,4 +1,4 @@
-pub use digest_macro_derive::DigestMacro;
+pub use digest_macro_derive::Digest;
 pub use hex;
 
 pub use multihash;

--- a/digest/tests/swap_digest.rs
+++ b/digest/tests/swap_digest.rs
@@ -245,6 +245,26 @@ fn given_two_nested_structs_with_same_value_return_same_multihash() {
 }
 
 #[test]
+fn given_two_nested_structs_with_diff_value_return_diff_multihash() {
+    let struct1 = NestedStruct {
+        foo: "phou".into(),
+        nest: DoubleFieldStruct {
+            foo: "foo".into(),
+            bar: "pub".into(),
+        },
+    };
+    let struct2 = OtherNestedStruct {
+        foo: "phou".into(),
+        nest: OtherDoubleFieldStruct {
+            foo: "foo".into(),
+            bar: "pub".into(),
+        },
+    };
+
+    assert_eq!(struct1.digest(), struct2.digest())
+}
+
+#[test]
 fn given_two_nested_enums_with_same_value_return_same_multihash() {
     let enum1 = NestedEnum::Bar(NestedStruct {
         foo: "foo".into(),

--- a/digest/tests/swap_digest.rs
+++ b/digest/tests/swap_digest.rs
@@ -68,8 +68,8 @@ enum OtherEnum {
 impl RootDigest for OtherEnum {
     fn root_digest(self) -> Multihash {
         let bytes = match self {
-            OtherEnum::Foo => digest(vec![0x00u8, 0x11u8]),
-            OtherEnum::Bar => digest(vec![0x0Eu8, 0x0Fu8]),
+            OtherEnum::Foo => vec![0x00u8, 0x11u8],
+            OtherEnum::Bar => vec![0x00u8, 0x11u8],
         };
 
         digest(&bytes)

--- a/digest/tests/swap_digest.rs
+++ b/digest/tests/swap_digest.rs
@@ -60,6 +60,7 @@ enum Enum {
     Bar,
 }
 
+#[allow(dead_code)]
 enum OtherEnum {
     Foo,
     Bar,

--- a/digest/tests/swap_digest.rs
+++ b/digest/tests/swap_digest.rs
@@ -1,4 +1,4 @@
-use digest::{digest, Digest, DigestMacro, FieldDigest, IntoDigestInput};
+use digest::{digest, Digest, FieldDigest, IntoDigestInput};
 
 use digest::multihash::Multihash;
 
@@ -16,7 +16,7 @@ impl From<&str> for MyString {
     }
 }
 
-#[derive(DigestMacro)]
+#[derive(Digest)]
 struct DoubleFieldStruct {
     #[digest_prefix = "0011"]
     foo: MyString,
@@ -48,7 +48,7 @@ impl Digest for OtherDoubleFieldStruct {
     }
 }
 
-#[derive(DigestMacro)]
+#[derive(Digest)]
 enum Enum {
     #[digest_prefix = "0011"]
     Foo,
@@ -72,7 +72,7 @@ impl Digest for OtherEnum {
     }
 }
 
-#[derive(DigestMacro)]
+#[derive(Digest)]
 struct NestedStruct {
     #[digest_prefix = "0011"]
     foo: MyString,
@@ -104,7 +104,7 @@ impl Digest for OtherNestedStruct {
     }
 }
 
-#[derive(DigestMacro)]
+#[derive(Digest)]
 enum NestedEnum {
     #[digest_prefix = "DEAD"]
     Foo,

--- a/digest/tests/swap_digest.rs
+++ b/digest/tests/swap_digest.rs
@@ -28,12 +28,12 @@ struct DoubleFieldStruct {
     bar: String,
 }
 
-struct OtherStruct {
+struct OtherDoubleFieldStruct {
     bar: String,
     foo: String,
 }
 
-impl RootDigest for OtherStruct {
+impl RootDigest for OtherDoubleFieldStruct {
     fn root_digest(self) -> Multihash {
         let mut digests = vec![];
         let foo_digest = self.foo.field_digest([0x00u8, 0x11u8].to_vec());
@@ -181,7 +181,7 @@ fn given_two_double_field_struct_with_same_data_return_same_multihash() {
         foo: "foo field".into(),
         bar: "bar field".into(),
     };
-    let struct2 = OtherStruct {
+    let struct2 = OtherDoubleFieldStruct {
         bar: "bar field".into(),
         foo: "foo field".into(),
     };

--- a/digest/tests/swap_digest.rs
+++ b/digest/tests/swap_digest.rs
@@ -4,9 +4,9 @@ use digest::multihash::Multihash;
 
 #[derive(DigestMacro)]
 struct DoubleFieldStruct {
-    #[digest_bytes = "0011"]
+    #[digest_prefix = "0011"]
     foo: String,
-    #[digest_bytes = "FFAA"]
+    #[digest_prefix = "FFAA"]
     bar: String,
 }
 
@@ -36,9 +36,9 @@ impl Digest for OtherDoubleFieldStruct {
 
 #[derive(DigestMacro)]
 enum Enum {
-    #[digest_bytes = "0011"]
+    #[digest_prefix = "0011"]
     Foo,
-    #[digest_bytes = "0E0F"]
+    #[digest_prefix = "0E0F"]
     Bar,
 }
 
@@ -61,9 +61,9 @@ impl Digest for OtherEnum {
 
 #[derive(DigestMacro)]
 struct NestedStruct {
-    #[digest_bytes = "0011"]
+    #[digest_prefix = "0011"]
     foo: String,
-    #[digest_bytes = "AA00"]
+    #[digest_prefix = "AA00"]
     nest: DoubleFieldStruct,
 }
 

--- a/digest/tests/swap_digest.rs
+++ b/digest/tests/swap_digest.rs
@@ -1,4 +1,4 @@
-use digest::{digest, Digest, FieldDigest, IntoDigestInput};
+use digest::{digest, field_digest, Digest, IntoDigestInput};
 
 use digest::multihash::Multihash;
 
@@ -32,9 +32,9 @@ struct OtherDoubleFieldStruct {
 impl Digest for OtherDoubleFieldStruct {
     fn digest(self) -> Multihash {
         let mut digests = vec![];
-        let foo_digest = self.foo.field_digest([0x00u8, 0x11u8].to_vec());
+        let foo_digest = field_digest(self.foo, [0x00u8, 0x11u8].to_vec());
         digests.push(foo_digest);
-        let bar_digest = self.bar.field_digest([0xFFu8, 0xAAu8].to_vec());
+        let bar_digest = field_digest(self.bar, [0xFFu8, 0xAAu8].to_vec());
         digests.push(bar_digest);
 
         digests.sort();
@@ -72,75 +72,14 @@ impl Digest for OtherEnum {
     }
 }
 
-#[derive(Digest)]
-struct NestedStruct {
-    #[digest_prefix = "0011"]
-    foo: MyString,
-    #[digest_prefix = "AA00"]
-    nest: DoubleFieldStruct,
-}
-
-struct OtherNestedStruct {
-    foo: MyString,
-    nest: OtherDoubleFieldStruct,
-}
-
-impl Digest for OtherNestedStruct {
-    fn digest(self) -> Multihash {
-        let mut digests = vec![];
-        let foo_digest = self.foo.field_digest([0x00u8, 0x11u8].to_vec());
-        digests.push(foo_digest);
-        let nest_digest = self.nest.field_digest([0xAAu8, 0x00u8].to_vec());
-        digests.push(nest_digest);
-
-        digests.sort();
-
-        let res = digests.into_iter().fold(vec![], |mut res, digest| {
-            res.append(&mut digest.into_bytes());
-            res
-        });
-
-        digest(&res)
-    }
-}
-
-#[derive(Digest)]
-enum NestedEnum {
-    #[digest_prefix = "DEAD"]
-    Foo,
-    #[digest_prefix = "BEEF"]
-    Bar(NestedStruct),
-}
-
-#[allow(dead_code)]
-enum OtherNestedEnum {
-    Foo,
-    Bar(OtherNestedStruct),
-}
-
-impl Digest for OtherNestedEnum {
-    fn digest(self) -> Multihash {
-        let bytes = match self {
-            OtherNestedEnum::Foo => vec![0xDEu8, 0xADu8],
-            OtherNestedEnum::Bar(other_nested_struct) => {
-                let mut bytes = vec![0xBEu8, 0xEFu8];
-                bytes.append(&mut other_nested_struct.digest().into_bytes());
-                bytes
-            }
-        };
-
-        digest(&bytes)
-    }
-}
-
 #[test]
 fn given_same_strings_return_same_multihash() {
     let str1: MyString = "simple string".into();
     let str2: MyString = "simple string".into();
 
     assert_eq!(
-        str1.field_digest("foo".into()),
-        str2.field_digest("foo".into())
+        field_digest(str1, "foo".into()),
+        field_digest(str2, "foo".into())
     )
 }
 
@@ -150,8 +89,8 @@ fn given_same_strings_different_names_return_diff_multihash() {
     let str2: MyString = "simple string".into();
 
     assert_ne!(
-        str1.field_digest("foo".into()),
-        str2.field_digest("bar".into())
+        field_digest(str1, "foo".into()),
+        field_digest(str2, "bar".into())
     )
 }
 
@@ -161,8 +100,8 @@ fn given_different_strings_return_different_multihash() {
     let str2: MyString = "longer string".into();
 
     assert_ne!(
-        str1.field_digest("foo".into()),
-        str2.field_digest("foo".into())
+        field_digest(str1, "foo".into()),
+        field_digest(str2, "foo".into())
     )
 }
 
@@ -222,64 +161,4 @@ fn given_two_enums_with_differnt_variant_return_different_multihash() {
     let enum2 = OtherEnum::Bar;
 
     assert_eq!(enum1.digest(), enum2.digest())
-}
-
-#[test]
-fn given_two_nested_structs_with_same_value_return_same_multihash() {
-    let struct1 = NestedStruct {
-        foo: "foo".into(),
-        nest: DoubleFieldStruct {
-            foo: "phou".into(),
-            bar: "pub".into(),
-        },
-    };
-    let struct2 = OtherNestedStruct {
-        foo: "foo".into(),
-        nest: OtherDoubleFieldStruct {
-            foo: "phou".into(),
-            bar: "pub".into(),
-        },
-    };
-
-    assert_eq!(struct1.digest(), struct2.digest())
-}
-
-#[test]
-fn given_two_nested_structs_with_diff_value_return_diff_multihash() {
-    let struct1 = NestedStruct {
-        foo: "phou".into(),
-        nest: DoubleFieldStruct {
-            foo: "foo".into(),
-            bar: "pub".into(),
-        },
-    };
-    let struct2 = OtherNestedStruct {
-        foo: "phou".into(),
-        nest: OtherDoubleFieldStruct {
-            foo: "foo".into(),
-            bar: "pub".into(),
-        },
-    };
-
-    assert_eq!(struct1.digest(), struct2.digest())
-}
-
-#[test]
-fn given_two_nested_enums_with_same_value_return_same_multihash() {
-    let enum1 = NestedEnum::Bar(NestedStruct {
-        foo: "foo".into(),
-        nest: DoubleFieldStruct {
-            foo: "faa".into(),
-            bar: "restaurant".into(),
-        },
-    });
-    let enum2 = OtherNestedEnum::Bar(OtherNestedStruct {
-        foo: "foo".into(),
-        nest: OtherDoubleFieldStruct {
-            foo: "faa".into(),
-            bar: "restaurant".into(),
-        },
-    });
-
-    assert_eq!(enum1.digest(), enum2.digest());
 }

--- a/digest/tests/swap_digest.rs
+++ b/digest/tests/swap_digest.rs
@@ -1,8 +1,8 @@
-use digest::{digest, FieldDigest, RootDigest, RootDigestMacro};
+use digest::{digest, Digest, DigestMacro, FieldDigest};
 
 use digest::multihash::Multihash;
 
-#[derive(RootDigestMacro)]
+#[derive(DigestMacro)]
 struct DoubleFieldStruct {
     #[digest_bytes = "0011"]
     foo: String,
@@ -15,8 +15,8 @@ struct OtherDoubleFieldStruct {
     foo: String,
 }
 
-impl RootDigest for OtherDoubleFieldStruct {
-    fn root_digest(self) -> Multihash {
+impl Digest for OtherDoubleFieldStruct {
+    fn digest(self) -> Multihash {
         let mut digests = vec![];
         let foo_digest = self.foo.field_digest([0x00u8, 0x11u8].to_vec());
         digests.push(foo_digest);
@@ -34,7 +34,7 @@ impl RootDigest for OtherDoubleFieldStruct {
     }
 }
 
-#[derive(RootDigestMacro)]
+#[derive(DigestMacro)]
 enum Enum {
     #[digest_bytes = "0011"]
     Foo,
@@ -48,8 +48,8 @@ enum OtherEnum {
     Bar,
 }
 
-impl RootDigest for OtherEnum {
-    fn root_digest(self) -> Multihash {
+impl Digest for OtherEnum {
+    fn digest(self) -> Multihash {
         let bytes = match self {
             OtherEnum::Foo => vec![0x00u8, 0x11u8],
             OtherEnum::Bar => vec![0x00u8, 0x11u8],
@@ -103,7 +103,7 @@ fn given_same_double_field_struct_return_same_multihash() {
         bar: "second field".into(),
     };
 
-    assert_eq!(struct1.root_digest(), struct2.root_digest())
+    assert_eq!(struct1.digest(), struct2.digest())
 }
 
 #[test]
@@ -117,7 +117,7 @@ fn given_different_double_field_struct_return_different_multihash() {
         bar: "different field".into(),
     };
 
-    assert_ne!(struct1.root_digest(), struct2.root_digest())
+    assert_ne!(struct1.digest(), struct2.digest())
 }
 
 #[test]
@@ -131,7 +131,7 @@ fn given_two_double_field_struct_with_same_data_return_same_multihash() {
         foo: "foo field".into(),
     };
 
-    assert_eq!(struct1.root_digest(), struct2.root_digest())
+    assert_eq!(struct1.digest(), struct2.digest())
 }
 
 #[test]
@@ -139,5 +139,5 @@ fn given_two_enums_with_same_bytes_per_variant_return_same_multihash() {
     let enum1 = Enum::Foo;
     let enum2 = OtherEnum::Foo;
 
-    assert_eq!(enum1.root_digest(), enum2.root_digest())
+    assert_eq!(enum1.digest(), enum2.digest())
 }

--- a/digest/tests/swap_digest.rs
+++ b/digest/tests/swap_digest.rs
@@ -52,6 +52,30 @@ impl RootDigest for OtherStruct {
     }
 }
 
+#[derive(RootDigestMacro)]
+enum Enum {
+    #[digest_bytes = "0011"]
+    Foo,
+    #[digest_bytes = "0E0F"]
+    Bar,
+}
+
+enum OtherEnum {
+    Foo,
+    Bar,
+}
+
+impl RootDigest for OtherEnum {
+    fn root_digest(self) -> Multihash {
+        let bytes = match self {
+            OtherEnum::Foo => digest(vec![0x00u8, 0x11u8]),
+            OtherEnum::Bar => digest(vec![0x0Eu8, 0x0Fu8]),
+        };
+
+        digest(&bytes)
+    }
+}
+
 #[test]
 fn given_same_strings_return_same_multihash() {
     let str1 = String::from("simple string");
@@ -163,4 +187,12 @@ fn given_two_double_field_struct_with_same_data_return_same_multihash() {
     };
 
     assert_eq!(struct1.root_digest(), struct2.root_digest())
+}
+
+#[test]
+fn given_two_enums_with_same_bytes_per_variant_return_same_multihash() {
+    let enum1 = Enum::Foo;
+    let enum2 = OtherEnum::Foo;
+
+    assert_eq!(enum1.root_digest(), enum2.root_digest())
 }

--- a/digest/tests/swap_digest.rs
+++ b/digest/tests/swap_digest.rs
@@ -56,7 +56,6 @@ enum Enum {
     Bar,
 }
 
-#[allow(dead_code)]
 enum OtherEnum {
     Foo,
     Bar,
@@ -184,6 +183,14 @@ fn given_two_double_field_struct_with_same_data_return_same_multihash() {
 fn given_two_enums_with_same_bytes_per_variant_return_same_multihash() {
     let enum1 = Enum::Foo;
     let enum2 = OtherEnum::Foo;
+
+    assert_eq!(enum1.digest(), enum2.digest())
+}
+
+#[test]
+fn given_two_enums_with_differnt_variant_return_different_multihash() {
+    let enum1 = Enum::Foo;
+    let enum2 = OtherEnum::Bar;
 
     assert_eq!(enum1.digest(), enum2.digest())
 }

--- a/digest/tests/swap_digest.rs
+++ b/digest/tests/swap_digest.rs
@@ -2,24 +2,6 @@ use digest::{digest, FieldDigest, RootDigest, RootDigestMacro};
 
 use digest::multihash::Multihash;
 
-struct NewType(String);
-
-impl RootDigest for NewType {
-    fn root_digest(self) -> Multihash {
-        self.0.field_digest("0".into())
-    }
-}
-
-struct SingleFieldStruct {
-    field: String,
-}
-
-impl RootDigest for SingleFieldStruct {
-    fn root_digest(self) -> Multihash {
-        self.field.field_digest("field".into())
-    }
-}
-
 #[derive(RootDigestMacro)]
 struct DoubleFieldStruct {
     #[digest_bytes = "0011"]
@@ -108,44 +90,6 @@ fn given_different_strings_return_different_multihash() {
         str1.field_digest("foo".into()),
         str2.field_digest("foo".into())
     )
-}
-
-#[test]
-fn given_same_newtypes_return_same_multihash() {
-    let new_type1 = NewType("simple string".into());
-    let new_type2 = NewType("simple string".into());
-
-    assert_eq!(new_type1.root_digest(), new_type2.root_digest())
-}
-
-#[test]
-fn given_different_newtypes_return_different_multihash() {
-    let new_type1 = NewType("simple string".into());
-    let new_type2 = NewType("longer string.".into());
-
-    assert_ne!(new_type1.root_digest(), new_type2.root_digest())
-}
-
-#[test]
-fn given_same_single_field_struct_return_same_multihash() {
-    let struct1 = SingleFieldStruct {
-        field: "foo".into(),
-    };
-    let struct2 = SingleFieldStruct {
-        field: "foo".into(),
-    };
-
-    assert_eq!(struct1.root_digest(), struct2.root_digest())
-}
-
-#[test]
-fn given_single_field_struct_and_new_type_with_same_inner_return_different_multihash() {
-    let single_field_struct = SingleFieldStruct {
-        field: "foo".into(),
-    };
-    let new_type = NewType("foo".into());
-
-    assert_ne!(single_field_struct.root_digest(), new_type.root_digest())
 }
 
 #[test]


### PR DESCRIPTION
## Interface 

3 traits:
- `IntoDigestInput`: The consumer must implement this trait on their basic data types. It basically allow them to tell the lib how they want such type to be transformed in a byte array
- `Digest`: The consumer must use `MacroDigest` derive macro to implement this trait on their data structures, using the `digest_prefix` attribute to specify the prefix applied to fields before hashing in hex
- `FieldDigest`: This is an internal sealed type, the consumer should not touch it.

## Nested structs digest algorithm

1. Hash each field,
	a. If the field is a basic data type: concatenate prefix + result of `into_digest_input`, hash it,
	b. If the field is a data structure: concatenate prefix + result of `digest` (of the struct),
2. Order hash results,
3. Concatenate ordered hash results,
4. Hash them.

Note, if the field of an enum is a unit variant, then only the matching prefix is hashed.

Resolves #2112.