### PR TITLE
Check for redeem/refund spent outpoint using identity

### DIFF
--- a/cnd/src/bitcoin.rs
+++ b/cnd/src/bitcoin.rs
@@ -26,6 +26,9 @@ impl PublicKey {
     {
         secp256k1::PublicKey::from_secret_key(secp, secret_key).into()
     }
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.to_bytes()
+    }
 }
 
 impl From<secp256k1::PublicKey> for PublicKey {

--- a/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
+++ b/cnd/src/swap_protocols/rfc003/bitcoin/htlc_events.rs
@@ -92,12 +92,14 @@ where
         htlc_deployment: &Deployed<htlc_location::Bitcoin, transaction::Bitcoin>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed<transaction::Bitcoin>> {
-        let (transaction, _) =
-            watch_for_spent_outpoint(self, start_of_swap, htlc_deployment.location, vec![vec![
-                1u8,
-            ]])
-            .instrument(tracing::info_span!("htlc_redeemed"))
-            .await?;
+        let (transaction, _) = watch_for_spent_outpoint(
+            self,
+            start_of_swap,
+            htlc_deployment.location,
+            htlc_params.redeem_identity,
+        )
+        .instrument(tracing::info_span!("htlc_redeemed"))
+        .await?;
 
         let secret = extract_secret(&transaction, &htlc_params.secret_hash)
             .expect("Redeem transaction must contain secret");
@@ -118,14 +120,18 @@ where
 {
     async fn htlc_refunded(
         &self,
-        _htlc_params: &HtlcParams<B, asset::Bitcoin, identity::Bitcoin>,
+        htlc_params: &HtlcParams<B, asset::Bitcoin, identity::Bitcoin>,
         htlc_deployment: &Deployed<htlc_location::Bitcoin, transaction::Bitcoin>,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded<transaction::Bitcoin>> {
-        let (transaction, _) =
-            watch_for_spent_outpoint(self, start_of_swap, htlc_deployment.location, vec![vec![]])
-                .instrument(tracing::info_span!("htlc_refunded"))
-                .await?;
+        let (transaction, _) = watch_for_spent_outpoint(
+            self,
+            start_of_swap,
+            htlc_deployment.location,
+            htlc_params.refund_identity,
+        )
+        .instrument(tracing::info_span!("htlc_refunded"))
+        .await?;
 
         Ok(Refunded { transaction })
     }


### PR DESCRIPTION
Decide whether refund or redeem transaction using identity
rather than checking for a 1 or 0 on the witness stack.

Closes #2270