### PR TITLE
Switch ether to erc20 for halight swaps

### DIFF
--- a/api_tests/tests/communication.ts
+++ b/api_tests/tests/communication.ts
@@ -19,7 +19,7 @@ describe("communication", () => {
         "Alice creates and then Bob creates, it finalizes",
         twoActorTest(async ({ alice, bob }) => {
             const bodies = (await SwapFactory.newSwap(alice, bob))
-                .hanEthereumEtherHalightLightningBitcoin;
+                .herc20EthereumErc20HalightLightningBitcoin;
 
             await alice.createSwap(bodies.alice);
             await sleep(500);
@@ -34,7 +34,7 @@ describe("communication", () => {
         "Bob creates and then Alice creates, it finalizes",
         twoActorTest(async ({ alice, bob }) => {
             const bodies = (await SwapFactory.newSwap(alice, bob))
-                .hanEthereumEtherHalightLightningBitcoin;
+                .herc20EthereumErc20HalightLightningBitcoin;
 
             await bob.createSwap(bodies.bob);
             await sleep(500);
@@ -49,7 +49,7 @@ describe("communication", () => {
         "swap-announced-with-wrong-peer-id-does-not-finalize",
         twoActorTest(async ({ alice, bob }) => {
             const bodies = (await SwapFactory.newSwap(alice, bob))
-                .hanEthereumEtherHalightLightningBitcoin;
+                .herc20EthereumErc20HalightLightningBitcoin;
 
             // Simulate that Bob is awaiting a swap from a different peer-id than Alice node's peer-id.
             bodies.bob.peer.peer_id =

--- a/api_tests/tests/erc20_halight.ts
+++ b/api_tests/tests/erc20_halight.ts
@@ -8,10 +8,10 @@ import { sleep } from "../src/utils";
 import { twoActorTest } from "../src/actor_test";
 
 it(
-    "han-ethereum-ether-halight-lightning-bitcoin-alice-redeems-bob-redeems",
+    "herc20-ethereum-erc20-halight-lightning-bitcoin-alice-redeems-bob-redeems",
     twoActorTest(async ({ alice, bob }) => {
         const bodies = (await SwapFactory.newSwap(alice, bob))
-            .hanEthereumEtherHalightLightningBitcoin;
+            .herc20EthereumErc20HalightLightningBitcoin;
 
         await alice.createSwap(bodies.alice);
         await sleep(500);
@@ -19,6 +19,7 @@ it(
 
         await alice.init();
 
+        await alice.deploy();
         await alice.fund();
 
         // we must not wait for bob's funding because `sendpayment` on a hold-invoice is a blocking call.

--- a/api_tests/tests/lightning_routes.ts
+++ b/api_tests/tests/lightning_routes.ts
@@ -13,10 +13,10 @@ import {
 
 describe("Lightning routes tests", () => {
     it(
-        "create-han-ethereum-ether-halight-lightning-bitcoin-returns-bad-request",
+        "create-herc20-ethereum-erc20-halight-lightning-bitcoin-returns-bad-request",
         twoActorTest(async ({ alice, bob }) => {
             const bodies = (await SwapFactory.newSwap(alice, bob, true))
-                .hanEthereumEtherHalightLightningBitcoin;
+                .herc20EthereumErc20HalightLightningBitcoin;
 
             const expectedProblem = {
                 status: 400,
@@ -26,12 +26,12 @@ describe("Lightning routes tests", () => {
             };
 
             await expect(
-                alice.cnd.createHanEthereumEtherHalightLightningBitcoin(
+                alice.cnd.createHerc20EthereumErc20HalightLightningBitcoin(
                     bodies.alice
                 )
             ).rejects.toMatchObject(expectedProblem);
             await expect(
-                bob.cnd.createHanEthereumEtherHalightLightningBitcoin(
+                bob.cnd.createHerc20EthereumErc20HalightLightningBitcoin(
                     bodies.bob
                 )
             ).rejects.toMatchObject(expectedProblem);
@@ -39,17 +39,17 @@ describe("Lightning routes tests", () => {
     );
 
     it(
-        "create-herc20-ethereum-erc20-halight-lightning-bitcoin-returns-route-not-supported",
+        "create-han-ethereum-ether-halight-lightning-bitcoin-returns-route-not-supported",
         twoActorTest(async ({ alice, bob }) => {
             const bodies = (await SwapFactory.newSwap(alice, bob, true))
-                .herc20EthereumErc20HalightLightningBitcoin;
+                .hanEthereumEtherHalightLightningBitcoin;
             await expect(
-                alice.cnd.createHerc20EthereumErc20HalightLightningBitcoin(
+                alice.cnd.createHanEthereumEtherHalightLightningBitcoin(
                     bodies.alice
                 )
             ).rejects.toThrow("Route not yet supported.");
             await expect(
-                bob.cnd.createHerc20EthereumErc20HalightLightningBitcoin(
+                bob.cnd.createHanEthereumEtherHalightLightningBitcoin(
                     bodies.bob
                 )
             ).rejects.toThrow("Route not yet supported.");

--- a/cnd/src/asset/ethereum/erc20.rs
+++ b/cnd/src/asset/ethereum/erc20.rs
@@ -31,6 +31,10 @@ impl Erc20Quantity {
         let buf = self.0.to_bytes_be();
         U256::from_big_endian(&buf)
     }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.to_bytes_le()
+    }
 }
 
 impl FromWei<U256> for Erc20Quantity {

--- a/cnd/src/http_api/route_factory.rs
+++ b/cnd/src/http_api/route_factory.rs
@@ -156,6 +156,14 @@ pub fn create(
         .and(facade.clone())
         .and_then(http_api::routes::action_fund);
 
+    let lightning_action_deploy = swaps
+        .and(warp::get())
+        .and(warp::path::param::<LocalSwapId>())
+        .and(warp::path("deploy"))
+        .and(warp::path::end())
+        .and(facade.clone())
+        .and_then(http_api::routes::action_deploy);
+
     let lightning_action_redeem = swaps
         .and(warp::get())
         .and(warp::path::param::<LocalSwapId>())
@@ -187,6 +195,7 @@ pub fn create(
         .or(get_halight_swap)
         .or(lightning_action_init)
         .or(lightning_action_fund)
+        .or(lightning_action_deploy)
         .or(lightning_action_redeem)
         .or(lightning_action_refund)
         .recover(http_api::unpack_problem)

--- a/cnd/src/http_api/routes.rs
+++ b/cnd/src/http_api/routes.rs
@@ -606,31 +606,27 @@ impl FundAction for AliceHerc20HalightBitcoinState {
     type Output = ethereum::CallContract;
 
     fn fund_action(&self) -> Option<Self::Output> {
-        match self.beta_ledger_state {
-            halight::State::Opened(_) => match self.alpha_ledger_state {
-                LedgerState::Deployed { htlc_location, .. } => {
-                    let htlc_params = self.finalized_swap.herc20_params();
-                    let chain_id = ChainId::regtest();
-                    let gas_limit = Erc20Htlc::fund_tx_gas_limit();
+        match (&self.alpha_ledger_state, &self.beta_ledger_state) {
+            (LedgerState::Deployed { htlc_location, .. }, halight::State::Opened(_)) => {
+                let htlc_params = self.finalized_swap.herc20_params();
+                let chain_id = ChainId::regtest();
+                let gas_limit = Erc20Htlc::fund_tx_gas_limit();
 
-                    let htlc_address =
-                        blockchain_contracts::ethereum::Address(htlc_location.into());
+                let htlc_address = blockchain_contracts::ethereum::Address((*htlc_location).into());
 
-                    let data = Erc20Htlc::transfer_erc20_tx_payload(
-                        htlc_params.asset.quantity.into(),
-                        htlc_address,
-                    );
+                let data = Erc20Htlc::transfer_erc20_tx_payload(
+                    htlc_params.asset.quantity.into(),
+                    htlc_address,
+                );
 
-                    Some(ethereum::CallContract {
-                        to: htlc_params.asset.token_contract,
-                        data: Some(Bytes(data)),
-                        gas_limit,
-                        chain_id,
-                        min_block_timestamp: None,
-                    })
-                }
-                _ => None,
-            },
+                Some(ethereum::CallContract {
+                    to: htlc_params.asset.token_contract,
+                    data: Some(Bytes(data)),
+                    gas_limit,
+                    chain_id,
+                    min_block_timestamp: None,
+                })
+            }
             _ => None,
         }
     }

--- a/cnd/src/http_api/routes/index.rs
+++ b/cnd/src/http_api/routes/index.rs
@@ -62,7 +62,7 @@ pub async fn post_han_ethereum_halight_bitcoin(
     body: serde_json::Value,
     _facade: Facade,
 ) -> Result<warp::reply::Json, Rejection> {
-    let _body = Body::<Herc20EthereumErc20, HalightLightningBitcoin>::deserialize(&body)
+    let _body = Body::<HanEthereumEther, HalightLightningBitcoin>::deserialize(&body)
         .map_err(anyhow::Error::new)
         .map_err(problem::from_anyhow)
         .map_err(warp::reject::custom)?;

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -25,7 +25,7 @@ use crate::{
     swap_protocols::{
         halight,
         halight::{LndConnectorAsReceiver, LndConnectorAsSender, LndConnectorParams, States},
-        herc20_quickfix, ledger,
+        herc20_rfc003_watcher, ledger,
         rfc003::{
             self,
             create_swap::HtlcParams,
@@ -1212,7 +1212,7 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<comit_ln::BehaviourOutEvent> fo
                                     let token_contract = create_swap_params.token_contract.into();
                                     let erc20 = Erc20::new(token_contract, asset);
 
-                                    herc20_quickfix::new_herc20_swap(
+                                    herc20_rfc003_watcher::new_herc20_swap(
                                         local_swap_id,
                                         connector,
                                         self.alpha_ledger_states.clone(),
@@ -1249,7 +1249,7 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<comit_ln::BehaviourOutEvent> fo
                                     let token_contract = create_swap_params.token_contract.into();
                                     let erc20 = Erc20::new(token_contract, asset);
 
-                                    self::herc20_quickfix::new_herc20_swap(
+                                    self::herc20_rfc003_watcher::new_herc20_swap(
                                         local_swap_id,
                                         connector,
                                         self.alpha_ledger_states.clone(),

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -635,7 +635,7 @@ impl NetworkBehaviourEventProcess<oneshot_behaviour::OutEvent<finalize::Message>
 mod tests {
     use super::*;
     use crate::{
-        asset::{ethereum::FromWei, AssetKind::Erc20, Erc20Quantity},
+        asset::{ethereum::FromWei, Erc20Quantity},
         lightning,
         network::{test_swarm, DialInformation},
         swap_protocols::EthereumIdentity,

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -12,11 +12,10 @@ use crate::{
     swap_protocols::{
         ledger::{ethereum::ChainId, lightning, Ethereum},
         rfc003::{create_swap::HtlcParams, DeriveSecret, Secret, SecretHash},
-        HanEtherereumHalightBitcoinCreateSwapParams, LocalSwapId, Role, SharedSwapId,
+        Herc20HalightBitcoinCreateSwapParams, LocalSwapId, Role, SharedSwapId,
     },
     timestamp::Timestamp,
 };
-use blockchain_contracts::ethereum::rfc003::ether_htlc::EtherHtlc;
 use digest::Digest;
 use futures::AsyncWriteExt;
 use libp2p::{
@@ -43,7 +42,7 @@ mod swaps;
 pub enum BehaviourOutEvent {
     SwapFinalized {
         local_swap_id: LocalSwapId,
-        swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
+        swap_params: Herc20HalightBitcoinCreateSwapParams,
         secret_hash: SecretHash,
         ethereum_identity: identity::Ethereum,
     },
@@ -105,7 +104,7 @@ impl ComitLN {
     pub fn initiate_communication(
         &mut self,
         id: LocalSwapId,
-        create_swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
+        create_swap_params: Herc20HalightBitcoinCreateSwapParams,
     ) -> anyhow::Result<()> {
         let digest = create_swap_params.digest();
         tracing::trace!("Swap creation request received: {}", digest);
@@ -142,7 +141,7 @@ impl ComitLN {
     pub fn get_created_swap(
         &self,
         swap_id: &LocalSwapId,
-    ) -> Option<HanEtherereumHalightBitcoinCreateSwapParams> {
+    ) -> Option<Herc20HalightBitcoinCreateSwapParams> {
         self.swaps.get_created_swap(swap_id)
     }
 
@@ -186,10 +185,15 @@ impl ComitLN {
             Role::Bob => create_swap_params.lightning_identity,
         };
 
+        let erc20 = asset::Erc20 {
+            token_contract: create_swap_params.token_contract.into(),
+            quantity: create_swap_params.ethereum_amount,
+        };
+
         Some(FinalizedSwap {
             alpha_ledger: Ethereum::new(ChainId::regtest()),
             beta_ledger: lightning::Regtest,
-            alpha_asset: create_swap_params.ethereum_amount.clone(),
+            alpha_asset: erc20,
             beta_asset: create_swap_params.lightning_amount,
             alpha_ledger_redeem_identity,
             alpha_ledger_refund_identity,
@@ -213,7 +217,7 @@ impl ComitLN {
         peer: PeerId,
         swap_id: SharedSwapId,
         local_swap_id: LocalSwapId,
-        create_swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
+        create_swap_params: Herc20HalightBitcoinCreateSwapParams,
     ) {
         let addresses = self.announce.addresses_of_peer(&peer);
         self.secret_hash
@@ -251,7 +255,7 @@ impl ComitLN {
         peer: libp2p::PeerId,
         io: ReplySubstream<NegotiatedSubstream>,
         shared_swap_id: SharedSwapId,
-        create_swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
+        create_swap_params: Herc20HalightBitcoinCreateSwapParams,
     ) {
         // Confirm
         tokio::task::spawn(io.send(shared_swap_id));
@@ -314,7 +318,7 @@ impl fmt::Display for SwapExists {
 pub struct FinalizedSwap {
     pub alpha_ledger: Ethereum,
     pub beta_ledger: lightning::Regtest,
-    pub alpha_asset: asset::Ether,
+    pub alpha_asset: asset::Erc20,
     pub beta_asset: asset::Bitcoin,
     pub alpha_ledger_refund_identity: identity::Ethereum,
     pub alpha_ledger_redeem_identity: identity::Ethereum,
@@ -329,7 +333,7 @@ pub struct FinalizedSwap {
 }
 
 impl FinalizedSwap {
-    pub fn han_params(&self) -> EtherHtlc {
+    pub fn herc20_params(&self) -> HtlcParams<Ethereum, asset::Erc20, identity::Ethereum> {
         HtlcParams {
             asset: self.alpha_asset.clone(),
             ledger: Ethereum::new(ChainId::regtest()),
@@ -338,7 +342,6 @@ impl FinalizedSwap {
             expiry: self.alpha_expiry,
             secret_hash: self.secret_hash,
         }
-        .into()
     }
 }
 
@@ -632,7 +635,7 @@ impl NetworkBehaviourEventProcess<oneshot_behaviour::OutEvent<finalize::Message>
 mod tests {
     use super::*;
     use crate::{
-        asset::{ethereum::FromWei, Ether},
+        asset::{ethereum::FromWei, AssetKind::Erc20, Erc20Quantity},
         lightning,
         network::{test_swarm, DialInformation},
         swap_protocols::EthereumIdentity,
@@ -645,12 +648,12 @@ mod tests {
     fn make_alice_swap_params(
         bob_peer_id: PeerId,
         bob_addr: Multiaddr,
-        ether: asset::Ether,
+        erc20: asset::Erc20,
         lnbtc: asset::Bitcoin,
         ethereum_absolute_expiry: Timestamp,
         lightning_cltv_expiry: Timestamp,
-    ) -> HanEtherereumHalightBitcoinCreateSwapParams {
-        HanEtherereumHalightBitcoinCreateSwapParams {
+    ) -> Herc20HalightBitcoinCreateSwapParams {
+        Herc20HalightBitcoinCreateSwapParams {
             role: Role::Alice,
             peer: DialInformation {
                 peer_id: bob_peer_id,
@@ -658,21 +661,22 @@ mod tests {
             },
             ethereum_identity: EthereumIdentity::from(identity::Ethereum::random()),
             ethereum_absolute_expiry,
-            ethereum_amount: ether,
+            ethereum_amount: erc20.quantity,
             lightning_identity: lightning::PublicKey::random(),
             lightning_cltv_expiry,
             lightning_amount: lnbtc,
+            token_contract: erc20.token_contract.into(),
         }
     }
 
     fn make_bob_swap_params(
         alice_peer_id: PeerId,
-        ether: asset::Ether,
+        erc20: asset::Erc20,
         lnbtc: asset::Bitcoin,
         ethereum_absolute_expiry: Timestamp,
         lightning_cltv_expiry: Timestamp,
-    ) -> HanEtherereumHalightBitcoinCreateSwapParams {
-        HanEtherereumHalightBitcoinCreateSwapParams {
+    ) -> Herc20HalightBitcoinCreateSwapParams {
+        Herc20HalightBitcoinCreateSwapParams {
             role: Role::Bob,
             peer: DialInformation {
                 peer_id: alice_peer_id,
@@ -680,10 +684,11 @@ mod tests {
             },
             ethereum_identity: EthereumIdentity::from(identity::Ethereum::random()),
             ethereum_absolute_expiry,
-            ethereum_amount: ether,
+            ethereum_amount: erc20.quantity,
             lightning_identity: lightning::PublicKey::random(),
             lightning_cltv_expiry,
             lightning_amount: lnbtc,
+            token_contract: erc20.token_contract.into(),
         }
     }
 
@@ -695,7 +700,11 @@ mod tests {
         let (mut bob_swarm, bob_addr, bob_peer_id) =
             test_swarm::new(ComitLN::new(RootSeed::new_random(thread_rng()).unwrap()));
 
-        let ether = Ether::from_wei(9_001_000_000_000_000_000_000u128);
+        let erc20 = asset::Erc20 {
+            token_contract: Default::default(),
+            quantity: Erc20Quantity::from_wei(9_001_000_000_000_000_000_000u128),
+        };
+
         let lnbtc = asset::Bitcoin::from_sat(42);
         let ethereum_expiry = Timestamp::from(100);
         let lightning_expiry = Timestamp::from(200);
@@ -706,7 +715,7 @@ mod tests {
                 make_alice_swap_params(
                     bob_peer_id,
                     bob_addr,
-                    ether.clone(),
+                    erc20.clone(),
                     lnbtc,
                     ethereum_expiry,
                     lightning_expiry,
@@ -718,7 +727,7 @@ mod tests {
                 LocalSwapId::default(),
                 make_bob_swap_params(
                     alice_peer_id,
-                    ether,
+                    erc20,
                     lnbtc,
                     ethereum_expiry,
                     lightning_expiry,

--- a/cnd/src/swap_protocols.rs
+++ b/cnd/src/swap_protocols.rs
@@ -3,7 +3,7 @@ mod facade;
 pub mod halight;
 pub mod han;
 pub mod herc20;
-pub mod herc20_quickfix;
+pub mod herc20_rfc003_watcher;
 pub mod ledger;
 pub mod ledger_states;
 pub mod rfc003;

--- a/cnd/src/swap_protocols.rs
+++ b/cnd/src/swap_protocols.rs
@@ -3,6 +3,7 @@ mod facade;
 pub mod halight;
 pub mod han;
 pub mod herc20;
+pub mod herc20_quickfix;
 pub mod ledger;
 pub mod ledger_states;
 pub mod rfc003;
@@ -71,6 +72,12 @@ pub trait FundAction {
     type Output;
 
     fn fund_action(&self) -> Option<Self::Output>;
+}
+
+pub trait DeployAction {
+    type Output;
+
+    fn deploy_action(&self) -> Option<Self::Output>;
 }
 
 /// Describes how to get the `redeem` action from the current state.

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 /// before communication with the other node has started
 #[derive(Clone, Digest, Debug, PartialEq)]
 #[digest(hash = "SwapDigest")]
-pub struct HanEtherereumHalightBitcoinCreateSwapParams {
+pub struct Herc20HalightBitcoinCreateSwapParams {
     #[digest(ignore)]
     pub role: Role,
     #[digest(ignore)]
@@ -23,7 +23,9 @@ pub struct HanEtherereumHalightBitcoinCreateSwapParams {
     #[digest(prefix = "2001")]
     pub ethereum_absolute_expiry: Timestamp,
     #[digest(prefix = "2002")]
-    pub ethereum_amount: asset::Ether,
+    pub ethereum_amount: asset::Erc20Quantity,
+    #[digest(ignore)]
+    pub token_contract: EthereumIdentity,
     #[digest(ignore)]
     pub lightning_identity: identity::Lightning,
     #[digest(prefix = "3001")]
@@ -39,6 +41,12 @@ impl ToDigestInput for asset::Bitcoin {
 }
 
 impl ToDigestInput for asset::Ether {
+    fn to_digest_input(&self) -> Vec<u8> {
+        self.to_bytes()
+    }
+}
+
+impl ToDigestInput for asset::Erc20Quantity {
     fn to_digest_input(&self) -> Vec<u8> {
         self.to_bytes()
     }
@@ -84,7 +92,7 @@ impl Facade {
     pub async fn initiate_communication(
         &self,
         id: LocalSwapId,
-        swap_params: HanEtherereumHalightBitcoinCreateSwapParams,
+        swap_params: Herc20HalightBitcoinCreateSwapParams,
     ) -> anyhow::Result<()> {
         self.swarm.initiate_communication(id, swap_params).await
     }
@@ -96,7 +104,7 @@ impl Facade {
     pub async fn get_created_swap(
         &self,
         id: LocalSwapId,
-    ) -> Option<HanEtherereumHalightBitcoinCreateSwapParams> {
+    ) -> Option<Herc20HalightBitcoinCreateSwapParams> {
         self.swarm.get_created_swap(id).await
     }
 }

--- a/cnd/src/swap_protocols/herc20_quickfix.rs
+++ b/cnd/src/swap_protocols/herc20_quickfix.rs
@@ -1,0 +1,178 @@
+use crate::{
+    asset, htlc_location, identity,
+    swap_protocols::{state, Ledger, LocalSwapId},
+    timestamp::Timestamp,
+    transaction,
+};
+use chrono::{NaiveDateTime, Utc};
+use futures::future::{self, Either};
+use genawaiter::sync::{Co, Gen};
+
+use crate::{
+    btsieve::ethereum::{Cache, Web3Connector},
+    swap_protocols::{
+        ledger,
+        rfc003::{
+            create_swap::{HtlcParams, SwapEvent},
+            events::{
+                Deployed, HtlcDeployed, HtlcFunded, HtlcRedeemed, HtlcRefunded, Redeemed, Refunded,
+            },
+            LedgerState,
+        },
+        LedgerStates, Role,
+    },
+};
+use genawaiter::GeneratorState;
+use std::sync::Arc;
+use tracing_futures::Instrument;
+
+/// Htlc ERC20 Token atomic swap protocol.
+
+/// Data required to create a swap that involves an ERC20 token.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CreatedSwap {
+    pub amount: asset::Erc20Quantity,
+    pub identity: identity::Ethereum,
+    pub chain_id: u32,
+    pub token_contract: identity::Ethereum,
+    pub absolute_expiry: u32,
+}
+
+/// Herc20 specific data for an in progress swap.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct InProgressSwap {
+    pub ledger: Ledger,
+    pub refund_identity: identity::Ethereum,
+    pub redeem_identity: identity::Ethereum,
+    pub expiry: Timestamp, // This is the absolute_expiry for now.
+}
+
+pub async fn new_herc20_swap(
+    swap_id: LocalSwapId,
+    connector: Arc<Cache<Web3Connector>>,
+    ethereum_ledger_state: Arc<LedgerStates>,
+    htlc_params: HtlcParams<ledger::Ethereum, asset::Erc20, identity::Ethereum>,
+    role: Role,
+) {
+    create_watcher::<_, _, _, _, htlc_location::Ethereum, _, transaction::Ethereum>(
+        connector.as_ref(),
+        ethereum_ledger_state,
+        swap_id,
+        htlc_params,
+        Utc::now().naive_local(),
+    )
+    .instrument(tracing::error_span!("alpha_ledger", swap_id = %swap_id, role = %role))
+    .await
+}
+
+/// Returns a future that tracks the swap negotiated from the given request and
+/// accept response on a ledger.
+///
+/// The current implementation is naive in the sense that it does not take into
+/// account situations where it is clear that no more events will happen even
+/// though in theory, there could. For example:
+/// - funded
+/// - refunded
+///
+/// It is highly unlikely for Bob to fund the HTLC now, yet the current
+/// implementation is still waiting for that.
+async fn create_watcher<C, S, L, A, H, I, T>(
+    ethereum_connector: &C,
+    ledger_state: Arc<S>,
+    swap_id: LocalSwapId,
+    htlc_params: HtlcParams<L, A, I>,
+    accepted_at: NaiveDateTime,
+) where
+    C: HtlcFunded<L, A, H, I, T>
+        + HtlcDeployed<L, A, H, I, T>
+        + HtlcRedeemed<L, A, H, I, T>
+        + HtlcRefunded<L, A, H, I, T>,
+    S: state::Update<SwapEvent<A, H, T>> + state::Insert<LedgerState<A, H, T>>,
+    L: Clone,
+    A: Ord + Clone,
+    H: Clone,
+    I: Clone,
+    T: Clone,
+{
+    ledger_state
+        .insert(swap_id, LedgerState::<A, H, T>::NotDeployed)
+        .await;
+
+    // construct a generator that watches alpha and beta ledger concurrently
+    let mut generator = Gen::new({
+        |co| async {
+            watch_ledger::<C, L, A, H, I, T>(&ethereum_connector, co, htlc_params, accepted_at)
+                .await
+        }
+    });
+
+    loop {
+        // wait for events to be emitted as the generator executes
+        match generator.async_resume().await {
+            // every event that is yielded is passed on
+            GeneratorState::Yielded(event) => {
+                tracing::info!("swap {} yielded event {}", swap_id, event);
+                ledger_state.update(&swap_id, event).await;
+            }
+            // the generator stopped executing, this means there are no more events that can be
+            // watched.
+            GeneratorState::Complete(Ok(_)) => {
+                tracing::info!("swap {} finished", swap_id);
+                return;
+            }
+            GeneratorState::Complete(Err(e)) => {
+                tracing::error!("swap {} failed with {:?}", swap_id, e);
+                return;
+            }
+        }
+    }
+}
+
+/// Returns a future that waits for events to happen on a ledger.
+///
+/// Each event is yielded through the controller handle (co) of the coroutine.
+async fn watch_ledger<C, L, A, H, I, T>(
+    ethereum_connector: &C,
+    co: Co<SwapEvent<A, H, T>>,
+    htlc_params: HtlcParams<L, A, I>,
+    start_of_swap: NaiveDateTime,
+) -> anyhow::Result<()>
+where
+    C: HtlcFunded<L, A, H, I, T>
+        + HtlcDeployed<L, A, H, I, T>
+        + HtlcRedeemed<L, A, H, I, T>
+        + HtlcRefunded<L, A, H, I, T>,
+    Deployed<H, T>: Clone,
+    Redeemed<T>: Clone,
+    Refunded<T>: Clone,
+{
+    let deployed = ethereum_connector
+        .htlc_deployed(&htlc_params, start_of_swap)
+        .await?;
+    co.yield_(SwapEvent::Deployed(deployed.clone())).await;
+
+    let funded = ethereum_connector
+        .htlc_funded(&htlc_params, &deployed, start_of_swap)
+        .await?;
+    co.yield_(SwapEvent::Funded(funded)).await;
+
+    let redeemed = ethereum_connector.htlc_redeemed(&htlc_params, &deployed, start_of_swap);
+
+    let refunded = ethereum_connector.htlc_refunded(&htlc_params, &deployed, start_of_swap);
+
+    match future::try_select(redeemed, refunded).await {
+        Ok(Either::Left((redeemed, _))) => {
+            co.yield_(SwapEvent::Redeemed(redeemed.clone())).await;
+        }
+        Ok(Either::Right((refunded, _))) => {
+            co.yield_(SwapEvent::Refunded(refunded.clone())).await;
+        }
+        Err(either) => {
+            let (error, _other_future) = either.factor_first();
+
+            return Err(error);
+        }
+    }
+
+    Ok(())
+}

--- a/cnd/src/swap_protocols/herc20_rfc003_watcher.rs
+++ b/cnd/src/swap_protocols/herc20_rfc003_watcher.rs
@@ -26,7 +26,7 @@ use genawaiter::GeneratorState;
 use std::sync::Arc;
 use tracing_futures::Instrument;
 
-/// Htlc ERC20 Token atomic swap protocol.
+// Temporary file for spinning up the ledger watcher for Erc20-Halight swaps.
 
 /// Data required to create a swap that involves an ERC20 token.
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
In an attempt to get cnd into a state where we can bring the current db and the lightning swaps together this PR changes `HanEthereumEther-HalightLightningBitcoin` swaps to `Herc20EthereumErc20-HalightLightningBitcoin` swaps.

Note that I did not act upon the new `herc20` protocol code yet, but used the rfc003 watcher for monitoring Ethereum. 

Would get this merged asap and then finally connect use the new DB 😀