### PR TITLE
 Do not initiate a swap for identical parameters

### DIFF
--- a/api_tests/tests/ether_halight.ts
+++ b/api_tests/tests/ether_halight.ts
@@ -74,3 +74,22 @@ it(
         return expect(bobResponsePromise).rejects.toThrowError();
     })
 );
+
+// This test could be anywhere, it is just here because this endpoint was the first of the spilt protocols implemented.
+it(
+    "alice-cannot-create-two-identical-swaps",
+    twoActorTest(async ({ alice, bob }) => {
+        // arrange
+        const bodies = (await SwapFactory.newSwap(alice, bob))
+            .hanEthereumEtherHalightLightningBitcoin;
+
+        await alice.createSwap(bodies.alice);
+        await sleep(200);
+
+        // act
+        const response = alice.createSwap(bodies.alice);
+
+        // assert
+        await expect(response).rejects.toThrow("Swap already exists.");
+    })
+);

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -335,9 +335,7 @@ impl ComitNode {
         swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
     ) -> anyhow::Result<()> {
         self.supports_halight()?;
-
-        self.comit_ln.initiate_communication(id, swap_params);
-        Ok(())
+        self.comit_ln.initiate_communication(id, swap_params)
     }
 
     pub fn get_finalized_swap(&mut self, id: LocalSwapId) -> Option<comit_ln::FinalizedSwap> {

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 /// This represent the information available on a swap
 /// before communication with the other node has started
-#[derive(Clone, Digest, Debug)]
+#[derive(Clone, Digest, Debug, PartialEq)]
 #[digest(hash = "SwapDigest")]
 pub struct HanEtherereumHalightBitcoinCreateSwapParams {
     #[digest(ignore)]
@@ -42,7 +42,7 @@ impl IntoDigestInput for asset::Ether {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EthereumIdentity(identity::Ethereum);
 
 impl From<identity::Ethereum> for EthereumIdentity {


### PR DESCRIPTION
If a swap has already been initiated we do not want to initiate a second time otherwise there will be ambiguity in the system later during the communication protocols since the swap digest is based off of the created swap parameters.

There is more than one solution to this problem but for now just iterate over the current swaps and if one exists with these parameters already abort initiation.

Now with testing, patch 2 adds a failing e2e test, based on @thomaseizinger observation that patch 1 returns a 500 error.  Patch 3 fixes the tests.  PR is 'untested' because I cannot run e2e tests on my machine currently ...

Fixes: #2490