### PR TITLE
Upload e2e test logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,31 @@ jobs:
           cd api_tests
           yarn install
           yarn ci
+
+      - name: Upload bitcoind log
+        if: failure()
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: e2e-logs-bitcoind.log
+          path: api_tests/log/bitcoind/regtest/debug.log
+
+      - name: Upload parity log
+        if: failure()
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: e2e-logs-parity.log
+          path: api_tests/log/parity/parity.log
+
+      - name: Upload lnd logs
+        if: failure()
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: e2e-logs-lnd
+          path: api_tests/log/lnd-*/logs/bitcoin/regtest/lnd.log
+
+      - name: Upload e2e logs
+        if: failure()
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: e2e-test-logs
+          path: api_tests/log/tests/


### PR DESCRIPTION
Note: lnd are ignored for now. Not sure if there are useful logs in there. @D4nte : any thoughts? 

I opted against uploading the whole `api/log` folder due to its size: `api/log` contains `api/log/parity` and `api/log/bitcoind` which can get rather big. These folders contain the whole blockchain data. 

Uploaded files are auto-deleted after [90 days](https://github.community/t5/GitHub-Actions/Managing-Actions-storage-space/m-p/41424/highlight/true#M4618). 

I'm using a preview feature of the upload archive action. Afaik, eventually they will offer multi-file upload and we can merge the multiple steps into one. 

This plugin is not yet _stable_ hence I recommend to only use it for the logs for now and not for other actions such as binary or releases. If these uploads fail it's way more annoying than if a log file upload fails :) 
