### PR TITLE
Add SQL tables for split protocols - 10%

### DIFF
--- a/cnd/migrations/2020-04-09-030124_create-message-tables/down.sql
+++ b/cnd/migrations/2020-04-09-030124_create-message-tables/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+
+DROP TABLE finalized_swaps;

--- a/cnd/migrations/2020-04-09-030124_create-message-tables/up.sql
+++ b/cnd/migrations/2020-04-09-030124_create-message-tables/up.sql
@@ -1,0 +1,11 @@
+-- Your SQL goes here
+
+CREATE TABLE finalized_swaps
+(
+    id INTEGER          NOT NULL PRIMARY KEY,
+    swap_id UNIQUE      NOT NULL,
+    alpha_identity      NOT NULL,
+    beta_identity,      NOT NULL,
+    secret_hash         NOT NULL,
+    at DATETIME DEFAULT CURRENT_TIMESTAMP
+)

--- a/cnd/src/db/schema.rs
+++ b/cnd/src/db/schema.rs
@@ -1,106 +1,181 @@
 table! {
-   rfc003_bitcoin_ethereum_bitcoin_ether_request_messages {
-       id -> Integer,
-       swap_id -> Text,
-       bitcoin_network -> Text,
-       ethereum_chain_id -> BigInt,
-       bitcoin_amount -> Text,
-       ether_amount -> Text,
-       hash_function -> Text,
-       bitcoin_refund_identity -> Text,
-       ethereum_redeem_identity -> Text,
-       bitcoin_expiry -> BigInt,
-       ethereum_expiry -> BigInt,
-       secret_hash -> Text,
-   }
+    rfc003_bitcoin_ethereum_bitcoin_ether_request_messages {
+        id -> Integer,
+        swap_id -> Text,
+        bitcoin_network -> Text,
+        ethereum_chain_id -> BigInt,
+        bitcoin_amount -> Text,
+        ether_amount -> Text,
+        hash_function -> Text,
+        bitcoin_refund_identity -> Text,
+        ethereum_redeem_identity -> Text,
+        bitcoin_expiry -> BigInt,
+        ethereum_expiry -> BigInt,
+        secret_hash -> Text,
+    }
 }
 
 table! {
-   rfc003_ethereum_bitcoin_ether_bitcoin_request_messages {
-       id -> Integer,
-       swap_id -> Text,
-       ethereum_chain_id -> BigInt,
-       bitcoin_network -> Text,
-       ether_amount -> Text,
-       bitcoin_amount -> Text,
-       hash_function -> Text,
-       ethereum_refund_identity -> Text,
-       bitcoin_redeem_identity -> Text,
-       ethereum_expiry -> BigInt,
-       bitcoin_expiry -> BigInt,
-       secret_hash -> Text,
-   }
+    rfc003_ethereum_bitcoin_ether_bitcoin_request_messages {
+        id -> Integer,
+        swap_id -> Text,
+        ethereum_chain_id -> BigInt,
+        bitcoin_network -> Text,
+        ether_amount -> Text,
+        bitcoin_amount -> Text,
+        hash_function -> Text,
+        ethereum_refund_identity -> Text,
+        bitcoin_redeem_identity -> Text,
+        ethereum_expiry -> BigInt,
+        bitcoin_expiry -> BigInt,
+        secret_hash -> Text,
+    }
 }
 
 table! {
-   rfc003_bitcoin_ethereum_bitcoin_erc20_request_messages {
-       id -> Integer,
-       swap_id -> Text,
-       bitcoin_network -> Text,
-       ethereum_chain_id -> BigInt,
-       bitcoin_amount -> Text,
-       erc20_amount -> Text,
-       erc20_token_contract -> Text,
-       hash_function -> Text,
-       bitcoin_refund_identity -> Text,
-       ethereum_redeem_identity -> Text,
-       bitcoin_expiry -> BigInt,
-       ethereum_expiry -> BigInt,
-       secret_hash -> Text,
-   }
+    rfc003_bitcoin_ethereum_bitcoin_erc20_request_messages {
+        id -> Integer,
+        swap_id -> Text,
+        bitcoin_network -> Text,
+        ethereum_chain_id -> BigInt,
+        bitcoin_amount -> Text,
+        erc20_amount -> Text,
+        erc20_token_contract -> Text,
+        hash_function -> Text,
+        bitcoin_refund_identity -> Text,
+        ethereum_redeem_identity -> Text,
+        bitcoin_expiry -> BigInt,
+        ethereum_expiry -> BigInt,
+        secret_hash -> Text,
+    }
 }
 
 table! {
-   rfc003_ethereum_bitcoin_erc20_bitcoin_request_messages {
-       id -> Integer,
-       swap_id -> Text,
-       ethereum_chain_id -> BigInt,
-       bitcoin_network -> Text,
-       erc20_amount -> Text,
-       erc20_token_contract -> Text,
-       bitcoin_amount -> Text,
-       hash_function -> Text,
-       ethereum_refund_identity -> Text,
-       bitcoin_redeem_identity -> Text,
-       ethereum_expiry -> BigInt,
-       bitcoin_expiry -> BigInt,
-       secret_hash -> Text,
-   }
+    rfc003_ethereum_bitcoin_erc20_bitcoin_request_messages {
+        id -> Integer,
+        swap_id -> Text,
+        ethereum_chain_id -> BigInt,
+        bitcoin_network -> Text,
+        erc20_amount -> Text,
+        erc20_token_contract -> Text,
+        bitcoin_amount -> Text,
+        hash_function -> Text,
+        ethereum_refund_identity -> Text,
+        bitcoin_redeem_identity -> Text,
+        ethereum_expiry -> BigInt,
+        bitcoin_expiry -> BigInt,
+        secret_hash -> Text,
+    }
 }
 
 table! {
-   rfc003_ethereum_bitcoin_accept_messages {
-       id -> Integer,
-       swap_id -> Text,
-       ethereum_redeem_identity -> Text,
-       bitcoin_refund_identity -> Text,
-       at -> Timestamp,
-   }
+    rfc003_ethereum_bitcoin_accept_messages {
+        id -> Integer,
+        swap_id -> Text,
+        ethereum_redeem_identity -> Text,
+        bitcoin_refund_identity -> Text,
+        at -> Timestamp,
+    }
 }
 
 table! {
-   rfc003_bitcoin_ethereum_accept_messages {
-       id -> Integer,
-       swap_id -> Text,
-       bitcoin_redeem_identity -> Text,
-       ethereum_refund_identity -> Text,
-       at -> Timestamp,
-   }
+    rfc003_bitcoin_ethereum_accept_messages {
+        id -> Integer,
+        swap_id -> Text,
+        bitcoin_redeem_identity -> Text,
+        ethereum_refund_identity -> Text,
+        at -> Timestamp,
+    }
 }
 
 table! {
-   rfc003_decline_messages {
-       id -> Integer,
-       swap_id -> Text,
-       reason -> Nullable<Text>,
-   }
+    rfc003_decline_messages {
+        id -> Integer,
+        swap_id -> Text,
+        reason -> Nullable<Text>,
+    }
 }
 
 table! {
-   rfc003_swaps {
-       id -> Integer,
-       swap_id -> Text,
-       role -> Text,
-       counterparty -> Text,
-   }
+    rfc003_swaps {
+        id -> Integer,
+        swap_id -> Text,
+        role -> Text,
+        counterparty -> Text,
+    }
+}
+
+// The new split protocol tables i.e., Han, HErc20, HALight.
+//
+
+table! {
+    created_swaps {
+        id -> Integer,
+        local_swap_id -> Text,
+        role -> Text,
+    }
+}
+
+// This is used by Alice to save dial info for created swaps.
+table! {
+    dial_infos {
+        id -> Integer,
+        local_swap_id -> Text,
+        dial_information -> Text,
+    }
+}
+// Alice can write this soon as she creates the swap, Bob can write it
+// after/during the communication protocol.
+table! {
+    secret_hashes {
+        id -> Integer,
+        local_swap_id -> Text,
+        secret_hash -> Text,
+    }
+}
+
+table! {
+    han_created_swaps {
+        id -> Integer,
+        local_swap_id -> Text,
+        network -> Text,            // i.e., 'regtest' for Bitcoin or '17' for Ethereum.  FIXME: Is this ok?
+        identity -> Text,
+        expiry -> BigInt,
+        amount -> Text,
+    }
+}
+
+table! {
+    herc20_created_swaps {
+        id -> Integer,
+        local_swap_id -> Text,
+        network -> Text,            // i.e., 'regtest' for Bitcoin or '17' for Ethereum.  FIXME: Is this ok?
+        identity -> Text,
+        expiry -> BigInt,
+        amount -> Text,
+        token_contract -> Text,
+    }
+}
+
+table! {
+    halight_created_swaps {
+        id -> Integer,
+        local_swap_id -> Text,
+        network -> Text,            // i.e., 'regtest' for Bitcoin or '17' for Ethereum.  FIXME: Is this ok?
+        identity -> Text,
+        expiry -> BigInt,
+        amount -> Text,
+    }
+}
+
+table! {
+    finalized_swaps {
+        id -> Integer,
+        local_id -> Text,
+        shared_swap_id -> Text,
+        alpha_redeem_identity -> Text,
+        beta_refund_identity -> Text,
+        secret_hash -> Text,
+        at -> Timestamp,
+    }
 }


### PR DESCRIPTION
New Draft PR to combine both the 'create' and 'finalize' tickets - this is going to have a lot of comments and will be difficult to follow having two PRs.  Thanks for your reviews so far @D4nte I believe I have included your comments in this work, but lets see.

This PR uses a totally different approach, adds a table for each protocol (Han, HErc20, HALight).  Also adds other tables for data that is known to Alice at a different stage than to Bob i.e., Alice knows the secret hash after the swap is created and before it is finalized whereas Bob only knows it after the swap is finalized. 

Resolves: #2177
Resolves: #2173 