### PR TITLE
Remove the changelog bot

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -40,11 +40,3 @@ pull_request_rules:
       - head~=^(?!release.*).*$
     actions:
       delete_head_branch:
-  - name: nag if changelog is not updated
-    conditions:
-      - "author!=dependabot-preview[bot]"
-      - "files!=CHANGELOG.md"
-      - review-requested!=''
-    actions:
-      comment:
-        message: "Are you sure the changelog does not need updating?"


### PR DESCRIPTION
Changelog bot was added to help us remember to update the changelog, after time it seems it is not achieving the desired purpose and at times it goes hyper and nags many times on a single PR.

Remove the changelog bot.

Fixes: #2333