### PR TITLE
Define the DB schema for finalized swaps

### DIFF
--- a/cnd/migrations/2020-04-09-030124_create-message-tables/down.sql
+++ b/cnd/migrations/2020-04-09-030124_create-message-tables/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+
+DROP TABLE finalized_swaps;

--- a/cnd/migrations/2020-04-09-030124_create-message-tables/up.sql
+++ b/cnd/migrations/2020-04-09-030124_create-message-tables/up.sql
@@ -6,5 +6,6 @@ CREATE TABLE finalized_swaps
     swap_id UNIQUE      NOT NULL,
     alpha_identity      NOT NULL,
     beta_identity,      NOT NULL,
-    secret_hash         NOT NULL
+    secret_hash         NOT NULL,
+    at DATETIME DEFAULT CURRENT_TIMESTAMP
 )

--- a/cnd/migrations/2020-04-09-030124_create-message-tables/up.sql
+++ b/cnd/migrations/2020-04-09-030124_create-message-tables/up.sql
@@ -1,0 +1,10 @@
+-- Your SQL goes here
+
+CREATE TABLE finalized_swaps
+(
+    id INTEGER          NOT NULL PRIMARY KEY,
+    swap_id UNIQUE      NOT NULL,
+    aplpha_identity     NOT NULL,
+    beta_identity,      NOT NULL,
+    secret_hash         NOT NULL
+)

--- a/cnd/migrations/2020-04-09-030124_create-message-tables/up.sql
+++ b/cnd/migrations/2020-04-09-030124_create-message-tables/up.sql
@@ -4,7 +4,7 @@ CREATE TABLE finalized_swaps
 (
     id INTEGER          NOT NULL PRIMARY KEY,
     swap_id UNIQUE      NOT NULL,
-    aplpha_identity     NOT NULL,
+    alpha_identity      NOT NULL,
     beta_identity,      NOT NULL,
     secret_hash         NOT NULL
 )

--- a/cnd/src/db/schema.rs
+++ b/cnd/src/db/schema.rs
@@ -112,5 +112,6 @@ table! {
         alpha_identity -> Text,
         beta_identity -> Text,
         secret_hash -> Text,
+       at -> Timestamp,
     }
 }

--- a/cnd/src/db/schema.rs
+++ b/cnd/src/db/schema.rs
@@ -104,3 +104,13 @@ table! {
        counterparty -> Text,
    }
 }
+
+table! {
+    finalized_swaps {
+        id -> Integer,
+        swap_id -> Text,
+        alpha_identity -> Text,
+        beta_identity -> Text,
+        secret_hash -> Text,
+    }
+}


### PR DESCRIPTION
Add a table to hold the data we learn from the communication protocols:

```
table! {
    finalized_swaps {
        id -> Integer,
        swap_id -> Text,
        alpha_identity -> Text,
        beta_identity -> Text,
        secret_hash -> Text,
    }
}
```

Create new migrations that include this table.

Choose to include the `secret_hash` even though for Alice this is known before the communication protocols start.  This keeps things symmetrical for Alice and Bob.  `secret_hash` may well appear in the 'created' swap table also (yet to be designed).  Having an extra row with the same data in two tables seems ok in favour of the added simplicity this enables.   Anyone think differently?

Resolves: #2177