### PR TITLE
Wait for a transaction being included before releasing the lock

### DIFF
--- a/api_tests/tests/ether_halight.ts
+++ b/api_tests/tests/ether_halight.ts
@@ -30,6 +30,7 @@ it(
         await alice.redeem();
         await bob.redeem();
 
+        // Wait until the wallet sees the new balance.
         await sleep(2000);
 
         await alice.assertBalances();


### PR DESCRIPTION
Our Geth test node mines a block every second.  When sending a
transaction we set the nonce to be the value that we first read from the
blockchain, if we try to do this twice within a block it fails (Geth
thinks we are trying to do a transaction replacement).

Solution; after sending a transaction we wait until it has 1 confirmation. Only then we continue and release the lock.

Fixes: Your pain.