### PR TITLE
Add a table for the walking skeleton created swap

### DIFF
--- a/cnd/src/db/schema.rs
+++ b/cnd/src/db/schema.rs
@@ -104,3 +104,30 @@ table! {
        counterparty -> Text,
    }
 }
+
+// We need a way to tie the 'created' swaps with the 'finalized' swaps, possible
+// methods include:
+//
+// - Add a `local_id` row to the finalized swaps table then use an SQL join to
+//   get the right row.
+//
+// - Add `finalized_id` to 'created' swaps table that refers to the `id` in
+//   `finalized_swaps`.
+
+table! {
+    han_ethereum_ether_halight_lightning_bitcoin_created_swaps {
+        id -> Integer,
+        role -> Text,
+        dial_information -> Text,
+        ethereum_chain_id -> BigInt,
+        bitcoin_network -> Text,
+        ether_amount -> Text,
+        bitcoin_amount -> Text,
+        alpha_identity -> Text,
+        beta_identity -> Text,
+        secret_hash -> Text,
+        ethereum_expiry -> BigInt,
+        bitcoin_expiry -> BigInt, // FIXME: Is this correct?
+        local_id -> Text,
+    }
+}


### PR DESCRIPTION
10% review please @D4nte and/or @thomaseizinger 

We need a way to persist data for created swaps.  We would like to be
able to eventually restart swaps so we need everything that was handed
to us by the user via the REST API.  Also, we will at some stage need to
be able to link the data in 'created' swaps with the data for
'finalized' swaps, making a comment about this since it is currently out
of scope.

Fixes: #2137 