### PR TITLE
Add debug logs to e2e tests

### DIFF
--- a/api_tests/src/wallets/ethereum.ts
+++ b/api_tests/src/wallets/ethereum.ts
@@ -120,7 +120,21 @@ export class EthereumWallet implements Wallet {
             gasLimit: 21000,
         });
 
-        await this.parity.provider.waitForTransaction(response.hash, 1);
+        this.logger.debug(
+            "Transaction: ",
+            response.hash,
+            " sent, waiting to be confirmed."
+        );
+        const transactionReceipt = await this.parity.provider.waitForTransaction(
+            response.hash,
+            1
+        );
+        this.logger.debug(
+            "Transaction: ",
+            transactionReceipt.transactionHash,
+            " confirmed in block: ",
+            transactionReceipt.blockHash
+        );
 
         const balance = await this.getBalanceByAsset(asset);
 


### PR DESCRIPTION
an attempt to make more sense of our e2e tests logs. 
Sometimes a transaction get's _stuck_ but we don't know which one.