### PR TITLE
Add the new database model

### DIFF
--- a/cnd/migrations/2020-05-06-105000_created-swap-tables/down.sql
+++ b/cnd/migrations/2020-05-06-105000_created-swap-tables/down.sql
@@ -1,0 +1,8 @@
+-- This file should undo anything in `up.sql`
+
+DROP TABLE swaps;
+DROP TABLE address_hints;
+DROP TABLE shared_swap_ids;
+DROP TABLE secret_hashes;
+DROP TABLE halights;
+DROP TABLE herc20s;

--- a/cnd/migrations/2020-05-06-105000_created-swap-tables/up.sql
+++ b/cnd/migrations/2020-05-06-105000_created-swap-tables/up.sql
@@ -1,0 +1,62 @@
+-- Your SQL goes here
+
+CREATE TABLE swaps
+(
+    id INTEGER			NOT NULL PRIMARY KEY,
+    local_swap_id UNIQUE	NOT NULL,
+    role			NOT NULL,
+    counterparty_peer_id	NOT NULL
+);
+
+CREATE TABLE secret_hashes
+(
+    id INTEGER			NOT NULL PRIMARY KEY,
+    swap_id INTEGER		NOT NULL,
+    secret_hash			NOT NULL,
+    FOREIGN KEY (swap_id)	REFERENCES swaps(id)
+);
+
+CREATE TABLE shared_swap_ids
+(
+    id INTEGER			NOT NULL PRIMARY KEY,
+    swap_id INTEGER		NOT NULL,
+    shared_swap_id		NOT NULL,
+    FOREIGN KEY (swap_id)	REFERENCES swaps(id)
+);
+
+CREATE TABLE address_hints
+(
+    id INTEGER			NOT NULL PRIMARY KEY,
+    peer_id UNIQUE		NOT NULL,
+    address_hint		NOT NULL,
+);
+
+CREATE TABLE herc20s
+(
+    id INTEGER			NOT NULL PRIMARY KEY,
+    swap_id INTEGER		NOT NULL,
+    amount			NOT NULL,
+    chain_id			NOT NULL,
+    expiry			NOT NULL,
+    hash_function		NOT NULL,
+    token_contract		NOT NULL,
+    redeem_identity,
+    refund_identity,
+    ledger			NOT NULL CHECK (ledger IN ('alpha', 'beta')),
+    FOREIGN KEY(swap_id)	REFERENCES swaps(id)
+);
+
+CREATE TABLE halights
+(
+    id INTEGER			NOT NULL PRIMARY KEY,
+    swap_id INTEGER		NOT NULL,
+    amount			NOT NULL,
+    network			NOT NULL,
+    chain			NOT NULL,
+    cltv_expiry			NOT NULL,
+    hash_function		NOT NULL,
+    redeem_identity,
+    refund_identity,
+    ledger			NOT NULL CHECK (ledger IN ('alpha', 'beta')),
+    FOREIGN KEY(swap_id)	REFERENCES swaps(id)
+);

--- a/cnd/src/db/load.rs
+++ b/cnd/src/db/load.rs
@@ -1,0 +1,54 @@
+use crate::{
+    db::{CreatedSwap, InProgressSwap, Sqlite},
+    swap_protocols::{halight, han, herc20, LocalSwapId},
+};
+use async_trait::async_trait;
+
+/// Load data from the database.
+#[async_trait]
+pub trait Load<T>: Send + Sync + 'static {
+    async fn load(&self, swap_id: LocalSwapId) -> anyhow::Result<Option<T>>;
+}
+
+#[async_trait]
+impl Load<InProgressSwap<han::InProgressSwap, halight::InProgressSwap>> for Sqlite {
+    async fn load(
+        &self,
+        _: LocalSwapId,
+    ) -> anyhow::Result<Option<InProgressSwap<han::InProgressSwap, halight::InProgressSwap>>> {
+        // NOTE: When implementing this be sure to return Ok(None) if the
+        // communication protocols have not been finalized and the data saved.
+        unimplemented!()
+    }
+}
+
+#[async_trait]
+impl Load<InProgressSwap<herc20::InProgressSwap, halight::InProgressSwap>> for Sqlite {
+    async fn load(
+        &self,
+        _: LocalSwapId,
+    ) -> anyhow::Result<Option<InProgressSwap<herc20::InProgressSwap, halight::InProgressSwap>>>
+    {
+        unimplemented!()
+    }
+}
+
+#[async_trait]
+impl Load<CreatedSwap<han::CreatedSwap, halight::CreatedSwap>> for Sqlite {
+    async fn load(
+        &self,
+        _: LocalSwapId,
+    ) -> anyhow::Result<Option<CreatedSwap<han::CreatedSwap, halight::CreatedSwap>>> {
+        unimplemented!()
+    }
+}
+
+#[async_trait]
+impl Load<CreatedSwap<herc20::CreatedSwap, halight::CreatedSwap>> for Sqlite {
+    async fn load(
+        &self,
+        _: LocalSwapId,
+    ) -> anyhow::Result<Option<CreatedSwap<herc20::CreatedSwap, halight::CreatedSwap>>> {
+        unimplemented!()
+    }
+}

