### PR TITLE
Add GitHub Action CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,128 @@
+name: CI
+
+on:
+  push:
+    branches-ignore:
+      - 'staging.tmp'
+      - 'trying.tmp'
+
+jobs:
+  static_analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Extract toolchain version from rust-toolchain
+        run: echo "::set-env name=RUST_TOOLCHAIN::$(cat rust-toolchain)"
+
+      - name: Install ${{ env.RUST_TOOLCHAIN }} toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Cache ~/.cargo/bin directory
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/bin
+          key: ubuntu-rust-${{ env.RUST_TOOLCHAIN }}-cargo-bin-directory
+
+      - name: Check formatting
+        run: make check_format
+
+      - name: Run linter
+        run: make clippy
+
+  build:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+        include:
+          - os: ubuntu-latest
+            binary-suffix: ""
+          - os: macos-latest
+            binary-suffix: ""
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Extract toolchain version from rust-toolchain
+        run: echo "::set-env name=RUST_TOOLCHAIN::$(cat rust-toolchain)"
+
+      - name: Install ${{ env.RUST_TOOLCHAIN }} toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Cache target directory
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ matrix.os }}-rust-${{ env.RUST_TOOLCHAIN }}-target-directory-${{ hashFiles('Cargo.lock') }}
+
+      - name: Cache ~/.cargo/registry directory
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ matrix.os }}-rust-${{ env.RUST_TOOLCHAIN }}-cargo-registry-directory-${{ hashFiles('Cargo.lock') }}
+
+      - name: Build ${{ matrix.os }} binary
+        run: make build
+
+      # Ignore tests on macos due to missing docker
+      - name: Run unit tests
+        if: matrix.os != 'macos-latest'
+        run: make test
+
+      - name: Upload cnd ${{ matrix.os }} binary
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v1
+        with:
+          name: cnd
+          path: target/debug/cnd
+
+
+  e2e_test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Download cnd binary
+        uses: actions/download-artifact@v1
+        with:
+          name: cnd
+          path: target/debug/
+
+      - name: Fix missing executable permission
+        run: |
+          chmod a+x target/debug/cnd
+
+      - name: Install NodeJS 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Install Go 1.13.3.
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.3'
+
+      - name: Install LND v0.9.0-beta
+        run: |
+          go get -d github.com/lightningnetwork/lnd
+          cd ~/go/src/github.com/lightningnetwork/lnd
+          git checkout v0.9.0-beta
+          make tags=invoicesrpc
+          make tags=invoicesrpc install
+
+      - name: Run e2e tests
+        run: |
+          export PATH=$HOME/.cargo/bin:$HOME/.local/bin:$HOME/go/bin:$PATH
+          make ci_gha

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,9 @@ doc:
 e2e: download_bc_nodes build
 	(cd ./api_tests; yarn install; yarn test)
 
+ci_gha: download_bc_nodes
+	(cd ./api_tests; yarn install; yarn ci)
+
 check_format: check_rust_format check_toml_format check_ts_format
 
 MODIFIED_FILES = $(shell git status --untracked-files=no --short)

--- a/api_tests/package.json
+++ b/api_tests/package.json
@@ -9,6 +9,7 @@
         "dry": "jest --config jest.config-dry.js --maxWorkers=4",
         "e2e": "yarn jest --config jest.config-e2e.js --runInBand --forceExit --bail",
         "test": "yarn dry && yarn e2e",
+        "ci": "tsc && yarn dry && yarn e2e",
         "fix": "tslint --project . --fix && prettier --write '**/*.{ts,js,json,yml}'"
     },
     "engines": {


### PR DESCRIPTION
Resolves #1407 

This PR introduces GitHub Action CI: 

Within this PR we execute the following targets: 
* `make build` on MacOS
* `make build` on Ubuntu
* `make test` on Ubuntu
* `make e2e` on Ubuntu

Note: 
I've added a new make target `ci_gha` (CI GitHubActions) so that we can keep circleCI running in parallel for some time. Once we decide to completely get rid of CircleCI we can remove/rename this field. I'll create a follow-up ticket on this

Not in this PR:
* `make test` on MacOS as GitHub Action MacOS does not provide Docker. Aperantly this will be provided in the future though. If so, we can run tests on MacOS as well (see here: https://github.com/actions/virtual-environments/issues/17#event-3067114887)
* `make build/test` on Windows as we do not have an implementation for `lnd_default_dir()` for windows (see here: https://github.com/comit-network/comit-rs/blob/93f58a1762c7c7a8da038a1ec2f22dccea1a21cb/cnd/src/lib.rs#L108-L118). I will track this in another ticket once this PR is merged.

Open TODOs:
* create ticket to fix windows build for github actions: see: https://github.com/comit-network/comit-rs/issues/2337
* create ticket to remove unneeded make target: https://github.com/comit-network/comit-rs/issues/2338