### PR TITLE
Bob does not reject announcement if the swap is not yet created

### DIFF
--- a/api_tests/src/actors/actor.ts
+++ b/api_tests/src/actors/actor.ts
@@ -480,11 +480,4 @@ export class Actor {
     get betaLedgerWallet() {
         return this.wallets.getWalletForLedger(this.betaLedger.name);
     }
-
-    /*
-     * This is split protocol specific. Check whether the communication has been finalised
-     */
-    public async assertSwapFinalized() {
-        // unimplemented
-    }
 }

--- a/api_tests/src/actors/actor.ts
+++ b/api_tests/src/actors/actor.ts
@@ -480,4 +480,11 @@ export class Actor {
     get betaLedgerWallet() {
         return this.wallets.getWalletForLedger(this.betaLedger.name);
     }
+
+    /*
+     * This is split protocol specific. Check whether the communication has been finalised
+     */
+    public async assertSwapFinalized() {
+        // unimplemented
+    }
 }

--- a/api_tests/tests/communication.ts
+++ b/api_tests/tests/communication.ts
@@ -36,9 +36,9 @@ describe("communication", () => {
             const bodies = (await SwapFactory.newSwap(alice, bob))
                 .hanEthereumEtherHalightLightningBitcoin;
 
-            await bob.createSwap(bodies.alice);
+            await bob.createSwap(bodies.bob);
             await sleep(500);
-            await alice.createSwap(bodies.bob);
+            await alice.createSwap(bodies.alice);
 
             await assertSwapFinalized(alice);
             await assertSwapFinalized(bob);

--- a/api_tests/tests/communication.ts
+++ b/api_tests/tests/communication.ts
@@ -11,6 +11,8 @@
 import { twoActorTest } from "../src/actor_test";
 import SwapFactory from "../src/actors/swap_factory";
 import { sleep } from "../src/utils";
+import { SwapStatus } from "../src/swap_response";
+import { Actor } from "../src/actors/actor";
 
 describe("communication", () => {
     it(
@@ -23,8 +25,8 @@ describe("communication", () => {
             await sleep(500);
             await bob.createSwap(bodies.bob);
 
-            await alice.assertSwapFinalized();
-            await bob.assertSwapFinalized();
+            await assertSwapFinalized(alice);
+            await assertSwapFinalized(bob);
         })
     );
 
@@ -38,8 +40,21 @@ describe("communication", () => {
             await sleep(500);
             await alice.createSwap(bodies.bob);
 
-            await alice.assertSwapFinalized();
-            await bob.assertSwapFinalized();
+            await assertSwapFinalized(alice);
+            await assertSwapFinalized(bob);
         })
     );
 });
+
+/**
+ * Assert that the communication phase has been finalized.
+ *
+ * No point adding it to `Actor` as it is only use in this test.
+ */
+async function assertSwapFinalized(actor: Actor) {
+    await actor.pollCndUntil(
+        actor.swap.self,
+        (swapResponse) =>
+            swapResponse.properties.status === SwapStatus.InProgress
+    );
+}

--- a/api_tests/tests/communication.ts
+++ b/api_tests/tests/communication.ts
@@ -1,0 +1,45 @@
+/**
+ * @ledger ethereum
+ * @ledger lightning
+ */
+
+// ******************************************** //
+// Test correct behaviour of the communication  //
+// phase from creation to finalisation          //
+// ******************************************** //
+
+import { twoActorTest } from "../src/actor_test";
+import SwapFactory from "../src/actors/swap_factory";
+import { sleep } from "../src/utils";
+
+describe("communication", () => {
+    it(
+        "Alice creates and then Bob creates, it finalizes",
+        twoActorTest(async ({ alice, bob }) => {
+            const bodies = (await SwapFactory.newSwap(alice, bob))
+                .hanEthereumEtherHalightLightningBitcoin;
+
+            await alice.createSwap(bodies.alice);
+            await sleep(500);
+            await bob.createSwap(bodies.bob);
+
+            await alice.assertSwapFinalized();
+            await bob.assertSwapFinalized();
+        })
+    );
+
+    it(
+        "Bob creates and then Alice creates, it finalizes",
+        twoActorTest(async ({ alice, bob }) => {
+            const bodies = (await SwapFactory.newSwap(alice, bob))
+                .hanEthereumEtherHalightLightningBitcoin;
+
+            await bob.createSwap(bodies.alice);
+            await sleep(500);
+            await alice.createSwap(bodies.bob);
+
+            await alice.assertSwapFinalized();
+            await bob.assertSwapFinalized();
+        })
+    );
+});

--- a/api_tests/tests/ether_halight.ts
+++ b/api_tests/tests/ether_halight.ts
@@ -13,11 +13,9 @@ it(
         const bodies = (await SwapFactory.newSwap(alice, bob))
             .hanEthereumEtherHalightLightningBitcoin;
 
-        // Bob needs to know about the swap first because he is not buffering incoming announcements about swaps he doesn't know about
-        await bob.createSwap(bodies.bob);
-        await sleep(500);
-
         await alice.createSwap(bodies.alice);
+        await sleep(500);
+        await bob.createSwap(bodies.bob);
 
         await alice.init();
 

--- a/api_tests/tests/ether_halight.ts
+++ b/api_tests/tests/ether_halight.ts
@@ -6,6 +6,8 @@
 import SwapFactory from "../src/actors/swap_factory";
 import { sleep } from "../src/utils";
 import { twoActorTest } from "../src/actor_test";
+import { Actor } from "../src/actors/actor";
+import { SwapStatus } from "../src/swap_response";
 
 it(
     "han-ethereum-ether-halight-lightning-bitcoin-alice-redeems-bob-redeems",
@@ -45,31 +47,17 @@ it(
         // Simulate that Bob is awaiting a swap from a different peer-id than Alice node's peer-id.
         bodies.bob.peer.peer_id =
             "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N";
-        await bob.createSwap(bodies.bob);
-        await sleep(500);
-
         await alice.createSwap(bodies.alice);
+        await bob.createSwap(bodies.bob);
 
-        const config = {
-            maxTimeoutSecs: 1,
-            tryIntervalSecs: 0.3,
-        };
+        await assertSwapCreated(alice);
+        await assertSwapCreated(bob);
 
-        // Due to the asynchronous nature of the announce protocol (and the fact that there is not error handling (yet)),
-        // this test only tests that the "init" action does not become available.
-        //
-        // Scenario details:
-        // 0) Alice and Bob agree on the swap params (negotiation); Alice gives Bob a peer-id that is not her node's peer-id.
-        // 1) Bob posts swap, retrieves local swap-ID
-        // 2) Alice posts swap, retrieves local swap-ID
-        //      2.1) Internally the announce protocol runs into an Error because Alice' peer-id does not match the one she gave Bob.
-        //              This Error, is however not visible to the outside.
-        //              The application is responsible for removing swaps that do not move forward after a given time.
-        const aliceResponsePromise = alice.init(config);
-        return expect(aliceResponsePromise).rejects.toThrowError();
-        // Same for Bob's side
-        const bobResponsePromise = bob.fund(config);
-        return expect(bobResponsePromise).rejects.toThrowError();
+        await sleep(1000);
+
+        // Assert that the swaps are still not finalized
+        await assertSwapCreated(alice);
+        await assertSwapCreated(bob);
     })
 );
 
@@ -91,3 +79,15 @@ it(
         await expect(response).rejects.toThrow("Swap already exists.");
     })
 );