--- a/cnd/src/db/load_swaps.rs
+++ b/cnd/src/db/load_swaps.rs
@@ -1,7 +1,7 @@
 use crate::{
     asset,
     db::{
-        schema,
+        rfc003_schema,
         wrapper_types::{
             custom_sql_types::{Text, U32},
             BitcoinNetwork, Erc20Amount, Ether, EthereumAddress, Satoshis,
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 use chrono::NaiveDateTime;
 use diesel::{self, prelude::*, RunQueryDsl};
 use impl_template::impl_template;
-use schema::{
+use rfc003_schema::{
     rfc003_bitcoin_ethereum_accept_messages,
     rfc003_bitcoin_ethereum_bitcoin_erc20_request_messages,
     rfc003_bitcoin_ethereum_bitcoin_ether_request_messages,
@@ -148,7 +148,7 @@ impl
             identity::Ethereum,
         >,
     > {
-        use schema::{
+        use rfc003_schema::{
             rfc003_bitcoin_ethereum_accept_messages as accept_messages,
             rfc003_bitcoin_ethereum_bitcoin_ether_request_messages as request_messages,
         };
@@ -271,7 +271,7 @@ impl
             identity::Bitcoin,
         >,
     > {
-        use schema::{
+        use rfc003_schema::{
             rfc003_ethereum_bitcoin_accept_messages as accept_messages,
             rfc003_ethereum_bitcoin_ether_bitcoin_request_messages as request_messages,
         };
@@ -398,7 +398,7 @@ impl
             identity::Ethereum,
         >,
     > {
-        use schema::{
+        use rfc003_schema::{
             rfc003_bitcoin_ethereum_accept_messages as accept_messages,
             rfc003_bitcoin_ethereum_bitcoin_erc20_request_messages as request_messages,
         };
@@ -526,7 +526,7 @@ impl
             identity::Bitcoin,
         >,
     > {
-        use schema::{
+        use rfc003_schema::{
             rfc003_ethereum_bitcoin_accept_messages as accept_messages,
             rfc003_ethereum_bitcoin_erc20_bitcoin_request_messages as request_messages,
         };

--- a/cnd/src/db/rfc003_schema.rs
+++ b/cnd/src/db/rfc003_schema.rs
@@ -1,0 +1,106 @@
+table! {
+   rfc003_bitcoin_ethereum_bitcoin_ether_request_messages {
+       id -> Integer,
+       swap_id -> Text,
+       bitcoin_network -> Text,
+       ethereum_chain_id -> BigInt,
+       bitcoin_amount -> Text,
+       ether_amount -> Text,
+       hash_function -> Text,
+       bitcoin_refund_identity -> Text,
+       ethereum_redeem_identity -> Text,
+       bitcoin_expiry -> BigInt,
+       ethereum_expiry -> BigInt,
+       secret_hash -> Text,
+   }
+}
+
+table! {
+   rfc003_ethereum_bitcoin_ether_bitcoin_request_messages {
+       id -> Integer,
+       swap_id -> Text,
+       ethereum_chain_id -> BigInt,
+       bitcoin_network -> Text,
+       ether_amount -> Text,
+       bitcoin_amount -> Text,
+       hash_function -> Text,
+       ethereum_refund_identity -> Text,
+       bitcoin_redeem_identity -> Text,
+       ethereum_expiry -> BigInt,
+       bitcoin_expiry -> BigInt,
+       secret_hash -> Text,
+   }
+}
+
+table! {
+   rfc003_bitcoin_ethereum_bitcoin_erc20_request_messages {
+       id -> Integer,
+       swap_id -> Text,
+       bitcoin_network -> Text,
+       ethereum_chain_id -> BigInt,
+       bitcoin_amount -> Text,
+       erc20_amount -> Text,
+       erc20_token_contract -> Text,
+       hash_function -> Text,
+       bitcoin_refund_identity -> Text,
+       ethereum_redeem_identity -> Text,
+       bitcoin_expiry -> BigInt,
+       ethereum_expiry -> BigInt,
+       secret_hash -> Text,
+   }
+}
+
+table! {
+   rfc003_ethereum_bitcoin_erc20_bitcoin_request_messages {
+       id -> Integer,
+       swap_id -> Text,
+       ethereum_chain_id -> BigInt,
+       bitcoin_network -> Text,
+       erc20_amount -> Text,
+       erc20_token_contract -> Text,
+       bitcoin_amount -> Text,
+       hash_function -> Text,
+       ethereum_refund_identity -> Text,
+       bitcoin_redeem_identity -> Text,
+       ethereum_expiry -> BigInt,
+       bitcoin_expiry -> BigInt,
+       secret_hash -> Text,
+   }
+}
+
+table! {
+   rfc003_ethereum_bitcoin_accept_messages {
+       id -> Integer,
+       swap_id -> Text,
+       ethereum_redeem_identity -> Text,
+       bitcoin_refund_identity -> Text,
+       at -> Timestamp,
+   }
+}
+
+table! {
+   rfc003_bitcoin_ethereum_accept_messages {
+       id -> Integer,
+       swap_id -> Text,
+       bitcoin_redeem_identity -> Text,
+       ethereum_refund_identity -> Text,
+       at -> Timestamp,
+   }
+}
+
+table! {
+   rfc003_decline_messages {
+       id -> Integer,
+       swap_id -> Text,
+       reason -> Nullable<Text>,
+   }
+}
+
+table! {
+   rfc003_swaps {
+       id -> Integer,
+       swap_id -> Text,
+       role -> Text,
+       counterparty -> Text,
+   }
+}

--- a/cnd/src/db/schema.rs
+++ b/cnd/src/db/schema.rs
@@ -1,106 +1,65 @@
+// LocalSwapId and SharedSwapId are encoded as Text and named local_swap_id, and
+// shared_swap_id respectively.  swap_id (Integer) is always a foreign key link
+// to the `swaps` table.
 table! {
-   rfc003_bitcoin_ethereum_bitcoin_ether_request_messages {
+   swaps {
        id -> Integer,
-       swap_id -> Text,
-       bitcoin_network -> Text,
-       ethereum_chain_id -> BigInt,
-       bitcoin_amount -> Text,
-       ether_amount -> Text,
-       hash_function -> Text,
-       bitcoin_refund_identity -> Text,
-       ethereum_redeem_identity -> Text,
-       bitcoin_expiry -> BigInt,
-       ethereum_expiry -> BigInt,
-       secret_hash -> Text,
-   }
-}
-
-table! {
-   rfc003_ethereum_bitcoin_ether_bitcoin_request_messages {
-       id -> Integer,
-       swap_id -> Text,
-       ethereum_chain_id -> BigInt,
-       bitcoin_network -> Text,
-       ether_amount -> Text,
-       bitcoin_amount -> Text,
-       hash_function -> Text,
-       ethereum_refund_identity -> Text,
-       bitcoin_redeem_identity -> Text,
-       ethereum_expiry -> BigInt,
-       bitcoin_expiry -> BigInt,
-       secret_hash -> Text,
-   }
-}
-
-table! {
-   rfc003_bitcoin_ethereum_bitcoin_erc20_request_messages {
-       id -> Integer,
-       swap_id -> Text,
-       bitcoin_network -> Text,
-       ethereum_chain_id -> BigInt,
-       bitcoin_amount -> Text,
-       erc20_amount -> Text,
-       erc20_token_contract -> Text,
-       hash_function -> Text,
-       bitcoin_refund_identity -> Text,
-       ethereum_redeem_identity -> Text,
-       bitcoin_expiry -> BigInt,
-       ethereum_expiry -> BigInt,
-       secret_hash -> Text,
-   }
-}
-
-table! {
-   rfc003_ethereum_bitcoin_erc20_bitcoin_request_messages {
-       id -> Integer,
-       swap_id -> Text,
-       ethereum_chain_id -> BigInt,
-       bitcoin_network -> Text,
-       erc20_amount -> Text,
-       erc20_token_contract -> Text,
-       bitcoin_amount -> Text,
-       hash_function -> Text,
-       ethereum_refund_identity -> Text,
-       bitcoin_redeem_identity -> Text,
-       ethereum_expiry -> BigInt,
-       bitcoin_expiry -> BigInt,
-       secret_hash -> Text,
-   }
-}
-
-table! {
-   rfc003_ethereum_bitcoin_accept_messages {
-       id -> Integer,
-       swap_id -> Text,
-       ethereum_redeem_identity -> Text,
-       bitcoin_refund_identity -> Text,
-       at -> Timestamp,
-   }
-}
-
-table! {
-   rfc003_bitcoin_ethereum_accept_messages {
-       id -> Integer,
-       swap_id -> Text,
-       bitcoin_redeem_identity -> Text,
-       ethereum_refund_identity -> Text,
-       at -> Timestamp,
-   }
-}
-
-table! {
-   rfc003_decline_messages {
-       id -> Integer,
-       swap_id -> Text,
-       reason -> Nullable<Text>,
-   }
-}
-
-table! {
-   rfc003_swaps {
-       id -> Integer,
-       swap_id -> Text,
+       local_swap_id -> Text,
        role -> Text,
-       counterparty -> Text,
+       counterparty_peer_id -> Text,
+   }
+}
+
+table! {
+   secret_hashes {
+       id -> Integer,
+       swap_id -> Integer,
+       secret_hash -> Text,
+   }
+}
+
+table! {
+   shared_swap_ids {
+       id -> Integer,
+       swap_id -> Integer,
+       shared_swap_id -> Text,
+   }
+}
+
+table! {
+   address_hints {
+       id -> Integer,
+       peer_id -> Text,
+       address_hint -> Text,
+   }
+}
+
+table! {
+   herc20s {
+       id -> Integer,
+       swap_id -> Integer,
+       amount -> Text,
+       chain_id -> BigInt,
+       expiry -> BigInt,
+       hash_function -> Text,
+       token_contract -> Text,
+       redeem_identity -> Nullable<Text>,
+       refund_identity -> Nullable<Text>,
+       ledger -> Text,
+   }
+}
+
+table! {
+   halights {
+       id -> Integer,
+       swap_id -> Integer,
+       amount -> Text,
+       network -> Text,
+       chain -> Text,
+       cltv_expiry -> BigInt,
+       hash_function -> Text,
+       redeem_identity -> Nullable<Text>,
+       refund_identity -> Nullable<Text>,
+       ledger -> Text,
    }
 }

--- a/cnd/src/db/swap.rs
+++ b/cnd/src/db/swap.rs
@@ -1,5 +1,5 @@
 use crate::{
-    db::{schema, wrapper_types::custom_sql_types::Text, Error, Sqlite},
+    db::{rfc003_schema, wrapper_types::custom_sql_types::Text, Error, Sqlite},
     diesel::{ExpressionMethods, OptionalExtension, QueryDsl},
     swap_protocols::{rfc003::SwapId, Role},
 };
@@ -35,7 +35,7 @@ impl Swap {
 #[async_trait]
 impl Retrieve for Sqlite {
     async fn get(&self, key: &SwapId) -> anyhow::Result<Swap> {
-        use self::schema::rfc003_swaps::dsl::*;
+        use self::rfc003_schema::rfc003_swaps::dsl::*;
 
         let record: QueryableSwap = self
             .do_in_transaction(|connection| {
@@ -53,7 +53,7 @@ impl Retrieve for Sqlite {
     }
 
     async fn all(&self) -> anyhow::Result<Vec<Swap>> {
-        use self::schema::rfc003_swaps::dsl::*;
+        use self::rfc003_schema::rfc003_swaps::dsl::*;
 
         let records: Vec<QueryableSwap> = self
             .do_in_transaction(|connection| rfc003_swaps.load(&*connection))

--- a/cnd/src/db/swap_types.rs
+++ b/cnd/src/db/swap_types.rs
@@ -1,7 +1,7 @@
 use crate::{
     asset, comit_api,
     db::{
-        schema,
+        rfc003_schema,
         wrapper_types::{custom_sql_types::Text, BitcoinNetwork},
         Sqlite,
     },
@@ -24,7 +24,7 @@ pub trait DetermineTypes: Send + Sync + 'static {
 #[async_trait]
 impl DetermineTypes for Sqlite {
     async fn determine_types(&self, key: &SwapId) -> anyhow::Result<SwapTypes> {
-        let role = self.role(key).await?;
+        let role = self.rfc003_role(key).await?;
 
         if let Some(bitcoin_network) = self
             .rfc003_bitcoin_ethereum_bitcoin_ether_request_messages_has_swap(key)
@@ -86,7 +86,7 @@ macro_rules! impl_has_swap {
     ($table:ident) => {
         paste::item! {
             async fn [<$table _has_swap>](&self, key: &SwapId) -> anyhow::Result<Option<BitcoinNetwork>> {
-                use schema::$table as swaps;
+                use rfc003_schema::$table as swaps;
 
                 let record: Option<QueryableSwap> = self.do_in_transaction(|connection| {
                     let key = Text(key);

--- a/cnd/src/db/tables.rs
+++ b/cnd/src/db/tables.rs
@@ -1,0 +1,768 @@
+use crate::{
+    db::{
+        schema::{address_hints, halights, herc20s, secret_hashes, shared_swap_ids, swaps},
+        wrapper_types::{
+            custom_sql_types::{Text, U32},
+            BitcoinNetwork, Erc20Amount, EthereumAddress, Satoshis,
+        },
+        Error, Sqlite,
+    },
+    identity, lightning,
+    swap_protocols::{self, rfc003, HashFunction, LocalSwapId, Role},
+};
+use diesel::{self, prelude::*, RunQueryDsl};
+use libp2p::{Multiaddr, PeerId};
+
+#[derive(Identifiable, Queryable, PartialEq, Debug)]
+#[table_name = "swaps"]
+pub struct Swap {
+    id: i32,
+    local_swap_id: Text<LocalSwapId>,
+    role: Text<Role>,
+    counterparty_peer_id: Text<PeerId>,
+}
+
+impl From<Swap> for ISwap {
+    fn from(swap: Swap) -> Self {
+        ISwap {
+            local_swap_id: swap.local_swap_id,
+            role: swap.role,
+            counterparty_peer_id: swap.counterparty_peer_id,
+        }
+    }
+}
+
+#[derive(Insertable, Debug, Clone)]
+#[table_name = "swaps"]
+pub struct ISwap {
+    local_swap_id: Text<LocalSwapId>,
+    role: Text<Role>,
+    counterparty_peer_id: Text<PeerId>,
+}
+
+impl ISwap {
+    pub fn new(swap_id: LocalSwapId, counterparty: PeerId, role: Role) -> Self {
+        ISwap {
+            local_swap_id: Text(swap_id),
+            role: Text(role),
+            counterparty_peer_id: Text(counterparty),
+        }
+    }
+}
+
+#[derive(Associations, Clone, Copy, Debug, Identifiable, Queryable, PartialEq)]
+#[belongs_to(Swap)]
+#[table_name = "secret_hashes"]
+pub struct SecretHash {
+    id: i32,
+    swap_id: i32,
+    secret_hash: Text<rfc003::SecretHash>,
+}
+
+#[derive(Insertable, Debug, Clone, Copy)]
+#[table_name = "secret_hashes"]
+pub struct ISecretHash {
+    swap_id: i32,
+    secret_hash: Text<rfc003::SecretHash>,
+}
+
+#[derive(Clone, Debug, Identifiable, Queryable, PartialEq)]
+#[table_name = "address_hints"]
+pub struct AddressHint {
+    id: i32,
+    peer_id: Text<PeerId>,
+    address_hint: Text<Multiaddr>,
+}
+
+#[derive(Insertable, Debug, Clone)]
+#[table_name = "address_hints"]
+pub struct IAddressHint {
+    peer_id: Text<PeerId>,
+    address_hint: Text<Multiaddr>,
+}
+
+#[derive(Associations, Clone, Copy, Debug, Identifiable, Queryable, PartialEq)]
+#[belongs_to(Swap)]
+#[table_name = "shared_swap_ids"]
+pub struct SharedSwapId {
+    id: i32,
+    swap_id: i32,
+    shared_swap_id: Text<swap_protocols::SharedSwapId>,
+}
+
+#[derive(Insertable, Debug, Clone, Copy)]
+#[table_name = "shared_swap_ids"]
+pub struct ISharedSwapId {
+    swap_id: i32,
+    shared_swap_id: Text<swap_protocols::SharedSwapId>,
+}
+
+#[derive(Associations, Clone, Debug, Identifiable, Queryable, PartialEq)]
+#[belongs_to(Swap)]
+#[table_name = "herc20s"]
+pub struct Herc20 {
+    id: i32,
+    swap_id: i32,
+    amount: Text<Erc20Amount>,
+    chain_id: U32,
+    expiry: U32,
+    hash_function: Text<HashFunction>,
+    token_contract: Text<EthereumAddress>,
+    redeem_identity: Option<Text<EthereumAddress>>,
+    refund_identity: Option<Text<EthereumAddress>>,
+    ledger: String,
+}
+
+#[derive(Insertable, Debug, Clone)]
+#[table_name = "herc20s"]
+pub struct IHerc20 {
+    pub swap_id: i32,
+    pub amount: Text<Erc20Amount>,
+    pub chain_id: U32,
+    pub expiry: U32,
+    pub hash_function: Text<HashFunction>,
+    pub token_contract: Text<EthereumAddress>,
+    pub redeem_identity: Option<Text<EthereumAddress>>,
+    pub refund_identity: Option<Text<EthereumAddress>>,
+    pub ledger: String,
+}
+
+impl IHerc20 {
+    pub fn with_swap_id(&self, swap_id: i32) -> Self {
+        IHerc20 {
+            swap_id,
+            amount: self.amount.clone(),
+            chain_id: self.chain_id,
+            expiry: self.expiry,
+            hash_function: self.hash_function,
+            token_contract: self.token_contract,
+            redeem_identity: self.redeem_identity,
+            refund_identity: self.refund_identity,
+            ledger: self.ledger.clone(),
+        }
+    }
+}
+
+#[derive(Associations, Clone, Debug, Identifiable, Queryable, PartialEq)]
+#[belongs_to(Swap)]
+#[table_name = "halights"]
+pub struct Halight {
+    id: i32,
+    swap_id: i32,
+    amount: Text<Satoshis>,
+    network: Text<BitcoinNetwork>,
+    chain: String,
+    cltv_expiry: U32,
+    hash_function: Text<HashFunction>,
+    redeem_identity: Option<Text<lightning::PublicKey>>,
+    refund_identity: Option<Text<lightning::PublicKey>>,
+    ledger: String,
+}
+
+#[derive(Insertable, Debug, Clone)]
+#[table_name = "halights"]
+pub struct IHalight {
+    pub swap_id: i32,
+    pub amount: Text<Satoshis>,
+    pub network: Text<BitcoinNetwork>,
+    pub chain: String,
+    pub cltv_expiry: U32,
+    pub hash_function: Text<HashFunction>,
+    pub redeem_identity: Option<Text<lightning::PublicKey>>,
+    pub refund_identity: Option<Text<lightning::PublicKey>>,
+    pub ledger: String,
+}
+
+impl IHalight {
+    pub fn with_swap_id(&self, swap_id: i32) -> Self {
+        IHalight {
+            swap_id,
+            amount: self.amount,
+            network: self.network,
+            chain: self.chain.clone(),
+            cltv_expiry: self.cltv_expiry,
+            hash_function: self.hash_function,
+            redeem_identity: self.redeem_identity,
+            refund_identity: self.refund_identity,
+            ledger: self.ledger.clone(),
+        }
+    }
+}
+
+impl Sqlite {
+    pub async fn role(&self, swap_id: LocalSwapId) -> anyhow::Result<Role> {
+        let swap = self.load_swap(swap_id).await?;
+        Ok(swap.role.0)
+    }
+
+    pub async fn save_swap(&self, insertable: &ISwap) -> anyhow::Result<()> {
+        self.do_in_transaction(|connection| {
+            diesel::insert_into(swaps::dsl::swaps)
+                .values(insertable)
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn load_swap(&self, swap_id: LocalSwapId) -> anyhow::Result<Swap> {
+        let record: Swap = self
+            .do_in_transaction(|connection| {
+                let key = Text(swap_id);
+
+                swaps::table
+                    .filter(swaps::local_swap_id.eq(key))
+                    .first(connection)
+                    .optional()
+            })
+            .await?
+            .ok_or(Error::SwapNotFound)?;
+
+        Ok(record)
+    }
+
+    pub async fn save_secret_hash(
+        &self,
+        swap_id: LocalSwapId,
+        secret_hash: rfc003::SecretHash,
+    ) -> anyhow::Result<()> {
+        self.do_in_transaction(|connection| {
+            let key = Text(swap_id);
+
+            let swap: Swap = swaps::table
+                .filter(swaps::local_swap_id.eq(key))
+                .first(connection)?;
+
+            let insertable = ISecretHash {
+                swap_id: swap.id,
+                secret_hash: Text(secret_hash),
+            };
+
+            diesel::insert_into(secret_hashes::dsl::secret_hashes)
+                .values(insertable)
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn load_secret_hash(
+        &self,
+        swap_id: LocalSwapId,
+    ) -> anyhow::Result<rfc003::SecretHash> {
+        let record: SecretHash = self
+            .do_in_transaction(|connection| {
+                let key = Text(swap_id);
+
+                let swap: Swap = swaps::table
+                    .filter(swaps::local_swap_id.eq(key))
+                    .first(connection)?;
+
+                SecretHash::belonging_to(&swap).first(connection).optional()
+            })
+            .await?
+            .ok_or(Error::SwapNotFound)?;
+
+        Ok(record.secret_hash.0)
+    }
+
+    pub async fn save_shared_swap_id(
+        &self,
+        swap_id: LocalSwapId,
+        shared_swap_id: swap_protocols::SharedSwapId,
+    ) -> anyhow::Result<()> {
+        self.do_in_transaction(|connection| {
+            let key = Text(swap_id);
+
+            let swap: Swap = swaps::table
+                .filter(swaps::local_swap_id.eq(key))
+                .first(connection)?;
+
+            let insertable = ISharedSwapId {
+                swap_id: swap.id,
+                shared_swap_id: Text(shared_swap_id),
+            };
+
+            diesel::insert_into(shared_swap_ids::dsl::shared_swap_ids)
+                .values(insertable)
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn load_shared_swap_id(
+        &self,
+        swap_id: LocalSwapId,
+    ) -> anyhow::Result<swap_protocols::SharedSwapId> {
+        let record: SharedSwapId = self
+            .do_in_transaction(|connection| {
+                let key = Text(swap_id);
+
+                let swap: Swap = swaps::table
+                    .filter(swaps::local_swap_id.eq(key))
+                    .first(connection)?;
+
+                SharedSwapId::belonging_to(&swap)
+                    .first(connection)
+                    .optional()
+            })
+            .await?
+            .ok_or(Error::SwapNotFound)?;
+
+        Ok(record.shared_swap_id.0)
+    }
+
+    /// This function is called depending on ones role and which side of the
+    /// swap halight is on.
+    /// - Called by Alice when halight is the alpha protocol.
+    /// - Called by Bob when when halight is the beta protocol.
+    pub async fn save_counterparty_halight_redeem_identity(
+        &self,
+        swap_id: LocalSwapId,
+        identity: identity::Lightning,
+    ) -> anyhow::Result<()> {
+        use crate::db::schema::halights::columns::redeem_identity;
+
+        self.do_in_transaction(|connection| {
+            let key = Text(swap_id);
+
+            let swap: Swap = swaps::table
+                .filter(swaps::local_swap_id.eq(key))
+                .first(connection)?;
+
+            diesel::update(halights::dsl::halights.filter(halights::swap_id.eq(swap.id)))
+                .set(redeem_identity.eq(Text(identity)))
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    /// This function is called depending on ones role and which side of the
+    /// swap halight is on.
+    /// - Called by Alice when halight is the beta protocol.
+    /// - Called by Bob when when halight is the alpha protocol.
+    pub async fn save_counterparty_halight_refund_identity(
+        &self,
+        swap_id: LocalSwapId,
+        identity: identity::Lightning,
+    ) -> anyhow::Result<()> {
+        use crate::db::schema::halights::columns::refund_identity;
+
+        self.do_in_transaction(|connection| {
+            let key = Text(swap_id);
+
+            let swap: Swap = swaps::table
+                .filter(swaps::local_swap_id.eq(key))
+                .first(connection)?;
+
+            diesel::update(halights::dsl::halights.filter(halights::swap_id.eq(swap.id)))
+                .set(refund_identity.eq(Text(identity)))
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    /// This function is called depending on ones role and which side of the
+    /// swap herc20 is on.
+    /// - Called by Alice when herc20 is the alpha protocol.
+    /// - Called by Bob when when herc20 is the beta protocol.
+    pub async fn save_counterparty_herc20_redeem_identity(
+        &self,
+        _swap_id_: LocalSwapId,
+        _identity: identity::Ethereum,
+    ) -> anyhow::Result<()> {
+        unimplemented!()
+    }
+
+    /// This function is called depending on ones role and which side of the
+    /// swap herc20 is on.
+    /// - Called by Alice when herc20 is the beta protocol.
+    /// - Called by Bob when when herc20 is the alpha protocol.
+    pub async fn save_counterparty_herc20_refund_identity(
+        &self,
+        _swap_id: LocalSwapId,
+        _identity: identity::Ethereum,
+    ) -> anyhow::Result<()> {
+        unimplemented!()
+    }
+
+    pub async fn save_address_hint(
+        &self,
+        peer_id: PeerId,
+        address_hint: &libp2p::Multiaddr,
+    ) -> anyhow::Result<()> {
+        self.do_in_transaction(|connection| {
+            let insertable = IAddressHint {
+                peer_id: Text(peer_id.clone()),
+                address_hint: Text(address_hint.clone()),
+            };
+
+            diesel::insert_into(address_hints::dsl::address_hints)
+                .values(insertable)
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn load_address_hint(&self, peer_id: &PeerId) -> anyhow::Result<libp2p::Multiaddr> {
+        let record: AddressHint = self
+            .do_in_transaction(|connection| {
+                let key = Text(peer_id);
+
+                address_hints::table
+                    .filter(address_hints::peer_id.eq(key))
+                    .first(connection)
+                    .optional()
+            })
+            .await?
+            .ok_or(Error::PeerIdNotFound)?;
+
+        Ok(record.address_hint.0)
+    }
+
+    pub(crate) async fn save_herc20_swap_detail(
+        &self,
+        swap_id: LocalSwapId,
+        data: &IHerc20,
+    ) -> anyhow::Result<()> {
+        self.do_in_transaction(|connection| {
+            let key = Text(swap_id);
+
+            let swap: Swap = swaps::table
+                .filter(swaps::local_swap_id.eq(key))
+                .first(connection)?;
+
+            let insertable = data.with_swap_id(swap.id);
+
+            diesel::insert_into(herc20s::dsl::herc20s)
+                .values(insertable)
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn load_herc20_swap_detail(&self, swap_id: LocalSwapId) -> anyhow::Result<Herc20> {
+        let record: Herc20 = self
+            .do_in_transaction(|connection| {
+                let key = Text(swap_id);
+
+                let swap: Swap = swaps::table
+                    .filter(swaps::local_swap_id.eq(key))
+                    .first(connection)?;
+
+                Herc20::belonging_to(&swap).first(connection).optional()
+            })
+            .await?
+            .ok_or(Error::SwapNotFound)?;
+
+        Ok(record)
+    }
+
+    pub async fn save_halight_swap_detail(
+        &self,
+        swap_id: LocalSwapId,
+        data: &IHalight,
+    ) -> anyhow::Result<()> {
+        self.do_in_transaction(|connection| {
+            let key = Text(swap_id);
+
+            let swap: Swap = swaps::table
+                .filter(swaps::local_swap_id.eq(key))
+                .first(connection)?;
+
+            let insertable = data.with_swap_id(swap.id);
+
+            diesel::insert_into(halights::dsl::halights)
+                .values(insertable)
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn load_halight_swap_detail(&self, swap_id: LocalSwapId) -> anyhow::Result<Halight> {
+        let record: Halight = self
+            .do_in_transaction(|connection| {
+                let key = Text(swap_id);
+
+                let swap: Swap = swaps::table
+                    .filter(swaps::local_swap_id.eq(key))
+                    .first(connection)?;
+
+                Halight::belonging_to(&swap).first(connection).optional()
+            })
+            .await?
+            .ok_or(Error::SwapNotFound)?;
+
+        Ok(record)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lightning;
+    use std::{path::PathBuf, str::FromStr};
+
+    fn temp_db() -> PathBuf {
+        let temp_file = tempfile::Builder::new()
+            .suffix(".sqlite")
+            .tempfile()
+            .unwrap();
+
+        temp_file.into_temp_path().to_path_buf()
+    }
+
+    fn insertable_swap() -> ISwap {
+        let swap_id =
+            LocalSwapId::from_str("ad2652ca-ecf2-4cc6-b35c-b4351ac28a34").expect("valid swap id");
+        let role = Role::Alice;
+        let peer_id = PeerId::from_str("QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY")
+            .expect("valid peer id");
+
+        ISwap {
+            local_swap_id: Text(swap_id),
+            role: Text(role),
+            counterparty_peer_id: Text(peer_id),
+        }
+    }
+
+    impl PartialEq<ISwap> for Swap {
+        fn eq(&self, other: &ISwap) -> bool {
+            self.local_swap_id == other.local_swap_id
+                && self.role == other.role
+                && self.counterparty_peer_id == other.counterparty_peer_id
+        }
+    }
+
+    impl PartialEq<IHerc20> for Herc20 {
+        fn eq(&self, other: &IHerc20) -> bool {
+            self.amount == other.amount
+                && self.chain_id == other.chain_id
+                && self.expiry == other.expiry
+                && self.hash_function == other.hash_function
+                && self.token_contract == other.token_contract
+                && self.redeem_identity == other.redeem_identity
+                && self.refund_identity == other.refund_identity
+                && self.ledger == other.ledger
+        }
+    }
+
+    impl PartialEq<IHalight> for Halight {
+        fn eq(&self, other: &IHalight) -> bool {
+            self.amount == other.amount
+                && self.network == other.network
+                && self.chain == other.chain
+                && self.cltv_expiry == other.cltv_expiry
+                && self.hash_function == other.hash_function
+                && self.redeem_identity == other.redeem_identity
+                && self.refund_identity == other.refund_identity
+                && self.ledger == other.ledger
+        }
+    }
+
+    #[tokio::test]
+    async fn roundtrip_swap() {
+        let path = temp_db();
+        let db = Sqlite::new(&path).expect("a new db");
+
+        let given = insertable_swap();
+        let swap_id = given.local_swap_id.0;
+
+        db.save_swap(&given)
+            .await
+            .expect("to be able to save a swap");
+
+        let loaded = db
+            .load_swap(swap_id)
+            .await
+            .expect("to be able to load a previously saved swap");
+
+        assert_eq!(loaded, given)
+    }
+
+    #[tokio::test]
+    async fn roundtrip_secret_hash() {
+        let path = temp_db();
+        let db = Sqlite::new(&path).expect("a new db");
+
+        let swap = insertable_swap();
+        let swap_id = swap.local_swap_id.0;
+
+        db.save_swap(&swap)
+            .await
+            .expect("to be able to save a swap");
+
+        let secret_hash = rfc003::SecretHash::from_str(
+            "bfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbf\
+             bfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbf",
+        )
+        .expect("valid secret hash");
+
+        db.save_secret_hash(swap_id, secret_hash)
+            .await
+            .expect("to be able to save secret hash");
+
+        let loaded = db
+            .load_secret_hash(swap_id)
+            .await
+            .expect("to be able to load a previously saved secret hash");
+
+        assert_eq!(loaded, secret_hash)
+    }
+
+    #[tokio::test]
+    async fn roundtrip_shared_swap_id() {
+        let path = temp_db();
+        let db = Sqlite::new(&path).expect("a new db");
+
+        let swap = insertable_swap();
+        let swap_id = swap.local_swap_id.0;
+
+        db.save_swap(&swap)
+            .await
+            .expect("to be able to save a swap");
+
+        let shared_swap_id =
+            swap_protocols::SharedSwapId::from_str("ad9999ca-ecf2-4cc6-b35c-b4351ac28a34")
+                .expect("valid swap id");
+
+        db.save_shared_swap_id(swap_id, shared_swap_id)
+            .await
+            .expect("to be able to save swap id");
+
+        let loaded = db
+            .load_shared_swap_id(swap_id)
+            .await
+            .expect("to be able to load a previously saved swap id");
+
+        assert_eq!(loaded, shared_swap_id)
+    }
+
+    #[tokio::test]
+    async fn roundtrip_address_hint() {
+        let path = temp_db();
+        let db = Sqlite::new(&path).expect("a new db");
+
+        let swap = insertable_swap();
+
+        db.save_swap(&swap)
+            .await
+            .expect("to be able to save a swap");
+
+        let peer_id = PeerId::from_str("QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY")
+            .expect("valid peer id");
+        let multi_addr = "/ip4/80.123.90.4/tcp/5432";
+        let address_hint: Multiaddr = multi_addr.parse().expect("valid multiaddress");
+
+        db.save_address_hint(peer_id.clone(), &address_hint)
+            .await
+            .expect("to be able to save address hint");
+
+        let loaded = db
+            .load_address_hint(&peer_id)
+            .await
+            .expect("to be able to load a previously saved address hint");
+
+        assert_eq!(loaded, address_hint)
+    }
+
+    #[tokio::test]
+    async fn roundtrip_herc20s() {
+        let path = temp_db();
+        let db = Sqlite::new(&path).expect("a new db");
+
+        let swap = insertable_swap();
+        let swap_id = swap.local_swap_id.0;
+
+        db.save_swap(&swap)
+            .await
+            .expect("to be able to save a swap");
+
+        let amount = Erc20Amount::from_str("12345").expect("valid ERC20 amount");
+        let ethereum_identity =
+            EthereumAddress::from_str("1111e8be41b21f651a71aaB1A85c6813b8bBcCf8")
+                .expect("valid etherum identity");
+        let redeem_identity = EthereumAddress::from_str("2222e8be41b21f651a71aaB1A85c6813b8bBcCf8")
+            .expect("valid redeem identity");
+        let refund_identity = EthereumAddress::from_str("3333e8be41b21f651a71aaB1A85c6813b8bBcCf8")
+            .expect("valid refund identity");
+
+        let given = IHerc20 {
+            swap_id: 0, // This is set when saving.
+            amount: Text(amount),
+            chain_id: U32(1337),
+            expiry: U32(123),
+            hash_function: Text(HashFunction::Sha256),
+            token_contract: Text(ethereum_identity),
+            redeem_identity: Some(Text(redeem_identity)),
+            refund_identity: Some(Text(refund_identity)),
+            ledger: "alpha".to_string(),
+        };
+
+        db.save_herc20_swap_detail(swap_id, &given)
+            .await
+            .expect("to be able to save swap details");
+
+        let loaded = db
+            .load_herc20_swap_detail(swap_id)
+            .await
+            .expect("to be able to load a previously saved swap details");
+
+        assert_eq!(loaded, given)
+    }
+
+    #[tokio::test]
+    async fn roundtrip_halights() {
+        let path = temp_db();
+        let db = Sqlite::new(&path).expect("a new db");
+
+        let swap = insertable_swap();
+        let swap_id = swap.local_swap_id.0;
+
+        db.save_swap(&swap)
+            .await
+            .expect("to be able to save a swap");
+
+        let amount = Satoshis::from_str("12345").expect("valid ERC20 amount");
+
+        let redeem_identity = lightning::PublicKey::random();
+        let refund_identity = lightning::PublicKey::random();
+
+        let given = IHalight {
+            swap_id: 0, // This is set when saving.
+            amount: Text(amount),
+            network: Text(BitcoinNetwork::Testnet),
+            chain: "bitcoin".to_string(),
+            cltv_expiry: U32(456),
+            hash_function: Text(HashFunction::Sha256),
+            redeem_identity: Some(Text(redeem_identity)),
+            refund_identity: Some(Text(refund_identity)),
+            ledger: "beta".to_string(),
+        };
+
+        db.save_halight_swap_detail(swap_id, &given)
+            .await
+            .expect("to be able to save swap details");
+
+        let loaded = db
+            .load_halight_swap_detail(swap_id)
+            .await
+            .expect("to be able to load a previously saved swap details");
+
+        assert_eq!(loaded, given)
+    }
+}

--- a/cnd/src/http_api/route_factory.rs
+++ b/cnd/src/http_api/route_factory.rs
@@ -133,12 +133,12 @@ pub fn create(
         .and(facade.clone())
         .and_then(http_api::routes::index::post_halight_bitcoin_herc20);
 
-    let get_halight_swap = swaps
+    let get_han_halight_swap = swaps
         .and(warp::get())
         .and(warp::path::param())
         .and(warp::path::end())
         .and(facade.clone())
-        .and_then(http_api::routes::get_halight_swap);
+        .and_then(http_api::routes::get_han_halight_swap);
 
     let lightning_action_init = swaps
         .and(warp::get())
@@ -184,7 +184,7 @@ pub fn create(
         .or(herc20_halight_bitcoin)
         .or(halight_bitcoin_han_ether)
         .or(halight_bitcoin_herc20)
-        .or(get_halight_swap)
+        .or(get_han_halight_swap)
         .or(lightning_action_init)
         .or(lightning_action_fund)
         .or(lightning_action_redeem)

--- a/cnd/src/http_api/routes/index.rs
+++ b/cnd/src/http_api/routes/index.rs
@@ -1,6 +1,6 @@
 use crate::{
     asset,
-    db::CreatedSwap,
+    db::{CreatedSwap, Save},
     http_api::{problem, routes::into_rejection, Http},
     identity,
     network::{DialInformation, ListenAddresses},
@@ -61,7 +61,10 @@ pub async fn get_info_siren(
 pub async fn post_han_ethereum_halight_bitcoin(
     body: serde_json::Value,
     facade: Facade,
-) -> Result<impl Reply, Rejection> {
+) -> Result<impl Reply, Rejection>
+where
+    Facade: Save<CreatedSwap<han::CreatedSwap, halight::CreatedSwap>>,
+{
     let body = Body::<HanEthereumEther, HalightLightningBitcoin>::deserialize(&body)
         .map_err(anyhow::Error::new)
         .map_err(problem::from_anyhow)
@@ -77,6 +80,7 @@ pub async fn post_han_ethereum_halight_bitcoin(
         alpha: body.alpha.into(),
         beta: body.beta.into(),
         peer: body.peer.peer_id,
+        address_hint: body.peer.address_hint,
         role: body.role.0,
     };
 
@@ -227,6 +231,6 @@ pub struct Herc20EthereumErc20 {
     pub amount: asset::Erc20Quantity,
     pub identity: identity::Ethereum,
     pub chain_id: u32,
-    pub contract_address: identity::Ethereum,
+    pub token_contract: identity::Ethereum,
     pub absolute_expiry: u32,
 }

--- a/cnd/src/lightning.rs
+++ b/cnd/src/lightning.rs
@@ -46,6 +46,12 @@ impl PublicKey {
     }
 }
 
+impl fmt::Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 impl From<secp256k1::PublicKey> for PublicKey {
     fn from(key: secp256k1::PublicKey) -> Self {
         Self(bitcoin::PublicKey {

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -168,7 +168,7 @@ fn main() -> anyhow::Result<()> {
         swap_communication_states,
         swap_error_states,
         seed,
-        db: database,
+        db: database.clone(),
         swarm: swarm.clone(),
     };
 
@@ -177,6 +177,7 @@ fn main() -> anyhow::Result<()> {
         swarm: swarm.clone(),
         alpha_ledger_states: Arc::clone(&alpha_ledger_states),
         beta_ledger_states: Arc::clone(&halight_states),
+        db: database,
     };
 
     let http_api_listener = runtime.block_on(bind_http_api_socket(&settings))?;

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -142,23 +142,6 @@ impl Swarm {
 
         guard.initiate_communication(id, swap_params)
     }
-
-    pub async fn get_finalized_swap(&self, id: LocalSwapId) -> Option<comit_ln::FinalizedSwap> {
-        let mut guard = self.inner.lock().await;
-        guard.get_finalized_swap(id)
-    }
-
-    pub async fn get_created_swap(
-        &self,
-        id: LocalSwapId,
-    ) -> Option<HanEtherereumHalightBitcoinCreateSwapParams> {
-        let mut guard = self.inner.lock().await;
-        guard.get_created_swap(id)
-    }
-
-    // On Bob's side, when an announce message is received execute the required
-    // communication protocols and write the finalized swap to the database.  Then
-    // spawn the same as is done for Alice.
 }
 
 struct TokioExecutor {
@@ -343,17 +326,6 @@ impl ComitNode {
     ) -> anyhow::Result<()> {
         self.supports_halight()?;
         self.comit_ln.initiate_communication(id, swap_params)
-    }
-
-    pub fn get_finalized_swap(&mut self, id: LocalSwapId) -> Option<comit_ln::FinalizedSwap> {
-        self.comit_ln.get_finalized_swap(id)
-    }
-
-    pub fn get_created_swap(
-        &mut self,
-        id: LocalSwapId,
-    ) -> Option<HanEtherereumHalightBitcoinCreateSwapParams> {
-        self.comit_ln.get_created_swap(&id)
     }
 
     fn supports_halight(&self) -> anyhow::Result<()> {

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -1,5 +1,5 @@
 use crate::{
-    asset, identity,
+    identity,
     network::{
         oneshot_behaviour,
         protocols::{
@@ -10,13 +10,11 @@ use crate::{
     },
     seed::{DeriveSwapSeed, RootSeed},
     swap_protocols::{
-        ledger::{ethereum::ChainId, lightning, Ethereum},
-        rfc003::{create_swap::HtlcParams, DeriveSecret, Secret, SecretHash},
+        rfc003::{DeriveSecret, SecretHash},
         HanEtherereumHalightBitcoinCreateSwapParams, LocalSwapId, Role, SharedSwapId,
     },
     timestamp::Timestamp,
 };
-use blockchain_contracts::ethereum::rfc003::ether_htlc::EtherHtlc;
 use digest::Digest;
 use futures::AsyncWriteExt;
 use libp2p::{
@@ -139,74 +137,6 @@ impl ComitLN {
         Ok(())
     }
 
-    pub fn get_created_swap(
-        &self,
-        swap_id: &LocalSwapId,
-    ) -> Option<HanEtherereumHalightBitcoinCreateSwapParams> {
-        self.swaps.get_created_swap(swap_id)
-    }
-
-    pub fn get_finalized_swap(&self, swap_id: LocalSwapId) -> Option<FinalizedSwap> {
-        let (id, create_swap_params) = match self.swaps.get_announced_swap(&swap_id) {
-            Some(swap) => swap,
-            None => return None,
-        };
-
-        let secret = match create_swap_params.role {
-            Role::Alice => Some(self.seed.derive_swap_seed(swap_id).derive_secret()),
-            Role::Bob => None,
-        };
-
-        let alpha_ledger_redeem_identity = match create_swap_params.role {
-            Role::Alice => match self.ethereum_identities.get(&id).copied() {
-                Some(identity) => identity,
-                None => return None,
-            },
-            Role::Bob => create_swap_params.ethereum_identity.into(),
-        };
-        let alpha_ledger_refund_identity = match create_swap_params.role {
-            Role::Alice => create_swap_params.ethereum_identity.into(),
-            Role::Bob => match self.ethereum_identities.get(&id).copied() {
-                Some(identity) => identity,
-                None => return None,
-            },
-        };
-        let beta_ledger_redeem_identity = match create_swap_params.role {
-            Role::Alice => create_swap_params.lightning_identity,
-            Role::Bob => match self.lightning_identities.get(&id).copied() {
-                Some(identity) => identity,
-                None => return None,
-            },
-        };
-        let beta_ledger_refund_identity = match create_swap_params.role {
-            Role::Alice => match self.lightning_identities.get(&id).copied() {
-                Some(identity) => identity,
-                None => return None,
-            },
-            Role::Bob => create_swap_params.lightning_identity,
-        };
-
-        Some(FinalizedSwap {
-            alpha_ledger: Ethereum::new(ChainId::regtest()),
-            beta_ledger: lightning::Regtest,
-            alpha_asset: create_swap_params.ethereum_amount.clone(),
-            beta_asset: create_swap_params.lightning_amount,
-            alpha_ledger_redeem_identity,
-            alpha_ledger_refund_identity,
-            beta_ledger_redeem_identity,
-            beta_ledger_refund_identity,
-            alpha_expiry: create_swap_params.ethereum_absolute_expiry,
-            beta_expiry: create_swap_params.lightning_cltv_expiry,
-            swap_id,
-            secret,
-            secret_hash: match self.secret_hashes.get(&id).copied() {
-                Some(secret_hash) => secret_hash,
-                None => return None,
-            },
-            role: create_swap_params.role,
-        })
-    }
-
     /// Once confirmation is received, exchange the information to then finalize
     fn alice_communicate(
         &mut self,
@@ -307,38 +237,6 @@ impl fmt::Display for SwapExists {
         // This impl is required to build but want to use a static string for
         // this when returning it via the REST API.
         write!(f, "")
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct FinalizedSwap {
-    pub alpha_ledger: Ethereum,
-    pub beta_ledger: lightning::Regtest,
-    pub alpha_asset: asset::Ether,
-    pub beta_asset: asset::Bitcoin,
-    pub alpha_ledger_refund_identity: identity::Ethereum,
-    pub alpha_ledger_redeem_identity: identity::Ethereum,
-    pub beta_ledger_refund_identity: identity::Lightning,
-    pub beta_ledger_redeem_identity: identity::Lightning,
-    pub alpha_expiry: Timestamp,
-    pub beta_expiry: Timestamp,
-    pub swap_id: LocalSwapId,
-    pub secret_hash: SecretHash,
-    pub secret: Option<Secret>,
-    pub role: Role,
-}
-
-impl FinalizedSwap {
-    pub fn han_params(&self) -> EtherHtlc {
-        HtlcParams {
-            asset: self.alpha_asset.clone(),
-            ledger: Ethereum::new(ChainId::regtest()),
-            redeem_identity: self.alpha_ledger_redeem_identity,
-            refund_identity: self.alpha_ledger_refund_identity,
-            expiry: self.alpha_expiry,
-            secret_hash: self.secret_hash,
-        }
-        .into()
     }
 }
 
@@ -632,10 +530,11 @@ impl NetworkBehaviourEventProcess<oneshot_behaviour::OutEvent<finalize::Message>
 mod tests {
     use super::*;
     use crate::{
-        asset::{ethereum::FromWei, Ether},
+        asset::{self, ethereum::FromWei, Ether},
         lightning,
         network::{test_swarm, DialInformation},
         swap_protocols::EthereumIdentity,
+        timestamp::Timestamp,
     };
     use digest::Digest;
     use futures::future;

--- a/cnd/src/network/comit_ln/swaps.rs
+++ b/cnd/src/network/comit_ln/swaps.rs
@@ -50,32 +50,6 @@ pub struct Swaps<T> {
 }
 
 impl<T> Swaps<T> {
-    /// Gets a swap that was created
-    pub fn get_created_swap(
-        &self,
-        local_swap_id: &LocalSwapId,
-    ) -> Option<HanEtherereumHalightBitcoinCreateSwapParams> {
-        self.swaps.get(local_swap_id).cloned()
-    }
-
-    /// Gets a swap that was announced
-    pub fn get_announced_swap(
-        &self,
-        local_swap_id: &LocalSwapId,
-    ) -> Option<(SharedSwapId, HanEtherereumHalightBitcoinCreateSwapParams)> {
-        let create_params = match self.swaps.get(local_swap_id) {
-            Some(create_params) => create_params,
-            None => return None,
-        };
-
-        let shared_swap_id = match self.swap_ids.get(local_swap_id) {
-            Some(shared_swap_id) => shared_swap_id,
-            None => return None,
-        };
-
-        Some((*shared_swap_id, create_params.clone()))
-    }
-
     /// Alice created and announced it a swap and is waiting for a confirmation
     /// from Bob
     pub fn create_as_pending_confirmation(

--- a/cnd/src/swap_protocols/halight.rs
+++ b/cnd/src/swap_protocols/halight.rs
@@ -1,11 +1,13 @@
 use crate::{
     asset, identity,
     swap_protocols::{
+        ledger::lightning,
         rfc003::{Secret, SecretHash},
         state,
         state::Update,
         LocalSwapId,
     },
+    timestamp::Timestamp,
 };
 use futures::{
     future::{self, Either},
@@ -32,6 +34,16 @@ pub struct CreatedSwap {
     pub identity: identity::Lightning,
     pub network: String,
     pub cltv_expiry: u32,
+}
+
+/// Halight specific data for an in progress swap.
+#[derive(Debug, Clone, Copy)]
+pub struct InProgressSwap {
+    pub ledger: lightning::Regtest,
+    pub asset: asset::Bitcoin,
+    pub refund_identity: identity::Lightning,
+    pub redeem_identity: identity::Lightning,
+    pub expiry: Timestamp, // This is the cltv_expiry for now.
 }
 
 /// Creates a new instance of the halight protocol.

--- a/cnd/src/swap_protocols/han.rs
+++ b/cnd/src/swap_protocols/han.rs
@@ -4,6 +4,7 @@ use crate::{
     htlc_location, identity,
     swap_protocols::{
         han, ledger,
+        ledger::Ethereum,
         rfc003::{
             create_swap::{HtlcParams, SwapEvent},
             events::{
@@ -13,6 +14,7 @@ use crate::{
         },
         state, LedgerStates, LocalSwapId, Role,
     },
+    timestamp::Timestamp,
     transaction,
 };
 use chrono::{NaiveDateTime, Utc};
@@ -33,6 +35,16 @@ pub struct CreatedSwap {
     pub identity: identity::Ethereum,
     pub chain_id: u32,
     pub absolute_expiry: u32,
+}
+
+/// Han specific data for an in progress swap.
+#[derive(Debug, Clone)]
+pub struct InProgressSwap {
+    pub ledger: Ethereum,
+    pub asset: asset::Ether,
+    pub refund_identity: identity::Ethereum,
+    pub redeem_identity: identity::Ethereum,
+    pub expiry: Timestamp, // This is the absolute_expiry for now.
 }
 
 pub async fn new_han_ethereum_ether_swap(

--- a/cnd/src/swap_protocols/herc20.rs
+++ b/cnd/src/swap_protocols/herc20.rs
@@ -1,9 +1,17 @@
+mod connector_impls;
+
+pub use connector_impls::*;
+
 use crate::{
-    asset, htlc_location, identity,
+    asset,
+    ethereum::Bytes,
+    htlc_location, identity,
     swap_protocols::{
+        ledger::Ethereum,
         rfc003::{Secret, SecretHash},
         state, LocalSwapId,
     },
+    timestamp::Timestamp,
     transaction,
 };
 use chrono::NaiveDateTime;
@@ -15,11 +23,7 @@ use genawaiter::sync::{Co, Gen};
 use std::collections::{hash_map::Entry, HashMap};
 use tokio::sync::Mutex;
 
-mod connector_impls;
-
-use crate::{ethereum::Bytes, timestamp::Timestamp};
 use blockchain_contracts::ethereum::rfc003::Erc20Htlc;
-pub use connector_impls::*;
 
 /// Htlc ERC20 Token atomic swap protocol.
 
@@ -29,8 +33,17 @@ pub struct CreatedSwap {
     pub amount: asset::Erc20Quantity,
     pub identity: identity::Ethereum,
     pub chain_id: u32,
-    pub contract_address: identity::Ethereum,
+    pub token_contract: identity::Ethereum,
     pub absolute_expiry: u32,
+}
+
+/// Herc20 specific data for an in progress swap.
+#[derive(Debug, Clone, Copy)]
+pub struct InProgressSwap {
+    pub ledger: Ethereum,
+    pub refund_identity: identity::Ethereum,
+    pub redeem_identity: identity::Ethereum,
+    pub expiry: Timestamp, // This is the absolute_expiry for now.
 }
 
 /// Resolves when said event has occurred.


### PR DESCRIPTION
This was https://github.com/comit-network/comit-rs/pull/2595 I have no clue what happened but suddenly that PR was closed?

In [spike 25](comit-network/spikes:0025-an-extensible-db-design.adoc@master) we designed a new database model. This patch is a first effort at implementing it. Includes code for herc20/halight swaps. Does unit testing of table loads/saves.

Ties in with the han/halight code already present. As such this is all a bit mixed up.  Some stuff is herc20/halight, some stuff is han/halgiht and some stuff is `unimplemented!`


Add tables to the schema, add load and save methods for individual tables.  Add a db API for saving/loading created swaps and also for loading in progress swaps.


Closes: #2545 