### PR TITLE
pull execution code from `ComitLn` up to `ComitNode` 

### DIFF
--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -127,7 +127,7 @@ fn main() -> anyhow::Result<()> {
     let swap_communication_states = Arc::new(SwapCommunicationStates::default());
 
     // HALight
-    let invoice_states = Arc::new(States::default());
+    let halight_state = Arc::new(States::default());
 
     let swap_error_states = Arc::new(SwapErrorStates::default());
 
@@ -141,14 +141,14 @@ fn main() -> anyhow::Result<()> {
         Arc::clone(&swap_communication_states),
         Arc::clone(&alpha_ledger_state),
         Arc::clone(&beta_ledger_state),
-        Arc::clone(&invoice_states),
+        Arc::clone(&halight_state),
         &database,
     )?;
 
     let facade2 = Facade2 {
         swarm: swarm.clone(),
         alpha_ledger_state: Arc::clone(&alpha_ledger_state),
-        beta_ledger_state: Arc::clone(&invoice_states),
+        beta_ledger_state: Arc::clone(&halight_state),
     };
 
     let deps = Facade {


### PR DESCRIPTION
This is in preparation for the libp2p tests, but it can be merged separately.
Pulls the "execution" (spawn watchers) code out of `ComitLn` into `ComitNode` and send an event after `finalize` from `ComitLn` to `ComitNode`. 

@D4nte @thomaseizinger decided to bring this in separate to avoid more brain-intense rebase on changes in `ComitLn` and `ComitNode`.

Note with `.danger_accept_invalid_certs(true)` on the reqwest client active the e2e tests pass locally for me. 

Note that the tests (to be added later) are planned like this in `ComitLn`:

```
#[cfg(test)]
mod tests {

    #[test]
    fn swap_communication_yields_correct_execution_parameters_for_alice() {

        // -- Basic outline of the test for Alice --

        // GIVEN a swap as Alice
        // use CreateSwapParams to create a swap

        // WHEN passed to the network behavior
        //      init swarm for Alice and Bob
        //      use [swarm].next_event() pattern to loop through events

        // THEN (the necessary communications happens and) we receive the
        // event with the identities and hash of secret set correctly.
    }

    #[test]
    fn swap_communication_yields_correct_execution_parameters_for_bob() {

        // same for Bob
        // The output should include hash_secret in addition to identities
    }
}
```