### PR TITLE
Ensure default is applied if lnd settings are not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Ensure that lnd parameters are defaulted if not present.
+
 ## [0.7.2] - 2020-03-26
 
 ## [0.7.1] - 2020-03-12

--- a/cnd/src/config.rs
+++ b/cnd/src/config.rs
@@ -5,17 +5,14 @@ pub mod validation;
 
 use crate::swap_protocols::ledger::ethereum;
 use libp2p::Multiaddr;
+use reqwest::Url;
 use serde::{Deserialize, Serialize};
-use std::{
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-    path::PathBuf,
-};
+use std::path::PathBuf;
 
 pub use self::{file::File, settings::Settings};
-use reqwest::Url;
 
 lazy_static::lazy_static! {
-    pub static ref LND_SOCKET: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+    pub static ref LND_URL: Url = Url::parse("https://localhost:8080").expect("static string to be a valid url");
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -37,7 +34,7 @@ pub struct Bitcoin {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Bitcoind {
-    pub node_url: reqwest::Url,
+    pub node_url: Url,
 }
 
 impl Default for Bitcoin {
@@ -90,7 +87,7 @@ impl Default for Ethereum {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Parity {
-    pub node_url: reqwest::Url,
+    pub node_url: Url,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -119,14 +116,14 @@ impl From<Lightning> for file::Lightning {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Lnd {
-    pub rest_api_socket: SocketAddr,
+    pub rest_api_url: Url,
     pub dir: PathBuf,
 }
 
 impl Default for Lnd {
     fn default() -> Self {
         Self {
-            rest_api_socket: *LND_SOCKET,
+            rest_api_url: LND_URL.clone(),
             dir: default_lnd_dir(),
         }
     }
@@ -176,13 +173,13 @@ mod tests {
     fn lnd_deserializes_correctly() {
         let actual = toml::from_str(
             r#"
-            rest_api_socket = "127.0.0.1:8080"
+            rest_api_url = "https://localhost:8080"
             dir = "~/.local/share/comit/lnd"
             "#,
         );
 
         let expected = Lnd {
-            rest_api_socket: *LND_SOCKET,
+            rest_api_url: LND_URL.clone(),
             dir: PathBuf::from("~/.local/share/comit/lnd"),
         };
 
@@ -195,7 +192,7 @@ mod tests {
             r#"
             network = "regtest"
             [lnd]
-            rest_api_socket = "127.0.0.1:8080"
+            rest_api_url = "https://localhost:8080"
             dir = "/path/to/lnd"
             "#,
         );
@@ -203,7 +200,7 @@ mod tests {
         let expected = Lightning {
             network: bitcoin::Network::Regtest,
             lnd: Lnd {
-                rest_api_socket: *LND_SOCKET,
+                rest_api_url: LND_URL.clone(),
                 dir: PathBuf::from("/path/to/lnd"),
             },
         };

--- a/cnd/src/config/file.rs
+++ b/cnd/src/config/file.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{Bitcoind, Data, Lightning, Network, Parity},
+    config::{Bitcoind, Data, Lnd, Network, Parity},
     swap_protocols::ledger::ethereum,
 };
 use config as config_rs;
@@ -34,6 +34,12 @@ pub struct Bitcoin {
 pub struct Ethereum {
     pub chain_id: ethereum::ChainId,
     pub parity: Option<Parity>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct Lightning {
+    pub network: bitcoin::Network,
+    pub lnd: Option<Lnd>,
 }
 
 impl File {
@@ -223,6 +229,7 @@ network = "regtest"
 
 [lightning.lnd]
 rest_api_socket = "127.0.0.1:8080"
+dir = "/foo/bar"
 "#;
         let file = File {
             network: Some(Network {
@@ -255,11 +262,8 @@ rest_api_socket = "127.0.0.1:8080"
             lightning: Some(Lightning {
                 network: bitcoin::Network::Regtest,
                 lnd: Some(Lnd {
-                    rest_api_socket: Some(SocketAddr::new(
-                        IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                        8080,
-                    )),
-                    dir: None,
+                    rest_api_socket: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080),
+                    dir: PathBuf::from("/foo/bar"),
                 }),
             }),
         };

--- a/cnd/src/config/file.rs
+++ b/cnd/src/config/file.rs
@@ -228,7 +228,7 @@ node_url = "http://localhost:8545/"
 network = "regtest"
 
 [lightning.lnd]
-rest_api_socket = "127.0.0.1:8080"
+rest_api_url = "https://localhost:8080"
 dir = "/foo/bar"
 "#;
         let file = File {
@@ -262,7 +262,7 @@ dir = "/foo/bar"
             lightning: Some(Lightning {
                 network: bitcoin::Network::Regtest,
                 lnd: Some(Lnd {
-                    rest_api_socket: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080),
+                    rest_api_url: "https://localhost:8080".parse().unwrap(),
                     dir: PathBuf::from("/foo/bar"),
                 }),
             }),

--- a/cnd/src/config/settings.rs
+++ b/cnd/src/config/settings.rs
@@ -218,7 +218,7 @@ impl Settings {
                     lnd: match lightning.lnd {
                         None => Lnd::default(),
                         Some(lnd) => Lnd {
-                            rest_api_socket: lnd.rest_api_socket,
+                            rest_api_url: lnd.rest_api_url,
                             dir: lnd.dir,
                         },
                     },


### PR DESCRIPTION
The `Settings` struct need to always have a the lightning settings set even if not present in the file to allow the initialisation of a lnd connector in `main.rs`.

Also, we use `reqwest` to target the lnd REST API so best to have a URL in the file to avoid conversion later down the stream.