### PR TITLE
Run tests on MacOS in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
 
       # Ignore tests on macos due to missing docker
       - name: Run unit tests
-        if: matrix.os != 'macos-latest'
         run: make test
 
       - name: Upload cnd ${{ matrix.os }} binary


### PR DESCRIPTION
https://github.com/actions/virtual-environments/issues/17 was closed and Docker should be available on MacOS. 

Let's give it a try :)