### PR TITLE
Add token_contract to the digest for herc20 swaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3532,7 +3532,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
 dependencies = [
- "proc-macro2 1.0.12",
+ "proc-macro2 1.0.13",
  "quote 1.0.5",
  "syn 1.0.22",
 ]

--- a/cnd/src/ethereum.rs
+++ b/cnd/src/ethereum.rs
@@ -26,6 +26,10 @@ impl Address {
         address.0.copy_from_slice(src);
         address
     }
+
+    pub fn as_bytes(&self) -> &[u8; 20] {
+        &self.0
+    }
 }
 
 #[cfg(test)]

--- a/cnd/src/ethereum.rs
+++ b/cnd/src/ethereum.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 #[derive(Debug, Default, Copy, Clone, PartialEq, Deserialize)]
-pub struct H64(#[serde(with = "SerHex::<StrictPfx>")] [u8; 8]);
+struct H64(#[serde(with = "SerHex::<StrictPfx>")] [u8; 8]);
 
 #[derive(
     Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -26,7 +26,7 @@ pub struct Herc20HalightBitcoinCreateSwapParams {
     pub ethereum_absolute_expiry: Timestamp,
     #[digest(prefix = "2002")]
     pub ethereum_amount: asset::Erc20Quantity,
-    #[digest(ignore)]
+    #[digest(prefix = "2003")]
     pub token_contract: identity::Ethereum,
     #[digest(ignore)]
     pub lightning_identity: identity::Lightning,
@@ -57,7 +57,7 @@ pub struct HbitHerc20SwapParams {
     pub ethereum_expiry: Timestamp,
     #[digest(prefix = "3002")]
     pub erc20_amount: asset::Erc20Quantity,
-    #[digest(ignore)]
+    #[digest(prefix = "3003")]
     pub token_contract: identity::Ethereum,
 }
 
@@ -95,7 +95,7 @@ pub struct Herc20HbitSwapParams {
     pub ethereum_expiry: Timestamp,
     #[digest(prefix = "2002")]
     pub erc20_amount: asset::Erc20Quantity,
-    #[digest(ignore)]
+    #[digest(prefix = "2003")]
     pub token_contract: identity::Ethereum,
     #[digest(ignore)]
     pub bitcoin_identity: identity::Bitcoin,
@@ -141,6 +141,12 @@ impl ToDigestInput for asset::Ether {
 impl ToDigestInput for asset::Erc20Quantity {
     fn to_digest_input(&self) -> Vec<u8> {
         self.to_bytes()
+    }
+}
+
+impl ToDigestInput for identity::Ethereum {
+    fn to_digest_input(&self) -> Vec<u8> {
+        self.clone().as_bytes().to_vec()
     }
 }
 


### PR DESCRIPTION
Swaps that involve the Herc20 protocol should include the token contract address in the digest since there may be multiple swaps including different tokens.

- Patch 1 updates `proc-macro2`
- Patch 2 removes 'pub' from H64 
- Patch 3 adds the `token_contract` field to digest

Fixes: #2626