### PR TITLE
ComitLN Integration Test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,15 +2624,44 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.7",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2671,11 +2700,73 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2895,6 +2986,7 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2932dc07acd2066ff2e3921a4419606b220ba6cd03a9935123856cc534877056"
 dependencies = [
+ "rand 0.6.5",
  "secp256k1-sys",
  "serde",
 ]

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -67,6 +67,7 @@ warp = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 base64 = "0.12"
+bitcoin = { version = "0.23", features = ["rand"] }
 bitcoincore-rpc = "0.10.0"
 quickcheck = "0.9.2"
 regex = "1.3"
@@ -74,3 +75,4 @@ serde_urlencoded = "0.6"
 spectral = { version = "0.6", default-features = false }
 tempfile = "3.1.0"
 testcontainers = "0.9"
+

--- a/cnd/src/ethereum.rs
+++ b/cnd/src/ethereum.rs
@@ -28,6 +28,20 @@ impl Address {
     }
 }
 
+#[cfg(test)]
+impl Address {
+    /// Generates a random address for use in tests where the actual value
+    /// doesn't / shouldn't matter.
+    pub fn random() -> Address {
+        use rand::RngCore;
+
+        let mut buffer = [0u8; 20];
+        rand::thread_rng().fill_bytes(&mut buffer);
+
+        Address(buffer)
+    }
+}
+
 impl From<[u8; 20]> for Address {
     fn from(bytes: [u8; 20]) -> Self {
         Address(bytes)

--- a/cnd/src/lightning.rs
+++ b/cnd/src/lightning.rs
@@ -32,6 +32,20 @@ impl PublicKey {
     }
 }
 
+#[cfg(test)]
+impl PublicKey {
+    /// Generates a random public key for use in tests where the actual value
+    /// doesn't / shouldn't matter.
+    pub fn random() -> PublicKey {
+        use secp256k1::{rand::thread_rng, Secp256k1};
+
+        let secp = Secp256k1::new();
+        let mut rng = thread_rng();
+        let (_, public_key) = secp.generate_keypair(&mut rng);
+        PublicKey::from(public_key)
+    }
+}
+
 impl From<secp256k1::PublicKey> for PublicKey {
     fn from(key: secp256k1::PublicKey) -> Self {
         Self(bitcoin::PublicKey {

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -2,6 +2,8 @@ pub mod comit_ln;
 pub mod oneshot_behaviour;
 pub mod oneshot_protocol;
 pub mod protocols;
+#[cfg(test)]
+pub mod test_swarm;
 pub mod transport;
 
 pub use transport::ComitTransport;

--- a/cnd/src/network/test_swarm.rs
+++ b/cnd/src/network/test_swarm.rs
@@ -1,0 +1,43 @@
+use libp2p::{
+    core::{muxing::StreamMuxerBox, upgrade::Version},
+    secio::SecioConfig,
+    swarm::{IntoProtocolsHandler, NetworkBehaviour, ProtocolsHandler, SwarmBuilder},
+    yamux, Multiaddr, PeerId, Transport,
+};
+use std::{future::Future, pin::Pin, time::Duration};
+
+/// An adaptor struct for libp2p that spawns futures into the current
+/// thread-local runtime.
+struct GlobalSpawnTokioExecutor;
+
+impl libp2p::core::Executor for GlobalSpawnTokioExecutor {
+    fn exec(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>) {
+        let _ = tokio::spawn(future);
+    }
+}
+
+pub fn new<B: NetworkBehaviour>(behaviour: B) -> (libp2p::Swarm<B>, Multiaddr, PeerId) where <<<B as NetworkBehaviour>::ProtocolsHandler as IntoProtocolsHandler>::Handler as ProtocolsHandler>::InEvent: Clone{
+    let keypair = libp2p::identity::Keypair::generate_ed25519();
+    let peer_id = PeerId::from(keypair.public());
+
+    let transport = libp2p::core::transport::memory::MemoryTransport::default()
+        .upgrade(Version::V1)
+        .authenticate(SecioConfig::new(keypair))
+        .multiplex(yamux::Config::default())
+        .map(|(peer, muxer), _| (peer, StreamMuxerBox::new(muxer)))
+        .timeout(Duration::from_secs(5))
+        .boxed();
+
+    let mut swarm: libp2p::Swarm<B> = SwarmBuilder::new(transport, behaviour, peer_id.clone())
+        .executor(Box::new(GlobalSpawnTokioExecutor))
+        .build();
+
+    let address_port = rand::random::<u64>();
+    let addr = format!("/memory/{}", address_port)
+        .parse::<Multiaddr>()
+        .unwrap();
+
+    libp2p::Swarm::listen_on(&mut swarm, addr.clone()).unwrap();
+
+    (swarm, addr, peer_id)
+}


### PR DESCRIPTION
Add test to check announced ethereum lightning swap is finalized

Added a happy path integration test that checks if Alice and
Bob have agreed upon an Ethereum-Lightning swap to execute.
This test is used to check that the libp2p network behaviour
abstraction generates a SwapFinalized event as expected.

Closes #2303

I can't assert_eq on most of the fields because partial_eq is not implemented for the types