### PR TITLE
Add new database model

### DIFF
--- a/cnd/migrations/2020-05-06-105000_tables/down.sql
+++ b/cnd/migrations/2020-05-06-105000_tables/down.sql
@@ -1,0 +1,9 @@
+-- This file should undo anything in `up.sql`
+
+DROP TABLE swaps;
+DROP TABLE secret_hashes;
+DROP TABLE shared_swap_ids;
+DROP TABLE address_hints;
+DROP TABLE herc20s;
+DROP TABLE halights;
+

--- a/cnd/migrations/2020-05-06-105000_tables/up.sql
+++ b/cnd/migrations/2020-05-06-105000_tables/up.sql
@@ -1,0 +1,62 @@
+-- Your SQL goes here
+
+CREATE TABLE swaps
+(
+    id                          INTEGER NOT NULL PRIMARY KEY,
+    local_swap_id               UNIQUE NOT NULL,
+    role                        NOT NULL,
+    counterparty_peer_id        NOT NULL
+);
+
+CREATE TABLE secret_hashes
+(
+    id                          INTEGER NOT NULL PRIMARY KEY,
+    swap_id                     INTEGER NOT NULL,
+    secret_hash                 NULL,
+    FOREIGN KEY (swap_id)       REFERENCES swaps(id)
+);
+
+CREATE TABLE shared_swap_ids
+(
+    id                          INTEGER NOT NULL PRIMARY KEY,
+    swap_id                     INTEGER NOT NULL,
+    shared_swap_id              NOT NULL,
+    FOREIGN KEY (swap_id)       REFERENCES swaps(id)
+);
+
+CREATE TABLE address_hints
+(
+    id                          INTEGER NOT NULL PRIMARY KEY,
+    peer_id                     UNIQUE NOT NULL,
+    address_hint                NOT NULL
+);
+
+CREATE TABLE herc20s
+(
+    id                          INTEGER NOT NULL PRIMARY KEY,
+    swap_id                     INTEGER NOT NULL,
+    amount                      NOT NULL,
+    chain_id                    NOT NULL,
+    expiry                      NOT NULL,
+    hash_function               NOT NULL,
+    token_contract              NOT NULL,
+    redeem_identity,
+    refund_identity,
+    ledger                      NOT NULL,
+    FOREIGN KEY(swap_id)        REFERENCES swaps(id)
+);
+
+CREATE TABLE halights
+(
+    id                          INTEGER NOT NULL PRIMARY KEY,
+    swap_id                     INTEGER NOT NULL,
+    amount                      NOT NULL,
+    network                     NOT NULL,
+    chain                       NOT NULL,
+    cltv_expiry                 NOT NULL,
+    hash_function               NOT NULL,
+    redeem_identity,
+    refund_identity,
+    ledger                      NOT NULL,
+    FOREIGN KEY(swap_id)        REFERENCES swaps(id)
+);

