### PR TITLE
Define the interface to save created swaps to the db

### DIFF
--- a/cnd/src/db.rs
+++ b/cnd/src/db.rs
@@ -21,9 +21,10 @@ pub use self::{
 
 use crate::{
     db::wrapper_types::custom_sql_types::Text,
-    swap_protocols::{rfc003::SwapId, Role},
+    swap_protocols::{rfc003::SwapId, LocalSwapId, Role},
 };
 use diesel::{self, prelude::*, sqlite::SqliteConnection};
+use libp2p::PeerId;
 use std::{
     ffi::OsStr,
     path::{Path, PathBuf},
@@ -130,6 +131,25 @@ struct QueryableSwapRole {
 pub enum Error {
     #[error("swap not found")]
     SwapNotFound,
+}
+
+/// Data required to create a swap.
+///
+/// 'create' a swap is defined as the process of initiating a swap within `cnd`.
+/// The data required to do so is assumed to have been negotiated between the
+/// two parties prior to each creating the swap.
+#[derive(Debug, Clone)]
+pub struct CreatedSwap<A, B> {
+    /// Node specific swap identifier.
+    pub swap_id: LocalSwapId,
+    /// The parameters used on the alpha ledger.
+    pub alpha: A,
+    /// The parameters used on the beta ledger.
+    pub beta: B,
+    /// Peer ID of the swap counterparty.
+    pub peer: PeerId,
+    /// Role of the node in this swap, Alice or Bob.
+    pub role: Role,
 }
 
 #[cfg(test)]

--- a/cnd/src/db/save.rs
+++ b/cnd/src/db/save.rs
@@ -6,10 +6,11 @@ use crate::{
             custom_sql_types::{Text, U32},
             BitcoinNetwork, Erc20Amount, Ether, EthereumAddress, Satoshis,
         },
-        Sqlite, Swap,
+        CreatedSwap, Sqlite, Swap,
     },
     identity,
     swap_protocols::{
+        halight, han,
         ledger::{self, Ethereum},
         rfc003::{Accept, Decline, Request, SecretHash, SwapId},
         HashFunction, Role,
@@ -503,5 +504,15 @@ impl Save<Decline> for Sqlite {
         .await?;
 
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Save<CreatedSwap<han::CreatedSwap, halight::CreatedSwap>> for Sqlite {
+    async fn save(
+        &self,
+        _: CreatedSwap<han::CreatedSwap, halight::CreatedSwap>,
+    ) -> anyhow::Result<()> {
+        unimplemented!()
     }
 }

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -78,7 +78,7 @@ pub struct Facade {
 
 impl Facade {
     pub async fn save<A, B>(&self, _: CreatedSwap<A, B>) -> anyhow::Result<()> {
-        unimplemented!()
+        Ok(())
     }
 
     pub async fn initiate_communication(

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -1,5 +1,7 @@
 use crate::{
-    asset, identity,
+    asset,
+    db::CreatedSwap,
+    identity,
     network::{comit_ln, protocols::announce::SwapDigest, DialInformation, Swarm},
     swap_protocols::{halight, LedgerStates, LocalSwapId, Role},
     timestamp::Timestamp,
@@ -75,7 +77,9 @@ pub struct Facade {
 }
 
 impl Facade {
-    pub async fn save(&self, _id: LocalSwapId, _swap_params: ()) {}
+    pub async fn save<A, B>(&self, _: CreatedSwap<A, B>) -> anyhow::Result<()> {
+        unimplemented!()
+    }
 
     pub async fn initiate_communication(
         &self,

--- a/cnd/src/swap_protocols/halight.rs
+++ b/cnd/src/swap_protocols/halight.rs
@@ -1,8 +1,11 @@
-use crate::swap_protocols::{
-    rfc003::{Secret, SecretHash},
-    state,
-    state::Update,
-    LocalSwapId,
+use crate::{
+    asset, identity,
+    swap_protocols::{
+        rfc003::{Secret, SecretHash},
+        state,
+        state::Update,
+        LocalSwapId,
+    },
 };
 use futures::{
     future::{self, Either},
@@ -18,6 +21,18 @@ use tokio::sync::Mutex;
 mod connector;
 
 pub use connector::*;
+
+/// Htlc Lightning Bitcoin atomic swap protocol.
+
+/// Data required to create a swap that involves bitcoin on the lightning
+/// network.
+#[derive(Clone, Debug)]
+pub struct CreatedSwap {
+    pub amount: asset::Bitcoin,
+    pub identity: identity::Lightning,
+    pub network: String,
+    pub cltv_expiry: u32,
+}
 
 /// Creates a new instance of the halight protocol.
 ///

--- a/cnd/src/swap_protocols/han.rs
+++ b/cnd/src/swap_protocols/han.rs
@@ -24,6 +24,17 @@ use genawaiter::{
 use std::sync::Arc;
 use tracing_futures::Instrument;
 
+/// Htlc Native Ethereum atomic swap protocol.
+
+/// Data required to create a swap that involves Ether.
+#[derive(Clone, Debug)]
+pub struct CreatedSwap {
+    pub amount: asset::Ether,
+    pub identity: identity::Ethereum,
+    pub chain_id: u32,
+    pub absolute_expiry: u32,
+}
+
 pub async fn new_han_ethereum_ether_swap(
     swap_id: LocalSwapId,
     connector: Arc<Cache<Web3Connector>>,

--- a/cnd/src/swap_protocols/herc20.rs
+++ b/cnd/src/swap_protocols/herc20.rs
@@ -21,7 +21,19 @@ use crate::{ethereum::Bytes, timestamp::Timestamp};
 use blockchain_contracts::ethereum::rfc003::Erc20Htlc;
 pub use connector_impls::*;
 
-/// Resolves when said event has occured.
+/// Htlc ERC20 Token atomic swap protocol.
+
+/// Data required to create a swap that involves an ERC20 token.
+#[derive(Clone, Debug)]
+pub struct CreatedSwap {
+    pub amount: asset::Erc20Quantity,
+    pub identity: identity::Ethereum,
+    pub chain_id: u32,
+    pub contract_address: identity::Ethereum,
+    pub absolute_expiry: u32,
+}
+
+/// Resolves when said event has occurred.
 #[async_trait::async_trait]
 pub trait WaitForDeployed {
     async fn wait_for_deployed(&self, params: Params) -> anyhow::Result<Deployed>;


### PR DESCRIPTION
Users can create an ether/lightning swap via the REST API.  We would
like a way to save the data that the user provides into the database.
As a first step in doing so define an interface between the controller
and the database.

(The logic in this PR was originally done in: #2513)

Fixes: #2158