### PR TITLE
Upgrade comit-sdk to 0.16.0

### DIFF
--- a/api_tests/package.json
+++ b/api_tests/package.json
@@ -36,7 +36,7 @@
         "bitcoin-core": "^3.0.0",
         "bitcoinjs-lib": "^5.1.7",
         "chmod": "^0.2.1",
-        "comit-sdk": "^0.15.6",
+        "comit-sdk": "^0.16.0",
         "download": "^8.0.0",
         "ethers": "^4.0.47",
         "find-cache-dir": "^3.3.1",

--- a/api_tests/src/actors/actor.ts
+++ b/api_tests/src/actors/actor.ts
@@ -1023,14 +1023,12 @@ export class Actor {
             "; finalCltvDelta: ",
             finalCltvDelta
         );
-        const resp = await this.wallets.lightning.inner.sendPayment(
+        return this.wallets.lightning.inner.sendPayment(
             toPubkey,
             satAmount,
             secretHash,
             finalCltvDelta
         );
-        this.logger.debug("LN: Send Payment Response:", resp);
-        return resp;
     }
 
     /** Settles the invoice once it is `accepted`.

--- a/api_tests/tests/lnd_sanity.ts
+++ b/api_tests/tests/lnd_sanity.ts
@@ -43,7 +43,7 @@ describe("E2E: Sanity - LND Alice pays Bob", () => {
                 3600,
                 finalCltvDelta
             );
-            const paymentPromise = alice.lnSendPayment(
+            const paymentSettled = await alice.lnSendPayment(
                 bob,
                 satAmount,
                 secretHash,
@@ -52,7 +52,7 @@ describe("E2E: Sanity - LND Alice pays Bob", () => {
 
             await bob.lnSettleInvoice(secret, secretHash);
 
-            const pay = await paymentPromise;
+            const pay = await paymentSettled();
             expect(pay.paymentPreimage.toString("hex")).toEqual(secret);
 
             await bob.lnAssertInvoiceSettled(secretHash);

--- a/api_tests/yarn.lock
+++ b/api_tests/yarn.lock
@@ -1843,10 +1843,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-comit-sdk@^0.15.6:
-  version "0.15.6"
-  resolved "https://registry.yarnpkg.com/comit-sdk/-/comit-sdk-0.15.6.tgz#263276aa4a4b4137e1e6112c96611e34d595e06d"
-  integrity sha512-BfpfbExsrC4LpokJICyMMu40H1LXJNe+r+pxDpE/CTEOyC2MDULAMXXwfCD0HrOH+Sg7ALSAWhp0eaBkmdH6Kw==
+comit-sdk@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/comit-sdk/-/comit-sdk-0.16.0.tgz#850c74db3101de337f66700eb4d545e03addc9bf"
+  integrity sha512-quwlGLenAoWWtmTgj8jhqF5q2Wi6+SffkbGoV43FPC9qXPw6Wo9xcWhiW8MBwy9BESqCpt3kKH8tI55C2C3x0A==
   dependencies:
     "@radar/lnrpc" "^0.9.1-beta"
     axios "^0.19.2"


### PR DESCRIPTION
Uses the change done in https://github.com/comit-network/comit-js-sdk/pull/229

The `sendPayment` API now resolves when the payment
is `in flight`, allowing us to await it.

We can then later await the returned function to wait
for the payment to be settled.

Related to comit-network/comit-sdk#180