### PR TITLE
Install libssl-dev inside the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster
 
 RUN apt-get update && \
     apt-get install -y \
-    tini \
+    tini libssl-dev \
  && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --create-home --shell /bin/bash cnd


### PR DESCRIPTION
Simply fix and resolves #2238 

Once merged I'll trigger a release to test it.