### PR TITLE
Add 'create swaps' tables for the protocol pairs 

### DIFF
--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -35,8 +35,8 @@ libp2p-comit = { path = "../libp2p-comit" }
 libsqlite3-sys = { version = ">=0.8.0, <0.13.0", features = ["bundled"] }
 log = { version = "0.4", features = ["serde"] }
 lru = "0.4.3"
-num = "0.2"
 multihash = "0.10"
+num = "0.2"
 paste = "0.1"
 pem = "0.7"
 primitive-types = { version = "0.7.0", features = ["serde"] }

--- a/cnd/migrations/2020-04-09-030124_create-message-tables/down.sql
+++ b/cnd/migrations/2020-04-09-030124_create-message-tables/down.sql
@@ -1,3 +1,8 @@
 -- This file should undo anything in `up.sql`
 
+DROP TABLE han_ethereum_created_swaps;
+DROP TABLE han_bitcoin_created_swaps;
+DROP TABLE herc20_created_swaps;
+DROP TABLE halight_created_swaps;
+DROP TABLE finalized_swaps;
 DROP TABLE finalized_swaps;

--- a/cnd/migrations/2020-04-09-030124_create-message-tables/down.sql
+++ b/cnd/migrations/2020-04-09-030124_create-message-tables/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+
+DROP TABLE finalized_swaps;

--- a/cnd/migrations/2020-04-09-030124_create-message-tables/up.sql
+++ b/cnd/migrations/2020-04-09-030124_create-message-tables/up.sql
@@ -1,0 +1,11 @@
+-- Your SQL goes here
+
+CREATE TABLE finalized_swaps
+(
+    id INTEGER          NOT NULL PRIMARY KEY,
+    swap_id UNIQUE      NOT NULL,
+    alpha_identity      NOT NULL,
+    beta_identity,      NOT NULL,
+    secret_hash         NOT NULL,
+    at DATETIME DEFAULT CURRENT_TIMESTAMP
+)

--- a/cnd/migrations/2020-04-09-030124_create-message-tables/up.sql
+++ b/cnd/migrations/2020-04-09-030124_create-message-tables/up.sql
@@ -1,11 +1,64 @@
 -- Your SQL goes here
 
+CREATE TABLE dial_infos
+(
+        id             INTEGER NOT NULL PRIMARY KEY,
+        local_swap_id  UNIQUE NOT NULL,
+        peer_id        NOT NULL
+);
+
+CREATE TABLE han_ethereum_created_swaps
+(
+        id             INTEGER NOT NULL PRIMARY KEY,
+        local_swap_id  UNIQUE NOT NULL,
+        role           NOT NULL,
+        chain_id       NOT NULL,
+        my_identity    NOT NULL,
+        expiry         NOT NULL,
+        amount         NOT NULL
+);
+
+CREATE TABLE han_bitcoin_created_swaps
+(
+        id             INTEGER NOT NULL PRIMARY KEY,
+        local_swap_id  UNIQUE NOT NULL,
+        role           NOT NULL,
+        network        NOT NULL,
+        my_identity    NOT NULL,
+        expiry         NOT NULL,
+        amount         NOT NULL
+);
+
+
+CREATE TABLE herc20_created_swaps
+(
+        id             INTEGER NOT NULL PRIMARY KEY,
+        local_swap_id  UNIQUE NOT NULL,
+        role           NOT NULL,
+        chain_id       NOT NULL,
+        my_identity    NOT NULL,
+        expiry         NOT NULL,
+        amount         NOT NULL,
+        token_contract NOT NULL
+);
+
+CREATE TABLE halight_created_swaps
+(
+        id             INTEGER NOT NULL PRIMARY KEY,
+        local_swap_id  UNIQUE NOT NULL,
+        role           NOT NULL,
+        network        NOT NULL,
+        my_identity    NOT NULL,
+        expiry         NOT NULL,
+        amount         NOT NULL
+);
+
 CREATE TABLE finalized_swaps
 (
-    id INTEGER          NOT NULL PRIMARY KEY,
-    swap_id UNIQUE      NOT NULL,
+    id                  INTEGER NOT NULL PRIMARY KEY,
+    swap_id             UNIQUE NOT NULL,
     alpha_identity      NOT NULL,
-    beta_identity,      NOT NULL,
+    beta_identity       NOT NULL,
     secret_hash         NOT NULL,
-    at DATETIME DEFAULT CURRENT_TIMESTAMP
-)
+    finalized_at        DATETIME DEFAULT CURRENT_TIMESTAMP
+);

