### PR TITLE
Add peer-id check for Bob

### DIFF
--- a/api_tests/src/actors/actor.ts
+++ b/api_tests/src/actors/actor.ts
@@ -354,42 +354,32 @@ export class Actor {
         }
     }
 
-    public async init() {
+    public async init(config?: {
+        maxTimeoutSecs: number;
+        tryIntervalSecs: number;
+    }) {
         if (!this.swap) {
             throw new Error("Cannot init nonexistent swap");
         }
 
         const response = await this.swap.tryExecuteSirenAction<LedgerAction>(
             "init",
-            {
-                maxTimeoutSecs: 30,
-                tryIntervalSecs: 1,
-            }
+            config ? config : Actor.defaultActionConfig
         );
         await this.swap.doLedgerAction(response.data);
     }
 
-    public async waitForAction(
-        action: string,
-        maxTimeoutSecs?: number,
-        tryIntervalSecs?: number
-    ) {
-        if (!this.swap) {
-            throw new Error("Cannot init nonexistent swap");
-        }
-
-        return this.swap.tryExecuteSirenAction<LedgerAction>(action, {
-            maxTimeoutSecs: maxTimeoutSecs ? maxTimeoutSecs : 3,
-            tryIntervalSecs: tryIntervalSecs ? tryIntervalSecs : 1,
-        });
-    }
-
-    public async fund() {
+    public async fund(config?: {
+        maxTimeoutSecs: number;
+        tryIntervalSecs: number;
+    }) {
         if (!this.swap) {
             throw new Error("Cannot fund nonexistent swap");
         }
 
-        const txid = await this.swap.fund(Actor.defaultActionConfig);
+        const txid = await this.swap.fund(
+            config ? config : Actor.defaultActionConfig
+        );
 
         if (txid instanceof Transaction) {
             await txid.status(1);

--- a/api_tests/src/actors/actor.ts
+++ b/api_tests/src/actors/actor.ts
@@ -369,6 +369,21 @@ export class Actor {
         await this.swap.doLedgerAction(response.data);
     }
 
+    public async waitForAction(
+        action: string,
+        maxTimeoutSecs?: number,
+        tryIntervalSecs?: number
+    ) {
+        if (!this.swap) {
+            throw new Error("Cannot init nonexistent swap");
+        }
+
+        return this.swap.tryExecuteSirenAction<LedgerAction>(action, {
+            maxTimeoutSecs: maxTimeoutSecs ? maxTimeoutSecs : 3,
+            tryIntervalSecs: tryIntervalSecs ? tryIntervalSecs : 1,
+        });
+    }
+
     public async fund() {
         if (!this.swap) {
             throw new Error("Cannot fund nonexistent swap");

--- a/api_tests/tests/ether_halight.ts
+++ b/api_tests/tests/ether_halight.ts
@@ -3,9 +3,9 @@
  * @ledger lightning
  */
 
-import { twoActorTest } from "../src/actor_test";
 import SwapFactory from "../src/actors/swap_factory";
 import { sleep } from "../src/utils";
+import { twoActorTest } from "../src/actor_test";
 
 it(
     "han-ethereum-ether-halight-lightning-bitcoin-alice-redeems-bob-redeems",
@@ -34,5 +34,37 @@ it(
 
         await alice.assertBalances();
         await bob.assertBalances();
+    })
+);
+
+it(
+    "han-ethereum-ether-halight-lightning-bitcoin-alice-announces-with-wrong-peer-id",
+    twoActorTest(async ({ alice, bob }) => {
+        const bodies = (await SwapFactory.newSwap(alice, bob))
+            .hanEthereumEtherHalightLightningBitcoin;
+
+        // Simulate that Bob is awaiting a swap from a different peer-id than Alice node's peer-id.
+        bodies.bob.peer.peer_id =
+            "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N";
+        await bob.createSwap(bodies.bob);
+        await sleep(500);
+
+        await alice.createSwap(bodies.alice);
+
+        // Due to the asynchronous nature of the announce protocol (and the fact that there is not error handling (yet)),
+        // this test only tests that the "init" action does not become available.
+        //
+        // Scenario details:
+        // 0) Alice and Bob agree on the swap params (negotiation); Alice gives Bob a peer-id that is not her node's peer-id.
+        // 1) Bob posts swap, retrieves local swap-ID
+        // 2) Alice posts swap, retrieves local swap-ID
+        //      2.1) Internally the announce protocol runs into an Error because Alice' peer-id does not match the one she gave Bob.
+        //              This Error, is however not visible to the outside.
+        //              The application is responsible for removing swaps that do not move forward after a given time.
+        const aliceResponsePromise = alice.waitForAction("init");
+        return expect(aliceResponsePromise).rejects.toThrowError();
+        // Same for Bob's side
+        const bobResponsePromise = bob.waitForAction("fund");
+        return expect(bobResponsePromise).rejects.toThrowError();
     })
 );

--- a/api_tests/tests/ether_halight.ts
+++ b/api_tests/tests/ether_halight.ts
@@ -51,6 +51,11 @@ it(
 
         await alice.createSwap(bodies.alice);
 
+        const config = {
+            maxTimeoutSecs: 1,
+            tryIntervalSecs: 0.3,
+        };
+
         // Due to the asynchronous nature of the announce protocol (and the fact that there is not error handling (yet)),
         // this test only tests that the "init" action does not become available.
         //
@@ -61,10 +66,10 @@ it(
         //      2.1) Internally the announce protocol runs into an Error because Alice' peer-id does not match the one she gave Bob.
         //              This Error, is however not visible to the outside.
         //              The application is responsible for removing swaps that do not move forward after a given time.
-        const aliceResponsePromise = alice.waitForAction("init");
+        const aliceResponsePromise = alice.init(config);
         return expect(aliceResponsePromise).rejects.toThrowError();
         // Same for Bob's side
-        const bobResponsePromise = bob.waitForAction("fund");
+        const bobResponsePromise = bob.fund(config);
         return expect(bobResponsePromise).rejects.toThrowError();
     })
 );

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -306,17 +306,54 @@ impl NetworkBehaviourEventProcess<announce::behaviour::BehaviourOutEvent> for Co
     fn inject_event(&mut self, event: announce::behaviour::BehaviourOutEvent) {
         match event {
             announce::behaviour::BehaviourOutEvent::ReceivedAnnouncement { peer, mut io } => {
+                // Check if there are any errors before modifying the hash-map.
+                match self.swaps_waiting_for_announcement.get(&io.swap_digest) {
+                    Some(local_swap_id) => {
+                        // Verify that the peer-id announcing the swap matches the peer-id agreed on
+                        // in the swap parameters. In case they don't match
+                        // the swap has to stay available in swaps awaiting announcement
+                        // but the current announcement will be rejected by closing the response
+                        // channel.
+
+                        let create_swap_params = self.swaps.get(&local_swap_id).unwrap();
+                        if peer != create_swap_params.peer.peer_id {
+                            tracing::warn!(
+                                "Peer {} announced a swap ({}), but the peer-id {} of the swap awaiting announcement does not match.",
+                                peer,
+                                io.swap_digest,
+                                create_swap_params.peer.peer_id
+                            );
+                            tokio::task::spawn(async move {
+                                let _ = io.io.close().await;
+                            });
+
+                            return;
+                        }
+                    }
+                    None => {
+                        tracing::warn!(
+                            "Peer {} announced a swap ({}) we don't know about",
+                            peer,
+                            io.swap_digest
+                        );
+
+                        tokio::task::spawn(async move {
+                            let _ = io.io.close().await;
+                        });
+
+                        return;
+                    }
+                }
+
                 if let Some(local_swap_id) =
                     self.swaps_waiting_for_announcement.remove(&io.swap_digest)
                 {
+                    let create_swap_params = self.swaps.get(&local_swap_id).unwrap();
                     let shared_swap_id = SharedSwapId::default();
-
                     self.swap_ids
                         .insert(local_swap_id.clone(), shared_swap_id.clone());
 
                     tokio::task::spawn(io.send(shared_swap_id));
-
-                    let create_swap_params = self.swaps.get(&local_swap_id).unwrap();
 
                     let addresses = self.announce.addresses_of_peer(&peer);
                     self.secret_hash
@@ -344,16 +381,6 @@ impl NetworkBehaviourEventProcess<announce::behaviour::BehaviourOutEvent> for Co
 
                     self.communication_state
                         .insert(shared_swap_id, CommunicationState::default());
-                } else {
-                    tracing::warn!(
-                        "Peer {} announced a swap ({}) we don't know about",
-                        peer,
-                        io.swap_digest
-                    );
-
-                    tokio::task::spawn(async move {
-                        let _ = io.io.close().await;
-                    });
                 }
             }
             announce::behaviour::BehaviourOutEvent::ReceivedConfirmation {


### PR DESCRIPTION
resolves #2389

Note that I packed the rejection upon Bob providing an `address_hint` into a separate PR https://github.com/comit-network/comit-rs/pull/2507
I don't think we need this at the moment.