### PR TITLE
Trigger draft-new-release GitHub Action on issue open and re-open

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -2,7 +2,7 @@ name: "Draft new release"
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [opened, reopened]
 
 jobs:
   draft-new-release:


### PR DESCRIPTION
Fixes #2327.

- Remove trigger on labelling so that the flow is not triggered twice.
- Add reopened trigger in case mistakes are made when first opening
  the draft-new-release issue.

---

Aligns it with what we already do in `comit-network/comit-js-sdk`, which @D4nte fixed a while back.