### PR TITLE
Avoid double download of lnd binary

### DIFF
--- a/api_tests/package.json
+++ b/api_tests/package.json
@@ -27,7 +27,6 @@
         "@types/glob": "^7.1.1",
         "@types/jasmine": "^3.5.10",
         "@types/jest": "^25.2.1",
-        "@types/log4js": "^2.3.5",
         "@types/node": "^13.13",
         "@types/proper-lockfile": "^4.1.1",
         "@types/rimraf": "^3.0.0",

--- a/api_tests/yarn.lock
+++ b/api_tests/yarn.lock
@@ -693,13 +693,6 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/log4js@^2.3.5":
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/@types/log4js/-/log4js-2.3.5.tgz#4d1e56da53d3c1820c08e9cd5092e68c3e1e822f"
-  integrity sha512-SwF8LkSHqHy9A8GQ67NAYJiGl8zzP4Qtx65Wa+IOxDGdMHxKeoQZjg7m2M1erIT6VK0DYHpu2aTbdLkdkuMHjw==
-  dependencies:
-    log4js "*"
-
 "@types/long@*", "@types/long@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
@@ -4011,7 +4004,7 @@ lodash@^4.0.0, lodash@^4.17.13, lodash@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-log4js@*, log4js@^6.2.1:
+log4js@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/log4js/-/log4js-6.2.1.tgz#fc23a3bf287f40f5b48259958e5e0ed30d558eeb"
   integrity sha512-7n+Oqxxz7VcQJhIlqhcYZBTpbcQ7XsR0MUIfJkx/n3VUjkAS4iUr+4UJlhxf28RvP9PMGQXbgTUhLApnu0XXgA==


### PR DESCRIPTION
When investigating the spawn ETXTBSY error I noticed
that both alice and bob try to download the lnd binary.
The spawn error happens for lnd and in the logs we see
alice's download finishing but it never does for bob.

Best case, it fixes the spawn issue, worst case, it
saves time and bandwidth.