### PR TITLE
Do not consume `self` on `digest`

### DIFF
--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -107,7 +107,7 @@ impl ComitLN {
         id: LocalSwapId,
         create_swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
     ) -> anyhow::Result<()> {
-        let digest = create_swap_params.clone().digest();
+        let digest = create_swap_params.digest();
         tracing::trace!("Swap creation request received: {}", digest);
 
         match create_swap_params.role {

--- a/cnd/src/network/comit_ln/swaps.rs
+++ b/cnd/src/network/comit_ln/swaps.rs
@@ -266,7 +266,7 @@ impl<T> Swaps<T> {
         self.pending_announcement
             .retain(|_, id| *id != *local_swap_id);
 
-        let finalized_digest = create_params.clone().digest();
+        let finalized_digest = create_params.digest();
 
         self.timestamps
             .retain(|digest, _| *digest != finalized_digest);
@@ -363,7 +363,7 @@ mod tests {
     #[test]
     fn created_swap_as_pending_confirmation_can_be_retrieved() {
         let create_params = create_params();
-        let digest = create_params.clone().digest();
+        let digest = create_params.digest();
         let local_swap_id = LocalSwapId::default();
         let mut swaps = Swaps::<()>::default();
 
@@ -382,7 +382,7 @@ mod tests {
     #[test]
     fn created_swap_as_pending_announcement_can_be_retrieved() {
         let create_params = create_params();
-        let digest = create_params.clone().digest();
+        let digest = create_params.digest();
         let local_swap_id = LocalSwapId::default();
         let mut swaps = Swaps::<()>::default();
 
@@ -407,8 +407,8 @@ mod tests {
         second_create_params.ethereum_identity =
             EthereumIdentity::from(identity::Ethereum::random());
 
-        let digest = first_create_params.clone().digest();
-        let second_digest = second_create_params.clone().digest();
+        let digest = first_create_params.digest();
+        let second_digest = second_create_params.digest();
 
         // The test is based on this assumption so making sure it's true
         assert_eq!(digest, second_digest);
@@ -444,8 +444,8 @@ mod tests {
         second_create_params.ethereum_identity =
             EthereumIdentity::from(identity::Ethereum::random());
 
-        let digest = first_create_params.clone().digest();
-        let second_digest = second_create_params.clone().digest();
+        let digest = first_create_params.digest();
+        let second_digest = second_create_params.digest();
 
         // The test is based on this assumption so making sure it's true
         assert_eq!(digest, second_digest);
@@ -476,7 +476,7 @@ mod tests {
     #[test]
     fn from_creation_to_finalisation_for_alice() {
         let create_params = create_params();
-        let digest = create_params.clone().digest();
+        let digest = create_params.digest();
         let local_swap_id = LocalSwapId::default();
         let mut swaps = Swaps::<()>::default();
 
@@ -507,7 +507,7 @@ mod tests {
     #[test]
     fn from_creation_then_announcement_to_finalisation_for_bob() {
         let create_params = create_params();
-        let digest = create_params.clone().digest();
+        let digest = create_params.digest();
         let local_swap_id = LocalSwapId::default();
 
         let mut swaps = Swaps::<ReplySubstream<NegotiatedSubstream>>::default();
@@ -537,7 +537,7 @@ mod tests {
     #[test]
     fn from_announcement_then_creation_to_finalisation_for_bob() {
         let create_params = create_params();
-        let digest = create_params.clone().digest();
+        let digest = create_params.digest();
         let local_swap_id = LocalSwapId::default();
         let mut swaps = Swaps::default();
 
@@ -568,9 +568,9 @@ mod tests {
         let mut swaps = Swaps::<()>::default();
 
         let create_params1 = create_params();
-        let digest1 = create_params1.clone().digest();
+        let digest1 = create_params1.digest();
         let create_params2 = create_params();
-        let digest2 = create_params2.clone().digest();
+        let digest2 = create_params2.digest();
         let create_params3 = create_params();
         let digest3 = create_params3.digest();
 
@@ -599,7 +599,7 @@ mod tests {
     #[test]
     fn old_finalized_swaps_are_not_cleaned_up() {
         let create_params = create_params();
-        let digest = create_params.clone().digest();
+        let digest = create_params.digest();
         let local_swap_id = LocalSwapId::default();
         let mut swaps = Swaps::<ReplySubstream<NegotiatedSubstream>>::default();
 
@@ -627,9 +627,9 @@ mod tests {
         let mut swaps = Swaps::<()>::default();
 
         let create_params1 = create_params();
-        let digest1 = create_params1.clone().digest();
+        let digest1 = create_params1.digest();
         let create_params2 = create_params();
-        let digest2 = create_params2.clone().digest();
+        let digest2 = create_params2.digest();
         let create_params3 = create_params();
         let digest3 = create_params3.digest();
 
@@ -662,8 +662,8 @@ mod tests {
         second_create_params.ethereum_identity =
             EthereumIdentity::from(identity::Ethereum::random());
 
-        let digest = first_create_params.clone().digest();
-        let second_digest = second_create_params.clone().digest();
+        let digest = first_create_params.digest();
+        let second_digest = second_create_params.digest();
 
         assert_eq!(digest, second_digest);
 
@@ -704,7 +704,7 @@ mod tests {
     #[test]
     fn given_move_pending_creation_to_communicate_errors_then_no_side_effects() {
         let create_params = create_params();
-        let digest = create_params.clone().digest();
+        let digest = create_params.digest();
         let local_swap_id = LocalSwapId::default();
         let mut swaps = Swaps::<()>::default();
 
@@ -718,7 +718,7 @@ mod tests {
     #[test]
     fn given_bob_receives_announcement_with_wrong_peer_id_then_error() {
         let create_params = create_params();
-        let digest = create_params.clone().digest();
+        let digest = create_params.digest();
         let local_swap_id = LocalSwapId::default();
 
         let mut swaps = Swaps::<()>::default();
@@ -735,7 +735,7 @@ mod tests {
     #[test]
     fn given_bob_receives_creation_with_different_peer_id_then_error() {
         let create_params = create_params();
-        let digest = create_params.clone().digest();
+        let digest = create_params.digest();
         let local_swap_id = LocalSwapId::default();
 
         let mut swaps = Swaps::<()>::default();

--- a/cnd/src/network/protocols/announce.rs
+++ b/cnd/src/network/protocols/announce.rs
@@ -2,7 +2,7 @@ pub mod behaviour;
 pub mod handler;
 pub mod protocol;
 
-use digest::IntoDigestInput;
+use digest::ToDigestInput;
 use libp2p::multihash::{self, Multihash};
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
@@ -16,9 +16,9 @@ impl SwapDigest {
     }
 }
 
-impl IntoDigestInput for SwapDigest {
-    fn into_digest_input(self) -> Vec<u8> {
-        self.0.into_bytes()
+impl ToDigestInput for SwapDigest {
+    fn to_digest_input(&self) -> Vec<u8> {
+        self.0.clone().into_bytes()
     }
 }
 

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -6,7 +6,7 @@ use crate::{
     swap_protocols::{halight, LedgerStates, LocalSwapId, Role},
     timestamp::Timestamp,
 };
-use digest::{Digest, IntoDigestInput};
+use digest::{Digest, ToDigestInput};
 use std::sync::Arc;
 
 /// This represent the information available on a swap
@@ -32,14 +32,14 @@ pub struct HanEtherereumHalightBitcoinCreateSwapParams {
     pub lightning_amount: asset::Bitcoin,
 }
 
-impl IntoDigestInput for asset::Bitcoin {
-    fn into_digest_input(self) -> Vec<u8> {
+impl ToDigestInput for asset::Bitcoin {
+    fn to_digest_input(&self) -> Vec<u8> {
         self.to_le_bytes().to_vec()
     }
 }
 
-impl IntoDigestInput for asset::Ether {
-    fn into_digest_input(self) -> Vec<u8> {
+impl ToDigestInput for asset::Ether {
+    fn to_digest_input(&self) -> Vec<u8> {
         self.to_bytes()
     }
 }
@@ -59,9 +59,9 @@ impl From<EthereumIdentity> for identity::Ethereum {
     }
 }
 
-impl IntoDigestInput for Timestamp {
-    fn into_digest_input(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+impl ToDigestInput for Timestamp {
+    fn to_digest_input(&self) -> Vec<u8> {
+        self.clone().to_bytes().to_vec()
     }
 }
 

--- a/digest-macro-derive/src/lib.rs
+++ b/digest-macro-derive/src/lib.rs
@@ -46,19 +46,19 @@ fn impl_digest_macro(ast: &syn::DeriveInput) -> TokenStream {
 
             let gen = quote! {
                     impl ::digest::Digest for #name
-                        where #(#types: ::digest::IntoDigestInput),*
+                        where #(#types: ::digest::ToDigestInput),*
                     {
                         type Hash = #hash_type;
 
-                        fn digest(self) -> Self::Hash {
-                            use ::digest::{Hash, IntoDigestInput};
+                        fn digest(&self) -> Self::Hash {
+                            use ::digest::{Hash, ToDigestInput};
                             let mut digests = vec![];
-                            #(digests.push(::digest::field_digest::<_, Self::Hash>(self.#idents, #bytes.to_vec())););*
+                            #(digests.push(::digest::field_digest::<_, Self::Hash>(&self.#idents, #bytes.to_vec())););*
 
                             digests.sort();
 
                             let bytes = digests.into_iter().fold(vec![], |mut bytes, digest| {
-                                bytes.append(&mut digest.into_digest_input());
+                                bytes.append(&mut digest.to_digest_input());
                                 bytes
                             });
 
@@ -104,14 +104,14 @@ fn impl_digest_macro(ast: &syn::DeriveInput) -> TokenStream {
                     {
                         type Hash = #hash_type;
 
-                        fn digest(self) -> Self::Hash {
-                            use ::digest::{Hash, IntoDigestInput};
+                        fn digest(&self) -> Self::Hash {
+                            use ::digest::{Hash, ToDigestInput};
 
-                            let bytes = match self {
+                            let bytes = match self.clone() {
                                 #(Self::#unit_variant_idents => #unit_variant_bytes.to_vec()),*,
                                 #(Self::#tuple_variant_idents(data) => {
                                         let mut bytes = #tuple_variant_bytes.to_vec();
-                                        bytes.append(&mut data.digest().into_digest_input());
+                                        bytes.append(&mut data.digest().to_digest_input());
                                         bytes
                                 }),*
                             };

--- a/digest/tests/swap_digest.rs
+++ b/digest/tests/swap_digest.rs
@@ -1,4 +1,4 @@
-use digest::{field_digest, Digest, Hash, IntoDigestInput};
+use digest::{field_digest, Digest, Hash, ToDigestInput};
 // This is to ensure that it works even if other macros are used on the same
 // struct
 use serde::Serialize;
@@ -6,9 +6,9 @@ use serde::Serialize;
 #[derive(Serialize)]
 struct MyString(String);
 
-impl IntoDigestInput for MyString {
-    fn into_digest_input(self) -> Vec<u8> {
-        self.0.into_bytes()
+impl ToDigestInput for MyString {
+    fn to_digest_input(&self) -> Vec<u8> {
+        self.0.clone().into_bytes()
     }
 }
 
@@ -27,9 +27,9 @@ impl digest::Hash for MultihashSha256 {
     }
 }
 
-impl IntoDigestInput for MultihashSha256 {
-    fn into_digest_input(self) -> Vec<u8> {
-        self.0.into_bytes()
+impl ToDigestInput for MultihashSha256 {
+    fn to_digest_input(&self) -> Vec<u8> {
+        self.0.clone().into_bytes()
     }
 }
 
@@ -54,11 +54,11 @@ struct OtherDoubleFieldStruct {
 impl Digest for OtherDoubleFieldStruct {
     type Hash = MultihashSha256;
 
-    fn digest(self) -> Self::Hash {
+    fn digest(&self) -> Self::Hash {
         let mut digests = vec![];
-        let foo_digest = field_digest::<_, Self::Hash>(self.foo, [0x00u8, 0x11u8].to_vec());
+        let foo_digest = field_digest::<_, Self::Hash>(&self.foo, [0x00u8, 0x11u8].to_vec());
         digests.push(foo_digest);
-        let bar_digest = field_digest::<_, Self::Hash>(self.bar, [0xFFu8, 0xAAu8].to_vec());
+        let bar_digest = field_digest::<_, Self::Hash>(&self.bar, [0xFFu8, 0xAAu8].to_vec());
         digests.push(bar_digest);
 
         digests.sort();
@@ -90,7 +90,7 @@ enum OtherEnum {
 
 impl Digest for OtherEnum {
     type Hash = MultihashSha256;
-    fn digest(self) -> Self::Hash {
+    fn digest(&self) -> Self::Hash {
         let bytes = match self {
             OtherEnum::Foo => vec![0x00u8, 0x11u8],
             OtherEnum::Bar => vec![0x00u8, 0x11u8],
@@ -106,8 +106,8 @@ fn given_same_strings_return_same_multihash() {
     let str2: MyString = "simple string".into();
 
     assert_eq!(
-        field_digest::<_, MultihashSha256>(str1, "foo".into()),
-        field_digest::<_, MultihashSha256>(str2, "foo".into())
+        field_digest::<_, MultihashSha256>(&str1, "foo".into()),
+        field_digest::<_, MultihashSha256>(&str2, "foo".into())
     )
 }
 
@@ -117,8 +117,8 @@ fn given_same_strings_different_names_return_diff_multihash() {
     let str2: MyString = "simple string".into();
 
     assert_ne!(
-        field_digest::<_, MultihashSha256>(str1, "foo".into()),
-        field_digest::<_, MultihashSha256>(str2, "bar".into())
+        field_digest::<_, MultihashSha256>(&str1, "foo".into()),
+        field_digest::<_, MultihashSha256>(&str2, "bar".into())
     )
 }
 
@@ -128,8 +128,8 @@ fn given_different_strings_return_different_multihash() {
     let str2: MyString = "longer string".into();
 
     assert_ne!(
-        field_digest::<_, MultihashSha256>(str1, "foo".into()),
-        field_digest::<_, MultihashSha256>(str2, "foo".into())
+        field_digest::<_, MultihashSha256>(&str1, "foo".into()),
+        field_digest::<_, MultihashSha256>(&str2, "foo".into())
     )
 }
 


### PR DESCRIPTION
Saves having a clone every time `digest` is called.