### PR TITLE
Fix changelog format to avoid release failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Fixed
+### Fixed
+
 -   Fix windows build.
 -   Return an error when creating a halight swap if lnd certificate or macaroon are unavailable instead of failing silently.
 


### PR DESCRIPTION
`Fixed` is a 2nd level header but in changelogs, it should be 3rd level.

I had trouble test-releasing when working on https://github.com/comit-network/comit-rs/issues/2242
@thomaseizinger pointed me to the problem.