### PR TITLE
Lock datadir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,7 @@ dependencies = [
  "directories",
  "ethbloom",
  "fern",
+ "fs2",
  "futures 0.3.4",
  "genawaiter",
  "hex 0.4.2",
@@ -1007,6 +1008,16 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "fuchsia-cprng"

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -22,6 +22,7 @@ digest-macro-derive = { path = "../digest-macro-derive" }
 directories = "2.0"
 ethbloom = "0.9.0"
 fern = { version = "0.6", features = ["colored"] }
+fs2 = "0.4.3"
 futures = { version = "0.3", features = ["async-await"], default-features = false }
 genawaiter = "0.99"
 hex = "0.4"

--- a/cnd/src/file_lock.rs
+++ b/cnd/src/file_lock.rs
@@ -1,0 +1,16 @@
+use anyhow::Context;
+use fs2::FileExt;
+use std::{fs::File, path::PathBuf};
+
+pub trait TryLockExclusive {
+    fn try_lock_exclusive(&self) -> anyhow::Result<File>;
+}
+
+impl TryLockExclusive for PathBuf {
+    fn try_lock_exclusive(&self) -> anyhow::Result<File> {
+        let file = File::open(self)?;
+        file.try_lock_exclusive()
+            .with_context(|| format!("Could not acquire file system lock on {}", self.display()))?;
+        Ok(file)
+    }
+}

--- a/cnd/src/lib.rs
+++ b/cnd/src/lib.rs
@@ -44,6 +44,7 @@ pub mod network;
 pub mod quickcheck;
 #[macro_use]
 pub mod seed;
+pub mod file_lock;
 pub mod jsonrpc;
 #[cfg(test)]
 pub mod spectral_ext;

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -53,9 +53,11 @@ fn main() -> anyhow::Result<()> {
 
     crate::trace::init_tracing(settings.logging.level)?;
 
-    let _locked_datadir = &settings.data.dir.try_lock_exclusive()?;
+    let database = Sqlite::new_in_dir(&settings.data.dir)?;
 
     let seed = RootSeed::from_dir_or_generate(&settings.data.dir, OsRng)?;
+
+    let _locked_datadir = &settings.data.dir.try_lock_exclusive()?;
 
     let mut runtime = runtime::Builder::new()
         .enable_all()
@@ -114,8 +116,6 @@ fn main() -> anyhow::Result<()> {
     let swap_communication_states = Arc::new(SwapCommunicationStates::default());
 
     let swap_error_states = Arc::new(SwapErrorStates::default());
-
-    let database = Sqlite::new_in_dir(&settings.data.dir)?;
 
     let swarm = Swarm::new(
         &settings,

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -27,6 +27,7 @@ use cnd::{
     seed::RootSeed,
     swap_protocols::{Facade, LedgerStates, SwapCommunicationStates, SwapErrorStates},
 };
+use fs2::FileExt;
 use rand::rngs::OsRng;
 use std::{process, sync::Arc};
 use structopt::StructOpt;
@@ -51,6 +52,12 @@ fn main() -> anyhow::Result<()> {
     }
 
     crate::trace::init_tracing(settings.logging.level)?;
+
+    let path = &settings.data.dir.to_path_buf();
+
+    let file = std::fs::File::open(&path)?;
+    file.try_lock_exclusive()?;
+    file.lock_exclusive()?;
 
     let seed = RootSeed::from_dir_or_generate(&settings.data.dir, OsRng)?;
 


### PR DESCRIPTION
Place a lock on the datadir specified in config. cnd aborts with
an error message if the specified datadir is already being used
by another cnd process.

Closes #2278