### PR TITLE
Use native node js API for fs

### DIFF
--- a/api_tests/src/bitcoin_miner.ts
+++ b/api_tests/src/bitcoin_miner.ts
@@ -1,6 +1,7 @@
-import { readFileAsync, sleep } from "./utils";
+import { sleep } from "./utils";
 import { BitcoinNodeConfig } from "./ledgers";
 import BitcoinRpcClient from "bitcoin-core";
+import { promises as asyncFs } from "fs";
 
 const configFile = process.argv[2];
 
@@ -8,9 +9,11 @@ const configFile = process.argv[2];
 run(configFile);
 
 async function run(configFile: string) {
-    const config: BitcoinNodeConfig = await readFileAsync(configFile, {
-        encoding: "utf-8",
-    }).then(JSON.parse);
+    const config: BitcoinNodeConfig = await asyncFs
+        .readFile(configFile, {
+            encoding: "utf-8",
+        })
+        .then(JSON.parse);
 
     const client = new BitcoinRpcClient({
         network: "regtest",

--- a/api_tests/src/environment/kill_nodes.ts
+++ b/api_tests/src/environment/kill_nodes.ts
@@ -1,8 +1,9 @@
 import glob from "glob";
-import { readFileAsync, rimrafAsync } from "../utils";
+import { rimrafAsync } from "../utils";
 import { promisify } from "util";
 import processExists from "process-exists";
 import path from "path";
+import { promises as asyncFs } from "fs";
 
 const globAsync = promisify(glob);
 
@@ -12,7 +13,7 @@ export default async function killNodes(locksDir: any) {
     });
 
     for (const pidFile of pidFiles) {
-        const content = await readFileAsync(path.join(locksDir, pidFile), {
+        const content = await asyncFs.readFile(path.join(locksDir, pidFile), {
             encoding: "utf-8",
         });
         const pid = parseInt(content, 10);

--- a/api_tests/src/environment/setup.ts
+++ b/api_tests/src/environment/setup.ts
@@ -1,4 +1,5 @@
-import { mkdirAsync, rimrafAsync } from "../utils";
+import { rimrafAsync } from "../utils";
+import { promises as asyncFs } from "fs";
 import path from "path";
 import killNodes from "./kill_nodes";
 
@@ -10,11 +11,11 @@ export default async (config: any) => {
 
     // make sure we have a clean log dir
     await rimrafAsync(logDir);
-    await mkdirAsync(logDir, { recursive: true });
+    await asyncFs.mkdir(logDir, { recursive: true });
 
     // make sure we don't have any left-over processes
     await killNodes(locksDir);
-    await mkdirAsync(locksDir, { recursive: true });
+    await asyncFs.mkdir(locksDir, { recursive: true });
 
     process.on("SIGINT", () => {
         process.stderr.write("SIGINT caught, cleaning up environment ...\n");

--- a/api_tests/src/ledgers/bitcoin_miner_instance.ts
+++ b/api_tests/src/ledgers/bitcoin_miner_instance.ts
@@ -11,19 +11,9 @@ export default class BitcoinMinerInstance {
         pidFile: string,
         logger: Logger
     ) {
-        if (!(await existsAsync(tsNode))) {
-            throw new Error(`ts-node binary does not exist: ${tsNode}`);
-        }
-
-        if (!(await existsAsync(minerPath))) {
-            throw new Error(`miner script does not exist: ${minerPath}`);
-        }
-
-        if (!(await existsAsync(bitcoindConfigFile))) {
-            throw new Error(
-                `bitcoind config file does not exist: ${bitcoindConfigFile}`
-            );
-        }
+        await existsAsync(tsNode);
+        await existsAsync(minerPath);
+        await existsAsync(bitcoindConfigFile);
 
         const miner = spawn(tsNode, [minerPath, bitcoindConfigFile], {
             stdio: "ignore",

--- a/api_tests/src/ledgers/bitcoin_miner_instance.ts
+++ b/api_tests/src/ledgers/bitcoin_miner_instance.ts
@@ -1,6 +1,7 @@
 import { spawn } from "child_process";
-import { existsAsync, writeFileAsync } from "../utils";
 import { Logger } from "log4js";
+import { promises as asyncFs } from "fs";
+import { existsAsync } from "../utils";
 
 export default class BitcoinMinerInstance {
     public static async start(
@@ -28,7 +29,7 @@ export default class BitcoinMinerInstance {
             stdio: "ignore",
         });
 
-        await writeFileAsync(pidFile, miner.pid, {
+        await asyncFs.writeFile(pidFile, miner.pid, {
             encoding: "utf-8",
         });
 

--- a/api_tests/src/ledgers/bitcoind_instance.ts
+++ b/api_tests/src/ledgers/bitcoind_instance.ts
@@ -116,8 +116,11 @@ export class BitcoindInstance implements LedgerInstance {
         // This path depends on the directory structure inside the archive
         const binaryPath = cacheDir(`bitcoin-${version}`, "bin", "bitcoind");
 
-        if (await existsAsync(binaryPath)) {
+        try {
+            await existsAsync(binaryPath);
             return binaryPath;
+        } catch (e) {
+            // Continue and download the file
         }
 
         const url = downloadUrlFor(version);

--- a/api_tests/src/ledgers/bitcoind_instance.ts
+++ b/api_tests/src/ledgers/bitcoind_instance.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, spawn } from "child_process";
-import * as fs from "fs";
 import * as path from "path";
-import { existsAsync, writeFileAsync } from "../utils";
+import { promises as asyncFs } from "fs";
+import { existsAsync } from "../utils";
 import getPort from "get-port";
 import { Logger } from "log4js";
 import waitForLogMessage from "../wait_for_log_message";
@@ -64,7 +64,7 @@ export class BitcoindInstance implements LedgerInstance {
 
         await waitForLogMessage(this.logPath(), "init message: Done loading");
 
-        const result = fs.readFileSync(
+        const result = await asyncFs.readFile(
             path.join(this.dataDir, "regtest", ".cookie"),
             "utf8"
         );
@@ -75,7 +75,7 @@ export class BitcoindInstance implements LedgerInstance {
 
         this.logger.info("bitcoind started with PID", this.process.pid);
 
-        await writeFileAsync(this.pidFile, this.process.pid, {
+        await asyncFs.writeFile(this.pidFile, this.process.pid, {
             encoding: "utf-8",
         });
     }
@@ -167,7 +167,7 @@ bind=0.0.0.0:${this.p2pPort}
 rpcbind=0.0.0.0:${this.rpcPort}
 `;
         const config = path.join(dataDir, "bitcoin.conf");
-        await writeFileAsync(config, output);
+        await asyncFs.writeFile(config, output);
     }
 }
 

--- a/api_tests/src/ledgers/lnd_instance.ts
+++ b/api_tests/src/ledgers/lnd_instance.ts
@@ -1,6 +1,7 @@
 import { ChildProcess, spawn } from "child_process";
-import { existsAsync, waitUntilFileExists, writeFileAsync } from "../utils";
+import { existsAsync, waitUntilFileExists } from "../utils";
 import * as path from "path";
+import { promises as asyncFs } from "fs";
 import getPort from "get-port";
 import waitForLogMessage from "../wait_for_log_message";
 import { Lnd } from "comit-sdk";
@@ -66,7 +67,7 @@ export class LndInstance implements LedgerInstance {
 
         this.logger.debug("lnd started with PID", this.process.pid);
 
-        await writeFileAsync(this.pidFile, this.process.pid, {
+        await asyncFs.writeFile(this.pidFile, this.process.pid, {
             encoding: "utf-8",
         });
     }
@@ -202,7 +203,7 @@ bitcoin.node=bitcoind
 bitcoind.dir=${this.bitcoindDataDir}
 `;
         const config = path.join(this.dataDir, "lnd.conf");
-        await writeFileAsync(config, output);
+        await asyncFs.writeFile(config, output);
     }
 
     private async findBinary(version: string): Promise<string> {

--- a/api_tests/src/ledgers/lnd_instance.ts
+++ b/api_tests/src/ledgers/lnd_instance.ts
@@ -226,8 +226,11 @@ bitcoind.dir=${this.bitcoindDataDir}
         // This path depends on the directory structure inside the archive
         const binaryPath = cacheDir(`lnd-${getArch()}-${version}`, "lnd");
 
-        if (await existsAsync(binaryPath)) {
+        try {
+            await existsAsync(binaryPath);
             return binaryPath;
+        } catch (e) {
+            // Continue and download the file
         }
 
         const url = downloadUrlFor(version);

--- a/api_tests/src/ledgers/parity_instance.ts
+++ b/api_tests/src/ledgers/parity_instance.ts
@@ -158,8 +158,11 @@ export class ParityInstance implements LedgerInstance {
         });
         const binaryPath = cacheDir(binaryName);
 
-        if (await existsAsync(binaryPath)) {
+        try {
+            await existsAsync(binaryPath);
             return binaryPath;
+        } catch (e) {
+            // Continue and download the file
         }
 
         const url = downloadUrl(version);

--- a/api_tests/src/ledgers/parity_instance.ts
+++ b/api_tests/src/ledgers/parity_instance.ts
@@ -1,6 +1,7 @@
 import { ChildProcess, spawn } from "child_process";
 import waitForLogMessage from "../wait_for_log_message";
-import { existsAsync, mkdirAsync, writeFileAsync } from "../utils";
+import { existsAsync } from "../utils";
+import { promises as asyncFs } from "fs";
 import getPort from "get-port";
 import { Logger } from "log4js";
 import { LedgerInstance } from "./index";
@@ -79,7 +80,7 @@ export class ParityInstance implements LedgerInstance {
 
         this.logger.info("parity started with PID", this.process.pid);
 
-        await writeFileAsync(this.pidFile, this.process.pid, {
+        await asyncFs.writeFile(this.pidFile, this.process.pid, {
             encoding: "utf-8",
         });
     }
@@ -99,9 +100,9 @@ export class ParityInstance implements LedgerInstance {
      */
     private static async writeFile(pathToFile: string, content: string) {
         const { dir } = path.parse(pathToFile);
-        await mkdirAsync(dir, { recursive: true });
+        await asyncFs.mkdir(dir, { recursive: true });
 
-        await writeFileAsync(pathToFile, content, {
+        await asyncFs.writeFile(pathToFile, content, {
             encoding: "utf-8",
         });
     }

--- a/api_tests/src/test_environment.ts
+++ b/api_tests/src/test_environment.ts
@@ -1,12 +1,6 @@
 import { Config } from "@jest/types";
-import {
-    execAsync,
-    existsAsync,
-    HarnessGlobal,
-    mkdirAsync,
-    readFileAsync,
-    writeFileAsync,
-} from "./utils";
+import { execAsync, existsAsync, HarnessGlobal } from "./utils";
+import { promises as asyncFs } from "fs";
 import NodeEnvironment from "jest-environment-node";
 import path from "path";
 import { LightningWallet } from "./wallets/lightning";
@@ -87,7 +81,7 @@ export default class TestEnvironment extends NodeEnvironment {
         });
 
         const testLogDir = path.join(this.logDir, "tests", this.testSuite);
-        await mkdirAsync(testLogDir, { recursive: true });
+        await asyncFs.mkdir(testLogDir, { recursive: true });
 
         this.global.getLogFile = (pathElements) =>
             path.join(testLogDir, ...pathElements);
@@ -100,7 +94,7 @@ export default class TestEnvironment extends NodeEnvironment {
 
         this.global.getDataDir = async (program) => {
             const dir = path.join(this.logDir, program);
-            await mkdirAsync(dir, { recursive: true });
+            await asyncFs.mkdir(dir, { recursive: true });
 
             return dir;
         };
@@ -362,7 +356,7 @@ export default class TestEnvironment extends NodeEnvironment {
                 "Found config file, we'll be using that configuration instead of starting another instance"
             );
 
-            const config = await readFileAsync(configFile, {
+            const config = await asyncFs.readFile(configFile, {
                 encoding: "utf-8",
             });
 
@@ -374,7 +368,7 @@ export default class TestEnvironment extends NodeEnvironment {
 
             const config = await makeConfig(instance);
 
-            await writeFileAsync(configFile, JSON.stringify(config), {
+            await asyncFs.writeFile(configFile, JSON.stringify(config), {
                 encoding: "utf-8",
             });
 
@@ -387,7 +381,7 @@ export default class TestEnvironment extends NodeEnvironment {
     private async getLockDirectory(process: string): Promise<string> {
         const dir = path.join(this.locksDir, process);
 
-        await mkdirAsync(dir, {
+        await asyncFs.mkdir(dir, {
             recursive: true,
         });
 

--- a/api_tests/src/test_environment.ts
+++ b/api_tests/src/test_environment.ts
@@ -174,9 +174,10 @@ export default class TestEnvironment extends NodeEnvironment {
 
         const minerPidFile = path.join(lockDir, "miner.pid");
 
-        const minerAlreadyRunning = await existsAsync(minerPidFile);
-
-        if (!minerAlreadyRunning) {
+        try {
+            await existsAsync(minerPidFile);
+        } catch (e) {
+            // miner is not running
             const tsNode = path.join(this.nodeModulesBinDir, "ts-node");
             const minerProgram = path.join(this.srcDir, "bitcoin_miner.ts");
 
@@ -349,9 +350,10 @@ export default class TestEnvironment extends NodeEnvironment {
         const configFile = path.join(lockDir, "config.json");
 
         this.logger.info("Checking for config file ", configFile);
-        const configFileExists = await existsAsync(configFile);
 
-        if (configFileExists) {
+        try {
+            await existsAsync(configFile);
+
             this.logger.info(
                 "Found config file, we'll be using that configuration instead of starting another instance"
             );
@@ -361,7 +363,7 @@ export default class TestEnvironment extends NodeEnvironment {
             });
 
             return JSON.parse(config);
-        } else {
+        } catch (e) {
             this.logger.info("No config file found, starting ledger");
 
             await instance.start();

--- a/api_tests/src/utils.ts
+++ b/api_tests/src/utils.ts
@@ -1,6 +1,7 @@
 import { ethers } from "ethers";
 import { Actor } from "./actors/actor";
 import { SwapRequest } from "comit-sdk";
+import { promises as asyncFs } from "fs";
 import * as fs from "fs";
 import { promisify } from "util";
 import { Global } from "@jest/types";
@@ -36,7 +37,8 @@ export interface LedgerConfig {
     bobLnd?: LightningNodeConfig;
 }
 
-export const existsAsync = promisify(fs.exists);
+export const existsAsync = (filepath: string) =>
+    asyncFs.access(filepath, fs.constants.F_OK);
 export const rimrafAsync = promisify(rimraf);
 export const execAsync = promisify(exec);
 
@@ -112,7 +114,11 @@ export async function createDefaultSwapRequest(counterParty: Actor) {
 export async function waitUntilFileExists(filepath: string) {
     let logFileExists = false;
     do {
-        await sleep(500);
-        logFileExists = await existsAsync(filepath);
+        try {
+            await existsAsync(filepath);
+            logFileExists = true;
+        } catch (e) {
+            await sleep(500);
+        }
     } while (!logFileExists);
 }

--- a/api_tests/src/utils.ts
+++ b/api_tests/src/utils.ts
@@ -36,12 +36,7 @@ export interface LedgerConfig {
     bobLnd?: LightningNodeConfig;
 }
 
-export const unlinkAsync = promisify(fs.unlink);
 export const existsAsync = promisify(fs.exists);
-export const openAsync = promisify(fs.open);
-export const mkdirAsync = promisify(fs.mkdir);
-export const writeFileAsync = promisify(fs.writeFile);
-export const readFileAsync = promisify(fs.readFile);
 export const rimrafAsync = promisify(rimraf);
 export const execAsync = promisify(exec);
 


### PR DESCRIPTION
We wrapped a number of node fs functions in promisify. There actually are promise version of such functions available so let's use them.

Also, exists API is deprecated so we'll replace it.