### PR TITLE
Cache api_tests/node_modules for GitHub Action CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,4 +132,6 @@ jobs:
       - name: Run e2e tests
         run: |
           export PATH=$HOME/.cargo/bin:$HOME/.local/bin:$HOME/go/bin:$PATH
-          make e2e_only
+          cd api_tests
+          yarn install
+          yarn ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,12 @@ jobs:
         with:
           node-version: '12.x'
 
+      - name: Cache node_modules directory
+        uses: actions/cache@v1
+        with:
+          path: api_tests/node_modules
+          key: ${{ matrix.os }}-node-modules-directory-${{ hashFiles('api_tests/package.json') }}
+
       - name: Install Go 1.13.3.
         uses: actions/setup-go@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Extract toolchain version from rust-toolchain
         run: echo "::set-env name=RUST_TOOLCHAIN::$(cat rust-toolchain)"
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Extract toolchain version from rust-toolchain
         run: echo "::set-env name=RUST_TOOLCHAIN::$(cat rust-toolchain)"
@@ -93,7 +93,7 @@ jobs:
     needs: build
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Download cnd-${{ matrix.os }} archive and extract cnd binary
         uses: actions/download-artifact@v1

--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,6 @@ doc:
 e2e: build
 	(cd ./api_tests; yarn install; yarn test)
 
-e2e_only:
-	(cd ./api_tests; yarn install; yarn ci)
-
 check_format: check_rust_format check_toml_format check_ts_format
 
 MODIFIED_FILES = $(shell git status --untracked-files=no --short)


### PR DESCRIPTION
Resolves #2353 

Two optimizations: 
1) caching node_modules
2) not installing rust-toolchain during e2e tests

For 2) I opted for going directly into `api_tests` to execute the e2e tests. 
The goal was to not install caro/toolchain for our e2e tests. 
The "problem" with our makefile is that we are using global variables.
Global variables in `make` are evaluated during makefile's "parsing" stage, not during execution stage. 

Give it a try and add this at the top of the makefile: 
```
$(warning A top-level warning)
$(warning Our toolchain is $(TOOLCHAIN))
```

The problem is that this is always executed. And hence, the toolchain is always installed for any make target.

We can go for optimizing the makefile but this is a whole other story. 

Next speedup will be done in: https://github.com/comit-network/comit-rs/issues/2369