### PR TITLE
Actually build hbit

### DIFF
--- a/comit/src/btsieve.rs
+++ b/comit/src/btsieve.rs
@@ -1,5 +1,6 @@
 pub mod bitcoin;
 pub mod ethereum;
+mod hbit_connector_impls;
 mod herc20_connector_impls;
 mod jsonrpc;
 

--- a/comit/src/btsieve/hbit_connector_impls.rs
+++ b/comit/src/btsieve/hbit_connector_impls.rs
@@ -4,11 +4,9 @@ use crate::{
         watch_for_created_outpoint, watch_for_spent_outpoint, BitcoindConnector, Cache,
     },
     hbit::{
-        Funded, HtlcFunded, HtlcRedeemed, HtlcRefunded, Redeemed,
-        Refunded,
-        extract_secret, Params,
+        self, Funded, Params, Redeemed, Refunded, WaitForFunded, WaitForRedeemed, WaitForRefunded,
     },
-},
+    htlc_location,
 };
 use chrono::NaiveDateTime;
 use std::cmp::Ordering;
@@ -28,8 +26,7 @@ impl WaitForFunded for Cache<BitcoindConnector> {
                 .instrument(tracing::info_span!("wait_for_funded"))
                 .await?;
 
-        let asset =
-            asset::Bitcoin::from_sat(transaction.output[location.vout as usize].value);
+        let asset = asset::Bitcoin::from_sat(transaction.output[location.vout as usize].value);
 
         let event = match expected_asset.cmp(&asset) {
             Ordering::Equal => Funded::Correctly {
@@ -53,19 +50,15 @@ impl WaitForRedeemed for Cache<BitcoindConnector> {
     async fn wait_for_redeemed(
         &self,
         params: &Params,
-        funded: &Funded,
+        location: htlc_location::Bitcoin,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Redeemed> {
-        let (transaction, _) = watch_for_spent_outpoint(
-            self,
-            start_of_swap,
-            funded.location,
-            params.redeem_identity,
-        )
-        .instrument(tracing::info_span!("wait_for_redeemed"))
-        .await?;
+        let (transaction, _) =
+            watch_for_spent_outpoint(self, start_of_swap, location, params.redeem_identity)
+                .instrument(tracing::info_span!("wait_for_redeemed"))
+                .await?;
 
-        let secret = extract_secret::extract_secret(&transaction, &params.secret_hash)
+        let secret = hbit::extract_secret(&transaction, &params.secret_hash)
             .expect("Redeem transaction must contain secret");
 
         Ok(Redeemed {
@@ -80,17 +73,13 @@ impl WaitForRefunded for Cache<BitcoindConnector> {
     async fn wait_for_refunded(
         &self,
         params: &Params,
-        funded: &Funded,
+        location: htlc_location::Bitcoin,
         start_of_swap: NaiveDateTime,
     ) -> anyhow::Result<Refunded> {
-        let (transaction, _) = watch_for_spent_outpoint(
-            self,
-            start_of_swap,
-            funded.location,
-            params.refund_identity,
-        )
-        .instrument(tracing::info_span!("wait_for_refunded"))
-        .await?;
+        let (transaction, _) =
+            watch_for_spent_outpoint(self, start_of_swap, location, params.refund_identity)
+                .instrument(tracing::info_span!("wait_for_refunded"))
+                .await?;
 
         Ok(Refunded { transaction })
     }

--- a/comit/src/lib.rs
+++ b/comit/src/lib.rs
@@ -4,6 +4,7 @@ pub mod bitcoin;
 pub mod btsieve;
 pub mod ethereum;
 pub mod halight;
+pub mod hbit;
 pub mod herc20;
 pub mod htlc_location;
 pub mod identity;


### PR DESCRIPTION
In Rust code is not built unless the module is declared in its parent module.

Add `hbit` to the root module so it is actually built. Fix the half baked effort I made when adding this module.