--- a/cnd/src/db/schema.rs
+++ b/cnd/src/db/schema.rs
@@ -1,106 +1,181 @@
 table! {
-   rfc003_bitcoin_ethereum_bitcoin_ether_request_messages {
-       id -> Integer,
-       swap_id -> Text,
-       bitcoin_network -> Text,
-       ethereum_chain_id -> BigInt,
-       bitcoin_amount -> Text,
-       ether_amount -> Text,
-       hash_function -> Text,
-       bitcoin_refund_identity -> Text,
-       ethereum_redeem_identity -> Text,
-       bitcoin_expiry -> BigInt,
-       ethereum_expiry -> BigInt,
-       secret_hash -> Text,
-   }
+    rfc003_bitcoin_ethereum_bitcoin_ether_request_messages {
+        id -> Integer,
+        swap_id -> Text,
+        bitcoin_network -> Text,
+        ethereum_chain_id -> BigInt,
+        bitcoin_amount -> Text,
+        ether_amount -> Text,
+        hash_function -> Text,
+        bitcoin_refund_identity -> Text,
+        ethereum_redeem_identity -> Text,
+        bitcoin_expiry -> BigInt,
+        ethereum_expiry -> BigInt,
+        secret_hash -> Text,
+    }
 }
 
 table! {
-   rfc003_ethereum_bitcoin_ether_bitcoin_request_messages {
-       id -> Integer,
-       swap_id -> Text,
-       ethereum_chain_id -> BigInt,
-       bitcoin_network -> Text,
-       ether_amount -> Text,
-       bitcoin_amount -> Text,
-       hash_function -> Text,
-       ethereum_refund_identity -> Text,
-       bitcoin_redeem_identity -> Text,
-       ethereum_expiry -> BigInt,
-       bitcoin_expiry -> BigInt,
-       secret_hash -> Text,
-   }
+    rfc003_ethereum_bitcoin_ether_bitcoin_request_messages {
+        id -> Integer,
+        swap_id -> Text,
+        ethereum_chain_id -> BigInt,
+        bitcoin_network -> Text,
+        ether_amount -> Text,
+        bitcoin_amount -> Text,
+        hash_function -> Text,
+        ethereum_refund_identity -> Text,
+        bitcoin_redeem_identity -> Text,
+        ethereum_expiry -> BigInt,
+        bitcoin_expiry -> BigInt,
+        secret_hash -> Text,
+    }
 }
 
 table! {
-   rfc003_bitcoin_ethereum_bitcoin_erc20_request_messages {
-       id -> Integer,
-       swap_id -> Text,
-       bitcoin_network -> Text,
-       ethereum_chain_id -> BigInt,
-       bitcoin_amount -> Text,
-       erc20_amount -> Text,
-       erc20_token_contract -> Text,
-       hash_function -> Text,
-       bitcoin_refund_identity -> Text,
-       ethereum_redeem_identity -> Text,
-       bitcoin_expiry -> BigInt,
-       ethereum_expiry -> BigInt,
-       secret_hash -> Text,
-   }
+    rfc003_bitcoin_ethereum_bitcoin_erc20_request_messages {
+        id -> Integer,
+        swap_id -> Text,
+        bitcoin_network -> Text,
+        ethereum_chain_id -> BigInt,
+        bitcoin_amount -> Text,
+        erc20_amount -> Text,
+        erc20_token_contract -> Text,
+        hash_function -> Text,
+        bitcoin_refund_identity -> Text,
+        ethereum_redeem_identity -> Text,
+        bitcoin_expiry -> BigInt,
+        ethereum_expiry -> BigInt,
+        secret_hash -> Text,
+    }
 }
 
 table! {
-   rfc003_ethereum_bitcoin_erc20_bitcoin_request_messages {
-       id -> Integer,
-       swap_id -> Text,
-       ethereum_chain_id -> BigInt,
-       bitcoin_network -> Text,
-       erc20_amount -> Text,
-       erc20_token_contract -> Text,
-       bitcoin_amount -> Text,
-       hash_function -> Text,
-       ethereum_refund_identity -> Text,
-       bitcoin_redeem_identity -> Text,
-       ethereum_expiry -> BigInt,
-       bitcoin_expiry -> BigInt,
-       secret_hash -> Text,
-   }
+    rfc003_ethereum_bitcoin_erc20_bitcoin_request_messages {
+        id -> Integer,
+        swap_id -> Text,
+        ethereum_chain_id -> BigInt,
+        bitcoin_network -> Text,
+        erc20_amount -> Text,
+        erc20_token_contract -> Text,
+        bitcoin_amount -> Text,
+        hash_function -> Text,
+        ethereum_refund_identity -> Text,
+        bitcoin_redeem_identity -> Text,
+        ethereum_expiry -> BigInt,
+        bitcoin_expiry -> BigInt,
+        secret_hash -> Text,
+    }
 }
 
 table! {
-   rfc003_ethereum_bitcoin_accept_messages {
-       id -> Integer,
-       swap_id -> Text,
-       ethereum_redeem_identity -> Text,
-       bitcoin_refund_identity -> Text,
-       at -> Timestamp,
-   }
+    rfc003_ethereum_bitcoin_accept_messages {
+        id -> Integer,
+        swap_id -> Text,
+        ethereum_redeem_identity -> Text,
+        bitcoin_refund_identity -> Text,
+        at -> Timestamp,
+    }
 }
 
 table! {
-   rfc003_bitcoin_ethereum_accept_messages {
-       id -> Integer,
-       swap_id -> Text,
-       bitcoin_redeem_identity -> Text,
-       ethereum_refund_identity -> Text,
-       at -> Timestamp,
-   }
+    rfc003_bitcoin_ethereum_accept_messages {
+        id -> Integer,
+        swap_id -> Text,
+        bitcoin_redeem_identity -> Text,
+        ethereum_refund_identity -> Text,
+        at -> Timestamp,
+    }
 }
 
 table! {
-   rfc003_decline_messages {
-       id -> Integer,
-       swap_id -> Text,
-       reason -> Nullable<Text>,
-   }
+    rfc003_decline_messages {
+        id -> Integer,
+        swap_id -> Text,
+        reason -> Nullable<Text>,
+    }
 }
 
 table! {
-   rfc003_swaps {
-       id -> Integer,
-       swap_id -> Text,
-       role -> Text,
-       counterparty -> Text,
-   }
+    rfc003_swaps {
+        id -> Integer,
+        swap_id -> Text,
+        role -> Text,
+        counterparty -> Text,
+    }
+}
+
+// The new split protocol tables i.e., Han, HErc20, HALight.
+//
+
+// This is used by Alice to save dial info for created swaps.
+table! {
+    dial_infos {
+        id -> Integer,
+        local_swap_id -> Text,
+        // We need something here, right?
+        peer_id -> Text, // Optional.  FIXME: Do we want this?
+        address_hints -> Text,  // Optional.  FIXME: Do we want this?
+    }
+}
+
+table! {
+    han_ethereum_created_swaps {
+        id -> Integer,
+        local_swap_id -> Text,
+        role -> Text,
+        chain_id -> Text,
+        my_identity -> Text,
+        expiry -> BigInt,
+        amount -> Text,
+    }
+}
+
+table! {
+    han_bitcoin_created_swaps {
+        id -> Integer,
+        local_swap_id -> Text,
+        role -> Text,
+        network -> Text,
+        my_identity -> Text,
+        expiry -> BigInt,
+        amount -> Text,
+    }
+}
+
+table! {
+    herc20_created_swaps {
+        id -> Integer,
+        local_swap_id -> Text,
+        role -> Text,
+        network -> Text,
+        my_identity -> Text,
+        expiry -> BigInt,
+        amount -> Text,
+        token_contract -> Text,
+    }
+}
+
+table! {
+    halight_created_swaps {
+        id -> Integer,
+        local_swap_id -> Text,
+        role -> Text,
+        network -> Text,
+        my_identity -> Text,
+        expiry -> BigInt,
+        amount -> Text,
+    }
+}
+
+table! {
+    finalized_swaps {
+        id -> Integer,
+        local_swap_id -> Text,
+        shared_swap_id -> Text,
+        counterparty_alpha_identity -> Text,
+        counterparty_beta_identity -> Text,
+        secret_hash -> Text,
+        finalized_at -> Timestamp,
+    }
 }

--- a/cnd/src/db/schema.rs
+++ b/cnd/src/db/schema.rs
@@ -113,9 +113,7 @@ table! {
     dial_infos {
         id -> Integer,
         local_swap_id -> Text,
-        // We need something here, right?
-        peer_id -> Text, // Optional.  FIXME: Do we want this?
-        address_hints -> Text,  // Optional.  FIXME: Do we want this?
+        peer_id -> Text,
     }
 }
 


### PR DESCRIPTION
We need a way to persist data for created swaps.  We would like to be able to eventually restart swaps so we need everything that was handed to us by the user via the REST API.  Also, we will at some stage need to be able to link the data in 'created' swaps with the data for 'finalized' swaps, here we do this by storing the `local_swap_id`.

Add 'create swaps' tables for each of the protocol pairs we support.  Also add migrations.

This [closed PR](https://github.com/comit-network/comit-rs/pull/2432/files) shows another way of solving this same ticket.  We are currently unsure which method is best.

Fixes: #2173