### PR TITLE
Add context to ledger connector errors 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,7 @@ dependencies = [
  "ambassador",
  "anyhow",
  "async-trait",
+ "atty",
  "base64 0.12.0",
  "bigdecimal",
  "bitcoin",

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -9,6 +9,7 @@ description = "Reference implementation of a COMIT network daemon."
 ambassador = "0.2"
 anyhow = "1"
 async-trait = "0.1"
+atty = "0.2"
 base64 = "0.12.0"
 bigdecimal = "0.1.2"
 bitcoin = { version = "0.23", features = ["use-serde"] }
@@ -75,4 +76,3 @@ serde_urlencoded = "0.6"
 spectral = { version = "0.6", default-features = false }
 tempfile = "3.1.0"
 testcontainers = "0.9"
-

--- a/cnd/src/btsieve/bitcoin.rs
+++ b/cnd/src/btsieve/bitcoin.rs
@@ -11,13 +11,9 @@ use crate::{
     },
     identity,
 };
-use bitcoin::{
-    consensus::{encode::deserialize, Decodable},
-    BitcoinHash, OutPoint,
-};
+use bitcoin::{self, BitcoinHash, OutPoint};
 use chrono::NaiveDateTime;
 use genawaiter::{sync::Gen, GeneratorState};
-use reqwest::{Client, Url};
 
 type Hash = bitcoin::BlockHash;
 type Block = bitcoin::Block;
@@ -126,67 +122,5 @@ impl Predates for Block {
         let block_time = self.header.time as i64;
 
         block_time < unix_timestamp
-    }
-}
-
-pub async fn bitcoin_http_request_for_hex_encoded_object<T>(
-    request_url: Url,
-    client: &Client,
-) -> anyhow::Result<T>
-where
-    T: Decodable,
-{
-    let response_text = client.get(request_url).send().await?.text().await?;
-    let decoded_response = decode_response(response_text)?;
-
-    Ok(decoded_response)
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("unsupported network: {0}")]
-    UnsupportedNetwork(String),
-    #[error("reqwest: ")]
-    Reqwest(#[from] reqwest::Error),
-    #[error("hex: ")]
-    Hex(#[from] hex::FromHexError),
-    #[error("deserialization: ")]
-    Deserialization(#[from] bitcoin::consensus::encode::Error),
-}
-
-pub fn decode_response<T>(response_text: String) -> Result<T, Error>
-where
-    T: Decodable,
-{
-    let bytes = hex::decode(response_text.trim()).map_err(Error::Hex)?;
-    deserialize(bytes.as_slice()).map_err(Error::Deserialization)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::transaction;
-    use spectral::prelude::*;
-
-    #[test]
-    fn can_decode_tx_from_bitcoind_http_interface() {
-        // the line break here is on purpose, as it is returned like that from bitcoind
-        let transaction = r#"02000000014135047eff77c95bce4955f630bc3e334690d31517176dbc23e9345493c48ecf000000004847304402200da78118d6970bca6f152a6ca81fa8c4dde856680eb6564edb329ce1808207c402203b3b4890dd203cc4c9361bbbeb7ebce70110d4b07f411208b2540b10373755ba01feffffff02644024180100000017a9142464790f3a3fddb132691fac9fd02549cdc09ff48700a3e1110000000017a914c40a2c4fd9dcad5e1694a41ca46d337eb59369d78765000000
-"#.to_owned();
-
-        let bytes = decode_response::<transaction::Bitcoin>(transaction);
-
-        assert_that(&bytes).is_ok();
-    }
-
-    #[test]
-    fn can_decode_block_from_bitcoind_http_interface() {
-        // the line break here is on purpose, as it is returned like that from bitcoind
-        let block = r#"00000020837603de6069115e22e7fbf063c2a6e3bc3b3206f0b7e08d6ab6c168c2e50d4a9b48676dedc93d05f677778c1d83df28fd38d377548340052823616837666fb8be1b795dffff7f200000000001020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0401650101ffffffff0200f2052a0100000023210205980e76eee77386241a3a7a5af65e910fb7be411b98e609f7c0d97c50ab8ebeac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000
-"#.to_owned();
-
-        let bytes = decode_response::<Block>(block);
-
-        assert_that(&bytes).is_ok();
     }
 }

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -98,7 +98,7 @@ fn main() -> anyhow::Result<()> {
             validate_blockchain_config(&connector, *chain_id)
                 .await
                 .or_else::<anyhow::Error, _>(|e| {
-                    let conn_error = e.downcast::<jsonrpc::Error>()?;
+                    let conn_error = e.downcast::<jsonrpc::ConnectionFailed>()?;
                     tracing::warn!("Could not validate Ethereum node config: {}", conn_error);
 
                     Ok(())

--- a/cnd/src/trace.rs
+++ b/cnd/src/trace.rs
@@ -1,3 +1,4 @@
+use atty::{self, Stream};
 use log::LevelFilter;
 use tracing::{info, subscriber, Level};
 use tracing_log::LogTracer;
@@ -11,8 +12,10 @@ pub fn init_tracing(level: log::LevelFilter) -> anyhow::Result<()> {
     // We want upstream library log messages, just only at Info level.
     LogTracer::init_with_filter(LevelFilter::Info)?;
 
+    let is_terminal = atty::is(Stream::Stdout);
     let subscriber = FmtSubscriber::builder()
         .with_max_level(level_from_level_filter(level))
+        .with_ansi(is_terminal)
         .finish();
 
     subscriber::set_global_default(subscriber)?;


### PR DESCRIPTION
Fixes #2368.

Instead of using `tracing` like the original ticket suggests, we use `anyhow::Context`. It should be easier for a developer to get all the error information from the error stack, rather than having to cross-reference with cnd's logs.

Feel free to be nitpicky in terms of error messages, unnecessary errors, missing errors, etc.