### PR TITLE
Do not panic during halight communication if no lnd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## Fixed
--   Fix windows build
+-   Fix windows build.
+-   Return an error when creating a halight swap if lnd certificate or macaroon are unavailable instead of failing silently.
 
 ## [0.7.3] - 2020-04-14
 

--- a/api_tests/tests/lightning_routes.ts
+++ b/api_tests/tests/lightning_routes.ts
@@ -13,20 +13,23 @@ import {
 
 describe("Lightning routes tests", () => {
     it(
-        "create-han-ethereum-ether-halight-lightning-bitcoin-returns-created",
+        "create-han-ethereum-ether-halight-lightning-bitcoin-returns-bad-request",
         twoActorTest(async ({ alice, bob }) => {
             const bodies = (await SwapFactory.newSwap(alice, bob, true))
                 .hanEthereumEtherHalightLightningBitcoin;
 
-            const aliceSwapLocation = await alice.cnd.createHanEthereumEtherHalightLightningBitcoin(
-                bodies.alice
-            );
-            const bobSwapLocation = await bob.cnd.createHanEthereumEtherHalightLightningBitcoin(
-                bodies.bob
-            );
-
-            expect(bobSwapLocation).toBeTruthy();
-            expect(aliceSwapLocation).toBeTruthy();
+            await expect(
+                alice.cnd.createHanEthereumEtherHalightLightningBitcoin(
+                    bodies.alice
+                )
+            ).rejects.toThrow("lightning is not configured.");
+            try {
+                await bob.cnd.createHanEthereumEtherHalightLightningBitcoin(
+                    bodies.bob
+                );
+            } catch (err) {
+                expect(err.status).toBe(400);
+            }
         })
     );
 

--- a/cnd/src/http_api/routes/index.rs
+++ b/cnd/src/http_api/routes/index.rs
@@ -89,12 +89,17 @@ pub async fn post_han_ethereum_halight_bitcoin(
 
     facade.save(id, ()).await;
 
-    facade.initiate_communication(id, body.into()).await;
-
-    Ok(warp::reply::with_status(
-        warp::reply::with_header(reply, "Location", format!("/swaps/{}", id)),
-        StatusCode::CREATED,
-    ))
+    facade
+        .initiate_communication(id, body.into())
+        .await
+        .map(|_| {
+            warp::reply::with_status(
+                warp::reply::with_header(reply, "Location", format!("/swaps/{}", id)),
+                StatusCode::CREATED,
+            )
+        })
+        .map_err(problem::from_anyhow)
+        .map_err(into_rejection)
 }
 
 // `warp::reply::Json` is used as a return type to please the compiler

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -115,12 +115,19 @@ fn main() -> anyhow::Result<()> {
         ))
     };
 
-    let lnd_connector_params = LndConnectorParams {
-        lnd_url: settings.lightning.lnd.rest_api_url.clone(),
-        retry_interval_ms: 100,
-        certificate_path: settings.lightning.lnd.cert_path.clone(),
-        macaroon_path: settings.lightning.lnd.readonly_macaroon_path.clone(),
-    };
+    let lnd_connector_params = LndConnectorParams::new(
+        settings.lightning.lnd.rest_api_url.clone(),
+        100,
+        settings.lightning.lnd.cert_path.clone(),
+        settings.lightning.lnd.readonly_macaroon_path.clone(),
+    )
+    .map_err(|err| {
+        tracing::warn!(
+            "Could not read initialise lnd configuration, halight will not be available: {:?}",
+            err
+        );
+    })
+    .ok();
 
     // RCF003 protocol
     let rfc003_alpha_ledger_states = Arc::new(rfc003::LedgerStates::default());

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -1188,12 +1188,11 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<comit_ln::BehaviourOutEvent> fo
         match event {
             comit_ln::BehaviourOutEvent::SwapFinalized {
                 local_swap_id,
-                swap_params,
+                swap_params: create_swap_params,
                 secret_hash,
                 ethereum_identity,
             } => {
-                let role = swap_params.role;
-                let create_swap_params = swap_params;
+                let role = create_swap_params.role;
 
                 match self.lnd_connector_params {
                     None => { tracing::error!("Internal Failure: lnd connectors are not initialised, no action has been taken. This should be unreachable.") }
@@ -1216,7 +1215,6 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<comit_ln::BehaviourOutEvent> fo
                                     let asset = create_swap_params.ethereum_amount.clone();
                                     let ledger = ledger::Ethereum::default();
                                     let expiry = create_swap_params.ethereum_absolute_expiry;
-                                    let secret_hash = secret_hash;
 
                                     han::new_han_ethereum_ether_swap(
                                         local_swap_id,
@@ -1252,7 +1250,6 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<comit_ln::BehaviourOutEvent> fo
                                     let asset = create_swap_params.ethereum_amount.clone();
                                     let ledger = ledger::Ethereum::default();
                                     let expiry = create_swap_params.ethereum_absolute_expiry;
-                                    let secret_hash = secret_hash;
 
                                     self::han::new_han_ethereum_ether_swap(
                                         local_swap_id,

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -16,6 +16,7 @@ use crate::{
     config::Settings,
     db::{Save, Sqlite, Swap},
     htlc_location,
+    http_api::LedgerNotConfigured,
     libp2p_comit_ext::{FromHeader, ToHeader},
     network::comit_ln::ComitLN,
     seed::RootSeed,
@@ -81,7 +82,7 @@ impl Swarm {
         seed: RootSeed,
         bitcoin_connector: Arc<bitcoin::Cache<BitcoindConnector>>,
         ethereum_connector: Arc<ethereum::Cache<Web3Connector>>,
-        lnd_connector_params: LndConnectorParams,
+        lnd_connector_params: Option<LndConnectorParams>,
         swap_communication_states: Arc<SwapCommunicationStates>,
         rfc003_alpha_ledger_states: Arc<rfc003::LedgerStates>,
         rfc003_beta_ledger_states: Arc<rfc003::LedgerStates>,
@@ -154,7 +155,7 @@ impl Swarm {
         &self,
         id: LocalSwapId,
         swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
-    ) {
+    ) -> anyhow::Result<()> {
         let mut guard = self.inner.lock().await;
 
         guard.initiate_communication(id, swap_params)
@@ -228,9 +229,7 @@ pub struct ComitNode {
     #[behaviour(ignore)]
     pub ethereum_connector: Arc<ethereum::Cache<Web3Connector>>,
     #[behaviour(ignore)]
-    lnd_connector_as_sender: Arc<LndConnectorAsSender>,
-    #[behaviour(ignore)]
-    lnd_connector_as_receiver: Arc<LndConnectorAsReceiver>,
+    lnd_connector_params: Option<Arc<LndConnectorParams>>,
 
     #[behaviour(ignore)]
     pub seed: RootSeed,
@@ -296,7 +295,7 @@ impl ComitNode {
     pub fn new(
         bitcoin_connector: Arc<bitcoin::Cache<BitcoindConnector>>,
         ethereum_connector: Arc<ethereum::Cache<Web3Connector>>,
-        lnd_connector_params: LndConnectorParams,
+        lnd_connector_params: Option<LndConnectorParams>,
         swap_communication_states: Arc<SwapCommunicationStates>,
         rfc003_alpha_ledger_states: Arc<rfc003::LedgerStates>,
         rfc003_beta_ledger_states: Arc<rfc003::LedgerStates>,
@@ -333,8 +332,7 @@ impl ComitNode {
             db,
             response_channels: Arc::new(Mutex::new(HashMap::new())),
             task_executor,
-            lnd_connector_as_sender: Arc::new(lnd_connector_params.clone().into()),
-            lnd_connector_as_receiver: Arc::new(lnd_connector_params.into()),
+            lnd_connector_params: lnd_connector_params.map(Arc::new),
             halight_states,
         })
     }
@@ -353,12 +351,24 @@ impl ComitNode {
         &mut self,
         id: LocalSwapId,
         swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
-    ) {
-        self.comit_ln.initiate_communication(id, swap_params)
+    ) -> anyhow::Result<()> {
+        self.supports_halight()?;
+
+        self.comit_ln.initiate_communication(id, swap_params);
+        Ok(())
     }
 
     pub fn get_finalized_swap(&mut self, id: LocalSwapId) -> Option<comit_ln::FinalizedSwap> {
         self.comit_ln.get_finalized_swap(id)
+    }
+
+    fn supports_halight(&self) -> anyhow::Result<()> {
+        match self.lnd_connector_params {
+            Some(_) => Ok(()),
+            None => Err(anyhow::Error::from(LedgerNotConfigured {
+                ledger: "lightning",
+            })),
+        }
     }
 }
 
@@ -1054,7 +1064,7 @@ impl SendRequest for Swarm {
         let id = request.swap_id;
         let request = request
             .try_into()
-            .expect("constructing a frame::OutoingRequest should never fail!");
+            .expect("constructing a frame::OutgoingRequest should never fail!");
 
         let result = {
             let mut guard = self.inner.lock().await;
@@ -1185,90 +1195,82 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<comit_ln::BehaviourOutEvent> fo
                 let role = swap_params.role;
                 let create_swap_params = swap_params;
 
-                match role {
-                    Role::Alice => {
-                        tokio::task::spawn({
-                            let lnd_connector = (*self.lnd_connector_as_receiver)
-                                .clone()
-                                .read_certificate()
-                                .expect("Failure reading tls certificate")
-                                .read_macaroon()
-                                .expect("Failure reading macaroon");
+                match self.lnd_connector_params {
+                    None => { tracing::error!("Internal Failure: lnd connectors are not initialised, no action has been taken. This should be unreachable.") }
+                    Some(ref lnd_connector_params) => {
+                        match role {
+                            Role::Alice => {
+                                tokio::task::spawn({
+                                    let lnd_connector: LndConnectorAsReceiver = (**lnd_connector_params).clone().into();
+                                    halight::new_halight_swap(local_swap_id, secret_hash, self.halight_states.clone(), lnd_connector)
+                                        .instrument(
+                                            tracing::error_span!("beta_ledger", swap_id = %local_swap_id, role = %role),
+                                        )
+                                });
 
-                            halight::new_halight_swap(local_swap_id, secret_hash, self.halight_states.clone(), lnd_connector)
-                                .instrument(
-                                    tracing::error_span!("beta_ledger", swap_id = %local_swap_id, role = %role),
-                                )
-                        });
+                                tokio::task::spawn({
+                                    let connector = self.ethereum_connector.clone();
+                                    let alice_ethereum_identity = create_swap_params.ethereum_identity;
+                                    let bob_ethereum_identity = ethereum_identity;
 
-                        tokio::task::spawn({
-                            let connector = self.ethereum_connector.clone();
-                            let alice_ethereum_identity = create_swap_params.ethereum_identity;
-                            let bob_ethereum_identity = ethereum_identity;
+                                    let asset = create_swap_params.ethereum_amount.clone();
+                                    let ledger = ledger::Ethereum::default();
+                                    let expiry = create_swap_params.ethereum_absolute_expiry;
+                                    let secret_hash = secret_hash;
 
-                            let asset = create_swap_params.ethereum_amount.clone();
-                            let ledger = ledger::Ethereum::default();
-                            let expiry = create_swap_params.ethereum_absolute_expiry;
-                            let secret_hash = secret_hash;
+                                    han::new_han_ethereum_ether_swap(
+                                        local_swap_id,
+                                        connector,
+                                        self.alpha_ledger_states.clone(),
+                                        HtlcParams {
+                                            asset,
+                                            ledger,
+                                            redeem_identity: bob_ethereum_identity,
+                                            refund_identity: alice_ethereum_identity.into(),
+                                            expiry,
+                                            secret_hash,
+                                        },
+                                        role,
+                                    )
+                                });
+                            }
 
-                            han::new_han_ethereum_ether_swap(
-                                local_swap_id,
-                                connector,
-                                self.alpha_ledger_states.clone(),
-                                HtlcParams {
-                                    asset,
-                                    ledger,
-                                    redeem_identity: bob_ethereum_identity,
-                                    refund_identity: alice_ethereum_identity.into(),
-                                    expiry,
-                                    secret_hash,
-                                },
-                                role,
-                            )
-                        });
-                    }
+                            Role::Bob => {
+                                tokio::task::spawn({
+                                    let lnd_connector: LndConnectorAsSender = (**lnd_connector_params).clone().into();
+                                    self::halight::new_halight_swap(local_swap_id, secret_hash, self.halight_states.clone(), lnd_connector)
+                                        .instrument(
+                                            tracing::error_span!("beta_ledger", swap_id = %local_swap_id, role = %role),
+                                        )
+                                });
 
-                    Role::Bob => {
-                        tokio::task::spawn({
-                            let lnd_connector = (*self.lnd_connector_as_sender)
-                                .clone()
-                                .read_certificate()
-                                .expect("Failure reading tls certificate")
-                                .read_macaroon()
-                                .expect("Failure reading macaroon");
+                                tokio::task::spawn({
+                                    let connector = self.ethereum_connector.clone();
+                                    let alice_ethereum_identity = ethereum_identity;
+                                    let bob_ethereum_identity = create_swap_params.ethereum_identity;
 
-                            self::halight::new_halight_swap(local_swap_id, secret_hash, self.halight_states.clone(), lnd_connector)
-                                .instrument(
-                                    tracing::error_span!("beta_ledger", swap_id = %local_swap_id, role = %role),
-                                )
-                        });
+                                    let asset = create_swap_params.ethereum_amount.clone();
+                                    let ledger = ledger::Ethereum::default();
+                                    let expiry = create_swap_params.ethereum_absolute_expiry;
+                                    let secret_hash = secret_hash;
 
-                        tokio::task::spawn({
-                            // This is Bob
-                            let connector = self.ethereum_connector.clone();
-                            let alice_ethereum_identity = ethereum_identity;
-                            let bob_ethereum_identity = create_swap_params.ethereum_identity;
-
-                            let asset = create_swap_params.ethereum_amount.clone();
-                            let ledger = ledger::Ethereum::default();
-                            let expiry = create_swap_params.ethereum_absolute_expiry;
-                            let secret_hash = secret_hash;
-
-                            self::han::new_han_ethereum_ether_swap(
-                                local_swap_id,
-                                connector,
-                                self.alpha_ledger_states.clone(),
-                                HtlcParams {
-                                    asset,
-                                    ledger,
-                                    redeem_identity: bob_ethereum_identity.into(),
-                                    refund_identity: alice_ethereum_identity,
-                                    expiry,
-                                    secret_hash,
-                                },
-                                role,
-                            )
-                        });
+                                    self::han::new_han_ethereum_ether_swap(
+                                        local_swap_id,
+                                        connector,
+                                        self.alpha_ledger_states.clone(),
+                                        HtlcParams {
+                                            asset,
+                                            ledger,
+                                            redeem_identity: bob_ethereum_identity.into(),
+                                            refund_identity: alice_ethereum_identity,
+                                            expiry,
+                                            secret_hash,
+                                        },
+                                        role,
+                                    )
+                                });
+                            }
+                        }
                     }
                 }
             }

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -81,8 +81,8 @@ impl Facade {
         &self,
         id: LocalSwapId,
         swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
-    ) {
-        self.swarm.initiate_communication(id, swap_params).await;
+    ) -> anyhow::Result<()> {
+        self.swarm.initiate_communication(id, swap_params).await
     }
 
     pub async fn get_finalized_swap(&self, id: LocalSwapId) -> Option<comit_ln::FinalizedSwap> {


### PR DESCRIPTION
In the main, only the path to lnd certificate and macaroon
were passed. The files were read only during the finalize
step of the communication, leading to a panic if not
present or unreadable.

The logic has been modified to provide the following
functionality:
- An attempt is made to read the files when starting cnd,
the result is an `Option` passed down to the swarm.
- When a halight swap is created on the REST API,
the `Option` is checked and an error is returned to the
caller if it's `None`
- During the finalize phase, we assume that the check was
previously done so we should not be able to finalize a
halight swap if the `Option` is `None`. However, if there
is a bug, we log an error a do not finalize (nor panic).

Resolves #2489