### PR TITLE
BitcoindWallet and upgrade bitcoind to 0.19.1

### DIFF
--- a/api_tests/src/actor_test.ts
+++ b/api_tests/src/actor_test.ts
@@ -33,7 +33,7 @@ function nActorTest(
         } finally {
             for (const actorName of actorNames) {
                 const actor = actors.getActorByName(actorName);
-                await Promise.all([actor.stop(), actor.wallets.close()]);
+                await actor.stop();
             }
         }
         done();

--- a/api_tests/src/bitcoin_miner.ts
+++ b/api_tests/src/bitcoin_miner.ts
@@ -18,14 +18,15 @@ async function run(configFile: string) {
         port: config.rpcPort,
         username: config.username,
         password: config.password,
+        wallet: "miner",
     });
 
     // only coins after the first 101 are spendable
-    await client.generateToAddress(101, await client.getNewAddress());
+    const address = await client.getNewAddress();
+    await client.generateToAddress(101, address);
 
     while (true) {
-        await client.generateToAddress(1, await client.getNewAddress());
-
+        await client.generateToAddress(1, address);
         await sleep(1000);
     }
 }

--- a/api_tests/src/ledgers/bitcoin_miner_instance.ts
+++ b/api_tests/src/ledgers/bitcoin_miner_instance.ts
@@ -34,6 +34,10 @@ export default class BitcoinMinerInstance {
 
         miner.unref();
 
+        miner.on("error", (error) => {
+            logger.error("bitcoin miner threw an error ", error);
+        });
+
         miner.on("exit", (code) => {
             logger.warn("bitcoin miner exited with code ", code);
         });

--- a/api_tests/src/ledgers/bitcoind_instance.ts
+++ b/api_tests/src/ledgers/bitcoind_instance.ts
@@ -42,7 +42,7 @@ export class BitcoindInstance implements LedgerInstance {
     ) {}
 
     public async start() {
-        const bin = await this.findBinary("0.17.0");
+        const bin = await this.findBinary("0.19.1");
 
         this.logger.info("Using binary", bin);
 

--- a/api_tests/src/ledgers/bitcoind_instance.ts
+++ b/api_tests/src/ledgers/bitcoind_instance.ts
@@ -156,7 +156,7 @@ export class BitcoindInstance implements LedgerInstance {
 server=1
 printtoconsole=1
 rpcallowip=0.0.0.0/0
-nodebug=1
+debug=http, db, rpc
 rest=1
 acceptnonstdtxn=0
 zmqpubrawblock=tcp://127.0.0.1:${this.zmqPubRawBlockPort}
@@ -165,6 +165,7 @@ zmqpubrawtx=tcp://127.0.0.1:${this.zmqPubRawTxPort}
 [regtest]
 bind=0.0.0.0:${this.p2pPort}
 rpcbind=0.0.0.0:${this.rpcPort}
+wallet=miner
 `;
         const config = path.join(dataDir, "bitcoin.conf");
         await writeFileAsync(config, output);

--- a/api_tests/src/test_environment.ts
+++ b/api_tests/src/test_environment.ts
@@ -113,19 +113,7 @@ export default class TestEnvironment extends NodeEnvironment {
     async teardown() {
         await super.teardown();
 
-        await this.cleanupAll();
-
         loggerShutdown();
-    }
-
-    async cleanupAll() {
-        const tasks = [];
-
-        for (const [, wallet] of Object.entries(this.global.lndWallets)) {
-            tasks.push(wallet.close());
-        }
-
-        await Promise.all(tasks);
     }
 
     /**

--- a/api_tests/src/wallets/bitcoind_wallet.ts
+++ b/api_tests/src/wallets/bitcoind_wallet.ts
@@ -1,0 +1,88 @@
+import { BitcoinWallet } from "comit-sdk";
+import { BitcoinNodeConfig } from "../ledgers";
+import BitcoinRpcClient from "bitcoin-core";
+
+export class BitcoindWallet implements BitcoinWallet {
+    constructor(private readonly client: BitcoinRpcClient) {}
+
+    public static async newInstance(
+        network: string,
+        hdKey: string,
+        config: BitcoinNodeConfig
+    ): Promise<BitcoindWallet> {
+        const bitcoinRpcClient = new BitcoinRpcClient({
+            network,
+            host: "localhost",
+            port: config.rpcPort,
+            username: config.username,
+            password: config.password,
+            wallet: "miner",
+        });
+
+        // everything before is the same for every xprv
+        const walletName = hdKey.substr(16, 20);
+        const createWalletResponse = await bitcoinRpcClient.createWallet(
+            walletName
+        );
+
+        const client = new BitcoinRpcClient({
+            network,
+            host: "localhost",
+            port: config.rpcPort,
+            username: config.username,
+            password: config.password,
+            wallet: createWalletResponse.name,
+        });
+
+        let descriptor = `wpkh(${hdKey}/0h/0h/*h)`;
+
+        const descriptorInfo = await client.getDescriptorInfo(descriptor);
+        descriptor = `${descriptor}#${descriptorInfo.checksum}`;
+
+        const request = {
+            desc: descriptor,
+            timestamp: 0,
+            range: 0,
+        };
+        // no need to rescan as we mint only after the initialization
+        const options = { rescan: false };
+        const importMultiResponse = await client.importMulti(
+            [request],
+            options
+        );
+
+        if (!importMultiResponse[0].success) {
+            return Promise.reject("Could not import xprv key");
+        }
+
+        return new BitcoindWallet(client);
+    }
+
+    public async broadcastTransaction(
+        transactionHex: string,
+        _network: string
+    ): Promise<string> {
+        return this.client.sendRawTransaction(transactionHex);
+    }
+
+    public async getAddress(): Promise<string> {
+        return this.client.getNewAddress();
+    }
+
+    public async getBalance(): Promise<number> {
+        return this.client.getBalance();
+    }
+
+    public getFee(): string {
+        return "150";
+    }
+
+    public async sendToAddress(
+        address: string,
+        satoshis: number,
+        _network: string
+    ): Promise<string> {
+        const bitcoin = satoshis / 100_000_000;
+        return this.client.sendToAddress(address, bitcoin);
+    }
+}

--- a/api_tests/src/wallets/index.ts
+++ b/api_tests/src/wallets/index.ts
@@ -85,20 +85,6 @@ export class Wallets {
                 }
         }
     }
-
-    public async close(): Promise<void[]> {
-        const tasks = [];
-
-        if (this.wallets.lightning) {
-            tasks.push(this.wallets.lightning.close());
-        }
-
-        if (this.wallets.bitcoin) {
-            tasks.push(this.wallets.bitcoin.close());
-        }
-
-        return Promise.all(tasks);
-    }
 }
 
 export async function pollUntilMinted(

--- a/api_tests/src/wallets/lightning.ts
+++ b/api_tests/src/wallets/lightning.ts
@@ -169,8 +169,4 @@ export class LightningWallet implements Wallet {
         await sleep(500);
         return this.pollUntilChannelIsOpen(outpoint);
     }
-
-    public async close(): Promise<void> {
-        return this.bitcoinWallet.close();
-    }
 }

--- a/api_tests/types/bitcoin-core/index.d.ts
+++ b/api_tests/types/bitcoin-core/index.d.ts
@@ -25,16 +25,58 @@ declare module "bitcoin-core" {
         password: string;
         host: string;
         port: number;
+        wallet: string;
+    }
+
+    interface GetDescriptorInfo {
+        descriptor: string;
+        checksum: string;
+        isrange: boolean;
+        issolvable: boolean;
+        hasprivatekeys: boolean;
+    }
+
+    // note: (for us) unneeded fields are not provided in this interface
+    interface ImportMultiRequest {
+        desc: string;
+        timestamp: number | string;
+        range: number;
+    }
+
+    interface ImportMultiResponse {
+        success: boolean;
+    }
+
+    interface ImportMultiOptions {
+        rescan: boolean;
+    }
+
+    interface CreateWalletResponse {
+        name: string;
+        warning: string;
     }
 
     export default class BitcoinRpcClient {
         public constructor(args: ClientConstructorArgs);
+
+        public getBalance(): Promise<number>;
 
         public getBlockchainInfo(): Promise<GetBlockchainInfoResponse>;
 
         public getBlockCount(): Promise<number>;
 
         public getNewAddress(): Promise<string>;
+
+        public getDescriptorInfo(
+            descriptor: string
+        ): Promise<GetDescriptorInfo>;
+
+        public importMulti(
+            request: ImportMultiRequest[],
+            options: ImportMultiOptions
+        ): Promise<ImportMultiResponse[]>;
+
+        public createWallet(name: string): Promise<CreateWalletResponse>;
 
         public getRawTransaction(
             txId: string,


### PR DESCRIPTION
This is a potential fix for this bug in the sdk : comit-network/comit-js-sdk#177.
In order to make this work I had to upgrade bitcoind to 0.19.1

If we are happy with this wallet I propose to: 

1) move the `BitcoindWallet` into the sdk, i.e. fix the original issue comit-network/comit-js-sdk#177
2) release the sdk and 
  a) use the latest sdk in the e2e tests (i.e. remove the `BitcoindWallet` and use the one from the sdk)
  b) use the latest sdk version in the examples. For that, we will need to upgrade bitcoind in create-comit-app

