### PR TITLE
Actually assert the full error response

### DIFF
--- a/api_tests/tests/lightning_routes.ts
+++ b/api_tests/tests/lightning_routes.ts
@@ -18,18 +18,22 @@ describe("Lightning routes tests", () => {
             const bodies = (await SwapFactory.newSwap(alice, bob, true))
                 .hanEthereumEtherHalightLightningBitcoin;
 
-            await expect(
-                alice.cnd.createHanEthereumEtherHalightLightningBitcoin(
-                    bodies.alice
-                )
-            ).rejects.toThrow("lightning is not configured.");
-            try {
-                await bob.cnd.createHanEthereumEtherHalightLightningBitcoin(
-                    bodies.bob
-                );
-            } catch (err) {
-                expect(err.status).toBe(400);
-            }
+            const aliceResponse = alice.cnd.createHanEthereumEtherHalightLightningBitcoin(
+                bodies.alice
+            );
+            const bobResponse = bob.cnd.createHanEthereumEtherHalightLightningBitcoin(
+                bodies.bob
+            );
+
+            const expectedProblem = {
+                status: 400,
+                title: "lightning is not configured.",
+                detail:
+                    "lightning ledger is not properly configured, swap involving this ledger are not available.",
+            };
+
+            await expect(aliceResponse).rejects.toMatchObject(expectedProblem);
+            await expect(bobResponse).rejects.toMatchObject(expectedProblem);
         })
     );
 


### PR DESCRIPTION
I realized while taking a look at our current e2e tests that we are not always asserting error responses in the same way and also not all aspects of it.

I've played around with Jest a bit and I believe I've found a concise way of covering the whole error response.

Putting this PR up for people to take inspiration from.
Please use this format from now on when you assert error responses from cnd and migrate other tests to test format if you come across some as part of other work.

Thanks :)

Asking everyone for review so everyone knows!