### PR TITLE
Fix comment typo - no trippers around here please

### DIFF
--- a/cnd/src/http_api/problem.rs
+++ b/cnd/src/http_api/problem.rs
@@ -38,7 +38,7 @@ pub struct LedgerNotConfigured {
     pub ledger: &'static str,
 }
 
-// tracing trippers clippy warning, issue reported: https://github.com/tokio-rs/tracing/issues/553
+// tracing triggers clippy warning, issue reported: https://github.com/tokio-rs/tracing/issues/553
 #[allow(clippy::cognitive_complexity)]
 pub fn from_anyhow(e: anyhow::Error) -> HttpApiProblem {
     let e = match e.downcast::<HttpApiProblem>() {


### PR DESCRIPTION
Fix amusing comment typo
```
-// tracing trippers clippy warning, issue reported: https://github.com/tokio-rs/tracing/issues/553
+// tracing triggers clippy warning, issue reported: https://github.com/tokio-rs/tracing/issues/553
```