### PR TITLE
Run CI on pull-requests on selected push actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,12 @@ name: CI
 
 on:
   push:
-    branches-ignore:
-      - 'staging.tmp'
-      - 'trying.tmp'
+    branches:
+      - 'staging'
+      - 'trying'
+      - 'master'
+      - 'dev'
+  pull_request:
 
 jobs:
   static_analysis:


### PR DESCRIPTION
Currently, we are only running the CI on branch pushes which prevents external contributors from triggering the CI for a PR they raised.