### PR TITLE
Introduce `new` functions in protocol modules

### DIFF
--- a/cnd/src/lib.rs
+++ b/cnd/src/lib.rs
@@ -18,7 +18,6 @@
 // an enum created by `strum_discriminants`.
 #[macro_use]
 extern crate strum_macros;
-
 #[macro_use]
 extern crate diesel;
 #[macro_use]
@@ -28,12 +27,6 @@ extern crate diesel_migrations;
 pub mod libp2p_comit_ext;
 #[macro_use]
 pub mod db;
-
-pub mod comit_api;
-pub mod config;
-pub mod http_api;
-pub mod init_swap;
-pub mod load_swaps;
 #[macro_use]
 pub mod network;
 #[cfg(test)]
@@ -42,10 +35,17 @@ pub mod proptest;
 pub mod quickcheck;
 #[macro_use]
 pub mod seed;
-pub mod file_lock;
 #[cfg(test)]
 pub mod spectral_ext;
+
+pub mod comit_api;
+pub mod config;
+pub mod file_lock;
+pub mod http_api;
+pub mod init_swap;
+pub mod load_swaps;
 pub mod swap_protocols;
+mod tracing_ext;
 
 use anyhow::Context;
 use std::{

--- a/cnd/src/swap_protocols/halight.rs
+++ b/cnd/src/swap_protocols/halight.rs
@@ -11,9 +11,8 @@ use std::{
 };
 use tokio::sync::Mutex;
 
-/// HTLC Lightning Bitcoin atomic swap protocol.
-
-/// Creates a new instance of the halight protocol.
+/// Creates a new instance of the halight protocol, annotated with tracing spans
+/// and saves all events in the `States` hashmap.
 ///
 /// This wrapper functions allows us to reuse code within `cnd` without having
 /// to give knowledge about tracing or the state hashmaps to the `comit` crate.

--- a/cnd/src/swap_protocols/halight.rs
+++ b/cnd/src/swap_protocols/halight.rs
@@ -1,4 +1,9 @@
-use crate::swap_protocols::{state, state::Update, LocalSwapId};
+use crate::{
+    swap_protocols::{state, state::Update, LocalSwapId},
+    tracing_ext::InstrumentProtocol,
+};
+pub use comit::{halight::*, identity};
+use comit::{Protocol, Role, Side};
 use futures::TryStreamExt;
 use std::{
     collections::{hash_map::Entry, HashMap},
@@ -6,29 +11,29 @@ use std::{
 };
 use tokio::sync::Mutex;
 
-pub use comit::{halight::*, identity};
-
 /// HTLC Lightning Bitcoin atomic swap protocol.
 
 /// Creates a new instance of the halight protocol.
 ///
-/// This function delegates to the `new` function for the actual protocol
-/// implementation. Its main purpose is to annotate the protocol instance with
-/// logging information and store the events yielded by the protocol.
-pub async fn new_halight_swap<C>(
+/// This wrapper functions allows us to reuse code within `cnd` without having
+/// to give knowledge about tracing or the state hashmaps to the `comit` crate.
+pub async fn new<C>(
     id: LocalSwapId,
     params: Params,
-    state_store: Arc<States>,
+    role: Role,
+    side: Side,
+    states: Arc<States>,
     connector: C,
 ) where
     C: WaitForOpened + WaitForAccepted + WaitForSettled + WaitForCancelled,
 {
-    let mut events = new(&connector, params)
+    let mut events = comit::halight::new(&connector, params)
+        .instrument_protocol(id, role, side, Protocol::Halight)
         .inspect_ok(|event| tracing::info!("yielded event {}", event))
         .inspect_err(|error| tracing::error!("swap failed with {:?}", error));
 
     while let Ok(Some(event)) = events.try_next().await {
-        state_store.update(&id, event).await;
+        states.update(&id, event).await;
     }
 
     tracing::info!("swap finished");

--- a/cnd/src/tracing_ext.rs
+++ b/cnd/src/tracing_ext.rs
@@ -1,0 +1,19 @@
+use crate::swap_protocols::LocalSwapId;
+use comit::{Protocol, Role, Side};
+use tracing_futures::{Instrument, Instrumented};
+
+/// Extension trait for easily applying a consistent span across all protocol
+/// instantiations.
+pub trait InstrumentProtocol: Sized {
+    fn instrument_protocol(
+        self,
+        id: LocalSwapId,
+        role: Role,
+        side: Side,
+        protocol: Protocol,
+    ) -> Instrumented<Self> {
+        self.instrument(tracing::error_span!("", swap_id = %id, role = %role, side = %side, protocol = %protocol))
+    }
+}
+
+impl<T> InstrumentProtocol for T {}


### PR DESCRIPTION
This allows us to conveniently create new instances of protocols without duplicating that code all over the place.