+
+/**
+ * Assert that the swap has been created via the REST API bu tthe communication phase has not been finalized.
+ *
+ * No point adding it to `Actor` as it is only use in this test.
+ */
+async function assertSwapCreated(actor: Actor) {
+    await actor.pollCndUntil(
+        actor.swap.self,
+        (swapResponse) => swapResponse.properties.status === SwapStatus.Created
+    );
+}

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -145,8 +145,15 @@ impl Swarm {
 
     pub async fn get_finalized_swap(&self, id: LocalSwapId) -> Option<comit_ln::FinalizedSwap> {
         let mut guard = self.inner.lock().await;
-
         guard.get_finalized_swap(id)
+    }
+
+    pub async fn get_created_swap(
+        &self,
+        id: LocalSwapId,
+    ) -> Option<HanEtherereumHalightBitcoinCreateSwapParams> {
+        let mut guard = self.inner.lock().await;
+        guard.get_created_swap(id)
     }
 
     // On Bob's side, when an announce message is received execute the required
@@ -340,6 +347,13 @@ impl ComitNode {
 
     pub fn get_finalized_swap(&mut self, id: LocalSwapId) -> Option<comit_ln::FinalizedSwap> {
         self.comit_ln.get_finalized_swap(id)
+    }
+
+    pub fn get_created_swap(
+        &mut self,
+        id: LocalSwapId,
+    ) -> Option<HanEtherereumHalightBitcoinCreateSwapParams> {
+        self.comit_ln.get_created_swap(id)
     }
 
     fn supports_halight(&self) -> anyhow::Result<()> {

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -156,6 +156,13 @@ impl ComitLN {
         Ok(())
     }
 
+    pub fn get_created_swap(
+        &self,
+        swap_id: LocalSwapId,
+    ) -> Option<HanEtherereumHalightBitcoinCreateSwapParams> {
+        self.swaps.get(&swap_id).cloned()
+    }
+
     pub fn get_finalized_swap(&self, swap_id: LocalSwapId) -> Option<FinalizedSwap> {
         let create_swap_params = match self.swaps.get(&swap_id) {
             Some(body) => body,
@@ -619,6 +626,7 @@ impl NetworkBehaviourEventProcess<oneshot_behaviour::OutEvent<finalize::Message>
             .expect("this should exist");
 
         if state.sent_finalized && state.received_finalized {
+            tracing::info!("Swap {} is finalized.", swap_id);
             let local_swap_id = self
                 .swap_ids
                 .iter()

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -55,13 +55,18 @@ pub struct ComitLN {
     #[behaviour(ignore)]
     events: VecDeque<BehaviourOutEvent>,
 
-    /// Swaps as Alice
+    /// In role of Alice; swaps exist in here once a swap is created by Alice
+    /// (and up until an announce confirmation is received from Bob).
     #[behaviour(ignore)]
     swaps_waiting_for_confirmation: HashMap<SwapDigest, LocalSwapId>,
-
-    /// Swaps as Bob
+    /// In role of Bob; swaps exist in here if Bob creates the swap _before_ an
+    /// announce message is received from Alice (and up until the announce
+    /// message arrives).
     #[behaviour(ignore)]
     swaps_waiting_for_announcement: HashMap<SwapDigest, LocalSwapId>,
+    /// In role of Bob; swaps exist in here if Bob creates the swap _after_ an
+    /// announce message is received from Alice (and up until Bob creates the
+    /// swap).
     #[behaviour(ignore)]
     swaps_waiting_for_creation:
         HashMap<SwapDigest, (libp2p::PeerId, ReplySubstream<NegotiatedSubstream>)>,

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -334,7 +334,7 @@ impl fmt::Display for SwapExists {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct FinalizedSwap {
     pub alpha_ledger: Ethereum,
     pub beta_ledger: lightning::Regtest,

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -92,4 +92,11 @@ impl Facade {
     pub async fn get_finalized_swap(&self, id: LocalSwapId) -> Option<comit_ln::FinalizedSwap> {
         self.swarm.get_finalized_swap(id).await
     }
+
+    pub async fn get_created_swap(
+        &self,
+        id: LocalSwapId,
+    ) -> Option<HanEtherereumHalightBitcoinCreateSwapParams> {
+        self.swarm.get_created_swap(id).await
+    }
 }


### PR DESCRIPTION
Bob now stores swaps announced by Alice even if they are not yet created.

When Bob creates a swap (via REST API), then it checks such swaps and proceed with confirmation and communication if present.

Please note I amended the current test to check this behaviour to avoid adding one more full swap e2e test.

Helps with #2488.