--- a/cnd/src/db/created_swap.rs
+++ b/cnd/src/db/created_swap.rs
@@ -1,0 +1,237 @@
+use crate::{
+    db::{
+        tables::{InsertableHalight, InsertableHerc20, InsertableSwap},
+        wrapper_types::{
+            custom_sql_types::{Text, U32},
+            EthereumAddress,
+        },
+        CreatedSwap, Error, Load, Save, Sqlite,
+    },
+    swap_protocols::{halight, han, herc20, HashFunction, Ledger, LocalSwapId, Role},
+};
+use async_trait::async_trait;
+
+#[async_trait]
+impl Save<CreatedSwap<han::CreatedSwap, halight::CreatedSwap>> for Sqlite {
+    async fn save(
+        &self,
+        _: CreatedSwap<han::CreatedSwap, halight::CreatedSwap>,
+    ) -> anyhow::Result<()> {
+        unimplemented!()
+    }
+}
+
+#[async_trait]
+impl Save<CreatedSwap<herc20::CreatedSwap, halight::CreatedSwap>> for Sqlite {
+    async fn save(
+        &self,
+        created: CreatedSwap<herc20::CreatedSwap, halight::CreatedSwap>,
+    ) -> anyhow::Result<()> {
+        let local_swap_id = created.swap_id;
+        let role = created.role;
+
+        let swap = InsertableSwap::new(created.swap_id, created.peer.clone(), created.role);
+        self.save_swap(&swap).await?;
+
+        if let Some(address_hint) = created.address_hint {
+            self.save_address_hint(created.peer, &address_hint).await?;
+        }
+
+        // Save the herc20 details.
+        let redeem_identity = match role {
+            Role::Alice => None,
+            Role::Bob => Some(Text(EthereumAddress::from(created.alpha.identity))),
+        };
+        let refund_identity = match role {
+            Role::Alice => Some(Text(EthereumAddress::from(created.alpha.identity))),
+            Role::Bob => None,
+        };
+        assert!(redeem_identity.is_some() || refund_identity.is_some());
+
+        let herc = InsertableHerc20 {
+            swap_id: 0, // FK, set during save.
+            amount: Text(created.alpha.amount.into()),
+            chain_id: U32(created.alpha.chain_id),
+            expiry: U32(created.alpha.absolute_expiry),
+            hash_function: Text(HashFunction::Sha256),
+            token_contract: Text(created.alpha.token_contract.into()),
+            redeem_identity,
+            refund_identity,
+            ledger: Text(Ledger::Alpha),
+        };
+
+        self.save_herc20(local_swap_id, &herc).await?;
+
+        // Save the halight details.
+        let redeem_identity = match role {
+            Role::Alice => Some(Text(created.beta.identity)),
+            Role::Bob => None,
+        };
+        let refund_identity = match role {
+            Role::Alice => None,
+            Role::Bob => Some(Text(created.beta.identity)),
+        };
+        assert!(redeem_identity.is_some() || refund_identity.is_some());
+
+        let halight = InsertableHalight {
+            swap_id: 0, // FK, set during save.
+            amount: Text(created.beta.amount.into()),
+            network: Text(created.beta.network.into()),
+            chain: "bitcoin".to_string(), // We currently only support Lightning on top of Bitcoin.
+            cltv_expiry: U32(created.beta.cltv_expiry),
+            hash_function: Text(HashFunction::Sha256),
+            redeem_identity,
+            refund_identity,
+            ledger: Text(Ledger::Beta),
+        };
+        self.save_halight(local_swap_id, &halight).await?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Load<CreatedSwap<herc20::CreatedSwap, halight::CreatedSwap>> for Sqlite {
+    async fn load(
+        &self,
+        swap_id: LocalSwapId,
+    ) -> anyhow::Result<Option<CreatedSwap<herc20::CreatedSwap, halight::CreatedSwap>>> {
+        let swap = self.load_swap(swap_id).await?;
+        let herc20 = self.load_herc20(swap_id).await?;
+        let halight = self.load_halight(swap_id).await?;
+
+        let role = swap.role.0;
+        let peer = swap.counterparty_peer_id.0;
+
+        let address_hint = self.load_address_hint(&peer).await.ok();
+
+        let alpha_identity = match role {
+            Role::Alice => herc20
+                .refund_identity
+                .ok_or_else(|| Error::IdentityNotSet)?,
+            Role::Bob => herc20
+                .redeem_identity
+                .ok_or_else(|| Error::IdentityNotSet)?,
+        };
+        let beta_identity = match role {
+            Role::Alice => halight
+                .redeem_identity
+                .ok_or_else(|| Error::IdentityNotSet)?,
+            Role::Bob => halight
+                .refund_identity
+                .ok_or_else(|| Error::IdentityNotSet)?,
+        };
+
+        let alpha = herc20::CreatedSwap {
+            amount: herc20.amount.0.into(),
+            identity: alpha_identity.0.into(),
+            chain_id: herc20.chain_id.into(),
+            token_contract: herc20.token_contract.0.into(),
+            absolute_expiry: herc20.expiry.into(),
+        };
+
+        let beta = halight::CreatedSwap {
+            amount: halight.amount.0.into(),
+            identity: beta_identity.0,
+            network: halight.network.0.into(),
+            cltv_expiry: halight.cltv_expiry.into(),
+        };
+
+        let created = CreatedSwap {
+            swap_id,
+            alpha,
+            beta,
+            peer,
+            address_hint,
+            role,
+        };
+
+        Ok(Some(created))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        asset,
+        db::{
+            wrapper_types::{Erc20Amount, EthereumAddress},
+            Sqlite,
+        },
+        identity,
+        swap_protocols::ledger::lightning,
+        timestamp::Timestamp,
+    };
+    use libp2p::{Multiaddr, PeerId};
+    use std::{path::PathBuf, str::FromStr};
+
+    fn temp_db() -> PathBuf {
+        let temp_file = tempfile::Builder::new()
+            .suffix(".sqlite")
+            .tempfile()
+            .unwrap();
+
+        temp_file.into_temp_path().to_path_buf()
+    }
+
+    #[tokio::test]
+    async fn roundtrip_created_swap() {
+        let path = temp_db();
+        let db = Sqlite::new(&path).expect("a new db");
+
+        let local_swap_id =
+            LocalSwapId::from_str("111152ca-ecf2-4cc6-b35c-b4351ac28a34").expect("valid swap id");
+        let role = Role::Alice;
+        let peer = PeerId::from_str("QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY")
+            .expect("valid peer id");
+
+        let multi_addr = "/ip4/80.123.90.4/tcp/5432";
+        let address_hint: Multiaddr = multi_addr.parse().expect("valid multiaddress");
+
+        let alpha_amount = Erc20Amount::from_str("12345").expect("valid ERC20 amount");
+        let token_contract = EthereumAddress::from_str("1111e8be41b21f651a71aaB1A85c6813b8bBcCf8")
+            .expect("valid etherum identity");
+        let alpha_identity = EthereumAddress::from_str("2222e8be41b21f651a71aaB1A85c6813b8bBcCf8")
+            .expect("valid redeem identity");
+        let alpha_expiry = Timestamp::from(123u32);
+
+        let beta_amount = asset::Bitcoin::from_sat(999);
+        let beta_identity = identity::Lightning::random();
+        let beta_expiry = Timestamp::from(456u32);
+
+        let created: CreatedSwap<herc20::CreatedSwap, halight::CreatedSwap> = CreatedSwap {
+            swap_id: local_swap_id,
+            alpha: herc20::CreatedSwap {
+                amount: alpha_amount.into(),
+                identity: alpha_identity.into(),
+                chain_id: 1337,
+                token_contract: token_contract.into(),
+                absolute_expiry: alpha_expiry.into(),
+            },
+            beta: halight::CreatedSwap {
+                amount: beta_amount,
+                identity: beta_identity,
+                network: lightning::Regtest,
+                cltv_expiry: beta_expiry.into(),
+            },
+            peer,
+            address_hint: Some(address_hint),
+            role,
+        };
+
+        Save::<CreatedSwap<herc20::CreatedSwap, halight::CreatedSwap>>::save(&db, created.clone())
+            .await
+            .expect("to be able to save created swap");
+
+        let loaded = Load::<CreatedSwap<herc20::CreatedSwap, halight::CreatedSwap>>::load(
+            &db,
+            local_swap_id,
+        )
+        .await
+        .expect("to be able to load previously save created swap")
+        .expect("some created swap");
+
+        assert_eq!(loaded, created);
+    }
+}

--- a/cnd/src/db/in_progress_swap.rs
+++ b/cnd/src/db/in_progress_swap.rs
@@ -1,0 +1,61 @@
+use crate::{
+    db::{InProgressSwap, Load, Sqlite},
+    swap_protocols::{halight, herc20, Ledger, LocalSwapId},
+};
+use async_trait::async_trait;
+
+// This is tested in db/integration_tests/api.rs
+#[async_trait]
+impl Load<InProgressSwap<herc20::InProgressSwap, halight::InProgressSwap>> for Sqlite {
+    async fn load(
+        &self,
+        swap_id: LocalSwapId,
+    ) -> anyhow::Result<Option<InProgressSwap<herc20::InProgressSwap, halight::InProgressSwap>>>
+    {
+        let swap = self.load_swap(swap_id).await?;
+        let herc20 = self.load_herc20(swap_id).await?;
+        let halight = self.load_halight(swap_id).await?;
+        let secret_hash = self.load_secret_hash(swap_id).await?;
+
+        let role = swap.role.0;
+
+        let alpha_refund_identity = match herc20.refund_identity {
+            Some(id) => id.0,
+            None => return Ok(None),
+        };
+
+        let alpha_redeem_identity = match herc20.redeem_identity {
+            Some(id) => id.0,
+            None => return Ok(None),
+        };
+        let beta_refund_identity = match halight.refund_identity {
+            Some(id) => id.0,
+            None => return Ok(None),
+        };
+        let beta_redeem_identity = match halight.redeem_identity {
+            Some(id) => id.0,
+            None => return Ok(None),
+        };
+
+        let live = InProgressSwap {
+            swap_id,
+            secret_hash,
+            role,
+            alpha: herc20::InProgressSwap {
+                ledger: Ledger::Alpha,
+                refund_identity: alpha_refund_identity.into(),
+                redeem_identity: alpha_redeem_identity.into(),
+                expiry: herc20.expiry.into(),
+            },
+            beta: halight::InProgressSwap {
+                ledger: Ledger::Beta,
+                asset: halight.amount.0.into(),
+                refund_identity: beta_refund_identity,
+                redeem_identity: beta_redeem_identity,
+                expiry: halight.cltv_expiry.into(),
+            },
+        };
+
+        Ok(Some(live))
+    }
+}

--- a/cnd/src/db/integration_tests.rs
+++ b/cnd/src/db/integration_tests.rs
@@ -1,2 +1,3 @@
+mod api;
 mod db_roundtrips;
 mod serialization_format_stability;

--- a/cnd/src/db/integration_tests/api.rs
+++ b/cnd/src/db/integration_tests/api.rs
@@ -1,0 +1,134 @@
+use crate::{
+    asset,
+    db::{
+        wrapper_types::{Erc20Amount, EthereumAddress},
+        CreatedSwap, InProgressSwap, Load, Role, Save, Sqlite,
+    },
+    identity,
+    swap_protocols::{
+        halight, herc20,
+        ledger::lightning,
+        rfc003::{Secret, SecretHash},
+        Ledger, LocalSwapId, SharedSwapId,
+    },
+    timestamp::Timestamp,
+};
+use libp2p::{Multiaddr, PeerId};
+use std::{path::PathBuf, str::FromStr};
+
+fn temp_db() -> PathBuf {
+    let temp_file = tempfile::Builder::new()
+        .suffix(".sqlite")
+        .tempfile()
+        .unwrap();
+
+    temp_file.into_temp_path().to_path_buf()
+}
+
+// Tests that we can save and load to the database using the database API.
+#[tokio::test]
+async fn roundtrip_create_finalize_load() {
+    let path = temp_db();
+    let db = Sqlite::new(&path).expect("a new db");
+
+    let local_swap_id =
+        LocalSwapId::from_str("111152ca-ecf2-4cc6-b35c-b4351ac28a34").expect("valid swap id");
+    let role = Role::Alice;
+    let peer =
+        PeerId::from_str("QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY").expect("valid peer id");
+
+    let multi_addr = "/ip4/80.123.90.4/tcp/5432";
+    let address_hint: Multiaddr = multi_addr.parse().expect("valid multiaddress");
+
+    let alpha_amount = Erc20Amount::from_str("12345").expect("valid ERC20 amount");
+    let token_contract = EthereumAddress::from_str("1111e8be41b21f651a71aaB1A85c6813b8bBcCf8")
+        .expect("valid etherum identity");
+    let alpha_redeem_identity =
+        EthereumAddress::from_str("2222e8be41b21f651a71aaB1A85c6813b8bBcCf8")
+            .expect("valid redeem identity");
+    let alpha_refund_identity =
+        EthereumAddress::from_str("3333e8be41b21f651a71aaB1A85c6813b8bBcCf8")
+            .expect("valid refund identity");
+    let alpha_expiry = Timestamp::from(123u32);
+
+    let beta_amount = asset::Bitcoin::from_sat(999);
+    let beta_refund_identity = identity::Lightning::random();
+    let beta_redeem_identity = identity::Lightning::random();
+    let beta_expiry = Timestamp::from(456u32);
+
+    // Simulate REST API swap POST i.e., saving a created swap.
+    let created: CreatedSwap<herc20::CreatedSwap, halight::CreatedSwap> = CreatedSwap {
+        swap_id: local_swap_id,
+        alpha: herc20::CreatedSwap {
+            amount: alpha_amount.into(),
+            identity: alpha_refund_identity.into(),
+            chain_id: 1337,
+            token_contract: token_contract.into(),
+            absolute_expiry: alpha_expiry.into(),
+        },
+        beta: halight::CreatedSwap {
+            amount: beta_amount,
+            identity: beta_redeem_identity,
+            network: lightning::Regtest,
+            cltv_expiry: beta_expiry.into(),
+        },
+        peer,
+        address_hint: Some(address_hint),
+        role,
+    };
+    Save::<CreatedSwap<herc20::CreatedSwap, halight::CreatedSwap>>::save(&db, created)
+        .await
+        .expect("to be able to save created swap");
+
+    // Simulate announce message.
+    let shared_swap_id =
+        SharedSwapId::from_str("222252ca-ecf2-4cc6-b35c-b4351ac28a34").expect("valid swap id");
+    db.save_shared_swap_id(local_swap_id, shared_swap_id)
+        .await
+        .expect("to be able to save shared swap id");
+
+    // Simulate secret_hash message.
+    let secret = Secret::from(*b"This is our favourite passphrase");
+    let secret_hash = SecretHash::from(secret);
+
+    db.save_secret_hash(local_swap_id, secret_hash)
+        .await
+        .expect("to be able to save secret hash");
+
+    // Simulate identity messages.
+    db.save_counterparty_halight_refund_identity(local_swap_id, beta_refund_identity)
+        .await
+        .expect("to be able to save Lightning refund identity");
+    db.save_counterparty_herc20_redeem_identity(local_swap_id, alpha_redeem_identity.into())
+        .await
+        .expect("to be able to save Ethereum redeem identity");
+
+    let want: InProgressSwap<herc20::InProgressSwap, halight::InProgressSwap> = InProgressSwap {
+        swap_id: local_swap_id,
+        secret_hash,
+        role,
+        alpha: herc20::InProgressSwap {
+            ledger: Ledger::Alpha,
+            refund_identity: alpha_refund_identity.into(),
+            redeem_identity: alpha_redeem_identity.into(),
+            expiry: alpha_expiry,
+        },
+        beta: halight::InProgressSwap {
+            ledger: Ledger::Beta,
+            asset: beta_amount,
+            refund_identity: beta_refund_identity,
+            redeem_identity: beta_redeem_identity,
+            expiry: beta_expiry,
+        },
+    };
+
+    let got = Load::<InProgressSwap<herc20::InProgressSwap, halight::InProgressSwap>>::load(
+        &db,
+        local_swap_id,
+    )
+    .await
+    .expect("to be able to load an in progress swap")
+    .expect("to have gotten some in progress swap");
+
+    assert_eq!(got, want);
+}

--- a/cnd/src/db/load_swaps.rs
+++ b/cnd/src/db/load_swaps.rs
@@ -1,7 +1,7 @@
 use crate::{
     asset,
     db::{
-        schema,
+        rfc003_schema,
         wrapper_types::{
             custom_sql_types::{Text, U32},
             BitcoinNetwork, Erc20Amount, Ether, EthereumAddress, Satoshis,
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 use chrono::NaiveDateTime;
 use diesel::{self, prelude::*, RunQueryDsl};
 use impl_template::impl_template;
-use schema::{
+use rfc003_schema::{
     rfc003_bitcoin_ethereum_accept_messages,
     rfc003_bitcoin_ethereum_bitcoin_erc20_request_messages,
     rfc003_bitcoin_ethereum_bitcoin_ether_request_messages,
@@ -148,7 +148,7 @@ impl
             identity::Ethereum,
         >,
     > {
-        use schema::{
+        use rfc003_schema::{
             rfc003_bitcoin_ethereum_accept_messages as accept_messages,
             rfc003_bitcoin_ethereum_bitcoin_ether_request_messages as request_messages,
         };
@@ -271,7 +271,7 @@ impl
             identity::Bitcoin,
         >,
     > {
-        use schema::{
+        use rfc003_schema::{
             rfc003_ethereum_bitcoin_accept_messages as accept_messages,
             rfc003_ethereum_bitcoin_ether_bitcoin_request_messages as request_messages,
         };
@@ -398,7 +398,7 @@ impl
             identity::Ethereum,
         >,
     > {
-        use schema::{
+        use rfc003_schema::{
             rfc003_bitcoin_ethereum_accept_messages as accept_messages,
             rfc003_bitcoin_ethereum_bitcoin_erc20_request_messages as request_messages,
         };
@@ -526,7 +526,7 @@ impl
             identity::Bitcoin,
         >,
     > {
-        use schema::{
+        use rfc003_schema::{
             rfc003_ethereum_bitcoin_accept_messages as accept_messages,
             rfc003_ethereum_bitcoin_erc20_bitcoin_request_messages as request_messages,
         };

--- a/cnd/src/db/rfc003_schema.rs
+++ b/cnd/src/db/rfc003_schema.rs
@@ -1,0 +1,106 @@
+table! {
+   rfc003_bitcoin_ethereum_bitcoin_ether_request_messages {
+       id -> Integer,
+       swap_id -> Text,
+       bitcoin_network -> Text,
+       ethereum_chain_id -> BigInt,
+       bitcoin_amount -> Text,
+       ether_amount -> Text,
+       hash_function -> Text,
+       bitcoin_refund_identity -> Text,
+       ethereum_redeem_identity -> Text,
+       bitcoin_expiry -> BigInt,
+       ethereum_expiry -> BigInt,
+       secret_hash -> Text,
+   }
+}
+
+table! {
+   rfc003_ethereum_bitcoin_ether_bitcoin_request_messages {
+       id -> Integer,
+       swap_id -> Text,
+       ethereum_chain_id -> BigInt,
+       bitcoin_network -> Text,
+       ether_amount -> Text,
+       bitcoin_amount -> Text,
+       hash_function -> Text,
+       ethereum_refund_identity -> Text,
+       bitcoin_redeem_identity -> Text,
+       ethereum_expiry -> BigInt,
+       bitcoin_expiry -> BigInt,
+       secret_hash -> Text,
+   }
+}
+
+table! {
+   rfc003_bitcoin_ethereum_bitcoin_erc20_request_messages {
+       id -> Integer,
+       swap_id -> Text,
+       bitcoin_network -> Text,
+       ethereum_chain_id -> BigInt,
+       bitcoin_amount -> Text,
+       erc20_amount -> Text,
+       erc20_token_contract -> Text,
+       hash_function -> Text,
+       bitcoin_refund_identity -> Text,
+       ethereum_redeem_identity -> Text,
+       bitcoin_expiry -> BigInt,
+       ethereum_expiry -> BigInt,
+       secret_hash -> Text,
+   }
+}
+
+table! {
+   rfc003_ethereum_bitcoin_erc20_bitcoin_request_messages {
+       id -> Integer,
+       swap_id -> Text,
+       ethereum_chain_id -> BigInt,
+       bitcoin_network -> Text,
+       erc20_amount -> Text,
+       erc20_token_contract -> Text,
+       bitcoin_amount -> Text,
+       hash_function -> Text,
+       ethereum_refund_identity -> Text,
+       bitcoin_redeem_identity -> Text,
+       ethereum_expiry -> BigInt,
+       bitcoin_expiry -> BigInt,
+       secret_hash -> Text,
+   }
+}
+
+table! {
+   rfc003_ethereum_bitcoin_accept_messages {
+       id -> Integer,
+       swap_id -> Text,
+       ethereum_redeem_identity -> Text,
+       bitcoin_refund_identity -> Text,
+       at -> Timestamp,
+   }
+}
+
+table! {
+   rfc003_bitcoin_ethereum_accept_messages {
+       id -> Integer,
+       swap_id -> Text,
+       bitcoin_redeem_identity -> Text,
+       ethereum_refund_identity -> Text,
+       at -> Timestamp,
+   }
+}
+
+table! {
+   rfc003_decline_messages {
+       id -> Integer,
+       swap_id -> Text,
+       reason -> Nullable<Text>,
+   }
+}
+
+table! {
+   rfc003_swaps {
+       id -> Integer,
+       swap_id -> Text,
+       role -> Text,
+       counterparty -> Text,
+   }
+}

--- a/cnd/src/db/schema.rs
+++ b/cnd/src/db/schema.rs
@@ -1,106 +1,65 @@
+// LocalSwapId and SharedSwapId are encoded as Text and named local_swap_id, and
+// shared_swap_id respectively.  swap_id (Integer) is always a foreign key link
+// to the `swaps` table.
 table! {
-   rfc003_bitcoin_ethereum_bitcoin_ether_request_messages {
+   swaps {
        id -> Integer,
-       swap_id -> Text,
-       bitcoin_network -> Text,
-       ethereum_chain_id -> BigInt,
-       bitcoin_amount -> Text,
-       ether_amount -> Text,
-       hash_function -> Text,
-       bitcoin_refund_identity -> Text,
-       ethereum_redeem_identity -> Text,
-       bitcoin_expiry -> BigInt,
-       ethereum_expiry -> BigInt,
-       secret_hash -> Text,
-   }
-}
-
-table! {
-   rfc003_ethereum_bitcoin_ether_bitcoin_request_messages {
-       id -> Integer,
-       swap_id -> Text,
-       ethereum_chain_id -> BigInt,
-       bitcoin_network -> Text,
-       ether_amount -> Text,
-       bitcoin_amount -> Text,
-       hash_function -> Text,
-       ethereum_refund_identity -> Text,
-       bitcoin_redeem_identity -> Text,
-       ethereum_expiry -> BigInt,
-       bitcoin_expiry -> BigInt,
-       secret_hash -> Text,
-   }
-}
-
-table! {
-   rfc003_bitcoin_ethereum_bitcoin_erc20_request_messages {
-       id -> Integer,
-       swap_id -> Text,
-       bitcoin_network -> Text,
-       ethereum_chain_id -> BigInt,
-       bitcoin_amount -> Text,
-       erc20_amount -> Text,
-       erc20_token_contract -> Text,
-       hash_function -> Text,
-       bitcoin_refund_identity -> Text,
-       ethereum_redeem_identity -> Text,
-       bitcoin_expiry -> BigInt,
-       ethereum_expiry -> BigInt,
-       secret_hash -> Text,
-   }
-}
-
-table! {
-   rfc003_ethereum_bitcoin_erc20_bitcoin_request_messages {
-       id -> Integer,
-       swap_id -> Text,
-       ethereum_chain_id -> BigInt,
-       bitcoin_network -> Text,
-       erc20_amount -> Text,
-       erc20_token_contract -> Text,
-       bitcoin_amount -> Text,
-       hash_function -> Text,
-       ethereum_refund_identity -> Text,
-       bitcoin_redeem_identity -> Text,
-       ethereum_expiry -> BigInt,
-       bitcoin_expiry -> BigInt,
-       secret_hash -> Text,
-   }
-}
-
-table! {
-   rfc003_ethereum_bitcoin_accept_messages {
-       id -> Integer,
-       swap_id -> Text,
-       ethereum_redeem_identity -> Text,
-       bitcoin_refund_identity -> Text,
-       at -> Timestamp,
-   }
-}
-
-table! {
-   rfc003_bitcoin_ethereum_accept_messages {
-       id -> Integer,
-       swap_id -> Text,
-       bitcoin_redeem_identity -> Text,
-       ethereum_refund_identity -> Text,
-       at -> Timestamp,
-   }
-}
-
-table! {
-   rfc003_decline_messages {
-       id -> Integer,
-       swap_id -> Text,
-       reason -> Nullable<Text>,
-   }
-}
-
-table! {
-   rfc003_swaps {
-       id -> Integer,
-       swap_id -> Text,
+       local_swap_id -> Text,
        role -> Text,
-       counterparty -> Text,
+       counterparty_peer_id -> Text,
    }
+}
+
+table! {
+   secret_hashes {
+       id -> Integer,
+       swap_id -> Integer,
+       secret_hash -> Text,
+   }
+}
+
+table! {
+   shared_swap_ids {
+       id -> Integer,
+       swap_id -> Integer,
+       shared_swap_id -> Text,
+   }
+}
+
+table! {
+    address_hints {
+        id -> Integer,
+        peer_id -> Text,
+        address_hint -> Text,
+    }
+}
+
+table! {
+    herc20s {
+        id -> Integer,
+        swap_id -> Integer,
+        amount -> Text,
+        chain_id -> BigInt,
+        expiry -> BigInt,
+        hash_function -> Text,
+        token_contract -> Text,
+        redeem_identity -> Nullable<Text>,
+        refund_identity -> Nullable<Text>,
+        ledger -> Text,
+    }
+}
+
+table! {
+    halights {
+        id -> Integer,
+        swap_id -> Integer,
+        amount -> Text,
+        network -> Text,
+        chain -> Text,
+        cltv_expiry -> BigInt,
+        hash_function -> Text,
+        redeem_identity -> Nullable<Text>,
+        refund_identity -> Nullable<Text>,
+        ledger -> Text,
+    }
 }

--- a/cnd/src/db/swap.rs
+++ b/cnd/src/db/swap.rs
@@ -1,5 +1,5 @@
 use crate::{
-    db::{schema, wrapper_types::custom_sql_types::Text, Error, Sqlite},
+    db::{rfc003_schema, wrapper_types::custom_sql_types::Text, Error, Sqlite},
     diesel::{ExpressionMethods, OptionalExtension, QueryDsl},
     swap_protocols::{rfc003::SwapId, Role},
 };
@@ -35,7 +35,7 @@ impl Swap {
 #[async_trait]
 impl Retrieve for Sqlite {
     async fn get(&self, key: &SwapId) -> anyhow::Result<Swap> {
-        use self::schema::rfc003_swaps::dsl::*;
+        use self::rfc003_schema::rfc003_swaps::dsl::*;
 
         let record: QueryableSwap = self
             .do_in_transaction(|connection| {
@@ -53,7 +53,7 @@ impl Retrieve for Sqlite {
     }
 
     async fn all(&self) -> anyhow::Result<Vec<Swap>> {
-        use self::schema::rfc003_swaps::dsl::*;
+        use self::rfc003_schema::rfc003_swaps::dsl::*;
 
         let records: Vec<QueryableSwap> = self
             .do_in_transaction(|connection| rfc003_swaps.load(&*connection))

--- a/cnd/src/db/swap_types.rs
+++ b/cnd/src/db/swap_types.rs
@@ -1,7 +1,7 @@
 use crate::{
     asset, comit_api,
     db::{
-        schema,
+        rfc003_schema,
         wrapper_types::{custom_sql_types::Text, BitcoinNetwork},
         Sqlite,
     },
@@ -24,7 +24,7 @@ pub trait DetermineTypes: Send + Sync + 'static {
 #[async_trait]
 impl DetermineTypes for Sqlite {
     async fn determine_types(&self, key: &SwapId) -> anyhow::Result<SwapTypes> {
-        let role = self.role(key).await?;
+        let role = self.rfc003_role(key).await?;
 
         if let Some(bitcoin_network) = self
             .rfc003_bitcoin_ethereum_bitcoin_ether_request_messages_has_swap(key)
@@ -86,7 +86,7 @@ macro_rules! impl_has_swap {
     ($table:ident) => {
         paste::item! {
             async fn [<$table _has_swap>](&self, key: &SwapId) -> anyhow::Result<Option<BitcoinNetwork>> {
-                use schema::$table as swaps;
+                use rfc003_schema::$table as swaps;
 
                 let record: Option<QueryableSwap> = self.do_in_transaction(|connection| {
                     let key = Text(key);

--- a/cnd/src/db/tables.rs
+++ b/cnd/src/db/tables.rs
@@ -1,0 +1,798 @@
+use crate::{
+    db::{
+        schema::{address_hints, halights, herc20s, secret_hashes, shared_swap_ids, swaps},
+        wrapper_types::{
+            custom_sql_types::{Text, U32},
+            Erc20Amount, EthereumAddress, LightningNetwork, Satoshis,
+        },
+        Error, Sqlite,
+    },
+    identity, lightning,
+    swap_protocols::{self, rfc003, HashFunction, Ledger, LocalSwapId, Role},
+};
+use diesel::{self, prelude::*, RunQueryDsl};
+use libp2p::{Multiaddr, PeerId};
+
+#[derive(Identifiable, Queryable, PartialEq, Debug)]
+#[table_name = "swaps"]
+pub struct Swap {
+    id: i32,
+    pub local_swap_id: Text<LocalSwapId>,
+    pub role: Text<Role>,
+    pub counterparty_peer_id: Text<PeerId>,
+}
+
+impl From<Swap> for InsertableSwap {
+    fn from(swap: Swap) -> Self {
+        InsertableSwap {
+            local_swap_id: swap.local_swap_id,
+            role: swap.role,
+            counterparty_peer_id: swap.counterparty_peer_id,
+        }
+    }
+}
+
+#[derive(Insertable, Debug, Clone)]
+#[table_name = "swaps"]
+pub struct InsertableSwap {
+    local_swap_id: Text<LocalSwapId>,
+    role: Text<Role>,
+    counterparty_peer_id: Text<PeerId>,
+}
+
+impl InsertableSwap {
+    pub fn new(swap_id: LocalSwapId, counterparty: PeerId, role: Role) -> Self {
+        InsertableSwap {
+            local_swap_id: Text(swap_id),
+            role: Text(role),
+            counterparty_peer_id: Text(counterparty),
+        }
+    }
+}
+
+#[derive(Associations, Clone, Copy, Debug, Identifiable, Queryable, PartialEq)]
+#[belongs_to(Swap)]
+#[table_name = "secret_hashes"]
+pub struct SecretHash {
+    id: i32,
+    swap_id: i32,
+    pub secret_hash: Text<rfc003::SecretHash>,
+}
+
+#[derive(Insertable, Debug, Clone, Copy)]
+#[table_name = "secret_hashes"]
+pub struct InsertableSecretHash {
+    swap_id: i32,
+    secret_hash: Text<rfc003::SecretHash>,
+}
+
+#[derive(Clone, Debug, Identifiable, Queryable, PartialEq)]
+#[table_name = "address_hints"]
+pub struct AddressHint {
+    id: i32,
+    pub peer_id: Text<PeerId>,
+    pub address_hint: Text<Multiaddr>,
+}
+
+#[derive(Insertable, Debug, Clone)]
+#[table_name = "address_hints"]
+pub struct InsertableAddressHint {
+    peer_id: Text<PeerId>,
+    address_hint: Text<Multiaddr>,
+}
+
+#[derive(Associations, Clone, Copy, Debug, Identifiable, Queryable, PartialEq)]
+#[belongs_to(Swap)]
+#[table_name = "shared_swap_ids"]
+pub struct SharedSwapId {
+    id: i32,
+    swap_id: i32,
+    pub shared_swap_id: Text<swap_protocols::SharedSwapId>,
+}
+
+#[derive(Insertable, Debug, Clone, Copy)]
+#[table_name = "shared_swap_ids"]
+pub struct InsertableSharedSwapId {
+    swap_id: i32,
+    shared_swap_id: Text<swap_protocols::SharedSwapId>,
+}
+
+#[derive(Associations, Clone, Debug, Identifiable, Queryable, PartialEq)]
+#[belongs_to(Swap)]
+#[table_name = "herc20s"]
+pub struct Herc20 {
+    id: i32,
+    swap_id: i32,
+    pub amount: Text<Erc20Amount>,
+    pub chain_id: U32,
+    pub expiry: U32,
+    pub hash_function: Text<HashFunction>,
+    pub token_contract: Text<EthereumAddress>,
+    pub redeem_identity: Option<Text<EthereumAddress>>,
+    pub refund_identity: Option<Text<EthereumAddress>>,
+    pub ledger: Text<Ledger>,
+}
+
+#[derive(Insertable, Debug, Clone)]
+#[table_name = "herc20s"]
+pub struct InsertableHerc20 {
+    pub swap_id: i32,
+    pub amount: Text<Erc20Amount>,
+    pub chain_id: U32,
+    pub expiry: U32,
+    pub hash_function: Text<HashFunction>,
+    pub token_contract: Text<EthereumAddress>,
+    pub redeem_identity: Option<Text<EthereumAddress>>,
+    pub refund_identity: Option<Text<EthereumAddress>>,
+    pub ledger: Text<Ledger>,
+}
+
+impl InsertableHerc20 {
+    pub fn with_swap_id(&self, swap_id: i32) -> Self {
+        InsertableHerc20 {
+            swap_id,
+            amount: self.amount.clone(),
+            chain_id: self.chain_id,
+            expiry: self.expiry,
+            hash_function: self.hash_function,
+            token_contract: self.token_contract,
+            redeem_identity: self.redeem_identity,
+            refund_identity: self.refund_identity,
+            ledger: self.ledger,
+        }
+    }
+}
+
+#[derive(Associations, Clone, Debug, Identifiable, Queryable, PartialEq)]
+#[belongs_to(Swap)]
+#[table_name = "halights"]
+pub struct Halight {
+    id: i32,
+    swap_id: i32,
+    pub amount: Text<Satoshis>,
+    pub network: Text<LightningNetwork>,
+    pub chain: String,
+    pub cltv_expiry: U32,
+    pub hash_function: Text<HashFunction>,
+    pub redeem_identity: Option<Text<lightning::PublicKey>>,
+    pub refund_identity: Option<Text<lightning::PublicKey>>,
+    pub ledger: Text<Ledger>,
+}
+
+#[derive(Insertable, Debug, Clone)]
+#[table_name = "halights"]
+pub struct InsertableHalight {
+    pub swap_id: i32,
+    pub amount: Text<Satoshis>,
+    pub network: Text<LightningNetwork>,
+    pub chain: String,
+    pub cltv_expiry: U32,
+    pub hash_function: Text<HashFunction>,
+    pub redeem_identity: Option<Text<lightning::PublicKey>>,
+    pub refund_identity: Option<Text<lightning::PublicKey>>,
+    pub ledger: Text<Ledger>,
+}
+
+impl InsertableHalight {
+    pub fn with_swap_id(&self, swap_id: i32) -> Self {
+        InsertableHalight {
+            swap_id,
+            amount: self.amount,
+            network: self.network,
+            chain: self.chain.clone(),
+            cltv_expiry: self.cltv_expiry,
+            hash_function: self.hash_function,
+            redeem_identity: self.redeem_identity,
+            refund_identity: self.refund_identity,
+            ledger: self.ledger,
+        }
+    }
+}
+
+impl Sqlite {
+    pub async fn role(&self, swap_id: LocalSwapId) -> anyhow::Result<Role> {
+        let swap = self.load_swap(swap_id).await?;
+        Ok(swap.role.0)
+    }
+
+    pub async fn save_swap(&self, insertable: &InsertableSwap) -> anyhow::Result<()> {
+        self.do_in_transaction(|connection| {
+            diesel::insert_into(swaps::dsl::swaps)
+                .values(insertable)
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn load_swap(&self, swap_id: LocalSwapId) -> anyhow::Result<Swap> {
+        let record: Swap = self
+            .do_in_transaction(|connection| {
+                let key = Text(swap_id);
+
+                swaps::table
+                    .filter(swaps::local_swap_id.eq(key))
+                    .first(connection)
+                    .optional()
+            })
+            .await?
+            .ok_or(Error::SwapNotFound)?;
+
+        Ok(record)
+    }
+
+    pub async fn save_secret_hash(
+        &self,
+        swap_id: LocalSwapId,
+        secret_hash: rfc003::SecretHash,
+    ) -> anyhow::Result<()> {
+        self.do_in_transaction(|connection| {
+            let key = Text(swap_id);
+
+            let swap: Swap = swaps::table
+                .filter(swaps::local_swap_id.eq(key))
+                .first(connection)?;
+
+            let insertable = InsertableSecretHash {
+                swap_id: swap.id,
+                secret_hash: Text(secret_hash),
+            };
+
+            diesel::insert_into(secret_hashes::dsl::secret_hashes)
+                .values(insertable)
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn load_secret_hash(
+        &self,
+        swap_id: LocalSwapId,
+    ) -> anyhow::Result<rfc003::SecretHash> {
+        let record: SecretHash = self
+            .do_in_transaction(|connection| {
+                let key = Text(swap_id);
+
+                let swap: Swap = swaps::table
+                    .filter(swaps::local_swap_id.eq(key))
+                    .first(connection)?;
+
+                SecretHash::belonging_to(&swap).first(connection).optional()
+            })
+            .await?
+            .ok_or(Error::SwapNotFound)?;
+
+        Ok(record.secret_hash.0)
+    }
+
+    pub async fn save_shared_swap_id(
+        &self,
+        swap_id: LocalSwapId,
+        shared_swap_id: swap_protocols::SharedSwapId,
+    ) -> anyhow::Result<()> {
+        self.do_in_transaction(|connection| {
+            let key = Text(swap_id);
+
+            let swap: Swap = swaps::table
+                .filter(swaps::local_swap_id.eq(key))
+                .first(connection)?;
+
+            let insertable = InsertableSharedSwapId {
+                swap_id: swap.id,
+                shared_swap_id: Text(shared_swap_id),
+            };
+
+            diesel::insert_into(shared_swap_ids::dsl::shared_swap_ids)
+                .values(insertable)
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn load_shared_swap_id(
+        &self,
+        swap_id: LocalSwapId,
+    ) -> anyhow::Result<swap_protocols::SharedSwapId> {
+        let record: SharedSwapId = self
+            .do_in_transaction(|connection| {
+                let key = Text(swap_id);
+
+                let swap: Swap = swaps::table
+                    .filter(swaps::local_swap_id.eq(key))
+                    .first(connection)?;
+
+                SharedSwapId::belonging_to(&swap)
+                    .first(connection)
+                    .optional()
+            })
+            .await?
+            .ok_or(Error::SwapNotFound)?;
+
+        Ok(record.shared_swap_id.0)
+    }
+
+    /// This function is called depending on ones role and which side of the
+    /// swap halight is on.
+    /// - Called by Alice when halight is the alpha protocol.
+    /// - Called by Bob when when halight is the beta protocol.
+    pub async fn save_counterparty_halight_redeem_identity(
+        &self,
+        swap_id: LocalSwapId,
+        identity: identity::Lightning,
+    ) -> anyhow::Result<()> {
+        use crate::db::schema::halights::columns::redeem_identity;
+
+        self.do_in_transaction(|connection| {
+            let key = Text(swap_id);
+
+            let swap: Swap = swaps::table
+                .filter(swaps::local_swap_id.eq(key))
+                .first(connection)?;
+
+            diesel::update(halights::dsl::halights.filter(halights::swap_id.eq(swap.id)))
+                .set(redeem_identity.eq(Text(identity)))
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    /// This function is called depending on ones role and which side of the
+    /// swap halight is on.
+    /// - Called by Alice when halight is the beta protocol.
+    /// - Called by Bob when when halight is the alpha protocol.
+    pub async fn save_counterparty_halight_refund_identity(
+        &self,
+        swap_id: LocalSwapId,
+        identity: identity::Lightning,
+    ) -> anyhow::Result<()> {
+        use crate::db::schema::halights::columns::refund_identity;
+
+        self.do_in_transaction(|connection| {
+            let key = Text(swap_id);
+
+            let swap: Swap = swaps::table
+                .filter(swaps::local_swap_id.eq(key))
+                .first(connection)?;
+
+            diesel::update(halights::dsl::halights.filter(halights::swap_id.eq(swap.id)))
+                .set(refund_identity.eq(Text(identity)))
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    /// This function is called depending on ones role and which side of the
+    /// swap herc20 is on.
+    /// - Called by Alice when herc20 is the alpha protocol.
+    /// - Called by Bob when when herc20 is the beta protocol.
+    pub async fn save_counterparty_herc20_redeem_identity(
+        &self,
+        swap_id: LocalSwapId,
+        identity: identity::Ethereum,
+    ) -> anyhow::Result<()> {
+        use crate::db::schema::herc20s::columns::redeem_identity;
+
+        self.do_in_transaction(|connection| {
+            let key = Text(swap_id);
+
+            let swap: Swap = swaps::table
+                .filter(swaps::local_swap_id.eq(key))
+                .first(connection)?;
+
+            diesel::update(herc20s::dsl::herc20s.filter(herc20s::swap_id.eq(swap.id)))
+                .set(redeem_identity.eq(Text(identity)))
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    /// This function is called depending on ones role and which side of the
+    /// swap herc20 is on.
+    /// - Called by Alice when herc20 is the beta protocol.
+    /// - Called by Bob when when herc20 is the alpha protocol.
+    pub async fn save_counterparty_herc20_refund_identity(
+        &self,
+        swap_id: LocalSwapId,
+        identity: identity::Ethereum,
+    ) -> anyhow::Result<()> {
+        use crate::db::schema::herc20s::columns::refund_identity;
+
+        self.do_in_transaction(|connection| {
+            let key = Text(swap_id);
+
+            let swap: Swap = swaps::table
+                .filter(swaps::local_swap_id.eq(key))
+                .first(connection)?;
+
+            diesel::update(herc20s::dsl::herc20s.filter(herc20s::swap_id.eq(swap.id)))
+                .set(refund_identity.eq(Text(identity)))
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn save_address_hint(
+        &self,
+        peer_id: PeerId,
+        address_hint: &libp2p::Multiaddr,
+    ) -> anyhow::Result<()> {
+        self.do_in_transaction(|connection| {
+            let insertable = InsertableAddressHint {
+                peer_id: Text(peer_id.clone()),
+                address_hint: Text(address_hint.clone()),
+            };
+
+            diesel::insert_into(address_hints::dsl::address_hints)
+                .values(insertable)
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn load_address_hint(&self, peer_id: &PeerId) -> anyhow::Result<libp2p::Multiaddr> {
+        let record: AddressHint = self
+            .do_in_transaction(|connection| {
+                let key = Text(peer_id);
+
+                address_hints::table
+                    .filter(address_hints::peer_id.eq(key))
+                    .first(connection)
+                    .optional()
+            })
+            .await?
+            .ok_or(Error::PeerIdNotFound)?;
+
+        Ok(record.address_hint.0)
+    }
+
+    pub(crate) async fn save_herc20(
+        &self,
+        swap_id: LocalSwapId,
+        data: &InsertableHerc20,
+    ) -> anyhow::Result<()> {
+        self.do_in_transaction(|connection| {
+            let key = Text(swap_id);
+
+            let swap: Swap = swaps::table
+                .filter(swaps::local_swap_id.eq(key))
+                .first(connection)?;
+
+            let insertable = data.with_swap_id(swap.id);
+
+            diesel::insert_into(herc20s::dsl::herc20s)
+                .values(insertable)
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn load_herc20(&self, swap_id: LocalSwapId) -> anyhow::Result<Herc20> {
+        let record: Herc20 = self
+            .do_in_transaction(|connection| {
+                let key = Text(swap_id);
+
+                let swap: Swap = swaps::table
+                    .filter(swaps::local_swap_id.eq(key))
+                    .first(connection)?;
+
+                Herc20::belonging_to(&swap).first(connection).optional()
+            })
+            .await?
+            .ok_or(Error::SwapNotFound)?;
+
+        Ok(record)
+    }
+
+    pub async fn save_halight(
+        &self,
+        swap_id: LocalSwapId,
+        data: &InsertableHalight,
+    ) -> anyhow::Result<()> {
+        self.do_in_transaction(|connection| {
+            let key = Text(swap_id);
+
+            let swap: Swap = swaps::table
+                .filter(swaps::local_swap_id.eq(key))
+                .first(connection)?;
+
+            let insertable = data.with_swap_id(swap.id);
+
+            diesel::insert_into(halights::dsl::halights)
+                .values(insertable)
+                .execute(&*connection)
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn load_halight(&self, swap_id: LocalSwapId) -> anyhow::Result<Halight> {
+        let record: Halight = self
+            .do_in_transaction(|connection| {
+                let key = Text(swap_id);
+
+                let swap: Swap = swaps::table
+                    .filter(swaps::local_swap_id.eq(key))
+                    .first(connection)?;
+
+                Halight::belonging_to(&swap).first(connection).optional()
+            })
+            .await?
+            .ok_or(Error::SwapNotFound)?;
+
+        Ok(record)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lightning;
+    use std::{path::PathBuf, str::FromStr};
+
+    fn temp_db() -> PathBuf {
+        let temp_file = tempfile::Builder::new()
+            .suffix(".sqlite")
+            .tempfile()
+            .unwrap();
+
+        temp_file.into_temp_path().to_path_buf()
+    }
+
+    fn insertable_swap() -> InsertableSwap {
+        let swap_id =
+            LocalSwapId::from_str("ad2652ca-ecf2-4cc6-b35c-b4351ac28a34").expect("valid swap id");
+        let role = Role::Alice;
+        let peer_id = PeerId::from_str("QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY")
+            .expect("valid peer id");
+
+        InsertableSwap {
+            local_swap_id: Text(swap_id),
+            role: Text(role),
+            counterparty_peer_id: Text(peer_id),
+        }
+    }
+
+    impl PartialEq<InsertableSwap> for Swap {
+        fn eq(&self, other: &InsertableSwap) -> bool {
+            self.local_swap_id == other.local_swap_id
+                && self.role == other.role
+                && self.counterparty_peer_id == other.counterparty_peer_id
+        }
+    }
+
+    impl PartialEq<InsertableHerc20> for Herc20 {
+        fn eq(&self, other: &InsertableHerc20) -> bool {
+            self.amount == other.amount
+                && self.chain_id == other.chain_id
+                && self.expiry == other.expiry
+                && self.hash_function == other.hash_function
+                && self.token_contract == other.token_contract
+                && self.redeem_identity == other.redeem_identity
+                && self.refund_identity == other.refund_identity
+                && self.ledger == other.ledger
+        }
+    }
+
+    impl PartialEq<InsertableHalight> for Halight {
+        fn eq(&self, other: &InsertableHalight) -> bool {
+            self.amount == other.amount
+                && self.network == other.network
+                && self.chain == other.chain
+                && self.cltv_expiry == other.cltv_expiry
+                && self.hash_function == other.hash_function
+                && self.redeem_identity == other.redeem_identity
+                && self.refund_identity == other.refund_identity
+                && self.ledger == other.ledger
+        }
+    }
+
+    #[tokio::test]
+    async fn roundtrip_swap() {
+        let path = temp_db();
+        let db = Sqlite::new(&path).expect("a new db");
+
+        let given = insertable_swap();
+        let swap_id = given.local_swap_id.0;
+
+        db.save_swap(&given)
+            .await
+            .expect("to be able to save a swap");
+
+        let loaded = db
+            .load_swap(swap_id)
+            .await
+            .expect("to be able to load a previously saved swap");
+
+        assert_eq!(loaded, given)
+    }
+
+    #[tokio::test]
+    async fn roundtrip_secret_hash() {
+        let path = temp_db();
+        let db = Sqlite::new(&path).expect("a new db");
+
+        let swap = insertable_swap();
+        let swap_id = swap.local_swap_id.0;
+
+        db.save_swap(&swap)
+            .await
+            .expect("to be able to save a swap");
+
+        let secret_hash = rfc003::SecretHash::from_str(
+            "bfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbf\
+             bfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbf",
+        )
+        .expect("valid secret hash");
+
+        db.save_secret_hash(swap_id, secret_hash)
+            .await
+            .expect("to be able to save secret hash");
+
+        let loaded = db
+            .load_secret_hash(swap_id)
+            .await
+            .expect("to be able to load a previously saved secret hash");
+
+        assert_eq!(loaded, secret_hash)
+    }
+
+    #[tokio::test]
+    async fn roundtrip_shared_swap_id() {
+        let path = temp_db();
+        let db = Sqlite::new(&path).expect("a new db");
+
+        let swap = insertable_swap();
+        let swap_id = swap.local_swap_id.0;
+
+        db.save_swap(&swap)
+            .await
+            .expect("to be able to save a swap");
+
+        let shared_swap_id =
+            swap_protocols::SharedSwapId::from_str("ad9999ca-ecf2-4cc6-b35c-b4351ac28a34")
+                .expect("valid swap id");
+
+        db.save_shared_swap_id(swap_id, shared_swap_id)
+            .await
+            .expect("to be able to save swap id");
+
+        let loaded = db
+            .load_shared_swap_id(swap_id)
+            .await
+            .expect("to be able to load a previously saved swap id");
+
+        assert_eq!(loaded, shared_swap_id)
+    }
+
+    #[tokio::test]
+    async fn roundtrip_address_hint() {
+        let path = temp_db();
+        let db = Sqlite::new(&path).expect("a new db");
+
+        let swap = insertable_swap();
+
+        db.save_swap(&swap)
+            .await
+            .expect("to be able to save a swap");
+
+        let peer_id = PeerId::from_str("QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY")
+            .expect("valid peer id");
+        let multi_addr = "/ip4/80.123.90.4/tcp/5432";
+        let address_hint: Multiaddr = multi_addr.parse().expect("valid multiaddress");
+
+        db.save_address_hint(peer_id.clone(), &address_hint)
+            .await
+            .expect("to be able to save address hint");
+
+        let loaded = db
+            .load_address_hint(&peer_id)
+            .await
+            .expect("to be able to load a previously saved address hint");
+
+        assert_eq!(loaded, address_hint)
+    }
+
+    #[tokio::test]
+    async fn roundtrip_herc20s() {
+        let path = temp_db();
+        let db = Sqlite::new(&path).expect("a new db");
+
+        let swap = insertable_swap();
+        let swap_id = swap.local_swap_id.0;
+
+        db.save_swap(&swap)
+            .await
+            .expect("to be able to save a swap");
+
+        let amount = Erc20Amount::from_str("12345").expect("valid ERC20 amount");
+        let ethereum_identity =
+            EthereumAddress::from_str("1111e8be41b21f651a71aaB1A85c6813b8bBcCf8")
+                .expect("valid etherum identity");
+        let redeem_identity = EthereumAddress::from_str("2222e8be41b21f651a71aaB1A85c6813b8bBcCf8")
+            .expect("valid redeem identity");
+        let refund_identity = EthereumAddress::from_str("3333e8be41b21f651a71aaB1A85c6813b8bBcCf8")
+            .expect("valid refund identity");
+
+        let given = InsertableHerc20 {
+            swap_id: 0, // This is set when saving.
+            amount: Text(amount),
+            chain_id: U32(1337),
+            expiry: U32(123),
+            hash_function: Text(HashFunction::Sha256),
+            token_contract: Text(ethereum_identity),
+            redeem_identity: Some(Text(redeem_identity)),
+            refund_identity: Some(Text(refund_identity)),
+            ledger: Text(Ledger::Alpha),
+        };
+
+        db.save_herc20(swap_id, &given)
+            .await
+            .expect("to be able to save swap details");
+
+        let loaded = db
+            .load_herc20(swap_id)
+            .await
+            .expect("to be able to load a previously saved swap details");
+
+        assert_eq!(loaded, given)
+    }
+
+    #[tokio::test]
+    async fn roundtrip_halights() {
+        let path = temp_db();
+        let db = Sqlite::new(&path).expect("a new db");
+
+        let swap = insertable_swap();
+        let swap_id = swap.local_swap_id.0;
+
+        db.save_swap(&swap)
+            .await
+            .expect("to be able to save a swap");
+
+        let amount = Satoshis::from_str("12345").expect("valid ERC20 amount");
+
+        let redeem_identity = lightning::PublicKey::random();
+        let refund_identity = lightning::PublicKey::random();
+
+        let given = InsertableHalight {
+            swap_id: 0, // This is set when saving.
+            amount: Text(amount),
+            network: Text(LightningNetwork::Testnet),
+            chain: "bitcoin".to_string(),
+            cltv_expiry: U32(456),
+            hash_function: Text(HashFunction::Sha256),
+            redeem_identity: Some(Text(redeem_identity)),
+            refund_identity: Some(Text(refund_identity)),
+            ledger: Text(Ledger::Alpha),
+        };
+
+        db.save_halight(swap_id, &given)
+            .await
+            .expect("to be able to save swap details");
+
+        let loaded = db
+            .load_halight(swap_id)
+            .await
+            .expect("to be able to load a previously saved swap details");
+
+        assert_eq!(loaded, given)
+    }
+}

--- a/cnd/src/db/wrapper_types.rs
+++ b/cnd/src/db/wrapper_types.rs
@@ -1,4 +1,10 @@
-use crate::{asset, asset::Bitcoin, db::LedgerKind, identity, swap_protocols::ledger};
+use crate::{
+    asset,
+    asset::Bitcoin,
+    db::LedgerKind,
+    identity,
+    swap_protocols::ledger::{self, lightning},
+};
 use std::{fmt, str::FromStr};
 
 pub mod custom_sql_types;
@@ -126,6 +132,52 @@ impl From<EthereumAddress> for identity::Ethereum {
 impl From<identity::Ethereum> for EthereumAddress {
     fn from(address: identity::Ethereum) -> Self {
         EthereumAddress(address)
+    }
+}
+
+/// A wrapper type for Lightning networks.
+///
+/// This is then wrapped in the db::custom_sql_types::Text to be stored in DB
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LightningNetwork {
+    Mainnet,
+    Testnet,
+    Regtest,
+}
+
+impl From<lightning::Regtest> for LightningNetwork {
+    fn from(_: lightning::Regtest) -> Self {
+        LightningNetwork::Regtest
+    }
+}
+
+impl From<LightningNetwork> for lightning::Regtest {
+    fn from(_: LightningNetwork) -> Self {
+        lightning::Regtest
+    }
+}
+
+impl FromStr for LightningNetwork {
+    type Err = UnknownVariant;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "mainnet" => Ok(Self::Mainnet),
+            "testnet" => Ok(Self::Testnet),
+            "regtest" => Ok(Self::Regtest),
+            _ => Err(UnknownVariant),
+        }
+    }
+}
+
+impl fmt::Display for LightningNetwork {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Mainnet => "mainnet",
+            Self::Testnet => "testnet",
+            Self::Regtest => "regtest",
+        };
+        write!(f, "{}", s)
     }
 }
 

--- a/cnd/src/ethereum.rs
+++ b/cnd/src/ethereum.rs
@@ -62,6 +62,19 @@ impl FromStr for Address {
     }
 }
 
+impl Display for Address {
+    // This is duplicate code from LowerHex, is there a better way to do this?
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        for i in &self.0[..] {
+            write!(f, "{:02x}", i)?;
+        }
+        Ok(())
+    }
+}
+
 impl From<Address> for Hash {
     fn from(address: Address) -> Self {
         let mut h256 = Hash([0u8; 32]);

--- a/cnd/src/http_api/routes/index.rs
+++ b/cnd/src/http_api/routes/index.rs
@@ -5,8 +5,8 @@ use crate::{
     identity,
     network::{DialInformation, ListenAddresses},
     swap_protocols::{
-        halight, han, Facade, HanEtherereumHalightBitcoinCreateSwapParams, LocalSwapId,
-        Rfc003Facade, Role,
+        halight, han, ledger::lightning, Facade, HanEtherereumHalightBitcoinCreateSwapParams,
+        LocalSwapId, Rfc003Facade, Role,
     },
 };
 use http_api_problem::HttpApiProblem;
@@ -77,6 +77,7 @@ pub async fn post_han_ethereum_halight_bitcoin(
         alpha: body.alpha.into(),
         beta: body.beta.into(),
         peer: body.peer.peer_id,
+        address_hint: None,
         role: body.role.0,
     };
 
@@ -207,7 +208,7 @@ impl From<HanEthereumEther> for han::CreatedSwap {
 pub struct HalightLightningBitcoin {
     pub amount: Http<asset::Bitcoin>,
     pub identity: identity::Lightning,
-    pub network: String,
+    pub network: Http<lightning::Regtest>,
     pub cltv_expiry: u32,
 }
 
@@ -216,7 +217,7 @@ impl From<HalightLightningBitcoin> for halight::CreatedSwap {
         halight::CreatedSwap {
             amount: *p.amount,
             identity: p.identity,
-            network: p.network,
+            network: *p.network,
             cltv_expiry: p.cltv_expiry,
         }
     }

--- a/cnd/src/lightning.rs
+++ b/cnd/src/lightning.rs
@@ -46,6 +46,12 @@ impl PublicKey {
     }
 }
 
+impl fmt::Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 impl From<secp256k1::PublicKey> for PublicKey {
     fn from(key: secp256k1::PublicKey) -> Self {
         Self(bitcoin::PublicKey {

--- a/cnd/src/swap_protocols.rs
+++ b/cnd/src/swap_protocols.rs
@@ -40,6 +40,12 @@ pub enum SwapProtocol {
 }
 
 #[derive(Clone, Copy, Debug, Display, EnumString, PartialEq)]
+pub enum Ledger {
+    Alpha,
+    Beta,
+}
+
+#[derive(Clone, Copy, Debug, Display, EnumString, PartialEq)]
 pub enum Role {
     Alice,
     Bob,

--- a/cnd/src/swap_protocols/halight.rs
+++ b/cnd/src/swap_protocols/halight.rs
@@ -1,11 +1,13 @@
 use crate::{
     asset, identity,
     swap_protocols::{
+        ledger::lightning,
         rfc003::{Secret, SecretHash},
         state,
         state::Update,
-        LocalSwapId,
+        Ledger, LocalSwapId,
     },
+    timestamp::Timestamp,
 };
 use futures::{
     future::{self, Either},
@@ -26,12 +28,22 @@ pub use connector::*;
 
 /// Data required to create a swap that involves bitcoin on the lightning
 /// network.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CreatedSwap {
     pub amount: asset::Bitcoin,
     pub identity: identity::Lightning,
-    pub network: String,
+    pub network: lightning::Regtest,
     pub cltv_expiry: u32,
+}
+
+/// Halight specific data for an in progress swap.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct InProgressSwap {
+    pub ledger: Ledger,
+    pub asset: asset::Bitcoin,
+    pub refund_identity: identity::Lightning,
+    pub redeem_identity: identity::Lightning,
+    pub expiry: Timestamp, // This is the cltv_expiry for now.
 }
 
 /// Creates a new instance of the halight protocol.

--- a/cnd/src/swap_protocols/han.rs
+++ b/cnd/src/swap_protocols/han.rs
@@ -11,8 +11,9 @@ use crate::{
             },
             LedgerState,
         },
-        state, LedgerStates, LocalSwapId, Role,
+        state, Ledger, LedgerStates, LocalSwapId, Role,
     },
+    timestamp::Timestamp,
     transaction,
 };
 use chrono::{NaiveDateTime, Utc};
@@ -33,6 +34,16 @@ pub struct CreatedSwap {
     pub identity: identity::Ethereum,
     pub chain_id: u32,
     pub absolute_expiry: u32,
+}
+
+/// Han specific data for an in progress swap.
+#[derive(Debug, Clone)]
+pub struct InProgressSwap {
+    pub ledger: Ledger,
+    pub asset: asset::Ether,
+    pub refund_identity: identity::Ethereum,
+    pub redeem_identity: identity::Ethereum,
+    pub expiry: Timestamp, // This is the absolute_expiry for now.
 }
 
 pub async fn new_han_ethereum_ether_swap(


### PR DESCRIPTION
Another attempt at implementing the new database model.

This time; limited to only touching the database module (where possible) i.e., this PR defines and implements an API for as well as implementing the database code for `herc20 -> halight` swaps.

In this PR we have:
- Individual tables incl. save/load and unit tests
- A type `CreatedSwap` for saving a swap when it comes in on the REST API. Load and Save APi methods for this type incl. roundtrip unit test.
- Database methods to save all the individual message data types shared during the communication protocols.
- A type `InProgressSwap` to load an in progress swap.
- An integration test that simulates the flow of a swap from creation, through finalization, and into the 'in progress' state.