### PR TITLE
Improve Ethereum diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,7 @@ dependencies = [
  "http-api-problem",
  "impl-template",
  "lazy_static",
+ "levenshtein",
  "libp2p",
  "libp2p-comit",
  "libsqlite3-sys",
@@ -1539,6 +1540,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "levenshtein"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66189c12161c65c0023ceb53e2fccc0013311bcb36a7cbd0f9c5e938b408ac96"
 
 [[package]]
 name = "lexical-core"

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -29,6 +29,7 @@ hex = "0.4"
 http-api-problem = { version = "0.15", features = ["with_warp"] }
 impl-template = "1.0.0-alpha"
 lazy_static = "1"
+levenshtein = "1"
 libp2p = { version = "0.17", default-features = false, features = ["tcp", "secio", "yamux", "mplex", "mdns", "dns"] }
 libp2p-comit = { path = "../libp2p-comit" }
 libsqlite3-sys = { version = ">=0.8.0, <0.13.0", features = ["bundled"] }

--- a/cnd/src/ethereum.rs
+++ b/cnd/src/ethereum.rs
@@ -77,6 +77,12 @@ pub struct Block {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Bytes(#[serde(with = "SerHexSeq::<StrictPfx>")] pub Vec<u8>);
 
+impl AsRef<[u8]> for Bytes {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
 impl<T: Into<Vec<u8>>> From<T> for Bytes {
     fn from(data: T) -> Self {
         Bytes(data.into())

--- a/cnd/src/swap_protocols/rfc003/ethereum/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/ethereum/htlc_events.rs
@@ -80,9 +80,14 @@ impl
         htlc_params: &HtlcParams<Ethereum, asset::Ether, identity::Ethereum>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Deployed<htlc_location::Ethereum, transaction::Ethereum>> {
+        let expected_bytecode = htlc_params.bytecode();
+
         let (transaction, location) =
-            watch_for_contract_creation(self, start_of_swap, htlc_params.bytecode())
-                .instrument(tracing::info_span!("htlc_deployed"))
+            watch_for_contract_creation(self, start_of_swap, &expected_bytecode)
+                .instrument(tracing::trace_span!(
+                    "htlc_deployed",
+                    expected_bytecode = %hex::encode(&expected_bytecode.0)
+                ))
                 .await?;
 
         Ok(Deployed {
@@ -215,9 +220,14 @@ impl
         htlc_params: &HtlcParams<Ethereum, asset::Erc20, identity::Ethereum>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Deployed<htlc_location::Ethereum, transaction::Ethereum>> {
+        let expected_bytecode = htlc_params.clone().bytecode();
+
         let (transaction, location) =
-            watch_for_contract_creation(self, start_of_swap, htlc_params.clone().bytecode())
-                .instrument(tracing::info_span!("htlc_deployed"))
+            watch_for_contract_creation(self, start_of_swap, &expected_bytecode)
+                .instrument(tracing::trace_span!(
+                    "htlc_deployed",
+                    expected_bytecode = %hex::encode(&expected_bytecode.0)
+                ))
                 .await?;
 
         Ok(Deployed {


### PR DESCRIPTION
Improve the diagnostics during Ethereum matching in btsieve.

Add a levenshtein distance calculation when matching and warn if we try to match against a transaction that is 'close'. 

Add appropriate tracing spans to improve debugging output.

Done as part of the LN squad.