### PR TITLE
Stop bors to proceed if the `no-mergify` label is present

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -5,3 +5,4 @@ status = [
     "e2e_test (ubuntu-latest)"
 ]
 pr_status = ["license/cla"]
+block_labels = ["no-mergify"]


### PR DESCRIPTION
This is to prevent absence-minded developers to trigger bors even
though they set a no-mergify label in purpose to do some clean up before
merging a pull request.