### PR TITLE
Add hbit module

### DIFF
--- a/cnd/migrations/2020-05-06-105000_tables/down.sql
+++ b/cnd/migrations/2020-05-06-105000_tables/down.sql
@@ -6,4 +6,4 @@ DROP TABLE shared_swap_ids;
 DROP TABLE address_hints;
 DROP TABLE herc20s;
 DROP TABLE halights;
-
+DROP TABLE hbits;

--- a/cnd/migrations/2020-05-06-105000_tables/up.sql
+++ b/cnd/migrations/2020-05-06-105000_tables/up.sql
@@ -60,3 +60,16 @@ CREATE TABLE halights
     ledger                      NOT NULL,
     FOREIGN KEY(swap_id)        REFERENCES swaps(id)
 );
+
+CREATE TABLE hbits
+(
+    id                          INTEGER NOT NULL PRIMARY KEY,
+    swap_id                     INTEGER NOT NULL,
+    amount                      NOT NULL,
+    network                     NOT NULL,
+    hash_function               NOT NULL,
+    redeem_identity,
+    refund_identity,
+    ledger                      NOT NULL,
+    FOREIGN KEY(swap_id)        REFERENCES swaps(id)
+);

--- a/cnd/src/bitcoin.rs
+++ b/cnd/src/bitcoin.rs
@@ -31,6 +31,12 @@ impl PublicKey {
     }
 }
 
