### PR TITLE
Use debug instead of warn

### DIFF
--- a/api_tests/src/config.ts
+++ b/api_tests/src/config.ts
@@ -88,7 +88,7 @@ export class E2ETestActorConfig {
             }
             case "charlie":
                 {
-                    console.warn(
+                    console.debug(
                         "generating lnd config for charlie is not supported at this stage"
                     );
                 }


### PR DESCRIPTION
Currently we have a warn message that lnd not supported for charlie,
this is expected behaviour however the warning message is quite
verbose (and brightly coloured in some terminals).  To make the e2e
tests more pleasant to run we can use a debug statement, this makes the
number of lines in the output lower and the colour more mute.

With this applied the debug message looks like this:
```
  ● Console

    console.debug
      generating lnd config for charlie is not supported at this stage

      at E2ETestActorConfig.createLedgerConnectors (src/config.ts:91:29)
```
instead of the original
```
  console.warn
      generating lnd config for charlie is not supported at this stage

      89 |             case "charlie":
      90 |                 {
    > 91 |                     console.warn(
         |                             ^
      92 |                         "generating lnd config for charlie is not supported at this stage"
      93 |                     );
      94 |                 }
```