### PR TITLE
Move all swap hashmaps to a dedicated struct

### DIFF
--- a/api_tests/src/actors/actor.ts
+++ b/api_tests/src/actors/actor.ts
@@ -22,7 +22,12 @@ import { LedgerConfig, sleep } from "../utils";
 import { Actors } from "./index";
 import { Wallets } from "../wallets";
 import { defaultLedgerDescriptionForLedger } from "./defaults";
-import { EscrowStatus, LedgerState, SwapResponse } from "../swap_response";
+import {
+    EscrowStatus,
+    LedgerState,
+    SwapResponse,
+    SwapStatus,
+} from "../swap_response";
 
 export type ActorName = "alice" | "bob" | "charlie";
 
@@ -355,7 +360,7 @@ export class Actor {
         while (true) {
             await sleep(200);
             const entity = await this.swap.fetchDetails();
-            if (entity.properties.status === "SWAPPED") {
+            if (entity.properties.status === SwapStatus.Swapped) {
                 break;
             }
         }

--- a/api_tests/src/swap_response.ts
+++ b/api_tests/src/swap_response.ts
@@ -53,23 +53,23 @@ export interface Properties {
  */
 export enum SwapStatus {
     /**
-     * The swap was created but the communication phase hasn't yet been finalized
+     * The swap was created via the REST API but the communication phase hasn't yet been finalized.
      */
     Created = "CREATED",
     /**
-     * The communication was finalized and blockchain actions are needed or happening
+     * The communication was finalized and blockchain actions are needed or happening.
      */
     InProgress = "IN_PROGRESS",
     /**
-     * The swap is finished and the assets were swapped
+     * The swap is finished and the assets were swapped.
      */
     Swapped = "SWAPPED",
     /**
-     * The swap is finished and the assets were not swapped
+     * The swap is finished and the assets were not swapped.
      */
     NotSwapped = "NOT_SWAPPED",
     /**
-     * An unexpected internal failure aborted the swap
+     * An unexpected internal failure aborted the swap.
      */
     InternalFailure = "INTERNAL_FAILURE",
 }

--- a/api_tests/tests/communication.ts
+++ b/api_tests/tests/communication.ts
@@ -67,25 +67,6 @@ describe("communication", () => {
             await assertSwapCreated(bob);
         })
     );
-
-    // This test could be anywhere, it is just here because this endpoint was the first of the spilt protocols implemented.
-    it(
-        "alice-cannot-create-two-identical-swaps",
-        twoActorTest(async ({ alice, bob }) => {
-            // arrange
-            const bodies = (await SwapFactory.newSwap(alice, bob))
-                .hanEthereumEtherHalightLightningBitcoin;
-
-            await alice.createSwap(bodies.alice);
-            await sleep(200);
-
-            // act
-            const response = alice.createSwap(bodies.alice);
-
-            // assert
-            await expect(response).rejects.toThrow("Swap already exists.");
-        })
-    );
 });
 
 /**

--- a/api_tests/tests/communication.ts
+++ b/api_tests/tests/communication.ts
@@ -44,7 +44,61 @@ describe("communication", () => {
             await assertSwapFinalized(bob);
         })
     );
+
+    it(
+        "swap-announced-with-wrong-peer-id-does-not-finalize",
+        twoActorTest(async ({ alice, bob }) => {
+            const bodies = (await SwapFactory.newSwap(alice, bob))
+                .hanEthereumEtherHalightLightningBitcoin;
+
+            // Simulate that Bob is awaiting a swap from a different peer-id than Alice node's peer-id.
+            bodies.bob.peer.peer_id =
+                "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N";
+            await alice.createSwap(bodies.alice);
+            await bob.createSwap(bodies.bob);
+
+            await assertSwapCreated(alice);
+            await assertSwapCreated(bob);
+
+            await sleep(1000);
+
+            // Assert that the swaps are still not finalized
+            await assertSwapCreated(alice);
+            await assertSwapCreated(bob);
+        })
+    );
+
+    // This test could be anywhere, it is just here because this endpoint was the first of the spilt protocols implemented.
+    it(
+        "alice-cannot-create-two-identical-swaps",
+        twoActorTest(async ({ alice, bob }) => {
+            // arrange
+            const bodies = (await SwapFactory.newSwap(alice, bob))
+                .hanEthereumEtherHalightLightningBitcoin;
+
+            await alice.createSwap(bodies.alice);
+            await sleep(200);
+
+            // act
+            const response = alice.createSwap(bodies.alice);
+
+            // assert
+            await expect(response).rejects.toThrow("Swap already exists.");
+        })
+    );
 });
+
+/**
+ * Assert that the swap has been created via the REST API bu tthe communication phase has not been finalized.
+ *
+ * No point adding it to `Actor` as it is only use in this test.
+ */
+async function assertSwapCreated(actor: Actor) {
+    await actor.pollCndUntil(
+        actor.swap.self,
+        (swapResponse) => swapResponse.properties.status === SwapStatus.Created
+    );
+}
 
 /**
  * Assert that the communication phase has been finalized.

--- a/api_tests/tests/ether_halight.ts
+++ b/api_tests/tests/ether_halight.ts
@@ -6,8 +6,6 @@
 import SwapFactory from "../src/actors/swap_factory";
 import { sleep } from "../src/utils";
 import { twoActorTest } from "../src/actor_test";
-import { Actor } from "../src/actors/actor";
-import { SwapStatus } from "../src/swap_response";
 
 it(
     "han-ethereum-ether-halight-lightning-bitcoin-alice-redeems-bob-redeems",
@@ -37,57 +35,3 @@ it(
         await bob.assertBalances();
     })
 );
-
-it(
-    "han-ethereum-ether-halight-lightning-bitcoin-alice-announces-with-wrong-peer-id",
-    twoActorTest(async ({ alice, bob }) => {
-        const bodies = (await SwapFactory.newSwap(alice, bob))
-            .hanEthereumEtherHalightLightningBitcoin;
-
-        // Simulate that Bob is awaiting a swap from a different peer-id than Alice node's peer-id.
-        bodies.bob.peer.peer_id =
-            "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N";
-        await alice.createSwap(bodies.alice);
-        await bob.createSwap(bodies.bob);
-
-        await assertSwapCreated(alice);
-        await assertSwapCreated(bob);
-
-        await sleep(1000);
-
-        // Assert that the swaps are still not finalized
-        await assertSwapCreated(alice);
-        await assertSwapCreated(bob);
-    })
-);
-
-// This test could be anywhere, it is just here because this endpoint was the first of the spilt protocols implemented.
-it(
-    "alice-cannot-create-two-identical-swaps",
-    twoActorTest(async ({ alice, bob }) => {
-        // arrange
-        const bodies = (await SwapFactory.newSwap(alice, bob))
-            .hanEthereumEtherHalightLightningBitcoin;
-
-        await alice.createSwap(bodies.alice);
-        await sleep(200);
-
-        // act
-        const response = alice.createSwap(bodies.alice);
-
-        // assert
-        await expect(response).rejects.toThrow("Swap already exists.");
-    })
-);
-
-/**
- * Assert that the swap has been created via the REST API bu tthe communication phase has not been finalized.
- *
- * No point adding it to `Actor` as it is only use in this test.
- */
-async function assertSwapCreated(actor: Actor) {
-    await actor.pollCndUntil(
-        actor.swap.self,
-        (swapResponse) => swapResponse.properties.status === SwapStatus.Created
-    );
-}

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -353,7 +353,7 @@ impl ComitNode {
         &mut self,
         id: LocalSwapId,
     ) -> Option<HanEtherereumHalightBitcoinCreateSwapParams> {
-        self.comit_ln.get_created_swap(id)
+        self.comit_ln.get_created_swap(&id)
     }
 
     fn supports_halight(&self) -> anyhow::Result<()> {

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -4,7 +4,7 @@ use crate::{
         oneshot_behaviour,
         protocols::{
             announce,
-            announce::{behaviour::Announce, protocol::ReplySubstream, SwapDigest},
+            announce::{behaviour::Announce, protocol::ReplySubstream},
             ethereum_identity, finalize, lightning_identity, secret_hash,
         },
     },
@@ -31,6 +31,9 @@ use std::{
     fmt,
     task::{Context, Poll},
 };
+use swaps::Swaps;
+
+mod swaps;
 
 /// Event emitted  by the `ComitLn` behaviour.
 #[derive(Debug)]
@@ -54,27 +57,8 @@ pub struct ComitLN {
 
     #[behaviour(ignore)]
     events: VecDeque<BehaviourOutEvent>,
-
-    /// In role of Alice; swaps exist in here once a swap is created by Alice
-    /// (and up until an announce confirmation is received from Bob).
     #[behaviour(ignore)]
-    swaps_waiting_for_confirmation: HashMap<SwapDigest, LocalSwapId>,
-    /// In role of Bob; swaps exist in here if Bob creates the swap _before_ an
-    /// announce message is received from Alice (and up until the announce
-    /// message arrives).
-    #[behaviour(ignore)]
-    swaps_waiting_for_announcement: HashMap<SwapDigest, LocalSwapId>,
-    /// In role of Bob; swaps exist in here if Bob creates the swap _after_ an
-    /// announce message is received from Alice (and up until Bob creates the
-    /// swap).
-    #[behaviour(ignore)]
-    swaps_waiting_for_creation:
-        HashMap<SwapDigest, (libp2p::PeerId, ReplySubstream<NegotiatedSubstream>)>,
-
-    #[behaviour(ignore)]
-    swaps: HashMap<LocalSwapId, HanEtherereumHalightBitcoinCreateSwapParams>,
-    #[behaviour(ignore)]
-    swap_ids: HashMap<LocalSwapId, SharedSwapId>,
+    all_swaps: Swaps,
     #[behaviour(ignore)]
     ethereum_identities: HashMap<SharedSwapId, identity::Ethereum>,
     #[behaviour(ignore)]
@@ -106,11 +90,7 @@ impl ComitLN {
             lightning_identity: Default::default(),
             finalize: Default::default(),
             events: VecDeque::new(),
-            swaps_waiting_for_confirmation: Default::default(),
-            swaps_waiting_for_announcement: Default::default(),
-            swaps_waiting_for_creation: Default::default(),
-            swaps: Default::default(),
-            swap_ids: Default::default(),
+            all_swaps: Default::default(),
             ethereum_identities: Default::default(),
             lightning_identities: Default::default(),
             communication_state: Default::default(),
@@ -126,28 +106,27 @@ impl ComitLN {
     ) -> anyhow::Result<()> {
         let digest = create_swap_params.clone().digest();
         tracing::trace!("Swap creation request received: {}", digest);
-        if self.swaps_waiting_for_announcement.contains_key(&digest)
-            || self.swaps_waiting_for_confirmation.contains_key(&digest)
-        {
-            anyhow::bail!(SwapExists)
-        }
 
-        self.swaps.insert(id, create_swap_params.clone());
+        self.all_swaps
+            .create_swap(&digest, id.clone(), create_swap_params.clone())?;
 
         match create_swap_params.role {
             Role::Alice => {
                 tracing::info!("Starting announcement for swap: {}", digest);
                 self.announce
                     .start_announce_protocol(digest.clone(), create_swap_params.peer);
-                self.swaps_waiting_for_confirmation.insert(digest, id);
+                self.all_swaps.move_to_pending_confirmation(digest, id);
             }
             Role::Bob => {
-                if let Some((peer, io)) = self.swaps_waiting_for_creation.remove(&digest) {
+                if let Some((shared_swap_id, peer, io)) = self
+                    .all_swaps
+                    .move_pending_creation_to_communicate(&digest, id)
+                {
                     tracing::info!("Confirm & communicate for swap: {}", digest);
-                    self.bob_communicate(peer, io, &id)
+                    self.bob_communicate(peer, io, shared_swap_id, create_swap_params)
                 } else {
-                    self.swaps_waiting_for_announcement
-                        .insert(digest.clone(), id);
+                    self.all_swaps
+                        .move_to_pending_announcement(digest.clone(), id);
                     tracing::debug!("Swap {} waiting for announcement", digest);
                 }
             }
@@ -158,25 +137,20 @@ impl ComitLN {
 
     pub fn get_created_swap(
         &self,
-        swap_id: LocalSwapId,
+        swap_id: &LocalSwapId,
     ) -> Option<HanEtherereumHalightBitcoinCreateSwapParams> {
-        self.swaps.get(&swap_id).cloned()
+        self.all_swaps.get_created_swap(swap_id)
     }
 
     pub fn get_finalized_swap(&self, swap_id: LocalSwapId) -> Option<FinalizedSwap> {
-        let create_swap_params = match self.swaps.get(&swap_id) {
-            Some(body) => body,
+        let (id, create_swap_params) = match self.all_swaps.get_announced_swap(&swap_id) {
+            Some(swap) => swap,
             None => return None,
         };
 
         let secret = match create_swap_params.role {
             Role::Alice => Some(self.seed.derive_swap_seed(swap_id).derive_secret()),
             Role::Bob => None,
-        };
-
-        let id = match self.swap_ids.get(&swap_id).copied() {
-            Some(id) => id,
-            None => return None,
         };
 
         let alpha_ledger_redeem_identity = match create_swap_params.role {
@@ -235,6 +209,7 @@ impl ComitLN {
         peer: PeerId,
         swap_id: SharedSwapId,
         local_swap_id: LocalSwapId,
+        create_swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
     ) {
         let addresses = self.announce.addresses_of_peer(&peer);
         self.secret_hash
@@ -244,8 +219,6 @@ impl ComitLN {
         self.lightning_identity
             .register_addresses(peer.clone(), addresses.clone());
         self.finalize.register_addresses(peer.clone(), addresses);
-
-        let create_swap_params = self.swaps.get(&local_swap_id).unwrap();
 
         self.ethereum_identity.send(
             peer.clone(),
@@ -273,13 +246,9 @@ impl ComitLN {
         &mut self,
         peer: libp2p::PeerId,
         io: ReplySubstream<NegotiatedSubstream>,
-        local_swap_id: &LocalSwapId,
+        shared_swap_id: SharedSwapId,
+        create_swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
     ) {
-        let create_swap_params = self.swaps.get(&local_swap_id).unwrap();
-        let shared_swap_id = SharedSwapId::default();
-        self.swap_ids
-            .insert(local_swap_id.clone(), shared_swap_id.clone());
-
         // Confirm
         tokio::task::spawn(io.send(shared_swap_id));
 
@@ -436,15 +405,14 @@ impl NetworkBehaviourEventProcess<announce::behaviour::BehaviourOutEvent> for Co
                     tracing::trace_span!("swap", digest = format_args!("{}", io.swap_digest));
                 let _enter = span.enter();
                 // Check if there are any errors before modifying the hash-map.
-                match self.swaps_waiting_for_announcement.get(&io.swap_digest) {
-                    Some(local_swap_id) => {
+                match self.all_swaps.get_pending_announcement(&io.swap_digest) {
+                    Some((_, create_swap_params)) => {
                         // Verify that the peer-id announcing the swap matches the peer-id agreed on
                         // in the swap parameters. In case they don't match
                         // the swap has to stay available in swaps awaiting announcement
                         // but the current announcement will be rejected by closing the response
                         // channel.
 
-                        let create_swap_params = self.swaps.get(&local_swap_id).unwrap();
                         if peer != create_swap_params.peer.peer_id {
                             tracing::error!(
                                 "The peer-id {} of the swap awaiting announcement does not match expected peer-id {}",
@@ -460,33 +428,35 @@ impl NetworkBehaviourEventProcess<announce::behaviour::BehaviourOutEvent> for Co
                     }
                     None => {
                         tracing::debug!("Swap has not been created yet, parking it.");
-                        self.swaps_waiting_for_creation
-                            .insert((&io.swap_digest).clone(), (peer, *io));
+                        self.all_swaps.insert_pending_creation(
+                            (&io.swap_digest).clone(),
+                            peer,
+                            *io,
+                        );
 
                         return;
                     }
                 }
 
-                if let Some(local_swap_id) =
-                    self.swaps_waiting_for_announcement.remove(&io.swap_digest)
+                if let Some((shared_swap_id, create_params)) = self
+                    .all_swaps
+                    .move_pending_announcement_to_communicate(&io.swap_digest)
                 {
                     tracing::debug!("Swap confirmation and communication has started.");
-                    self.bob_communicate(peer, *io, &local_swap_id);
+                    self.bob_communicate(peer, *io, shared_swap_id, create_params);
                 }
             }
             announce::behaviour::BehaviourOutEvent::ReceivedConfirmation {
                 peer,
                 swap_digest,
-                swap_id,
+                swap_id: shared_swap_id,
             } => {
-                let local_swap_id = self
-                    .swaps_waiting_for_confirmation
-                    .remove(&swap_digest)
+                let (local_swap_id, create_params) = self
+                    .all_swaps
+                    .move_pending_confirmation_to_communicate(&swap_digest, shared_swap_id)
                     .expect("we must know about this digest");
 
-                self.swap_ids.insert(local_swap_id, swap_id);
-
-                self.alice_communicate(peer, swap_id, local_swap_id);
+                self.alice_communicate(peer, shared_swap_id, local_swap_id, create_params);
             }
             announce::behaviour::BehaviourOutEvent::Error { peer, error } => {
                 tracing::warn!(
@@ -625,26 +595,10 @@ impl NetworkBehaviourEventProcess<oneshot_behaviour::OutEvent<finalize::Message>
 
         if state.sent_finalized && state.received_finalized {
             tracing::info!("Swap {} is finalized.", swap_id);
-            let local_swap_id = self
-                .swap_ids
-                .iter()
-                .find_map(
-                    |(key, value)| {
-                        if *value == swap_id {
-                            Some(key)
-                        } else {
-                            None
-                        }
-                    },
-                )
-                .copied()
-                .unwrap();
-
-            let create_swap_params = self
-                .swaps
-                .get(&local_swap_id)
-                .cloned()
-                .expect("create swap params exist");
+            let (local_swap_id, create_swap_params) = self
+                .all_swaps
+                .finalize_swap(&swap_id)
+                .expect("Swap should be known");
 
             let secret_hash = self
                 .secret_hashes
@@ -653,9 +607,6 @@ impl NetworkBehaviourEventProcess<oneshot_behaviour::OutEvent<finalize::Message>
                 .expect("must exist");
 
             let ethereum_identity = self.ethereum_identities.get(&swap_id).copied().unwrap();
-
-            self.swaps_waiting_for_announcement
-                .retain(|_, id| *id != local_swap_id);
 
             self.events.push_back(BehaviourOutEvent::SwapFinalized {
                 local_swap_id,

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -116,8 +116,7 @@ impl ComitLN {
                 self.announce
                     .start_announce_protocol(digest.clone(), (&create_swap_params.peer).clone());
                 self.swaps
-                    .create_as_pending_confirmation(digest, id, create_swap_params)
-                    .map_err(anyhow::Error::from)?;
+                    .create_as_pending_confirmation(digest, id, create_swap_params)?;
             }
             Role::Bob => {
                 if let Ok((shared_swap_id, peer, io)) = self
@@ -127,9 +126,11 @@ impl ComitLN {
                     tracing::info!("Confirm & communicate for swap: {}", digest);
                     self.bob_communicate(peer, io, shared_swap_id, create_swap_params)
                 } else {
-                    self.swaps
-                        .create_as_pending_announcement(digest.clone(), id, create_swap_params)
-                        .map_err(anyhow::Error::from)?;
+                    self.swaps.create_as_pending_announcement(
+                        digest.clone(),
+                        id,
+                        create_swap_params,
+                    )?;
                     tracing::debug!("Swap {} waiting for announcement", digest);
                 }
             }

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -459,9 +459,7 @@ impl NetworkBehaviourEventProcess<announce::behaviour::BehaviourOutEvent> for Co
                         }
                     }
                     None => {
-                        tracing::debug!(
-                            "Swap has not been created yet, waiting for REST API request."
-                        );
+                        tracing::debug!("Swap has not been created yet, parking it.");
                         self.swaps_waiting_for_creation
                             .insert((&io.swap_digest).clone(), (peer, *io));
 

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -33,6 +33,9 @@ use std::{
 };
 use swaps::Swaps;
 
+/// Setting it at 5 minutes
+const PENDING_SWAP_EXPIRY_SECS: u32 = 5 * 60;
+
 mod swaps;
 
 /// Event emitted  by the `ComitLn` behaviour.
@@ -283,6 +286,9 @@ impl ComitLN {
         _cx: &mut Context<'_>,
         _params: &mut impl PollParameters,
     ) -> Poll<NetworkBehaviourAction<BIE, BehaviourOutEvent>> {
+        let time_limit = Timestamp::now().minus(PENDING_SWAP_EXPIRY_SECS);
+        self.swaps.clean_up_pending_swaps(time_limit);
+
         if let Some(event) = self.events.pop_front() {
             return Poll::Ready(NetworkBehaviourAction::GenerateEvent(event));
         }

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -58,7 +58,7 @@ pub struct ComitLN {
     #[behaviour(ignore)]
     events: VecDeque<BehaviourOutEvent>,
     #[behaviour(ignore)]
-    swaps: Swaps,
+    swaps: Swaps<ReplySubstream<NegotiatedSubstream>>,
     #[behaviour(ignore)]
     ethereum_identities: HashMap<SharedSwapId, identity::Ethereum>,
     #[behaviour(ignore)]
@@ -116,8 +116,9 @@ impl ComitLN {
                     .create_as_pending_confirmation(digest, id, create_swap_params);
             }
             Role::Bob => {
-                if let Some((shared_swap_id, peer, io)) =
-                    self.swaps.move_pending_creation_to_communicate(&digest, id)
+                if let Ok((shared_swap_id, peer, io)) = self
+                    .swaps
+                    .move_pending_creation_to_communicate(&digest, id, create_swap_params.clone())
                 {
                     tracing::info!("Confirm & communicate for swap: {}", digest);
                     self.bob_communicate(peer, io, shared_swap_id, create_swap_params)

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -447,9 +447,9 @@ impl NetworkBehaviourEventProcess<announce::behaviour::BehaviourOutEvent> for Co
                     }
                 }
 
-                if let Some((shared_swap_id, create_params)) = self
+                if let Ok((shared_swap_id, create_params)) = self
                     .swaps
-                    .move_pending_announcement_to_communicate(&io.swap_digest)
+                    .move_pending_announcement_to_communicate(&io.swap_digest, &peer)
                 {
                     tracing::debug!("Swap confirmation and communication has started.");
                     self.bob_communicate(peer, *io, shared_swap_id, create_params);

--- a/cnd/src/network/comit_ln/swaps.rs
+++ b/cnd/src/network/comit_ln/swaps.rs
@@ -74,9 +74,12 @@ impl<T> Swaps<T> {
         local_swap_id: LocalSwapId,
         create_swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
     ) -> Result<(), Error> {
-        match self.swaps.insert(local_swap_id, create_swap_params) {
-            Some(_) => return Err(Error::AlreadyExists),
-            None => {}
+        if self
+            .swaps
+            .insert(local_swap_id, create_swap_params)
+            .is_some()
+        {
+            return Err(Error::AlreadyExists);
         }
 
         self.pending_confirmation.insert(digest, local_swap_id);
@@ -113,9 +116,12 @@ impl<T> Swaps<T> {
         local_swap_id: LocalSwapId,
         create_swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
     ) -> Result<(), Error> {
-        match self.swaps.insert(local_swap_id, create_swap_params) {
-            Some(_) => return Err(Error::AlreadyExists),
-            None => {}
+        if self
+            .swaps
+            .insert(local_swap_id, create_swap_params)
+            .is_some()
+        {
+            return Err(Error::AlreadyExists);
         }
 
         self.pending_announcement.insert(digest, local_swap_id);
@@ -130,9 +136,10 @@ impl<T> Swaps<T> {
         peer: PeerId,
         io: T,
     ) -> Result<(), Error> {
-        match self.pending_creation.insert(digest, (peer, io)) {
-            Some(_) => Err(Error::AlreadyPendingCreation),
-            None => Ok(()),
+        if self.pending_creation.insert(digest, (peer, io)).is_some() {
+            Err(Error::AlreadyPendingCreation)
+        } else {
+            Ok(())
         }
     }
 
@@ -180,9 +187,12 @@ impl<T> Swaps<T> {
         local_swap_id: LocalSwapId,
         create_swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
     ) -> Result<(SharedSwapId, PeerId, T), Error> {
-        match self.swaps.insert(local_swap_id, create_swap_params) {
-            Some(_) => return Err(Error::AlreadyExists),
-            None => {}
+        if self
+            .swaps
+            .insert(local_swap_id, create_swap_params)
+            .is_some()
+        {
+            return Err(Error::AlreadyExists);
         }
 
         let (peer, io) = match self.pending_creation.remove(&digest) {
@@ -372,7 +382,7 @@ mod tests {
         let local_swap_id = LocalSwapId::default();
         let mut swaps = Swaps::<()>::default();
 
-        let _ = swaps
+        swaps
             .create_as_pending_confirmation(digest.clone(), local_swap_id, create_params.clone())
             .unwrap();
 
@@ -403,7 +413,7 @@ mod tests {
         let local_swap_id = LocalSwapId::default();
         let mut swaps = Swaps::<ReplySubstream<NegotiatedSubstream>>::default();
 
-        let _ = swaps
+        swaps
             .create_as_pending_announcement(digest.clone(), local_swap_id, create_params.clone())
             .unwrap();
 
@@ -432,8 +442,8 @@ mod tests {
         let local_swap_id = LocalSwapId::default();
         let mut swaps = Swaps::default();
 
-        let _ = swaps
-            .insert_pending_creation(digest.clone(), (&create_params).peer.peer_id.clone(), ())
+        swaps
+            .insert_pending_creation(digest.clone(), create_params.peer.peer_id.clone(), ())
             .unwrap();
 
         let (shared_swap_id, _peer, _io) = swaps

--- a/cnd/src/network/comit_ln/swaps.rs
+++ b/cnd/src/network/comit_ln/swaps.rs
@@ -249,4 +249,18 @@ mod tests {
 
         assert_eq!(create_swap.unwrap(), create_params)
     }
+
+    #[test]
+    fn same_swap_cannot_be_inserted_twice() {
+        let create_params = create_params();
+        let digest = create_params.clone().digest();
+        let local_swap_id = LocalSwapId::default();
+        let mut swaps = Swaps::default();
+
+        let creation1 = swaps.create_swap(&digest, local_swap_id.clone(), create_params.clone());
+
+        let creation2 = swaps.create_swap(&digest, local_swap_id.clone(), create_params.clone());
+
+        assert!(creation2.is_err())
+    }
 }

--- a/cnd/src/network/comit_ln/swaps.rs
+++ b/cnd/src/network/comit_ln/swaps.rs
@@ -13,62 +13,79 @@ pub struct Swaps {
     /// In role of Alice; swaps exist in here once a swap is created by Alice
     /// (and up until an announce confirmation is received from Bob).
     pending_confirmation: HashMap<SwapDigest, LocalSwapId>,
+
     /// In role of Bob; swaps exist in here if Bob creates the swap _before_ an
     /// announce message is received from Alice (and up until the announce
     /// message arrives).
     pending_announcement: HashMap<SwapDigest, LocalSwapId>,
-    /// In role of Bob; swaps exist in here if Bob creates the swap _after_ an
-    /// announce message is received from Alice (and up until Bob creates the
+    /// In role of Bob; swaps exist in here if Bob receives an announce message
+    /// from Alice _before_ Bob creates the swap (and up until Bob creates the
     /// swap).
     pending_creation: HashMap<SwapDigest, (PeerId, ReplySubstream<NegotiatedSubstream>)>,
 
+    /// Stores the swap as soon as it is created
     swaps: HashMap<LocalSwapId, HanEtherereumHalightBitcoinCreateSwapParams>,
+
+    /// Stores the shared swap id as soon as it is known.
+    /// Bob defines the shared swap id when he confirms the swap by replying to
+    /// an announce message from Alice.
     swap_ids: HashMap<LocalSwapId, SharedSwapId>,
 }
 
 impl Swaps {
-    pub fn insert_pending_creation(
+    /// Alice or Bob creates a swap.
+    /// A second function will be used to mark the swap as _pending
+    /// confirmation_ or _pending announcement_ depending on the role.
+    pub fn create_swap(
         &mut self,
-        digest: SwapDigest,
-        peer: PeerId,
-        io: ReplySubstream<NegotiatedSubstream>,
-    ) {
-        self.pending_creation.insert(digest, (peer, io));
+        digest: &SwapDigest,
+        local_swap_id: LocalSwapId,
+        create_swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
+    ) -> anyhow::Result<()> {
+        if self.pending_announcement.contains_key(&digest)
+            || self.pending_confirmation.contains_key(&digest)
+        {
+            return Err(anyhow::Error::from(SwapExists));
+        }
+
+        self.swaps.insert(local_swap_id, create_swap_params);
+
+        Ok(())
     }
 
-    pub fn get_pending_announcement(
+    /// Gets a swap that was created
+    pub fn get_created_swap(
         &self,
-        digest: &SwapDigest,
-    ) -> Option<(LocalSwapId, HanEtherereumHalightBitcoinCreateSwapParams)> {
-        self.pending_announcement
-            .get(digest)
-            .and_then(|local_swap_id| {
-                self.swaps
-                    .get(local_swap_id)
-                    .map(|create_params| (*local_swap_id, create_params.clone()))
-            })
+        local_swap_id: &LocalSwapId,
+    ) -> Option<HanEtherereumHalightBitcoinCreateSwapParams> {
+        self.swaps.get(local_swap_id).cloned()
     }
 
-    pub fn move_pending_announcement_to_communicate(
-        &mut self,
-        digest: &SwapDigest,
+    /// Gets a swap that was announced
+    pub fn get_announced_swap(
+        &self,
+        local_swap_id: &LocalSwapId,
     ) -> Option<(SharedSwapId, HanEtherereumHalightBitcoinCreateSwapParams)> {
-        let local_swap_id = match self.pending_announcement.remove(digest) {
-            Some(local_swap_id) => local_swap_id,
-            None => return None,
-        };
-
-        let create_params = match self.swaps.get(&local_swap_id) {
+        let create_params = match self.swaps.get(local_swap_id) {
             Some(create_params) => create_params,
             None => return None,
         };
 
-        let shared_swap_id = SharedSwapId::default();
-        self.swap_ids.insert(local_swap_id, shared_swap_id.clone());
+        let shared_swap_id = match self.swap_ids.get(local_swap_id) {
+            Some(shared_swap_id) => shared_swap_id,
+            None => return None,
+        };
 
-        Some((shared_swap_id, create_params.clone()))
+        Some((*shared_swap_id, create_params.clone()))
     }
 
+    /// Alice announced a swap and is waiting for a confirmation from Bob
+    pub fn move_to_pending_confirmation(&mut self, digest: SwapDigest, local_swap_id: LocalSwapId) {
+        self.pending_confirmation.insert(digest, local_swap_id);
+    }
+
+    /// Alice moves a swap announced (pending confirmation) to communicate upon
+    /// receiving a confirmation from Bob
     pub fn move_pending_confirmation_to_communicate(
         &mut self,
         digest: &SwapDigest,
@@ -89,31 +106,59 @@ impl Swaps {
         Some((local_swap_id, create_params.clone()))
     }
 
-    pub fn create_swap(
-        &mut self,
-        digest: &SwapDigest,
-        local_swap_id: LocalSwapId,
-        create_swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
-    ) -> anyhow::Result<()> {
-        if self.pending_announcement.contains_key(&digest)
-            || self.pending_confirmation.contains_key(&digest)
-        {
-            return Err(anyhow::Error::from(SwapExists));
-        }
-
-        self.swaps.insert(local_swap_id, create_swap_params);
-
-        Ok(())
-    }
-
-    pub fn move_to_pending_confirmation(&mut self, digest: SwapDigest, local_swap_id: LocalSwapId) {
-        self.pending_confirmation.insert(digest, local_swap_id);
-    }
-
+    /// Bob moves a swap to _pending announcement_ after creation.
     pub fn move_to_pending_announcement(&mut self, digest: SwapDigest, local_swap_id: LocalSwapId) {
         self.pending_announcement.insert(digest, local_swap_id);
     }
 
+    /// Bob received an announcement for a swap not yet created.
+    pub fn insert_pending_creation(
+        &mut self,
+        digest: SwapDigest,
+        peer: PeerId,
+        io: ReplySubstream<NegotiatedSubstream>,
+    ) {
+        self.pending_creation.insert(digest, (peer, io));
+    }
+
+    /// Bob: get a swap created but not yet announced
+    pub fn get_pending_announcement(
+        &self,
+        digest: &SwapDigest,
+    ) -> Option<(LocalSwapId, HanEtherereumHalightBitcoinCreateSwapParams)> {
+        self.pending_announcement
+            .get(digest)
+            .and_then(|local_swap_id| {
+                self.swaps
+                    .get(local_swap_id)
+                    .map(|create_params| (*local_swap_id, create_params.clone()))
+            })
+    }
+
+    /// Bob: Move a swap from pending announcement (created) to communicate upon
+    /// receiving an announcement and replying to it
+    pub fn move_pending_announcement_to_communicate(
+        &mut self,
+        digest: &SwapDigest,
+    ) -> Option<(SharedSwapId, HanEtherereumHalightBitcoinCreateSwapParams)> {
+        let local_swap_id = match self.pending_announcement.remove(digest) {
+            Some(local_swap_id) => local_swap_id,
+            None => return None,
+        };
+
+        let create_params = match self.swaps.get(&local_swap_id) {
+            Some(create_params) => create_params,
+            None => return None,
+        };
+
+        let shared_swap_id = SharedSwapId::default();
+        self.swap_ids.insert(local_swap_id, shared_swap_id.clone());
+
+        Some((shared_swap_id, create_params.clone()))
+    }
+
+    /// Bob moves a swap that was announced and pending creation to communicate
+    /// after receiving an announcement from Alice
     pub fn move_pending_creation_to_communicate(
         &mut self,
         digest: &SwapDigest,
@@ -130,30 +175,8 @@ impl Swaps {
         Some((shared_swap_id, peer, io))
     }
 
-    pub fn get_created_swap(
-        &self,
-        local_swap_id: &LocalSwapId,
-    ) -> Option<HanEtherereumHalightBitcoinCreateSwapParams> {
-        self.swaps.get(local_swap_id).cloned()
-    }
-
-    pub fn get_announced_swap(
-        &self,
-        local_swap_id: &LocalSwapId,
-    ) -> Option<(SharedSwapId, HanEtherereumHalightBitcoinCreateSwapParams)> {
-        let create_params = match self.swaps.get(local_swap_id) {
-            Some(create_params) => create_params,
-            None => return None,
-        };
-
-        let shared_swap_id = match self.swap_ids.get(local_swap_id) {
-            Some(shared_swap_id) => shared_swap_id,
-            None => return None,
-        };
-
-        Some((*shared_swap_id, create_params.clone()))
-    }
-
+    /// Either role finalizes a swap that was in the communication phase
+    /// This also proceeds with clean up from the various _pending_ stores.
     pub fn finalize_swap(
         &mut self,
         shared_swap_id: &SharedSwapId,

--- a/cnd/src/network/comit_ln/swaps.rs
+++ b/cnd/src/network/comit_ln/swaps.rs
@@ -495,21 +495,22 @@ mod tests {
             .unwrap();
 
         let shared_swap_id = SharedSwapId::default();
-        let (_local_swap_id, _create_params) = swaps
+        let (stored_local_swap_id, stored_create_params) = swaps
             .move_pending_confirmation_to_communicate(&digest, shared_swap_id)
             .unwrap();
 
-        assert_eq!(local_swap_id, _local_swap_id);
-        assert_eq!(create_params, _create_params);
+        assert_eq!(local_swap_id, stored_local_swap_id);
+        assert_eq!(create_params, stored_create_params);
 
-        let (_shared_swap_id, _create_params) = swaps.get_announced_swap(&local_swap_id).unwrap();
+        let (stored_shared_swap_id, stored_create_params) =
+            swaps.get_announced_swap(&local_swap_id).unwrap();
 
-        assert_eq!(shared_swap_id, _shared_swap_id);
-        assert_eq!(create_params, _create_params);
+        assert_eq!(shared_swap_id, stored_shared_swap_id);
+        assert_eq!(create_params, stored_create_params);
 
-        let (_local_swap_id, _create_params) = swaps.finalize_swap(&shared_swap_id).unwrap();
+        let (_, stored_create_params) = swaps.finalize_swap(&shared_swap_id).unwrap();
 
-        assert_eq!(create_params, _create_params);
+        assert_eq!(create_params, stored_create_params);
 
         assert!(!swaps.swap_in_pending_hashmaps(&digest));
     }
@@ -526,20 +527,21 @@ mod tests {
             .create_as_pending_announcement(digest.clone(), local_swap_id, create_params.clone())
             .unwrap();
 
-        let (shared_swap_id, _create_params) = swaps
+        let (shared_swap_id, stored_create_params) = swaps
             .move_pending_announcement_to_communicate(&digest, &create_params.peer.peer_id)
             .unwrap();
 
-        assert_eq!(create_params, _create_params);
+        assert_eq!(create_params, stored_create_params);
 
-        let (_shared_swap_id, _create_params) = swaps.get_announced_swap(&local_swap_id).unwrap();
+        let (stored_shared_swap_id, stored_create_params) =
+            swaps.get_announced_swap(&local_swap_id).unwrap();
 
-        assert_eq!(shared_swap_id, _shared_swap_id);
-        assert_eq!(create_params, _create_params);
+        assert_eq!(shared_swap_id, stored_shared_swap_id);
+        assert_eq!(create_params, stored_create_params);
 
-        let (_local_swap_id, _create_params) = swaps.finalize_swap(&shared_swap_id).unwrap();
+        let (_local_swap_id, stored_create_params) = swaps.finalize_swap(&shared_swap_id).unwrap();
 
-        assert_eq!(create_params, _create_params);
+        assert_eq!(create_params, stored_create_params);
 
         assert!(!swaps.swap_in_pending_hashmaps(&digest));
     }
@@ -559,15 +561,17 @@ mod tests {
             .move_pending_creation_to_communicate(&digest, local_swap_id, create_params.clone())
             .unwrap();
 
-        let (_shared_swap_id, _create_params) = swaps.get_announced_swap(&local_swap_id).unwrap();
+        let (stored_shared_swap_id, stored_create_params) =
+            swaps.get_announced_swap(&local_swap_id).unwrap();
 
-        assert_eq!(shared_swap_id, _shared_swap_id);
-        assert_eq!(create_params, _create_params);
+        assert_eq!(shared_swap_id, stored_shared_swap_id);
+        assert_eq!(create_params, stored_create_params);
 
-        let (_local_swap_id, _create_params) = swaps.finalize_swap(&shared_swap_id).unwrap();
+        let (stored_local_swap_id, stored_create_params) =
+            swaps.finalize_swap(&shared_swap_id).unwrap();
 
-        assert_eq!(local_swap_id, _local_swap_id);
-        assert_eq!(create_params, _create_params);
+        assert_eq!(local_swap_id, stored_local_swap_id);
+        assert_eq!(create_params, stored_create_params);
 
         assert!(!swaps.swap_in_pending_hashmaps(&digest));
     }

--- a/cnd/src/network/comit_ln/swaps.rs
+++ b/cnd/src/network/comit_ln/swaps.rs
@@ -384,6 +384,11 @@ mod tests {
         assert_eq!(local_swap_id, _local_swap_id);
         assert_eq!(create_params, _create_params);
 
+        let (_shared_swap_id, _create_params) = swaps.get_announced_swap(&local_swap_id).unwrap();
+
+        assert_eq!(shared_swap_id, _shared_swap_id);
+        assert_eq!(create_params, _create_params);
+
         let (_local_swap_id, _create_params) = swaps.finalize_swap(&shared_swap_id).unwrap();
 
         assert_eq!(create_params, _create_params);
@@ -408,6 +413,11 @@ mod tests {
 
         assert_eq!(create_params, _create_params);
 
+        let (_shared_swap_id, _create_params) = swaps.get_announced_swap(&local_swap_id).unwrap();
+
+        assert_eq!(shared_swap_id, _shared_swap_id);
+        assert_eq!(create_params, _create_params);
+
         let (_local_swap_id, _create_params) = swaps.finalize_swap(&shared_swap_id).unwrap();
 
         assert_eq!(create_params, _create_params);
@@ -429,6 +439,11 @@ mod tests {
         let (shared_swap_id, _peer, _io) = swaps
             .move_pending_creation_to_communicate(&digest, local_swap_id, create_params.clone())
             .unwrap();
+
+        let (_shared_swap_id, _create_params) = swaps.get_announced_swap(&local_swap_id).unwrap();
+
+        assert_eq!(shared_swap_id, _shared_swap_id);
+        assert_eq!(create_params, _create_params);
 
         let (_local_swap_id, _create_params) = swaps.finalize_swap(&shared_swap_id).unwrap();
 

--- a/cnd/src/network/comit_ln/swaps.rs
+++ b/cnd/src/network/comit_ln/swaps.rs
@@ -276,13 +276,13 @@ impl<T> Swaps<T> {
 
     /// Remove all pending (not finalized) swap older than `older_than`
     pub fn clean_up_pending_swaps(&mut self, older_than: Timestamp) {
-        let digests: Vec<SwapDigest> = self
+        let digests = self
             .timestamps
             .iter()
             .filter(|(_, timestamp)| **timestamp < older_than)
             .map(|(digest, _)| digest)
             .cloned()
-            .collect();
+            .collect::<Vec<_>>();
 
         self.pending_confirmation
             .retain(|digest, _| !digests.contains(digest));

--- a/cnd/src/network/comit_ln/swaps.rs
+++ b/cnd/src/network/comit_ln/swaps.rs
@@ -374,11 +374,8 @@ mod tests {
         );
 
         assert!(creation.is_ok());
-
         let created_swap = swaps.get_created_swap(&local_swap_id);
-
         assert!(created_swap.is_some());
-
         assert_eq!(created_swap.unwrap(), create_params)
     }
 
@@ -396,11 +393,8 @@ mod tests {
         );
 
         assert!(creation.is_ok());
-
         let created_swap = swaps.get_created_swap(&local_swap_id);
-
         assert!(created_swap.is_some());
-
         assert_eq!(created_swap.unwrap(), create_params)
     }
 
@@ -436,9 +430,7 @@ mod tests {
             swaps.create_as_pending_confirmation(digest, local_swap_id, second_create_params);
 
         assert!(creation.is_err());
-
         let stored_params = swaps.get_created_swap(&local_swap_id).unwrap();
-
         assert_eq!(stored_params, first_create_params);
     }
 
@@ -477,9 +469,7 @@ mod tests {
             swaps.create_as_pending_announcement(digest, local_swap_id, second_create_params);
 
         assert!(second_creation.is_err());
-
         let stored_params = swaps.get_created_swap(&local_swap_id).unwrap();
-
         assert_eq!(stored_params, first_create_params);
     }
 
@@ -511,7 +501,6 @@ mod tests {
         let (_, stored_create_params) = swaps.finalize_swap(&shared_swap_id).unwrap();
 
         assert_eq!(create_params, stored_create_params);
-
         assert!(!swaps.swap_in_pending_hashmaps(&digest));
     }
 
@@ -542,7 +531,6 @@ mod tests {
         let (_local_swap_id, stored_create_params) = swaps.finalize_swap(&shared_swap_id).unwrap();
 
         assert_eq!(create_params, stored_create_params);
-
         assert!(!swaps.swap_in_pending_hashmaps(&digest));
     }
 
@@ -572,7 +560,6 @@ mod tests {
 
         assert_eq!(local_swap_id, stored_local_swap_id);
         assert_eq!(create_params, stored_create_params);
-
         assert!(!swaps.swap_in_pending_hashmaps(&digest));
     }
 
@@ -708,10 +695,8 @@ mod tests {
         );
 
         assert!(res.is_err());
-
         let (stored_shared_swap_id, stored_create_params) =
             swaps.get_announced_swap(&local_swap_id).unwrap();
-
         assert_eq!(stored_shared_swap_id, shared_swap_id);
         assert_eq!(stored_create_params, first_create_params);
     }
@@ -726,9 +711,7 @@ mod tests {
         let res = swaps.move_pending_creation_to_communicate(&digest, local_swap_id, create_params);
 
         assert!(res.is_err());
-
         let res = swaps.get_announced_swap(&local_swap_id);
-
         assert!(res.is_none());
     }
 

--- a/cnd/src/network/comit_ln/swaps.rs
+++ b/cnd/src/network/comit_ln/swaps.rs
@@ -351,4 +351,28 @@ mod tests {
 
         assert!(!swaps.swap_in_pending_hashmaps(&digest));
     }
+
+    #[test]
+    fn from_creation_then_announcement_to_finalisation_for_bob() {
+        let create_params = create_params();
+        let digest = create_params.clone().digest();
+        let local_swap_id = LocalSwapId::default();
+        let mut swaps = Swaps::default();
+
+        let _ = swaps
+            .create_as_pending_announcement(digest.clone(), local_swap_id, create_params.clone())
+            .unwrap();
+
+        let (shared_swap_id, _create_params) = swaps
+            .move_pending_announcement_to_communicate(&digest)
+            .unwrap();
+
+        assert_eq!(create_params, _create_params);
+
+        let (_local_swap_id, _create_params) = swaps.finalize_swap(&shared_swap_id).unwrap();
+
+        assert_eq!(create_params, _create_params);
+
+        assert!(!swaps.swap_in_pending_hashmaps(&digest));
+    }
 }

--- a/cnd/src/network/comit_ln/swaps.rs
+++ b/cnd/src/network/comit_ln/swaps.rs
@@ -675,7 +675,7 @@ mod tests {
         let res = swaps.move_pending_creation_to_communicate(
             &digest,
             local_swap_id,
-            second_create_params.clone(),
+            second_create_params,
         );
 
         assert!(res.is_err());
@@ -694,11 +694,7 @@ mod tests {
         let local_swap_id = LocalSwapId::default();
         let mut swaps = Swaps::<()>::default();
 
-        let res = swaps.move_pending_creation_to_communicate(
-            &digest,
-            local_swap_id,
-            create_params.clone(),
-        );
+        let res = swaps.move_pending_creation_to_communicate(&digest, local_swap_id, create_params);
 
         assert!(res.is_err());
 

--- a/cnd/src/network/comit_ln/swaps.rs
+++ b/cnd/src/network/comit_ln/swaps.rs
@@ -1,0 +1,182 @@
+use crate::{
+    network::{
+        comit_ln::SwapExists,
+        protocols::announce::{protocol::ReplySubstream, SwapDigest},
+    },
+    swap_protocols::{HanEtherereumHalightBitcoinCreateSwapParams, LocalSwapId, SharedSwapId},
+};
+use libp2p::{swarm::NegotiatedSubstream, PeerId};
+use std::collections::HashMap;
+
+#[derive(Default, Debug)]
+pub struct Swaps {
+    /// In role of Alice; swaps exist in here once a swap is created by Alice
+    /// (and up until an announce confirmation is received from Bob).
+    pending_confirmation: HashMap<SwapDigest, LocalSwapId>,
+    /// In role of Bob; swaps exist in here if Bob creates the swap _before_ an
+    /// announce message is received from Alice (and up until the announce
+    /// message arrives).
+    pending_announcement: HashMap<SwapDigest, LocalSwapId>,
+    /// In role of Bob; swaps exist in here if Bob creates the swap _after_ an
+    /// announce message is received from Alice (and up until Bob creates the
+    /// swap).
+    pending_creation: HashMap<SwapDigest, (PeerId, ReplySubstream<NegotiatedSubstream>)>,
+
+    swaps: HashMap<LocalSwapId, HanEtherereumHalightBitcoinCreateSwapParams>,
+    swap_ids: HashMap<LocalSwapId, SharedSwapId>,
+}
+
+impl Swaps {
+    pub fn insert_pending_creation(
+        &mut self,
+        digest: SwapDigest,
+        peer: PeerId,
+        io: ReplySubstream<NegotiatedSubstream>,
+    ) {
+        self.pending_creation.insert(digest, (peer, io));
+    }
+
+    pub fn get_pending_announcement(
+        &self,
+        digest: &SwapDigest,
+    ) -> Option<(LocalSwapId, HanEtherereumHalightBitcoinCreateSwapParams)> {
+        self.pending_announcement
+            .get(digest)
+            .and_then(|local_swap_id| {
+                self.swaps
+                    .get(local_swap_id)
+                    .map(|create_params| (*local_swap_id, create_params.clone()))
+            })
+    }
+
+    pub fn move_pending_announcement_to_communicate(
+        &mut self,
+        digest: &SwapDigest,
+    ) -> Option<(SharedSwapId, HanEtherereumHalightBitcoinCreateSwapParams)> {
+        let local_swap_id = match self.pending_announcement.remove(digest) {
+            Some(local_swap_id) => local_swap_id,
+            None => return None,
+        };
+
+        let create_params = match self.swaps.get(&local_swap_id) {
+            Some(create_params) => create_params,
+            None => return None,
+        };
+
+        let shared_swap_id = SharedSwapId::default();
+        self.swap_ids.insert(local_swap_id, shared_swap_id.clone());
+
+        Some((shared_swap_id, create_params.clone()))
+    }
+
+    pub fn move_pending_confirmation_to_communicate(
+        &mut self,
+        digest: &SwapDigest,
+        shared_swap_id: SharedSwapId,
+    ) -> Option<(LocalSwapId, HanEtherereumHalightBitcoinCreateSwapParams)> {
+        let local_swap_id = match self.pending_confirmation.remove(digest) {
+            Some(local_swap_id) => local_swap_id,
+            None => return None,
+        };
+
+        let create_params = match self.swaps.get(&local_swap_id) {
+            Some(create_params) => create_params,
+            None => return None,
+        };
+
+        self.swap_ids.insert(local_swap_id, shared_swap_id);
+
+        Some((local_swap_id, create_params.clone()))
+    }
+
+    pub fn create_swap(
+        &mut self,
+        digest: &SwapDigest,
+        local_swap_id: LocalSwapId,
+        create_swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
+    ) -> anyhow::Result<()> {
+        if self.pending_announcement.contains_key(&digest)
+            || self.pending_confirmation.contains_key(&digest)
+        {
+            return Err(anyhow::Error::from(SwapExists));
+        }
+
+        self.swaps.insert(local_swap_id, create_swap_params);
+
+        Ok(())
+    }
+
+    pub fn move_to_pending_confirmation(&mut self, digest: SwapDigest, local_swap_id: LocalSwapId) {
+        self.pending_confirmation.insert(digest, local_swap_id);
+    }
+
+    pub fn move_to_pending_announcement(&mut self, digest: SwapDigest, local_swap_id: LocalSwapId) {
+        self.pending_announcement.insert(digest, local_swap_id);
+    }
+
+    pub fn move_pending_creation_to_communicate(
+        &mut self,
+        digest: &SwapDigest,
+        local_swap_id: LocalSwapId,
+    ) -> Option<(SharedSwapId, PeerId, ReplySubstream<NegotiatedSubstream>)> {
+        let (peer, io) = match self.pending_creation.remove(&digest) {
+            Some(value) => value,
+            None => return None,
+        };
+
+        let shared_swap_id = SharedSwapId::default();
+        self.swap_ids.insert(local_swap_id, shared_swap_id.clone());
+
+        Some((shared_swap_id, peer, io))
+    }
+
+    pub fn get_created_swap(
+        &self,
+        local_swap_id: &LocalSwapId,
+    ) -> Option<HanEtherereumHalightBitcoinCreateSwapParams> {
+        self.swaps.get(local_swap_id).cloned()
+    }
+
+    pub fn get_announced_swap(
+        &self,
+        local_swap_id: &LocalSwapId,
+    ) -> Option<(SharedSwapId, HanEtherereumHalightBitcoinCreateSwapParams)> {
+        let create_params = match self.swaps.get(local_swap_id) {
+            Some(create_params) => create_params,
+            None => return None,
+        };
+
+        let shared_swap_id = match self.swap_ids.get(local_swap_id) {
+            Some(shared_swap_id) => shared_swap_id,
+            None => return None,
+        };
+
+        Some((*shared_swap_id, create_params.clone()))
+    }
+
+    pub fn finalize_swap(
+        &mut self,
+        shared_swap_id: &SharedSwapId,
+    ) -> Option<(LocalSwapId, HanEtherereumHalightBitcoinCreateSwapParams)> {
+        let local_swap_id = match self.swap_ids.iter().find_map(|(key, value)| {
+            if *value == *shared_swap_id {
+                Some(key)
+            } else {
+                None
+            }
+        }) {
+            Some(local_swap_id) => local_swap_id,
+            None => return None,
+        };
+
+        let create_params = match self.swaps.get(&local_swap_id) {
+            Some(create_params) => create_params,
+            None => return None,
+        };
+
+        self.pending_announcement
+            .retain(|_, id| *id != *local_swap_id);
+
+        Some((*local_swap_id, create_params.clone()))
+    }
+}

--- a/cnd/src/network/comit_ln/swaps.rs
+++ b/cnd/src/network/comit_ln/swaps.rs
@@ -203,3 +203,50 @@ impl Swaps {
         Some((*local_swap_id, create_params.clone()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        asset,
+        asset::ethereum::FromWei,
+        identity,
+        network::DialInformation,
+        swap_protocols::{EthereumIdentity, Role},
+    };
+    use digest::Digest;
+
+    fn create_params() -> HanEtherereumHalightBitcoinCreateSwapParams {
+        HanEtherereumHalightBitcoinCreateSwapParams {
+            role: Role::Alice,
+            peer: DialInformation {
+                peer_id: PeerId::random(),
+                address_hint: None,
+            },
+            ethereum_identity: EthereumIdentity::from(identity::Ethereum::random()),
+            ethereum_absolute_expiry: 12345.into(),
+            ethereum_amount: asset::Ether::from_wei(9_001_000_000_000_000_000_000u128),
+            lightning_identity: identity::Lightning::random(),
+            lightning_cltv_expiry: 12345.into(),
+            lightning_amount: asset::Bitcoin::from_sat(1_000_000_000),
+        }
+    }
+
+    #[test]
+    fn created_swap_can_be_retrieved() {
+        let create_params = create_params();
+        let digest = create_params.clone().digest();
+        let local_swap_id = LocalSwapId::default();
+        let mut swaps = Swaps::default();
+
+        let creation = swaps.create_swap(&digest, local_swap_id.clone(), create_params.clone());
+
+        assert!(creation.is_ok());
+
+        let create_swap = swaps.get_created_swap(&local_swap_id);
+
+        assert!(create_swap.is_some());
+
+        assert_eq!(create_swap.unwrap(), create_params)
+    }
+}

--- a/cnd/src/timestamp.rs
+++ b/cnd/src/timestamp.rs
@@ -18,7 +18,11 @@ impl Timestamp {
     }
 
     pub fn plus(self, seconds: u32) -> Self {
-        Self(self.0.checked_add(seconds).unwrap_or(std::u32::MAX))
+        Self(self.0.saturating_add(seconds))
+    }
+
+    pub fn minus(self, seconds: u32) -> Self {
+        Self(self.0.saturating_sub(seconds))
     }
 
     pub fn to_bytes(self) -> [u8; 4] {


### PR DESCRIPTION
Having several different hashmap for each swap information
and status creates complexity in `ComitLn` and also creates
the risk of having bugs that lead to discrepancy between
the different hashmaps.

By moving all hashmap to a given struct that has a consistent
interface, it allows the focus on avoiding discrepancy
to be localized to this new `Swaps` struct.

It also later allows the migration of this `Swaps` struct
to a state machine if we see it as a gain.

Old pending swaps are also cleaned up. For now I put a hardcoded 5 minutes time out. We can decide to make it configurable at a later stage.

Resolves #2488