### PR TITLE
LN clean up

### DIFF
--- a/cnd/src/asset/bitcoin.rs
+++ b/cnd/src/asset/bitcoin.rs
@@ -1,4 +1,5 @@
 use bitcoin::{util::amount::Denomination, Amount};
+use digest::ToDigestInput;
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
@@ -28,6 +29,12 @@ impl fmt::Display for Bitcoin {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         let bitcoin = self.0.to_string_in(Denomination::Bitcoin);
         write!(f, "{} BTC", bitcoin)
+    }
+}
+
+impl ToDigestInput for Bitcoin {
+    fn to_digest_input(&self) -> Vec<u8> {
+        self.to_le_bytes().to_vec()
     }
 }
 

--- a/cnd/src/asset/ethereum/erc20.rs
+++ b/cnd/src/asset/ethereum/erc20.rs
@@ -2,6 +2,7 @@ use crate::{
     asset::ethereum::{Error, FromWei, TryFromWei},
     ethereum::{Address, U256},
 };
+use digest::ToDigestInput;
 use num::{pow::Pow, BigUint, Num, Zero};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::{fmt, str::FromStr};
@@ -77,6 +78,12 @@ impl From<Erc20Quantity> for blockchain_contracts::ethereum::TokenQuantity {
 impl fmt::Display for Erc20Quantity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl ToDigestInput for Erc20Quantity {
+    fn to_digest_input(&self) -> Vec<u8> {
+        self.0.to_bytes_le()
     }
 }
 

--- a/cnd/src/asset/ethereum/ether.rs
+++ b/cnd/src/asset/ethereum/ether.rs
@@ -3,6 +3,7 @@ use crate::{
     ethereum::U256,
 };
 use bigdecimal::BigDecimal;
+use digest::ToDigestInput;
 use lazy_static::lazy_static;
 use num::{bigint::Sign, pow::Pow, BigInt, BigUint, Num, Zero};
 use serde::{
@@ -135,6 +136,12 @@ impl Serialize for Ether {
         S: Serializer,
     {
         serializer.serialize_str(self.0.to_string().as_str())
+    }
+}
+
+impl ToDigestInput for Ether {
+    fn to_digest_input(&self) -> Vec<u8> {
+        self.to_bytes()
     }
 }
 

--- a/cnd/src/http_api/routes.rs
+++ b/cnd/src/http_api/routes.rs
@@ -139,7 +139,7 @@ pub async fn handle_get_halight_swap(
         LedgerState<asset::Erc20, htlc_location::Ethereum, transaction::Ethereum>,
     > = facade.alpha_ledger_states.get(&swap_id).await?;
 
-    let beta_ledger_state = facade.beta_ledger_states.get(&swap_id).await?;
+    let beta_ledger_state = facade.halight_states.get(&swap_id).await?;
 
     let created_swap = facade.get_created_swap(swap_id).await;
 
@@ -849,7 +849,7 @@ async fn handle_action_init(
         .ok_or_else(|| anyhow::anyhow!("alpha ledger state not found for {}", swap_id))?;
 
     let beta_ledger_state: halight::State = facade
-        .beta_ledger_states
+        .halight_states
         .get(&swap_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("beta ledger state not found for {}", swap_id))?;
@@ -902,7 +902,7 @@ async fn handle_action_deploy(
         .ok_or_else(|| anyhow::anyhow!("alpha ledger state not found for {}", swap_id))?;
 
     let beta_ledger_state: halight::State = facade
-        .beta_ledger_states
+        .halight_states
         .get(&swap_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("beta ledger state not found for {}", swap_id))?;
@@ -956,7 +956,7 @@ async fn handle_action_fund(
         .ok_or_else(|| anyhow::anyhow!("alpha ledger state not found for {}", swap_id))?;
 
     let beta_ledger_state: halight::State = facade
-        .beta_ledger_states
+        .halight_states
         .get(&swap_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("beta ledger state not found for {}", swap_id))?;
@@ -1017,7 +1017,7 @@ async fn handle_action_redeem(
         .ok_or_else(|| anyhow::anyhow!("alpha ledger state not found for {}", swap_id))?;
 
     let beta_ledger_state: halight::State = facade
-        .beta_ledger_states
+        .halight_states
         .get(&swap_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("beta ledger state not found for {}", swap_id))?;
@@ -1078,7 +1078,7 @@ async fn handle_action_refund(
         .ok_or_else(|| anyhow::anyhow!("alpha ledger state not found for {}", swap_id))?;
 
     let beta_ledger_state: halight::State = facade
-        .beta_ledger_states
+        .halight_states
         .get(&swap_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("beta ledger state not found for {}", swap_id))?;

--- a/cnd/src/http_api/routes/index.rs
+++ b/cnd/src/http_api/routes/index.rs
@@ -172,13 +172,13 @@ impl From<Body<Herc20EthereumErc20, HalightLightningBitcoin>>
         Self {
             role: body.role.0,
             peer: body.peer,
-            ethereum_identity: body.alpha.identity.into(),
+            ethereum_identity: body.alpha.identity,
             ethereum_absolute_expiry: body.alpha.absolute_expiry.into(),
             ethereum_amount: body.alpha.amount,
             lightning_identity: body.beta.identity,
             lightning_cltv_expiry: body.beta.cltv_expiry.into(),
             lightning_amount: body.beta.amount.0,
-            token_contract: body.alpha.contract_address.into(),
+            token_contract: body.alpha.contract_address,
         }
     }
 }

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -176,7 +176,7 @@ fn main() -> anyhow::Result<()> {
     let facade = Facade {
         swarm: swarm.clone(),
         alpha_ledger_states: Arc::clone(&alpha_ledger_states),
-        beta_ledger_states: Arc::clone(&halight_states),
+        halight_states: Arc::clone(&halight_states),
     };
 
     let http_api_listener = runtime.block_on(bind_http_api_socket(&settings))?;

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -1209,7 +1209,7 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<comit_ln::BehaviourOutEvent> fo
                                     let asset = create_swap_params.ethereum_amount.clone();
                                     let ledger = ledger::Ethereum::default();
                                     let expiry = create_swap_params.ethereum_absolute_expiry;
-                                    let token_contract = create_swap_params.token_contract.into();
+                                    let token_contract = create_swap_params.token_contract;
                                     let erc20 = Erc20::new(token_contract, asset);
 
                                     herc20_rfc003_watcher::new_herc20_swap(
@@ -1220,7 +1220,7 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<comit_ln::BehaviourOutEvent> fo
                                             asset: erc20,
                                             ledger,
                                             redeem_identity: bob_ethereum_identity,
-                                            refund_identity: alice_ethereum_identity.into(),
+                                            refund_identity: alice_ethereum_identity,
                                             expiry,
                                             secret_hash,
                                         },
@@ -1246,7 +1246,7 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<comit_ln::BehaviourOutEvent> fo
                                     let asset = create_swap_params.ethereum_amount.clone();
                                     let ledger = ledger::Ethereum::default();
                                     let expiry = create_swap_params.ethereum_absolute_expiry;
-                                    let token_contract = create_swap_params.token_contract.into();
+                                    let token_contract = create_swap_params.token_contract;
                                     let erc20 = Erc20::new(token_contract, asset);
 
                                     self::herc20_rfc003_watcher::new_herc20_swap(
@@ -1256,7 +1256,7 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<comit_ln::BehaviourOutEvent> fo
                                         HtlcParams {
                                             asset: erc20,
                                             ledger,
-                                            redeem_identity: bob_ethereum_identity.into(),
+                                            redeem_identity: bob_ethereum_identity,
                                             refund_identity: alice_ethereum_identity,
                                             expiry,
                                             secret_hash,

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -161,10 +161,10 @@ impl ComitLN {
                 Some(identity) => identity,
                 None => return None,
             },
-            Role::Bob => create_swap_params.ethereum_identity.into(),
+            Role::Bob => create_swap_params.ethereum_identity,
         };
         let alpha_ledger_refund_identity = match create_swap_params.role {
-            Role::Alice => create_swap_params.ethereum_identity.into(),
+            Role::Alice => create_swap_params.ethereum_identity,
             Role::Bob => match self.ethereum_identities.get(&id).copied() {
                 Some(identity) => identity,
                 None => return None,
@@ -186,7 +186,7 @@ impl ComitLN {
         };
 
         let erc20 = asset::Erc20 {
-            token_contract: create_swap_params.token_contract.into(),
+            token_contract: create_swap_params.token_contract,
             quantity: create_swap_params.ethereum_amount,
         };
 
@@ -230,7 +230,7 @@ impl ComitLN {
 
         self.ethereum_identity.send(
             peer.clone(),
-            ethereum_identity::Message::new(swap_id, create_swap_params.ethereum_identity.into()),
+            ethereum_identity::Message::new(swap_id, create_swap_params.ethereum_identity),
         );
         self.lightning_identity.send(
             peer.clone(),
@@ -272,10 +272,7 @@ impl ComitLN {
         // Communicate
         self.ethereum_identity.send(
             peer.clone(),
-            ethereum_identity::Message::new(
-                shared_swap_id,
-                create_swap_params.ethereum_identity.into(),
-            ),
+            ethereum_identity::Message::new(shared_swap_id, create_swap_params.ethereum_identity),
         );
         self.lightning_identity.send(
             peer,
@@ -638,7 +635,6 @@ mod tests {
         asset::{ethereum::FromWei, Erc20Quantity},
         lightning,
         network::{test_swarm, DialInformation},
-        swap_protocols::EthereumIdentity,
     };
     use digest::Digest;
     use futures::future;
@@ -659,13 +655,13 @@ mod tests {
                 peer_id: bob_peer_id,
                 address_hint: Some(bob_addr),
             },
-            ethereum_identity: EthereumIdentity::from(identity::Ethereum::random()),
+            ethereum_identity: identity::Ethereum::random(),
             ethereum_absolute_expiry,
             ethereum_amount: erc20.quantity,
             lightning_identity: lightning::PublicKey::random(),
             lightning_cltv_expiry,
             lightning_amount: lnbtc,
-            token_contract: erc20.token_contract.into(),
+            token_contract: erc20.token_contract,
         }
     }
 
@@ -682,13 +678,13 @@ mod tests {
                 peer_id: alice_peer_id,
                 address_hint: None,
             },
-            ethereum_identity: EthereumIdentity::from(identity::Ethereum::random()),
+            ethereum_identity: identity::Ethereum::random(),
             ethereum_absolute_expiry,
             ethereum_amount: erc20.quantity,
             lightning_identity: lightning::PublicKey::random(),
             lightning_cltv_expiry,
             lightning_amount: lnbtc,
-            token_contract: erc20.token_contract.into(),
+            token_contract: erc20.token_contract,
         }
     }
 

--- a/cnd/src/network/comit_ln/swaps.rs
+++ b/cnd/src/network/comit_ln/swaps.rs
@@ -338,11 +338,7 @@ impl Default for Swaps<()> {
 mod tests {
     use super::*;
     use crate::{
-        asset,
-        asset::ethereum::FromWei,
-        identity,
-        network::DialInformation,
-        swap_protocols::{EthereumIdentity, Role},
+        asset, asset::ethereum::FromWei, identity, network::DialInformation, swap_protocols::Role,
     };
     use digest::Digest;
 
@@ -353,13 +349,13 @@ mod tests {
                 peer_id: PeerId::random(),
                 address_hint: None,
             },
-            ethereum_identity: EthereumIdentity::from(identity::Ethereum::random()),
+            ethereum_identity: identity::Ethereum::random(),
             ethereum_absolute_expiry: 12345.into(),
             ethereum_amount: asset::Erc20Quantity::from_wei(9_001_000_000_000_000_000_000u128),
             lightning_identity: identity::Lightning::random(),
             lightning_cltv_expiry: 12345.into(),
             lightning_amount: asset::Bitcoin::from_sat(1_000_000_000),
-            token_contract: EthereumIdentity::from(identity::Ethereum::random()),
+            token_contract: identity::Ethereum::random(),
         }
     }
 
@@ -407,8 +403,7 @@ mod tests {
         let mut second_create_params = first_create_params.clone();
         // Ethereum identity is not part of the digest so both swaps should be
         // considered the same
-        second_create_params.ethereum_identity =
-            EthereumIdentity::from(identity::Ethereum::random());
+        second_create_params.ethereum_identity = identity::Ethereum::random();
 
         let digest = first_create_params.digest();
         let second_digest = second_create_params.digest();
@@ -444,8 +439,7 @@ mod tests {
 
         // Ethereum identity is not part of the digest so both swaps should be
         // considered the same
-        second_create_params.ethereum_identity =
-            EthereumIdentity::from(identity::Ethereum::random());
+        second_create_params.ethereum_identity = identity::Ethereum::random();
 
         let digest = first_create_params.digest();
         let second_digest = second_create_params.digest();
@@ -662,8 +656,7 @@ mod tests {
     fn given_bob_creates_dupe_swap_after_announcement_then_stored_params_are_unchanged() {
         let first_create_params = create_params();
         let mut second_create_params = first_create_params.clone();
-        second_create_params.ethereum_identity =
-            EthereumIdentity::from(identity::Ethereum::random());
+        second_create_params.ethereum_identity = identity::Ethereum::random();
 
         let digest = first_create_params.digest();
         let second_digest = second_create_params.digest();

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -19,13 +19,13 @@ pub struct Herc20HalightBitcoinCreateSwapParams {
     #[digest(ignore)]
     pub peer: DialInformation,
     #[digest(ignore)]
-    pub ethereum_identity: EthereumIdentity,
+    pub ethereum_identity: identity::Ethereum,
     #[digest(prefix = "2001")]
     pub ethereum_absolute_expiry: Timestamp,
     #[digest(prefix = "2002")]
     pub ethereum_amount: asset::Erc20Quantity,
     #[digest(ignore)]
-    pub token_contract: EthereumIdentity,
+    pub token_contract: identity::Ethereum,
     #[digest(ignore)]
     pub lightning_identity: identity::Lightning,
     #[digest(prefix = "3001")]
@@ -49,21 +49,6 @@ impl ToDigestInput for asset::Ether {
 impl ToDigestInput for asset::Erc20Quantity {
     fn to_digest_input(&self) -> Vec<u8> {
         self.to_bytes()
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct EthereumIdentity(identity::Ethereum);
-
-impl From<identity::Ethereum> for EthereumIdentity {
-    fn from(inner: identity::Ethereum) -> Self {
-        EthereumIdentity(inner)
-    }
-}
-
-impl From<EthereumIdentity> for identity::Ethereum {
-    fn from(outer: EthereumIdentity) -> Self {
-        outer.0
     }
 }
 

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -42,7 +42,7 @@ pub struct Facade {
     pub swarm: Swarm,
     // We currently only support Han-HALight, therefor 'alpha' is Ethereum and 'beta' is Lightning.
     pub alpha_ledger_states: Arc<LedgerStates>,
-    pub beta_ledger_states: Arc<halight::States>,
+    pub halight_states: Arc<halight::States>,
 }
 
 impl Facade {

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -6,7 +6,7 @@ use crate::{
     swap_protocols::{halight, LedgerStates, LocalSwapId, Role},
     timestamp::{RelativeTime, Timestamp},
 };
-use digest::{Digest, ToDigestInput};
+use digest::Digest;
 use std::sync::Arc;
 
 /// This represent the information available on a swap
@@ -32,36 +32,6 @@ pub struct Herc20HalightBitcoinCreateSwapParams {
     pub lightning_cltv_expiry: RelativeTime,
     #[digest(prefix = "3002")]
     pub lightning_amount: asset::Bitcoin,
-}
-
-impl ToDigestInput for asset::Bitcoin {
-    fn to_digest_input(&self) -> Vec<u8> {
-        self.to_le_bytes().to_vec()
-    }
-}
-
-impl ToDigestInput for asset::Ether {
-    fn to_digest_input(&self) -> Vec<u8> {
-        self.to_bytes()
-    }
-}
-
-impl ToDigestInput for asset::Erc20Quantity {
-    fn to_digest_input(&self) -> Vec<u8> {
-        self.to_bytes()
-    }
-}
-
-impl ToDigestInput for Timestamp {
-    fn to_digest_input(&self) -> Vec<u8> {
-        self.clone().to_bytes().to_vec()
-    }
-}
-
-impl ToDigestInput for RelativeTime {
-    fn to_digest_input(&self) -> Vec<u8> {
-        self.to_bytes().to_vec()
-    }
 }
 
 /// This is a facade that implements all the required traits and forwards them

--- a/cnd/src/timestamp.rs
+++ b/cnd/src/timestamp.rs
@@ -1,3 +1,4 @@
+use digest::ToDigestInput;
 use serde::{Deserialize, Serialize};
 use std::time::SystemTime;
 
@@ -52,6 +53,12 @@ impl From<Timestamp> for i64 {
     }
 }
 
+impl ToDigestInput for Timestamp {
+    fn to_digest_input(&self) -> Vec<u8> {
+        self.clone().to_bytes().to_vec()
+    }
+}
+
 /// A duration used to represent a relative timelock
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
 #[serde(transparent)]
@@ -78,5 +85,11 @@ impl From<RelativeTime> for u32 {
 impl From<u32> for RelativeTime {
     fn from(item: u32) -> Self {
         Self(item)
+    }
+}
+
+impl ToDigestInput for RelativeTime {
+    fn to_digest_input(&self) -> Vec<u8> {
+        self.to_bytes().to_vec()
     }
 }


### PR DESCRIPTION
While working on https://github.com/comit-network/comit-rs/issues/2606 clean up a few things.

In this PR do:
- Replace wrapper type `EthereumIdentity(identity::Ethereum)` with `identity::Ethereum`.
- Move `ToDigestInput` implementations into their respective modules (out of the facade).
- Rename facade field `beta_ledger_states` to be `halight_states` since it is of type `halight::States` _not_ beta ledger like we did in rfc003.