### PR TITLE
Libp2p integration tests for `ComitLn` network behaviour

### DIFF
--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -152,6 +152,9 @@ fn main() -> anyhow::Result<()> {
         beta_ledger_state: Arc::clone(&invoice_states),
     };
 
+    // await finalized on the swarm here (using [swarm].next() and condition inside loop - is there a more elegant way...?)
+    // trigger the execution from parameters returned by finalized
+
     let deps = Facade {
         bitcoin_connector,
         ethereum_connector,

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -6,6 +6,7 @@ pub mod transport;
 
 pub use transport::ComitTransport;
 
+use crate::network::protocols::finalized;
 use crate::{
     asset::AssetKind,
     btsieve::{
@@ -228,6 +229,123 @@ pub struct ComitNode {
     response_channels: Arc<Mutex<HashMap<SwapId, oneshot::Sender<Response>>>>,
     #[behaviour(ignore)]
     task_executor: Handle,
+}
+
+// TODO implement this
+impl NetworkBehaviourEventProcess<oneshot_behaviour::OutEvent<finalized::Message>> for ComitNode {
+    fn inject_event(&mut self, event: oneshot_behaviour::OutEvent<finalized::Message>) {
+        // TODO: Event matching logic, extract params
+
+        match event {}
+
+        !unimplemented!()
+
+        // let local_swap_id = event.local_swap_id;
+        //
+        // let create_swap_params = event.swap_params;
+        //
+        // let secret_hash = event.secret_hash;
+        //
+        // let invoice_states = event.invoice_state;
+        //
+        // let role = create_swap_params.role;
+
+        // TODO: The blockchain connectors should probably be constructed here?
+
+        // TODO: Spin up the blockchain watchers using code below (might equire pulling more code in from ComitLn)
+
+        // if role == Role::Alice {
+        //     tokio::task::spawn({
+        //         let lnd_connector = (*self.lnd_connector_as_receiver)
+        //             .clone()
+        //             .read_certificate()
+        //             .expect("Failure reading tls certificate")
+        //             .read_macaroon()
+        //             .expect("Failure reading macaroon");
+        //
+        //         new_halight_swap(local_swap_id, secret_hash, invoice_states, lnd_connector)
+        //             .instrument(
+        //                 tracing::error_span!("beta_ledger", swap_id = %local_swap_id, role = %role),
+        //             )
+        //     });
+        // } else {
+        //     // This is Bob
+        //     tokio::task::spawn({
+        //         let lnd_connector = (*self.lnd_connector_as_sender)
+        //             .clone()
+        //             .read_certificate()
+        //             .expect("Failure reading tls certificate")
+        //             .read_macaroon()
+        //             .expect("Failure reading macaroon");
+        //
+        //         new_halight_swap(local_swap_id, secret_hash, invoice_states, lnd_connector)
+        //             .instrument(
+        //                 tracing::error_span!("beta_ledger", swap_id = %local_swap_id, role = %role),
+        //             )
+        //     });
+        // }
+        //
+        // if role == Role::Alice {
+        //     tokio::task::spawn({
+        //         let connector = self.ethereum_connector.clone();
+        //         let alice_ethereum_identity = create_swap_params.ethereum_identity;
+        //         let bob_ethereum_identity =
+        //             self.ethereum_identities.get(&swap_id).copied().unwrap();
+        //
+        //         let asset = create_swap_params.ethereum_amount.clone();
+        //         let ledger = ledger::Ethereum::default();
+        //         let expiry = create_swap_params.ethereum_absolute_expiry;
+        //         let secret_hash = self
+        //             .secret_hashes
+        //             .get(&swap_id)
+        //             .copied()
+        //             .expect("must exist");
+        //
+        //         new_han_ethereum_ether_swap(
+        //             local_swap_id,
+        //             connector,
+        //             self.ethereum_ledger_state.clone(),
+        //             HtlcParams {
+        //                 asset,
+        //                 ledger,
+        //                 redeem_identity: bob_ethereum_identity,
+        //                 refund_identity: alice_ethereum_identity.into(),
+        //                 expiry,
+        //                 secret_hash,
+        //             },
+        //             role,
+        //         )
+        //     });
+        // } else {
+        //     tokio::task::spawn({
+        //         // This is Bob
+        //         let connector = self.ethereum_connector.clone();
+        //         let alice_ethereum_identity =
+        //             self.ethereum_identities.get(&swap_id).copied().unwrap();
+        //         let bob_ethereum_identity = create_swap_params.ethereum_identity;
+        //
+        //         let asset = create_swap_params.ethereum_amount.clone();
+        //         let ledger = ledger::Ethereum::default();
+        //         let expiry = create_swap_params.ethereum_absolute_expiry;
+        //         let secret_hash = self.secret_hashes.get(&swap_id).copied().unwrap();
+        //
+        //         new_han_ethereum_ether_swap(
+        //             local_swap_id,
+        //             connector,
+        //             self.ethereum_ledger_state.clone(),
+        //             HtlcParams {
+        //                 asset,
+        //                 ledger,
+        //                 redeem_identity: bob_ethereum_identity.into(),
+        //                 refund_identity: alice_ethereum_identity,
+        //                 expiry,
+        //                 secret_hash,
+        //             },
+        //             role,
+        //         )
+        //     });
+        // }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -902,9 +1020,12 @@ where
     Save::save(&db, swap_request.clone()).await?;
 
     swap_communication_states
-        .insert(id, SwapCommunication::Proposed {
-            request: swap_request,
-        })
+        .insert(
+            id,
+            SwapCommunication::Proposed {
+                request: swap_request,
+            },
+        )
         .await;
 
     alpha_ledger_state

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -539,6 +539,15 @@ impl NetworkBehaviourEventProcess<oneshot_behaviour::OutEvent<finalize::Message>
             .expect("this should exist");
 
         if state.sent_finalized && state.received_finalized {
+            // EXECUTION START
+            // TODO - Starting the watchers should not be part of the communication's finalize. This is a different concern and should be properly separated.
+            // Move this code to main.rs
+            // The NetworkBehavior should just yield finalize, spawning the execution watchers should be separate from that.
+
+            // Finalize has to return the necessary "information" to start execution.
+            // Hence, the swap-id, parameters and connectors have to be returned so the watching can be started outside.
+            // Once this is separate, it should be straight forward to test the NetworkBehavior using [swarm].next()
+
             let local_swap_id = self
                 .swap_ids
                 .iter()
@@ -720,4 +729,32 @@ async fn new_han_ethereum_ether_swap(
     )
     .instrument(tracing::error_span!("alpha_ledger", swap_id = %local_swap_id, role = %role))
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::swap_protocols::CreateSwapParams;
+
+    #[test]
+    fn swap_communication_yields_correct_execution_parameters_for_alice() {
+
+        // -- Basic outline ot the test for Alice --
+
+        // GIVEN a swap as Alice
+        // use CreateSwapParams to create a swap
+
+        // WHEN passed to the network behavior
+        //      init swarm for Alice and Bob
+        //      use [swarm].next_event() pattern to test
+
+        // THEN (the necessary communications happens and) we receive the identities
+        // check that what is returned by finalize contains the right parameters to start execution
+    }
+
+    #[test]
+    fn swap_communication_yields_correct_execution_parameters_for_bob() {
+
+        // TODO: after test for Alice is done do same for Bob
+        // The output should include hash_secret in addition to identities
+    }
 }

--- a/cnd/src/network/protocols.rs
+++ b/cnd/src/network/protocols.rs
@@ -2,5 +2,6 @@ pub mod announce;
 pub mod bitcoin_identity;
 pub mod ethereum_identity;
 pub mod finalize;
+pub mod finalized;
 pub mod lightning_identity;
 pub mod secret_hash;

--- a/cnd/src/network/protocols/finalized.rs
+++ b/cnd/src/network/protocols/finalized.rs
@@ -1,0 +1,38 @@
+use crate::swap_protocols::rfc003::SecretHash;
+use crate::swap_protocols::NodeLocalSwapId;
+use crate::{network::oneshot_protocol, swap_protocols::SwapId};
+use serde::{Deserialize, Serialize};
+
+// TODO: This might have to be changed to be a BehaviourOutEvent rather than using the oneshot
+
+/// The message for an internal event emit after finalized to trigger the execution
+#[derive(Clone, Copy, Deserialize, Debug, Serialize)]
+pub struct Message {
+    pub local_swap_id: NodeLocalSwapId,
+    pub swap_id: SwapId,
+    pub swap_params: CreatteSwapParams,
+    pub secret_hash: SecretHash,
+    pub invoice_state: InvoiceState,
+}
+
+impl Message {
+    pub fn new(
+        local_swap_id: NodeLocalSwapId,
+        swap_id: SwapId,
+        swap_params: CreatteSwapParams,
+        secret_hash: SecretHash,
+        invoice_state: InvoiceState,
+    ) -> Self {
+        Self {
+            local_swap_id,
+            swap_id,
+            swap_params,
+            secret_hash,
+            invoice_state,
+        }
+    }
+}
+
+impl oneshot_protocol::Message for Message {
+    const INFO: &'static str = "/comit/swap/finalized/1.0.0";
+}


### PR DESCRIPTION
outline the solution in comments for 10% review

Please just comment on this draft PR, no approvals. This is purely for discussing the solution.

The idea I discussed with @rishflab is to pull the code that actually starts the execution (by triggering the blockchain watchers) out of the `NetworkBehaviour` (`ComitLn`).

`finalize` would just return the information necessary to start the execution rather than starting it itself. We use the [`next_event()`](https://docs.rs/libp2p/0.18.0/libp2p/swarm/struct.ExpandedSwarm.html#method.next_event) function to listen for `finalize`. `finalize` returns all the necessary parameters to to actually start the execution.

Test for announce protocol that uses this pattern: https://github.com/comit-network/comit-rs/blob/announce-tests/cnd/src/network/protocols/announce/behaviour.rs#L213-L269