### PR TITLE
Store data only within a single transaction in the database

### DIFF
--- a/cnd/src/db.rs
+++ b/cnd/src/db.rs
@@ -99,7 +99,7 @@ impl Sqlite {
 
     async fn do_in_transaction<F, T, E>(&self, f: F) -> Result<T, E>
     where
-        F: Fn(&SqliteConnection) -> Result<T, E>,
+        F: FnOnce(&SqliteConnection) -> Result<T, E>,
         E: From<diesel::result::Error>,
     {
         let guard = self.connection.lock().await;

--- a/cnd/src/db/integration_tests/api.rs
+++ b/cnd/src/db/integration_tests/api.rs
@@ -76,7 +76,7 @@ async fn roundtrip_create_finalize_load() {
         address_hint: Some(address_hint),
         role,
     };
-    Save::<CreatedSwap<herc20::CreatedSwap, halight::CreatedSwap>>::save(&db, created)
+    db.save(created)
         .await
         .expect("to be able to save created swap");
 

--- a/cnd/src/db/tables.rs
+++ b/cnd/src/db/tables.rs
@@ -489,22 +489,20 @@ impl Sqlite {
         Ok(())
     }
 
-    pub async fn save_address_hint(
+    pub fn save_address_hint(
         &self,
+        connection: &SqliteConnection,
         peer_id: PeerId,
-        address_hint: &libp2p::Multiaddr,
+        address_hint: libp2p::Multiaddr,
     ) -> anyhow::Result<()> {
-        self.do_in_transaction(|connection| {
-            let insertable = InsertableAddressHint {
-                peer_id: Text(peer_id.clone()),
-                address_hint: Text(address_hint.clone()),
-            };
+        let insertable = InsertableAddressHint {
+            peer_id: Text(peer_id),
+            address_hint: Text(address_hint),
+        };
 
-            diesel::insert_into(address_hints::dsl::address_hints)
-                .values(insertable)
-                .execute(&*connection)
-        })
-        .await?;
+        diesel::insert_into(address_hints::dsl::address_hints)
+            .values(insertable)
+            .execute(connection)?;
 
         Ok(())
     }
@@ -717,9 +715,11 @@ mod tests {
         let multi_addr = "/ip4/80.123.90.4/tcp/5432";
         let address_hint: Multiaddr = multi_addr.parse().expect("valid multiaddress");
 
-        db.save_address_hint(peer_id.clone(), &address_hint)
-            .await
-            .expect("to be able to save address hint");
+        db.do_in_transaction(|conn| {
+            db.save_address_hint(conn, peer_id.clone(), address_hint.clone())
+        })
+        .await
+        .expect("to be able to save address hint");
 
         let loaded = db
             .load_address_hint(&peer_id)


### PR DESCRIPTION
We also took the opportunity to make the `Save` impl for `CreatedSwap` generic over any kind of protocol, regardless of the side (alpha or beta).

Fixes #2615.