+impl fmt::Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 impl From<secp256k1::PublicKey> for PublicKey {
     fn from(key: secp256k1::PublicKey) -> Self {
         Self(bitcoin::PublicKey {

--- a/cnd/src/db/schema.rs
+++ b/cnd/src/db/schema.rs
@@ -56,5 +56,18 @@ table! {
     }
 }
 
+table! {
+    hbits {
+        id -> Integer,
+        swap_id -> Integer,
+        amount -> Text,
+        network -> Text,
+        hash_function -> Text,
+        redeem_identity -> Nullable<Text>,
+        refund_identity -> Nullable<Text>,
+        ledger -> Text,
+    }
+}
+
 allow_tables_to_appear_in_same_query!(swaps, halights);
 allow_tables_to_appear_in_same_query!(swaps, herc20s);

--- a/cnd/src/http_api/route_factory.rs
+++ b/cnd/src/http_api/route_factory.rs
@@ -177,8 +177,22 @@ pub fn create(
         .and(warp::path::param::<LocalSwapId>())
         .and(warp::path("refund"))
         .and(warp::path::end())
-        .and(facade)
+        .and(facade.clone())
         .and_then(http_api::routes::action_refund);
+
+    let hbit_herc20 = warp::post()
+        .and(warp::path!("swaps" / "hbit" / "herc20"))
+        .and(warp::path::end())
+        .and(warp::body::json())
+        .and(facade.clone())
+        .and_then(http_api::routes::post::post_hbit_herc20);
+
+    let herc20_hbit = warp::post()
+        .and(warp::path!("swaps" / "herc20" / "hbit"))
+        .and(warp::path::end())
+        .and(warp::body::json())
+        .and(facade)
+        .and_then(http_api::routes::post::post_herc20_hbit);
 
     preflight_cors_route
         .or(rfc003_get_swap)
@@ -198,6 +212,8 @@ pub fn create(
         .or(lightning_action_deploy)
         .or(lightning_action_redeem)
         .or(lightning_action_refund)
+        .or(hbit_herc20)
+        .or(herc20_hbit)
         .recover(http_api::unpack_problem)
         .with(warp::log("http"))
         .with(cors)

--- a/cnd/src/http_api/routes.rs
+++ b/cnd/src/http_api/routes.rs
@@ -1,5 +1,6 @@
 pub mod index;
 pub mod peers;
+pub mod post;
 pub mod rfc003;
 
 use crate::{

--- a/cnd/src/http_api/routes.rs
+++ b/cnd/src/http_api/routes.rs
@@ -139,7 +139,7 @@ pub async fn handle_get_halight_swap(
         LedgerState<asset::Erc20, htlc_location::Ethereum, transaction::Ethereum>,
     > = facade.alpha_ledger_states.get(&swap_id).await?;
 
-    let beta_ledger_state = facade.beta_ledger_states.get(&swap_id).await?;
+    let beta_ledger_state = facade.halight_states.get(&swap_id).await?;
 
     let created_swap = facade.get_created_swap(swap_id).await;
 
@@ -849,7 +849,7 @@ async fn handle_action_init(
         .ok_or_else(|| anyhow::anyhow!("alpha ledger state not found for {}", swap_id))?;
 
     let beta_ledger_state: halight::State = facade
-        .beta_ledger_states
+        .halight_states
         .get(&swap_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("beta ledger state not found for {}", swap_id))?;
@@ -902,7 +902,7 @@ async fn handle_action_deploy(
         .ok_or_else(|| anyhow::anyhow!("alpha ledger state not found for {}", swap_id))?;
 
     let beta_ledger_state: halight::State = facade
-        .beta_ledger_states
+        .halight_states
         .get(&swap_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("beta ledger state not found for {}", swap_id))?;
@@ -956,7 +956,7 @@ async fn handle_action_fund(
         .ok_or_else(|| anyhow::anyhow!("alpha ledger state not found for {}", swap_id))?;
 
     let beta_ledger_state: halight::State = facade
-        .beta_ledger_states
+        .halight_states
         .get(&swap_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("beta ledger state not found for {}", swap_id))?;
@@ -1017,7 +1017,7 @@ async fn handle_action_redeem(
         .ok_or_else(|| anyhow::anyhow!("alpha ledger state not found for {}", swap_id))?;
 
     let beta_ledger_state: halight::State = facade
-        .beta_ledger_states
+        .halight_states
         .get(&swap_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("beta ledger state not found for {}", swap_id))?;
@@ -1078,7 +1078,7 @@ async fn handle_action_refund(
         .ok_or_else(|| anyhow::anyhow!("alpha ledger state not found for {}", swap_id))?;
 
     let beta_ledger_state: halight::State = facade
-        .beta_ledger_states
+        .halight_states
         .get(&swap_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("beta ledger state not found for {}", swap_id))?;

--- a/cnd/src/http_api/routes/index.rs
+++ b/cnd/src/http_api/routes/index.rs
@@ -172,13 +172,13 @@ impl From<Body<Herc20EthereumErc20, HalightLightningBitcoin>>
         Self {
             role: body.role.0,
             peer: body.peer,
-            ethereum_identity: body.alpha.identity.into(),
+            ethereum_identity: body.alpha.identity,
             ethereum_absolute_expiry: body.alpha.absolute_expiry.into(),
             ethereum_amount: body.alpha.amount,
             lightning_identity: body.beta.identity,
             lightning_cltv_expiry: body.beta.cltv_expiry.into(),
             lightning_amount: body.beta.amount.0,
-            token_contract: body.alpha.contract_address.into(),
+            token_contract: body.alpha.contract_address,
         }
     }
 }

--- a/cnd/src/http_api/routes/post.rs
+++ b/cnd/src/http_api/routes/post.rs
@@ -1,0 +1,164 @@
+use crate::{
+    asset,
+    db::{CreatedSwap, Save},
+    http_api::{problem, routes::into_rejection, Http},
+    identity,
+    network::{DialInformation, InitCommunication},
+    swap_protocols::{hbit, herc20, ledger, Facade, LocalSwapId, Role},
+};
+use serde::Deserialize;
+use warp::{http::StatusCode, Rejection, Reply};
+
+/// POST endpoints for the hbit/herc20 protocol pair.
+
+#[allow(clippy::needless_pass_by_value)]
+pub async fn post_hbit_herc20(
+    body: serde_json::Value,
+    facade: Facade,
+) -> Result<impl Reply, Rejection>
+where
+    Facade: Save<CreatedSwap<hbit::CreatedSwap, herc20::CreatedSwap>>
+        + InitCommunication<CreatedSwap<hbit::CreatedSwap, herc20::CreatedSwap>>,
+{
+    let body = Body::<Hbit, Herc20>::deserialize(&body)
+        .map_err(anyhow::Error::new)
+        .map_err(problem::from_anyhow)
+        .map_err(warp::reject::custom)?;
+
+    let swap_id = LocalSwapId::random();
+    let reply = warp::reply::reply();
+
+    let swap = hbit_herc20_created_swap_from_body(swap_id, body.clone());
+
+    facade
+        .save(swap.clone())
+        .await
+        .map_err(problem::from_anyhow)
+        .map_err(warp::reject::custom)?;
+
+    facade
+        .init_communication(swap_id, swap)
+        .await
+        .map(|_| {
+            warp::reply::with_status(
+                warp::reply::with_header(reply, "Location", format!("/swaps/{}", swap_id)),
+                StatusCode::CREATED,
+            )
+        })
+        .map_err(problem::from_anyhow)
+        .map_err(into_rejection)
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub async fn post_herc20_hbit(
+    body: serde_json::Value,
+    facade: Facade,
+) -> Result<impl Reply, Rejection>
+where
+    Facade: Save<CreatedSwap<herc20::CreatedSwap, hbit::CreatedSwap>>
+        + InitCommunication<CreatedSwap<herc20::CreatedSwap, hbit::CreatedSwap>>,
+{
+    let body = Body::<Herc20, Hbit>::deserialize(&body)
+        .map_err(anyhow::Error::new)
+        .map_err(problem::from_anyhow)
+        .map_err(warp::reject::custom)?;
+
+    let swap_id = LocalSwapId::random();
+    let reply = warp::reply::reply();
+
+    let swap = herc20_hbit_created_swap_from_body(swap_id, body.clone());
+
+    facade
+        .save(swap.clone())
+        .await
+        .map_err(problem::from_anyhow)
+        .map_err(warp::reject::custom)?;
+
+    facade
+        .init_communication(swap_id, swap)
+        .await
+        .map(|_| {
+            warp::reply::with_status(
+                warp::reply::with_header(reply, "Location", format!("/swaps/{}", swap_id)),
+                StatusCode::CREATED,
+            )
+        })
+        .map_err(problem::from_anyhow)
+        .map_err(into_rejection)
+}
+
+fn hbit_herc20_created_swap_from_body(
+    swap_id: LocalSwapId,
+    body: Body<Hbit, Herc20>,
+) -> CreatedSwap<hbit::CreatedSwap, herc20::CreatedSwap> {
+    CreatedSwap::<hbit::CreatedSwap, herc20::CreatedSwap> {
+        swap_id,
+        alpha: body.alpha.into(),
+        beta: body.beta.into(),
+        peer: body.peer.peer_id,
+        address_hint: None,
+        role: body.role.0,
+    }
+}
+
+fn herc20_hbit_created_swap_from_body(
+    swap_id: LocalSwapId,
+    body: Body<Herc20, Hbit>,
+) -> CreatedSwap<herc20::CreatedSwap, hbit::CreatedSwap> {
+    CreatedSwap::<herc20::CreatedSwap, hbit::CreatedSwap> {
+        swap_id,
+        alpha: body.alpha.into(),
+        beta: body.beta.into(),
+        peer: body.peer.peer_id,
+        address_hint: None,
+        role: body.role.0,
+    }
+}
+
+#[derive(serde::Deserialize, Clone, Debug)]
+pub struct Body<A, B> {
+    pub alpha: A,
+    pub beta: B,
+    pub peer: DialInformation,
+    pub role: Http<Role>,
+}
+
+#[derive(serde::Deserialize, Clone, Debug)]
+struct Hbit {
+    pub amount: Http<asset::Bitcoin>,
+    pub identity: identity::Bitcoin,
+    pub network: ledger::Bitcoin,
+    pub absolute_expiry: u32,
+}
+
+impl From<Hbit> for hbit::CreatedSwap {
+    fn from(p: Hbit) -> Self {
+        hbit::CreatedSwap {
+            amount: *p.amount,
+            identity: p.identity,
+            network: p.network,
+            absolute_expiry: p.absolute_expiry,
+        }
+    }
+}
+
+#[derive(serde::Deserialize, Clone, Debug)]
+struct Herc20 {
+    pub amount: asset::Erc20Quantity,
+    pub identity: identity::Ethereum,
+    pub chain_id: u32,
+    pub token_contract: identity::Ethereum,
+    pub absolute_expiry: u32,
+}
+
+impl From<Herc20> for herc20::CreatedSwap {
+    fn from(p: Herc20) -> Self {
+        herc20::CreatedSwap {
+            amount: p.amount,
+            identity: p.identity,
+            chain_id: p.chain_id,
+            token_contract: p.token_contract,
+            absolute_expiry: p.absolute_expiry,
+        }
+    }
+}

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -176,7 +176,7 @@ fn main() -> anyhow::Result<()> {
     let facade = Facade {
         swarm: swarm.clone(),
         alpha_ledger_states: Arc::clone(&alpha_ledger_states),
-        beta_ledger_states: Arc::clone(&halight_states),
+        halight_states: Arc::clone(&halight_states),
         db: database,
     };
 

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     comit_api::LedgerKind,
     config::Settings,
-    db::{ForSwap, Save, Sqlite, Swap},
+    db::{CreatedSwap, ForSwap, Save, Sqlite, Swap},
     htlc_location,
     http_api::LedgerNotConfigured,
     identity,
@@ -26,7 +26,7 @@ use crate::{
     swap_protocols::{
         halight,
         halight::{LndConnectorAsReceiver, LndConnectorAsSender, LndConnectorParams, States},
-        herc20_rfc003_watcher, ledger,
+        hbit, herc20, herc20_rfc003_watcher, ledger,
         rfc003::{
             self,
             create_swap::HtlcParams,
@@ -156,10 +156,6 @@ impl Swarm {
         let mut guard = self.inner.lock().await;
         guard.get_created_swap(id)
     }
-
-    // On Bob's side, when an announce message is received execute the required
-    // communication protocols and write the finalized swap to the database.  Then
-    // spawn the same as is done for Alice.
 }
 
 struct TokioExecutor {
@@ -346,6 +342,22 @@ impl ComitNode {
         self.comit_ln.initiate_communication(id, swap_params)
     }
 
+    fn init_hbit_herc20(
+        &mut self,
+        id: LocalSwapId,
+        swap: CreatedSwap<hbit::CreatedSwap, herc20::CreatedSwap>,
+    ) -> anyhow::Result<()> {
+        self.comit_ln.init_hbit_herc20(id, swap)
+    }
+
+    fn init_herc20_hbit(
+        &mut self,
+        id: LocalSwapId,
+        swap: CreatedSwap<herc20::CreatedSwap, hbit::CreatedSwap>,
+    ) -> anyhow::Result<()> {
+        self.comit_ln.init_herc20_hbit(id, swap)
+    }
+
     pub fn get_finalized_swap(&mut self, id: LocalSwapId) -> Option<comit_ln::FinalizedSwap> {
         self.comit_ln.get_finalized_swap(id)
     }
@@ -382,6 +394,37 @@ pub struct WhatBobLearnedFromAlice {
     pub secret_hash: SecretHash,
     pub refund_ethereum_identity: identity::Ethereum,
     pub redeem_lightning_identity: identity::Lightning,
+}
+
+/// Init the communication protocols.
+#[async_trait]
+pub trait InitCommunication<T> {
+    async fn init_communication(&self, swap_id: LocalSwapId, created_swap: T)
+        -> anyhow::Result<()>;
+}
+
+#[async_trait]
+impl InitCommunication<CreatedSwap<hbit::CreatedSwap, herc20::CreatedSwap>> for Swarm {
+    async fn init_communication(
+        &self,
+        swap_id: LocalSwapId,
+        created_swap: CreatedSwap<hbit::CreatedSwap, herc20::CreatedSwap>,
+    ) -> anyhow::Result<()> {
+        let mut guard = self.inner.lock().await;
+        guard.init_hbit_herc20(swap_id, created_swap)
+    }
+}
+
+#[async_trait]
+impl InitCommunication<CreatedSwap<herc20::CreatedSwap, hbit::CreatedSwap>> for Swarm {
+    async fn init_communication(
+        &self,
+        swap_id: LocalSwapId,
+        created_swap: CreatedSwap<herc20::CreatedSwap, hbit::CreatedSwap>,
+    ) -> anyhow::Result<()> {
+        let mut guard = self.inner.lock().await;
+        guard.init_herc20_hbit(swap_id, created_swap)
+    }
 }
 
 async fn handle_request(

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -973,18 +973,12 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<comit_ln::BehaviourOutEvent> fo
 
                 // third, we spawn the watcher for herc20
                 let (herc20_redeem_identity, herc20_refund_identity) = match role {
-                    Role::Alice => (
-                        ethereum_identity,
-                        create_swap_params.ethereum_identity.into(),
-                    ),
-                    Role::Bob => (
-                        create_swap_params.ethereum_identity.into(),
-                        ethereum_identity,
-                    ),
+                    Role::Alice => (ethereum_identity, create_swap_params.ethereum_identity),
+                    Role::Bob => (create_swap_params.ethereum_identity, ethereum_identity),
                 };
                 let params = HtlcParams {
                     asset: Erc20::new(
-                        create_swap_params.token_contract.into(),
+                        create_swap_params.token_contract,
                         create_swap_params.ethereum_amount,
                     ),
                     ledger: ledger::Ethereum::default(),

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -1,5 +1,7 @@
 use crate::{
-    asset, identity,
+    asset,
+    db::CreatedSwap,
+    identity,
     network::{
         oneshot_behaviour,
         protocols::{
@@ -10,6 +12,7 @@ use crate::{
     },
     seed::{DeriveSwapSeed, RootSeed},
     swap_protocols::{
+        hbit, herc20,
         ledger::{self, ethereum::ChainId},
         rfc003::{create_swap::HtlcParams, DeriveSecret, Secret, SecretHash},
         Herc20HalightBitcoinCreateSwapParams, LocalSwapId, Role, SharedSwapId,
@@ -136,6 +139,24 @@ impl ComitLN {
         }
 
         Ok(())
+    }
+
+    pub fn init_hbit_herc20(
+        &mut self,
+        _: LocalSwapId,
+        _: CreatedSwap<hbit::CreatedSwap, herc20::CreatedSwap>,
+    ) -> anyhow::Result<()> {
+        // As for initiate_communication()
+        unimplemented!()
+    }
+
+    pub fn init_herc20_hbit(
+        &mut self,
+        _: LocalSwapId,
+        _: CreatedSwap<herc20::CreatedSwap, hbit::CreatedSwap>,
+    ) -> anyhow::Result<()> {
+        // As for initiate_communication()
+        unimplemented!()
     }
 
     pub fn get_created_swap(

--- a/cnd/src/network/comit_ln.rs
+++ b/cnd/src/network/comit_ln.rs
@@ -161,10 +161,10 @@ impl ComitLN {
                 Some(identity) => identity,
                 None => return None,
             },
-            Role::Bob => create_swap_params.ethereum_identity.into(),
+            Role::Bob => create_swap_params.ethereum_identity,
         };
         let alpha_ledger_refund_identity = match create_swap_params.role {
-            Role::Alice => create_swap_params.ethereum_identity.into(),
+            Role::Alice => create_swap_params.ethereum_identity,
             Role::Bob => match self.ethereum_identities.get(&id).copied() {
                 Some(identity) => identity,
                 None => return None,
@@ -186,7 +186,7 @@ impl ComitLN {
         };
 
         let erc20 = asset::Erc20 {
-            token_contract: create_swap_params.token_contract.into(),
+            token_contract: create_swap_params.token_contract,
             quantity: create_swap_params.ethereum_amount,
         };
 
@@ -230,7 +230,7 @@ impl ComitLN {
 
         self.ethereum_identity.send(
             peer.clone(),
-            ethereum_identity::Message::new(swap_id, create_swap_params.ethereum_identity.into()),
+            ethereum_identity::Message::new(swap_id, create_swap_params.ethereum_identity),
         );
         self.lightning_identity.send(
             peer.clone(),
@@ -272,10 +272,7 @@ impl ComitLN {
         // Communicate
         self.ethereum_identity.send(
             peer.clone(),
-            ethereum_identity::Message::new(
-                shared_swap_id,
-                create_swap_params.ethereum_identity.into(),
-            ),
+            ethereum_identity::Message::new(shared_swap_id, create_swap_params.ethereum_identity),
         );
         self.lightning_identity.send(
             peer,
@@ -621,7 +618,6 @@ mod tests {
         asset::{ethereum::FromWei, Erc20Quantity},
         lightning,
         network::{test_swarm, DialInformation},
-        swap_protocols::EthereumIdentity,
     };
     use digest::Digest;
     use futures::future;
@@ -642,13 +638,13 @@ mod tests {
                 peer_id: bob_peer_id,
                 address_hint: Some(bob_addr),
             },
-            ethereum_identity: EthereumIdentity::from(identity::Ethereum::random()),
+            ethereum_identity: identity::Ethereum::random(),
             ethereum_absolute_expiry,
             ethereum_amount: erc20.quantity,
             lightning_identity: lightning::PublicKey::random(),
             lightning_cltv_expiry,
             lightning_amount: lnbtc,
-            token_contract: erc20.token_contract.into(),
+            token_contract: erc20.token_contract,
         }
     }
 
@@ -665,13 +661,13 @@ mod tests {
                 peer_id: alice_peer_id,
                 address_hint: None,
             },
-            ethereum_identity: EthereumIdentity::from(identity::Ethereum::random()),
+            ethereum_identity: identity::Ethereum::random(),
             ethereum_absolute_expiry,
             ethereum_amount: erc20.quantity,
             lightning_identity: lightning::PublicKey::random(),
             lightning_cltv_expiry,
             lightning_amount: lnbtc,
-            token_contract: erc20.token_contract.into(),
+            token_contract: erc20.token_contract,
         }
     }
 

--- a/cnd/src/network/comit_ln/swaps.rs
+++ b/cnd/src/network/comit_ln/swaps.rs
@@ -324,11 +324,7 @@ impl Default for Swaps<()> {
 mod tests {
     use super::*;
     use crate::{
-        asset,
-        asset::ethereum::FromWei,
-        identity,
-        network::DialInformation,
-        swap_protocols::{EthereumIdentity, Role},
+        asset, asset::ethereum::FromWei, identity, network::DialInformation, swap_protocols::Role,
     };
     use digest::Digest;
 
@@ -339,13 +335,13 @@ mod tests {
                 peer_id: PeerId::random(),
                 address_hint: None,
             },
-            ethereum_identity: EthereumIdentity::from(identity::Ethereum::random()),
+            ethereum_identity: identity::Ethereum::random(),
             ethereum_absolute_expiry: 12345.into(),
             ethereum_amount: asset::Erc20Quantity::from_wei(9_001_000_000_000_000_000_000u128),
             lightning_identity: identity::Lightning::random(),
             lightning_cltv_expiry: 12345.into(),
             lightning_amount: asset::Bitcoin::from_sat(1_000_000_000),
-            token_contract: EthereumIdentity::from(identity::Ethereum::random()),
+            token_contract: identity::Ethereum::random(),
         }
     }
 
@@ -393,8 +389,7 @@ mod tests {
         let mut second_create_params = first_create_params.clone();
         // Ethereum identity is not part of the digest so both swaps should be
         // considered the same
-        second_create_params.ethereum_identity =
-            EthereumIdentity::from(identity::Ethereum::random());
+        second_create_params.ethereum_identity = identity::Ethereum::random();
 
         let digest = first_create_params.digest();
         let second_digest = second_create_params.digest();
@@ -430,8 +425,7 @@ mod tests {
 
         // Ethereum identity is not part of the digest so both swaps should be
         // considered the same
-        second_create_params.ethereum_identity =
-            EthereumIdentity::from(identity::Ethereum::random());
+        second_create_params.ethereum_identity = identity::Ethereum::random();
 
         let digest = first_create_params.digest();
         let second_digest = second_create_params.digest();
@@ -648,8 +642,7 @@ mod tests {
     fn given_bob_creates_dupe_swap_after_announcement_then_stored_params_are_unchanged() {
         let first_create_params = create_params();
         let mut second_create_params = first_create_params.clone();
-        second_create_params.ethereum_identity =
-            EthereumIdentity::from(identity::Ethereum::random());
+        second_create_params.ethereum_identity = identity::Ethereum::random();
 
         let digest = first_create_params.digest();
         let second_digest = second_create_params.digest();

--- a/cnd/src/swap_protocols.rs
+++ b/cnd/src/swap_protocols.rs
@@ -2,17 +2,26 @@ pub mod actions;
 mod facade;
 pub mod halight;
 pub mod han;
+pub mod hbit;
 pub mod herc20;
 pub mod herc20_rfc003_watcher;
 pub mod ledger;
 pub mod ledger_states;
 pub mod rfc003;
 mod rfc003_facade;
+mod secret;
 pub mod state;
 mod swap_error_states;
 mod swap_id;
 
-pub use self::{facade::*, ledger_states::*, rfc003_facade::*, swap_error_states::*, swap_id::*};
+pub use self::{
+    facade::*,
+    ledger_states::*,
+    rfc003_facade::*,
+    secret::{FromErr, Secret, SecretHash},
+    swap_error_states::*,
+    swap_id::*,
+};
 
 use serde::{Deserialize, Serialize};
 

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -72,7 +72,7 @@ pub struct Facade {
     pub swarm: Swarm,
     // We currently only support Han-HALight, therefor 'alpha' is Ethereum and 'beta' is Lightning.
     pub alpha_ledger_states: Arc<LedgerStates>,
-    pub beta_ledger_states: Arc<halight::States>,
+    pub halight_states: Arc<halight::States>,
     pub db: Sqlite,
 }
 

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -19,13 +19,13 @@ pub struct Herc20HalightBitcoinCreateSwapParams {
     #[digest(ignore)]
     pub peer: DialInformation,
     #[digest(ignore)]
-    pub ethereum_identity: EthereumIdentity,
+    pub ethereum_identity: identity::Ethereum,
     #[digest(prefix = "2001")]
     pub ethereum_absolute_expiry: Timestamp,
     #[digest(prefix = "2002")]
     pub ethereum_amount: asset::Erc20Quantity,
     #[digest(ignore)]
-    pub token_contract: EthereumIdentity,
+    pub token_contract: identity::Ethereum,
     #[digest(ignore)]
     pub lightning_identity: identity::Lightning,
     #[digest(prefix = "3001")]
@@ -49,21 +49,6 @@ impl ToDigestInput for asset::Ether {
 impl ToDigestInput for asset::Erc20Quantity {
     fn to_digest_input(&self) -> Vec<u8> {
         self.to_bytes()
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct EthereumIdentity(identity::Ethereum);
-
-impl From<identity::Ethereum> for EthereumIdentity {
-    fn from(inner: identity::Ethereum) -> Self {
-        EthereumIdentity(inner)
-    }
-}
-
-impl From<EthereumIdentity> for identity::Ethereum {
-    fn from(outer: EthereumIdentity) -> Self {
-        outer.0
     }
 }
 

--- a/cnd/src/swap_protocols/hbit.rs
+++ b/cnd/src/swap_protocols/hbit.rs
@@ -1,0 +1,203 @@
+pub mod events;
+mod extract_secret;
+pub mod htlc_events;
+mod ledger_state;
+mod ledger_states;
+
+pub use self::{extract_secret::*, htlc_events::*, ledger_state::*, ledger_states::*};
+
+use crate::{
+    asset,
+    btsieve::bitcoin::{BitcoindConnector, Cache},
+    identity,
+    swap_protocols::{
+        hbit::{
+            events::{
+                Deployed, Funded, HtlcDeployed, HtlcFunded, HtlcRedeemed, HtlcRefunded, Redeemed,
+                Refunded,
+            },
+            LedgerStates,
+        },
+        ledger, Ledger, LocalSwapId, Role, SecretHash,
+    },
+    timestamp::Timestamp,
+};
+use ::bitcoin::{
+    hashes::{hash160, Hash},
+    Address,
+};
+use blockchain_contracts::bitcoin::rfc003::bitcoin_htlc::BitcoinHtlc;
+use chrono::{NaiveDateTime, Utc};
+use futures::future::{self, Either};
+use genawaiter::{
+    sync::{Co, Gen},
+    GeneratorState,
+};
+use std::sync::Arc;
+use tracing_futures::Instrument;
+
+/// Htlc Bitcoin atomic swap protocol.
+
+/// Data required to create a swap that involves Bitcoin.
+#[derive(Clone, Copy, Debug)]
+pub struct CreatedSwap {
+    pub amount: asset::Bitcoin,
+    pub identity: identity::Bitcoin,
+    pub network: ledger::Bitcoin,
+    pub absolute_expiry: u32,
+}
+
+/// Han specific data for an in progress swap.
+#[derive(Clone, Copy, Debug)]
+pub struct InProgressSwap {
+    pub ledger: Ledger,
+    pub asset: asset::Bitcoin,
+    pub refund_identity: identity::Bitcoin,
+    pub redeem_identity: identity::Bitcoin,
+    pub expiry: Timestamp, // This is the absolute_expiry for now.
+}
+
+pub async fn new_hbit_swap(
+    swap_id: LocalSwapId,
+    connector: Arc<Cache<BitcoindConnector>>,
+    ledger_states: Arc<LedgerStates>,
+    htlc_params: HtlcParams,
+    role: Role,
+) {
+    create_watcher(
+        connector,
+        ledger_states,
+        swap_id,
+        htlc_params,
+        Utc::now().naive_local(),
+    )
+    .instrument(tracing::error_span!("hbit", swap_id = %swap_id, role = %role))
+    .await
+}
+
+/// Returns a future that tracks the swap negotiated from the given request and
+/// accept response on a ledger.
+///
+/// The current implementation is naive in the sense that it does not take into
+/// account situations where it is clear that no more events will happen even
+/// though in theory, there could. For example:
+/// - funded
+/// - refunded
+///
+/// It is highly unlikely for Bob to fund the HTLC now, yet the current
+/// implementation is still waiting for that.
+async fn create_watcher(
+    connector: Arc<Cache<BitcoindConnector>>,
+    ledger_states: Arc<LedgerStates>,
+    swap_id: LocalSwapId,
+    htlc_params: HtlcParams,
+    accepted_at: NaiveDateTime,
+) {
+    ledger_states
+        .insert(swap_id, LedgerState::NotDeployed)
+        .await;
+
+    // construct a generator that watches alpha and beta ledger concurrently
+    let mut generator =
+        Gen::new({ |co| async { watch_ledger(connector, co, htlc_params, accepted_at).await } });
+
+    loop {
+        // wait for events to be emitted as the generator executes
+        match generator.async_resume().await {
+            // every event that is yielded is passed on
+            GeneratorState::Yielded(event) => {
+                tracing::info!("swap {} yielded event {}", swap_id, event);
+                ledger_states.update(&swap_id, event).await;
+            }
+            // the generator stopped executing, this means there are no more events that can be
+            // watched.
+            GeneratorState::Complete(Ok(_)) => {
+                tracing::info!("swap {} finished", swap_id);
+                return;
+            }
+            GeneratorState::Complete(Err(e)) => {
+                tracing::error!("swap {} failed with {:?}", swap_id, e);
+                return;
+            }
+        }
+    }
+}
+
+/// Returns a future that waits for events to happen on a ledger.
+///
+/// Each event is yielded through the controller handle (co) of the coroutine.
+async fn watch_ledger(
+    connector: Arc<Cache<BitcoindConnector>>,
+    co: Co<SwapEvent>,
+    htlc_params: HtlcParams,
+    start_of_swap: NaiveDateTime,
+) -> anyhow::Result<()> {
+    let deployed = connector.htlc_deployed(&htlc_params, start_of_swap).await?;
+    co.yield_(SwapEvent::Deployed(deployed.clone())).await;
+
+    let funded = connector
+        .htlc_funded(&htlc_params, &deployed, start_of_swap)
+        .await?;
+    co.yield_(SwapEvent::Funded(funded)).await;
+
+    let redeemed = connector.htlc_redeemed(&htlc_params, &deployed, start_of_swap);
+
+    let refunded = connector.htlc_refunded(&htlc_params, &deployed, start_of_swap);
+
+    match future::try_select(redeemed, refunded).await {
+        Ok(Either::Left((redeemed, _))) => {
+            co.yield_(SwapEvent::Redeemed(redeemed.clone())).await;
+        }
+        Ok(Either::Right((refunded, _))) => {
+            co.yield_(SwapEvent::Refunded(refunded.clone())).await;
+        }
+        Err(either) => {
+            let (error, _other_future) = either.factor_first();
+
+            return Err(error);
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct HtlcParams {
+    pub network: bitcoin::Network,
+    pub asset: asset::Bitcoin,
+    pub redeem_identity: identity::Bitcoin,
+    pub refund_identity: identity::Bitcoin,
+    pub expiry: Timestamp,
+    pub secret_hash: SecretHash,
+}
+
+#[derive(Debug, Clone, PartialEq, strum_macros::Display)]
+pub enum SwapEvent {
+    Deployed(Deployed),
+    Funded(Funded),
+    Redeemed(Redeemed),
+    Refunded(Refunded),
+}
+
+impl From<HtlcParams> for BitcoinHtlc {
+    fn from(htlc_params: HtlcParams) -> Self {
+        let refund_public_key = ::bitcoin::PublicKey::from(htlc_params.refund_identity);
+        let redeem_public_key = ::bitcoin::PublicKey::from(htlc_params.redeem_identity);
+
+        let refund_identity = hash160::Hash::hash(&refund_public_key.key.serialize());
+        let redeem_identity = hash160::Hash::hash(&redeem_public_key.key.serialize());
+
+        BitcoinHtlc::new(
+            htlc_params.expiry.into(),
+            refund_identity,
+            redeem_identity,
+            htlc_params.secret_hash.into_raw(),
+        )
+    }
+}
+
+impl HtlcParams {
+    pub fn compute_address(&self) -> Address {
+        BitcoinHtlc::from(*self).compute_address(self.network)
+    }
+}

--- a/cnd/src/swap_protocols/hbit/events.rs
+++ b/cnd/src/swap_protocols/hbit/events.rs
@@ -1,0 +1,75 @@
+use crate::{
+    asset, htlc_location,
+    swap_protocols::{hbit::HtlcParams, Secret},
+    transaction,
+};
+use chrono::NaiveDateTime;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Funded {
+    Correctly {
+        asset: asset::Bitcoin,
+        transaction: transaction::Bitcoin,
+    },
+    Incorrectly {
+        asset: asset::Bitcoin,
+        transaction: transaction::Bitcoin,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Redeemed {
+    pub transaction: transaction::Bitcoin,
+    pub secret: Secret,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Deployed {
+    pub location: htlc_location::Bitcoin,
+    pub transaction: transaction::Bitcoin,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Refunded {
+    pub transaction: transaction::Bitcoin,
+}
+
+#[async_trait::async_trait]
+pub trait HtlcFunded: Send + Sync + Sized + 'static {
+    async fn htlc_funded(
+        &self,
+        htlc_params: &HtlcParams,
+        htlc_deployment: &Deployed,
+        start_of_swap: NaiveDateTime,
+    ) -> anyhow::Result<Funded>;
+}
+
+#[async_trait::async_trait]
+pub trait HtlcDeployed {
+    async fn htlc_deployed(
+        &self,
+        htlc_params: &HtlcParams,
+        start_of_swap: NaiveDateTime,
+    ) -> anyhow::Result<Deployed>;
+}
+
+#[async_trait::async_trait]
+pub trait HtlcRedeemed: Send + Sync + Sized + 'static {
+    async fn htlc_redeemed(
+        &self,
+        htlc_params: &HtlcParams,
+        htlc_deployment: &Deployed,
+        start_of_swap: NaiveDateTime,
+    ) -> anyhow::Result<Redeemed>;
+}
+
+#[async_trait::async_trait]
+pub trait HtlcRefunded: Send + Sync + Sized + 'static {
+    async fn htlc_refunded(
+        &self,
+        htlc_params: &HtlcParams,
+        htlc_deployment: &Deployed,
+        start_of_swap: NaiveDateTime,
+    ) -> anyhow::Result<Refunded>;
+}

--- a/cnd/src/swap_protocols/hbit/extract_secret.rs
+++ b/cnd/src/swap_protocols/hbit/extract_secret.rs
@@ -1,0 +1,79 @@
+use crate::swap_protocols::{Secret, SecretHash};
+use bitcoin::Transaction;
+
+pub fn extract_secret(transaction: &Transaction, secret_hash: &SecretHash) -> Option<Secret> {
+    transaction.input.iter().find_map(|txin| {
+        txin.witness
+            .iter()
+            .find_map(|script_item| match Secret::from_vec(&script_item) {
+                Ok(secret) if secret.hash() == *secret_hash => Some(secret),
+                Ok(_) => None,
+                Err(_) => None,
+            })
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bitcoin::{consensus::encode::deserialize, OutPoint, Script, Transaction, TxIn};
+    use spectral::prelude::*;
+    use std::str::FromStr;
+
+    fn setup(secret: &Secret) -> Transaction {
+        Transaction {
+            version: 1,
+            lock_time: 0,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: Script::new(),
+                sequence: 0,
+                witness: vec![
+                    vec![],                          // Signature
+                    vec![],                          // Public key
+                    secret.as_raw_secret().to_vec(), // Secret
+                    vec![1u8],                       // Bool to enter redeem branch
+                    vec![],                          // Previous Script
+                ],
+            }],
+            output: vec![],
+        }
+    }
+
+    #[test]
+    fn extract_correct_secret() {
+        let secret = Secret::from(*b"This is our favourite passphrase");
+        let transaction = setup(&secret);
+
+        assert_that!(extract_secret(&transaction, &secret.hash()))
+            .is_some()
+            .is_equal_to(&secret);
+    }
+
+    #[test]
+    fn extract_incorrect_secret() {
+        let secret = Secret::from(*b"This is our favourite passphrase");
+        let transaction = setup(&secret);
+
+        let secret_hash = SecretHash::from_str(
+            "bfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbf\
+             bfbfbfbfbfbfbfbfbfbfbfbfbfbfbfbf",
+        )
+        .unwrap();
+        assert_that!(extract_secret(&transaction, &secret_hash)).is_none();
+    }
+
+    #[test]
+    fn extract_correct_secret_from_mainnet_transaction() {
+        let hex_tx = hex::decode("0200000000010124e06fe5594b941d06c7385dc7307ec694a41f7d307423121855ee17e47e06ad0100000000ffffffff0137aa0b000000000017a914050377baa6e8c5a07aed125d0ef262c6d5b67a038705483045022100d780139514f39ed943179e4638a519101bae875ec1220b226002bcbcb147830b0220273d1efb1514a77ee3dd4adee0e896b7e76be56c6d8e73470ae9bd91c91d700c01210344f8f459494f74ebb87464de9b74cdba3709692df4661159857988966f94262f20ec9e9fb3c669b2354ea026ab3da82968a2e7ab9398d5cbed4e78e47246f2423e01015b63a82091d6a24697ed31932537ae598d3de3131e1fcd0641b9ac4be7afcb376386d71e8876a9149f4a0cf348b478336cb1d87ea4c8313a7ca3de1967029000b27576a91465252e57f727a27f32c77098e14d88d8dbec01816888ac00000000").unwrap();
+        let transaction: Transaction = deserialize(&hex_tx).unwrap();
+        let hex_secret =
+            hex::decode("ec9e9fb3c669b2354ea026ab3da82968a2e7ab9398d5cbed4e78e47246f2423e")
+                .unwrap();
+        let secret = Secret::from_vec(&hex_secret).unwrap();
+
+        assert_that!(extract_secret(&transaction, &secret.hash()))
+            .is_some()
+            .is_equal_to(&secret);
+    }
+}

--- a/cnd/src/swap_protocols/hbit/htlc_events.rs
+++ b/cnd/src/swap_protocols/hbit/htlc_events.rs
@@ -1,0 +1,112 @@
+use crate::{
+    asset,
+    btsieve::bitcoin::{
+        watch_for_created_outpoint, watch_for_spent_outpoint, BitcoindConnector, Cache,
+    },
+    swap_protocols::hbit::{
+        events::{
+            Deployed, Funded, HtlcDeployed, HtlcFunded, HtlcRedeemed, HtlcRefunded, Redeemed,
+            Refunded,
+        },
+        extract_secret, HtlcParams,
+    },
+};
+use chrono::NaiveDateTime;
+use std::cmp::Ordering;
+use tracing_futures::Instrument;
+
+#[async_trait::async_trait]
+impl HtlcFunded for Cache<BitcoindConnector> {
+    async fn htlc_funded(
+        &self,
+        htlc_params: &HtlcParams,
+        htlc_deployment: &Deployed,
+        _start_of_swap: NaiveDateTime,
+    ) -> anyhow::Result<Funded> {
+        let expected_asset = htlc_params.asset;
+
+        let tx = &htlc_deployment.transaction;
+        let asset =
+            asset::Bitcoin::from_sat(tx.output[htlc_deployment.location.vout as usize].value);
+
+        let event = match expected_asset.cmp(&asset) {
+            Ordering::Equal => Funded::Correctly {
+                transaction: tx.clone(),
+                asset,
+            },
+            _ => Funded::Incorrectly {
+                transaction: tx.clone(),
+                asset,
+            },
+        };
+
+        Ok(event)
+    }
+}
+
+#[async_trait::async_trait]
+impl HtlcDeployed for Cache<BitcoindConnector> {
+    async fn htlc_deployed(
+        &self,
+        htlc_params: &HtlcParams,
+        start_of_swap: NaiveDateTime,
+    ) -> anyhow::Result<Deployed> {
+        let (transaction, location) =
+            watch_for_created_outpoint(self, start_of_swap, htlc_params.compute_address())
+                .instrument(tracing::info_span!("htlc_deployed"))
+                .await?;
+
+        Ok(Deployed {
+            location,
+            transaction,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl HtlcRedeemed for Cache<BitcoindConnector> {
+    async fn htlc_redeemed(
+        &self,
+        htlc_params: &HtlcParams,
+        htlc_deployment: &Deployed,
+        start_of_swap: NaiveDateTime,
+    ) -> anyhow::Result<Redeemed> {
+        let (transaction, _) = watch_for_spent_outpoint(
+            self,
+            start_of_swap,
+            htlc_deployment.location,
+            htlc_params.redeem_identity,
+        )
+        .instrument(tracing::info_span!("htlc_redeemed"))
+        .await?;
+
+        let secret = extract_secret::extract_secret(&transaction, &htlc_params.secret_hash)
+            .expect("Redeem transaction must contain secret");
+
+        Ok(Redeemed {
+            transaction,
+            secret,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl HtlcRefunded for Cache<BitcoindConnector> {
+    async fn htlc_refunded(
+        &self,
+        htlc_params: &HtlcParams,
+        htlc_deployment: &Deployed,
+        start_of_swap: NaiveDateTime,
+    ) -> anyhow::Result<Refunded> {
+        let (transaction, _) = watch_for_spent_outpoint(
+            self,
+            start_of_swap,
+            htlc_deployment.location,
+            htlc_params.refund_identity,
+        )
+        .instrument(tracing::info_span!("htlc_refunded"))
+        .await?;
+
+        Ok(Refunded { transaction })
+    }
+}

--- a/cnd/src/swap_protocols/hbit/ledger_state.rs
+++ b/cnd/src/swap_protocols/hbit/ledger_state.rs
@@ -1,0 +1,192 @@
+use crate::{
+    asset, htlc_location,
+    swap_protocols::{
+        hbit::events::{Deployed, Funded, Redeemed, Refunded},
+        Secret,
+    },
+    transaction,
+};
+use std::fmt::{self, Display};
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug, PartialEq)]
+pub enum LedgerState {
+    NotDeployed,
+    Deployed {
+        htlc_location: htlc_location::Bitcoin,
+        deploy_transaction: transaction::Bitcoin,
+    },
+    Funded {
+        htlc_location: htlc_location::Bitcoin,
+        deploy_transaction: transaction::Bitcoin,
+        fund_transaction: transaction::Bitcoin,
+        asset: asset::Bitcoin,
+    },
+    IncorrectlyFunded {
+        htlc_location: htlc_location::Bitcoin,
+        deploy_transaction: transaction::Bitcoin,
+        fund_transaction: transaction::Bitcoin,
+        asset: asset::Bitcoin,
+    },
+    Redeemed {
+        htlc_location: htlc_location::Bitcoin,
+        deploy_transaction: transaction::Bitcoin,
+        fund_transaction: transaction::Bitcoin,
+        redeem_transaction: transaction::Bitcoin,
+        asset: asset::Bitcoin,
+        secret: Secret,
+    },
+    Refunded {
+        htlc_location: htlc_location::Bitcoin,
+        deploy_transaction: transaction::Bitcoin,
+        fund_transaction: transaction::Bitcoin,
+        refund_transaction: transaction::Bitcoin,
+        asset: asset::Bitcoin,
+    },
+}
+
+impl Display for LedgerState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            LedgerState::NotDeployed { .. } => "NotDeployed".to_string(),
+            LedgerState::Deployed { .. } => "Deployed".to_string(),
+            LedgerState::Funded { .. } => "Funded".to_string(),
+            LedgerState::IncorrectlyFunded { .. } => "IncorrectlyFunded".to_string(),
+            LedgerState::Redeemed { .. } => "Redeemed".to_string(),
+            LedgerState::Refunded { .. } => "Refunded".to_string(),
+        };
+
+        write!(f, "{}", s)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum HtlcState {
+    NotDeployed,
+    Deployed,
+    Funded,
+    IncorrectlyFunded,
+    Redeemed,
+    Refunded,
+}
+
+impl LedgerState {
+    pub fn transition_to_deployed(&mut self, deployed: Deployed) {
+        let Deployed {
+            transaction,
+            location,
+        } = deployed;
+
+        match std::mem::replace(self, LedgerState::NotDeployed) {
+            LedgerState::NotDeployed => {
+                *self = LedgerState::Deployed {
+                    deploy_transaction: transaction,
+                    htlc_location: location,
+                }
+            }
+            other => panic!("expected state NotDeployed, got {}", other),
+        }
+    }
+
+    pub fn transition_to_funded(&mut self, funded: Funded) {
+        match std::mem::replace(self, LedgerState::NotDeployed) {
+            LedgerState::Deployed {
+                deploy_transaction,
+                htlc_location,
+            } => match funded {
+                Funded::Correctly { asset, transaction } => {
+                    *self = LedgerState::Funded {
+                        deploy_transaction,
+                        htlc_location,
+                        fund_transaction: transaction,
+                        asset,
+                    }
+                }
+                Funded::Incorrectly { asset, transaction } => {
+                    *self = LedgerState::IncorrectlyFunded {
+                        deploy_transaction,
+                        htlc_location,
+                        fund_transaction: transaction,
+                        asset,
+                    }
+                }
+            },
+            other => panic!("expected state Deployed, got {}", other),
+        }
+    }
+
+    pub fn transition_to_redeemed(&mut self, redeemed: Redeemed) {
+        let Redeemed {
+            transaction,
+            secret,
+        } = redeemed;
+
+        match std::mem::replace(self, LedgerState::NotDeployed) {
+            LedgerState::Funded {
+                deploy_transaction,
+                htlc_location,
+                asset,
+                fund_transaction,
+            } => {
+                *self = LedgerState::Redeemed {
+                    deploy_transaction,
+                    htlc_location,
+                    fund_transaction,
+                    redeem_transaction: transaction,
+                    asset,
+                    secret,
+                }
+            }
+            other => panic!("expected state Funded, got {}", other),
+        }
+    }
+
+    pub fn transition_to_refunded(&mut self, refunded: Refunded) {
+        let Refunded { transaction } = refunded;
+
+        match std::mem::replace(self, LedgerState::NotDeployed) {
+            LedgerState::Funded {
+                deploy_transaction,
+                htlc_location,
+                asset,
+                fund_transaction,
+            }
+            | LedgerState::IncorrectlyFunded {
+                deploy_transaction,
+                htlc_location,
+                asset,
+                fund_transaction,
+            } => {
+                *self = LedgerState::Refunded {
+                    deploy_transaction,
+                    htlc_location,
+                    fund_transaction,
+                    refund_transaction: transaction,
+                    asset,
+                }
+            }
+            other => panic!("expected state Funded or IncorrectlyFunded, got {}", other),
+        }
+    }
+}
+
+impl Default for HtlcState {
+    fn default() -> Self {
+        HtlcState::NotDeployed
+    }
+}
+
+#[cfg(test)]
+impl quickcheck::Arbitrary for HtlcState {
+    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        match g.next_u32() % 6 {
+            0 => HtlcState::NotDeployed,
+            1 => HtlcState::Deployed,
+            2 => HtlcState::Funded,
+            3 => HtlcState::IncorrectlyFunded,
+            4 => HtlcState::Redeemed,
+            5 => HtlcState::Refunded,
+            _ => unreachable!(),
+        }
+    }
+}

--- a/cnd/src/swap_protocols/hbit/ledger_states.rs
+++ b/cnd/src/swap_protocols/hbit/ledger_states.rs
@@ -1,0 +1,61 @@
+use crate::swap_protocols::{
+    hbit::{LedgerState, SwapEvent},
+    LocalSwapId,
+};
+use std::collections::HashMap;
+use tokio::sync::Mutex;
+
+#[derive(Default, Debug)]
+pub struct LedgerStates {
+    states: Mutex<HashMap<LocalSwapId, LedgerState>>,
+}
+
+impl LedgerStates {
+    pub async fn insert(&self, key: LocalSwapId, value: LedgerState) {
+        let mut states = self.states.lock().await;
+        states.insert(key, value);
+    }
+
+    pub async fn get(&self, key: &LocalSwapId) -> Option<LedgerState> {
+        let states = self.states.lock().await;
+        states.get(key).cloned()
+    }
+
+    pub async fn update(&self, key: &LocalSwapId, event: SwapEvent) {
+        let mut states = self.states.lock().await;
+        let ledger_state = match states.get_mut(key) {
+            Some(state) => state,
+            None => {
+                tracing::warn!("Value not found for key {}", key);
+                return;
+            }
+        };
+
+        match event {
+            SwapEvent::Deployed(deployed) => ledger_state.transition_to_deployed(deployed),
+            SwapEvent::Funded(funded) => ledger_state.transition_to_funded(funded),
+            SwapEvent::Redeemed(redeemed) => {
+                // what if redeemed.secret.hash() != secret_hash in request ??
+                ledger_state.transition_to_redeemed(redeemed);
+            }
+            SwapEvent::Refunded(refunded) => ledger_state.transition_to_refunded(refunded),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spectral::prelude::*;
+
+    #[tokio::test]
+    async fn insert_and_get_ledger_state() {
+        let ledger_states = LedgerStates::default();
+        let id = LocalSwapId::default();
+
+        ledger_states.insert(id, LedgerState::NotDeployed).await;
+
+        let res: Option<LedgerState> = ledger_states.get(&id).await;
+        assert_that(&res).contains_value(&LedgerState::NotDeployed);
+    }
+}

--- a/cnd/src/swap_protocols/secret.rs
+++ b/cnd/src/swap_protocols/secret.rs
@@ -1,0 +1,281 @@
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use sha2::{Digest, Sha256};
+use std::{
+    fmt::{self, Debug},
+    str::FromStr,
+};
+
+#[derive(PartialEq, Clone, Copy, Debug, thiserror::Error)]
+pub enum FromErr {
+    #[error("invalid length, expected: {expected:?}, got: {got:?}")]
+    InvalidLength { expected: usize, got: usize },
+    #[error("hex: ")]
+    FromHex(#[from] hex::FromHexError),
+}
+
+#[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
+pub struct SecretHash([u8; Self::LENGTH]);
+
+impl SecretHash {
+    pub const LENGTH: usize = 32;
+
+    pub fn as_raw(&self) -> &[u8; Self::LENGTH] {
+        &self.0
+    }
+
+    pub fn into_raw(self) -> [u8; Self::LENGTH] {
+        self.0
+    }
+}
+
+impl Debug for SecretHash {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str(&format!("SecretHash({:x})", self))
+    }
+}
+
+impl<'a> From<&'a SecretHash> for SecretHash {
+    fn from(s: &'a SecretHash) -> Self {
+        *s
+    }
+}
+
+impl fmt::Display for SecretHash {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str(&format!("{:x}", self))
+    }
+}
+
+impl fmt::LowerHex for SecretHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.write_str(hex::encode(&self.0).as_str())
+    }
+}
+
+impl Serialize for SecretHash {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{:x}", self))
+    }
+}
+
+impl<'de> Deserialize<'de> for SecretHash {
+    fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'vde> de::Visitor<'vde> for Visitor {
+            type Value = SecretHash;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+                formatter.write_str("a hex encoded 32 byte value")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<SecretHash, E>
+            where
+                E: de::Error,
+            {
+                SecretHash::from_str(v).map_err(|_| {
+                    de::Error::invalid_value(de::Unexpected::Str(v), &"hex encoded bytes")
+                })
+            }
+        }
+
+        deserializer.deserialize_str(Visitor)
+    }
+}
+
+impl FromStr for SecretHash {
+    type Err = FromErr;
+
+    fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
+        let vec = hex::decode(s)?;
+        if vec.len() != Self::LENGTH {
+            return Err(FromErr::InvalidLength {
+                expected: Self::LENGTH,
+                got: vec.len(),
+            });
+        }
+        let mut data = [0; Self::LENGTH];
+        let vec = &vec[..Self::LENGTH];
+        data.copy_from_slice(vec);
+        Ok(SecretHash(data))
+    }
+}
+
+impl From<[u8; Self::LENGTH]> for SecretHash {
+    fn from(hash: [u8; Self::LENGTH]) -> Self {
+        SecretHash(hash)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub struct Secret([u8; Self::LENGTH]);
+
+impl From<[u8; Self::LENGTH]> for Secret {
+    fn from(secret: [u8; Self::LENGTH]) -> Self {
+        Secret(secret)
+    }
+}
+
+impl From<Secret> for SecretHash {
+    fn from(secret: Secret) -> Self {
+        secret.hash()
+    }
+}
+
+impl Secret {
+    // Both values need to stay the same!
+    pub const LENGTH: usize = 32;
+    pub const LENGTH_U8: u8 = 32;
+
+    pub fn from_vec(vec: &[u8]) -> Result<Secret, FromErr> {
+        if vec.len() != Self::LENGTH {
+            return Err(FromErr::InvalidLength {
+                expected: Self::LENGTH,
+                got: vec.len(),
+            });
+        }
+        let mut data = [0; Self::LENGTH];
+        let vec = &vec[..Self::LENGTH];
+        data.copy_from_slice(vec);
+        Ok(Secret(data))
+    }
+
+    pub fn hash(&self) -> SecretHash {
+        let mut sha = Sha256::new();
+        sha.input(&self.0);
+        let hash: [u8; SecretHash::LENGTH] = sha.result().into();
+
+        SecretHash::from(hash)
+    }
+
+    pub fn as_raw_secret(&self) -> &[u8; Self::LENGTH] {
+        &self.0
+    }
+
+    pub fn into_raw_secret(self) -> [u8; Self::LENGTH] {
+        self.0
+    }
+}
+
+impl fmt::LowerHex for Secret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.write_str(hex::encode(&self.0).as_str())
+    }
+}
+
+impl FromStr for Secret {
+    type Err = FromErr;
+
+    fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
+        let vec = hex::decode(s)?;
+        Self::from_vec(&vec)
+    }
+}
+
+impl From<SecretHash> for [u8; 32] {
+    fn from(secret_hash: SecretHash) -> [u8; 32] {
+        secret_hash.0
+    }
+}
+
+impl<'de> Deserialize<'de> for Secret {
+    fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'vde> de::Visitor<'vde> for Visitor {
+            type Value = Secret;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+                formatter.write_str("a hex encoded 32 byte value")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Secret, E>
+            where
+                E: de::Error,
+            {
+                Secret::from_str(v).map_err(|_| {
+                    de::Error::invalid_value(de::Unexpected::Str(v), &"hex encoded bytes")
+                })
+            }
+        }
+
+        deserializer.deserialize_str(Visitor)
+    }
+}
+
+impl Serialize for Secret {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{:x}", self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_secret_hash_as_hex() {
+        let bytes = b"hello world, you are beautiful!!";
+        let secret = Secret::from(*bytes);
+        assert_eq!(
+            secret.hash().to_string(),
+            "68d627971643a6f97f27c58957826fcba853ec2077fd10ec6b93d8e61deb4cec"
+        );
+    }
+
+    #[test]
+    fn secret_hash_should_be_displayed_as_hex() {
+        let bytes = b"hello world, you are beautiful!!";
+        let secret = Secret::from(*bytes);
+
+        let hash = secret.hash();
+
+        let formatted_hash = hash.to_string();
+
+        assert_eq!(
+            formatted_hash,
+            "68d627971643a6f97f27c58957826fcba853ec2077fd10ec6b93d8e61deb4cec"
+        )
+    }
+
+    #[test]
+    fn round_trip_secret_serialization() {
+        let bytes = b"hello world, you are beautiful!!";
+        let secret = Secret::from(*bytes);
+
+        let json_secret = serde_json::to_string(&secret).unwrap();
+        let deser_secret = serde_json::from_str::<Secret>(json_secret.as_str()).unwrap();
+
+        assert_eq!(deser_secret, secret);
+    }
+
+    #[test]
+    fn invalid_length_from_str() {
+        let result =
+            Secret::from_str("68d627971643a6f97f27c58957826fcba853ec2077fd10ec6b93d8e61deb4c");
+
+        assert!(result.is_err());
+
+        assert_eq!(result.unwrap_err(), FromErr::InvalidLength {
+            expected: 32,
+            got: 31
+        });
+    }
+
+    #[test]
+    fn secret_length_is_consistent() {
+        assert_eq!(Secret::LENGTH, usize::from(Secret::LENGTH_U8));
+    }
+}

--- a/cnd/src/swap_protocols/swap_id.rs
+++ b/cnd/src/swap_protocols/swap_id.rs
@@ -9,6 +9,13 @@ use uuid::Uuid;
 pub struct LocalSwapId(Uuid);
 
 impl LocalSwapId {
+    /// Creates a new random swap id.
+    pub fn random() -> Self {
+        LocalSwapId(Uuid::new_v4())
+    }
+}
+
+impl LocalSwapId {
     pub fn as_bytes(&self) -> &[u8] {
         self.0.as_bytes()
     }
@@ -16,7 +23,7 @@ impl LocalSwapId {
 
 impl Default for LocalSwapId {
     fn default() -> Self {
-        LocalSwapId(Uuid::new_v4())
+        LocalSwapId::random()
     }
 }
 


### PR DESCRIPTION
We have been trying to implement the newly designed split protocols for ages now; this PR is a change of approach. Instead of pushing forward with the LN stuff hoping that a nice split protocols implementation will fall out this PR adds the herc20/hbit protocol pair.
 
Add an `hbit` module under `swap_protocols/` with the following things in mind:
- Do not use rfc003 types, duplicate rfc003 code into `hbit` if needed.
- Try not to break any current working code.

This PR adds two new end points for both swaps of the trading pair hbit/herc20. Save of the created swap is fully implemented.  No retrieval for this data from the data base, also the REST actions are not done (these are heavy users of data retrieval so will be interesting to implement on top of the new database design, this can be done after this merges without hampering our effort).
  
Adds `unimplemeneted!` for all entrypoints to the networking layer. 

Please note, during duplication of the generic rfc003 code the Deploy state was copied, this has not been removed - prefer doing so separately after merge.