### PR TITLE
Reject swap request if Bob specifies an `address_hint`

### DIFF
--- a/api_tests/src/actors/swap_factory.ts
+++ b/api_tests/src/actors/swap_factory.ts
@@ -94,7 +94,7 @@ export default class SwapFactory {
                     bobIdentities.lightning
                 ),
                 role: "Bob" as "Alice" | "Bob",
-                peer: await makePeer(alice),
+                peer: await makePeerIdOnly(alice),
             },
         };
 
@@ -123,7 +123,7 @@ export default class SwapFactory {
                     bobIdentities.lightning
                 ),
                 role: "Bob" as "Alice" | "Bob",
-                peer: await makePeer(alice),
+                peer: await makePeerIdOnly(alice),
             },
         };
 
@@ -152,7 +152,7 @@ export default class SwapFactory {
                 ),
 
                 role: "Bob" as "Alice" | "Bob",
-                peer: await makePeer(alice),
+                peer: await makePeerIdOnly(alice),
             },
         };
 
@@ -183,7 +183,7 @@ export default class SwapFactory {
                 ),
 
                 role: "Bob" as "Alice" | "Bob",
-                peer: await makePeer(alice),
+                peer: await makePeerIdOnly(alice),
             },
         };
 
@@ -231,6 +231,12 @@ async function makePeer(actor: Actor): Promise<Peer> {
         address_hint: await actor.cnd
             .getPeerListenAddresses()
             .then((addresses) => addresses[0]),
+    };
+}
+
+async function makePeerIdOnly(actor: Actor): Promise<Peer> {
+    return {
+        peer_id: await actor.cnd.getPeerId(),
     };
 }
 

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -346,6 +346,37 @@ impl NetworkBehaviourEventProcess<announce::behaviour::BehaviourOutEvent> for Co
                 }
 
                 if let Some(local_swap_id) =
+                    self.swaps_waiting_for_announcement.get(&io.swap_digest)
+                {
+                    let create_swap_params = self.swaps.get(&local_swap_id).unwrap();
+                    if peer != create_swap_params.peer.peer_id {
+                        tracing::warn!(
+                                "Peer {} announced a swap ({}), but the peer-id {} of the swap awaiting announcement does not match.",
+                                peer,
+                                io.swap_digest,
+                                create_swap_params.peer.peer_id
+                            );
+                        tokio::task::spawn(async move {
+                            let _ = io.io.close().await;
+                        });
+
+                        return;
+                    }
+                } else {
+                    tracing::warn!(
+                        "Peer {} announced a swap ({}) we don't know about",
+                        peer,
+                        io.swap_digest
+                    );
+
+                    tokio::task::spawn(async move {
+                        let _ = io.io.close().await;
+                    });
+
+                    return;
+                }
+
+                if let Some(local_swap_id) =
                     self.swaps_waiting_for_announcement.remove(&io.swap_digest)
                 {
                     let create_swap_params = self.swaps.get(&local_swap_id).unwrap();


### PR DESCRIPTION
I don't think we really need this but #2389 states that it should be considered. 
In order to implement this we should think about this further and restrict it role-specific in the `Body` model rather than the `Error` that I throw. This, however, is not trivial. I would just not implement this for now.

This is a follow-up for https://github.com/comit-network/comit-rs/pull/2506

Note: If I misunderstood something or this can actually be handled in a more trivial way let me know :)