### PR TITLE
Fix ethereum config validation

### DIFF
--- a/cnd/src/btsieve/ethereum/web3_connector.rs
+++ b/cnd/src/btsieve/ethereum/web3_connector.rs
@@ -81,13 +81,13 @@ impl ReceiptByHash for Web3Connector {
 #[async_trait]
 impl FetchNetworkId<ChainId> for Web3Connector {
     async fn network_id(&self) -> anyhow::Result<ChainId> {
-        let chain_id: ChainId = self
+        let chain_id: String = self
             .client
-            .send::<Vec<()>, ChainId>(jsonrpc::Request::new("net_version", vec![]))
+            .send::<Vec<()>, String>(jsonrpc::Request::new("net_version", vec![]))
             .await?;
 
         tracing::debug!("Fetched net_version from web3: {:?}", chain_id);
 
-        Ok(chain_id)
+        Ok(ChainId::from(chain_id.parse::<u32>()?))
     }
 }

--- a/cnd/src/jsonrpc.rs
+++ b/cnd/src/jsonrpc.rs
@@ -11,7 +11,7 @@ pub struct Client {
 pub enum Error {
     #[error("json-rpc request failed with code {code}: {message}")]
     JsonRpc { code: i64, message: String },
-    #[error("connection error")]
+    #[error("connection error: {0}")]
     Connection(#[from] reqwest::Error),
 }
 


### PR DESCRIPTION
Add custom deserialisation to handle string returned from
Ethereum's "json-rpc" API. Log details of Ethereum connection
errors.

Closes #2256