### PR TITLE
Improve the network module

### DIFF
--- a/cnd/src/db.rs
+++ b/cnd/src/db.rs
@@ -28,6 +28,7 @@ use crate::{
     swap_protocols::{rfc003::SwapId, LocalSwapId, Role},
 };
 use async_trait::async_trait;
+use comit::Protocol;
 use diesel::{self, prelude::*, sqlite::SqliteConnection};
 use libp2p::PeerId;
 use std::{
@@ -38,6 +39,13 @@ use std::{
 use tokio::sync::Mutex;
 
 /// This module provides persistent storage by way of Sqlite.
+
+#[derive(Clone, Copy, Debug)]
+pub struct Swap {
+    pub role: Role,
+    pub alpha: Protocol,
+    pub beta: Protocol,
+}
 
 /// Save date to the database.
 #[async_trait]

--- a/cnd/src/db/save_load_impls.rs
+++ b/cnd/src/db/save_load_impls.rs
@@ -1,16 +1,16 @@
 use crate::{
-    db,
     db::{
+        self,
         tables::{Insert, InsertableSwap, IntoInsertable},
         wrapper_types::custom_sql_types::Text,
-        CreatedSwap, ForSwap, Save, Sqlite,
+        CreatedSwap, Save, Sqlite,
     },
     http_api, respawn,
     swap_protocols::{LocalSwapId, Role, Side},
 };
 use anyhow::Context;
-use comit::{network, Protocol};
-use diesel::{prelude::*, sql_types};
+use comit::Protocol;
+use diesel::{sql_types, RunQueryDsl};
 
 mod rfc003;
 
@@ -49,42 +49,6 @@ where
         .await?;
 
         Ok(())
-    }
-}
-
-#[async_trait::async_trait]
-impl Save<ForSwap<network::WhatAliceLearnedFromBob>> for Sqlite {
-    async fn save(&self, swap: ForSwap<network::WhatAliceLearnedFromBob>) -> anyhow::Result<()> {
-        let local_swap_id = swap.local_swap_id;
-        let refund_lightning_identity = swap.data.refund_lightning_identity;
-        let redeem_ethereum_identity = swap.data.redeem_ethereum_identity;
-
-        self.do_in_transaction(|conn| {
-            self.update_halight_refund_identity(conn, local_swap_id, refund_lightning_identity)?;
-            self.update_herc20_redeem_identity(conn, local_swap_id, redeem_ethereum_identity)?;
-
-            Ok(())
-        })
-        .await
-    }
-}
-
-#[async_trait::async_trait]
-impl Save<ForSwap<network::WhatBobLearnedFromAlice>> for Sqlite {
-    async fn save(&self, swap: ForSwap<network::WhatBobLearnedFromAlice>) -> anyhow::Result<()> {
-        let local_swap_id = swap.local_swap_id;
-        let redeem_lightning_identity = swap.data.redeem_lightning_identity;
-        let refund_ethereum_identity = swap.data.refund_ethereum_identity;
-        let secret_hash = swap.data.secret_hash;
-
-        self.do_in_transaction(|conn| {
-            self.update_halight_redeem_identity(conn, local_swap_id, redeem_lightning_identity)?;
-            self.update_herc20_refund_identity(conn, local_swap_id, refund_ethereum_identity)?;
-            self.insert_secret_hash(conn, local_swap_id, secret_hash)?;
-
-            Ok(())
-        })
-        .await
     }
 }
 

--- a/cnd/src/http_api/routes/post.rs
+++ b/cnd/src/http_api/routes/post.rs
@@ -1,13 +1,12 @@
 use crate::{
     asset,
     db::{CreatedSwap, Save},
-    http_api::{problem, routes::into_rejection, DialInformation, Http},
+    http_api::{problem, DialInformation, Http},
     identity,
-    network::InitCommunication,
     swap_protocols::{hbit, herc20, Facade, LocalSwapId, Role},
 };
 use serde::Deserialize;
-use warp::{http::StatusCode, Rejection, Reply};
+use warp::Rejection;
 
 /// POST endpoints for the hbit/herc20 protocol pair.
 
@@ -15,10 +14,9 @@ use warp::{http::StatusCode, Rejection, Reply};
 pub async fn post_hbit_herc20(
     body: serde_json::Value,
     facade: Facade,
-) -> Result<impl Reply, Rejection>
+) -> Result<warp::reply::Json, Rejection>
 where
-    Facade: Save<CreatedSwap<hbit::CreatedSwap, herc20::CreatedSwap>>
-        + InitCommunication<CreatedSwap<hbit::CreatedSwap, herc20::CreatedSwap>>,
+    Facade: Save<CreatedSwap<hbit::CreatedSwap, herc20::CreatedSwap>>,
 {
     let body = Body::<Hbit, Herc20>::deserialize(&body)
         .map_err(anyhow::Error::new)
@@ -26,7 +24,7 @@ where
         .map_err(warp::reject::custom)?;
 
     let swap_id = LocalSwapId::random();
-    let reply = warp::reply::reply();
+    let _reply = warp::reply::reply();
 
     let swap = hbit_herc20_created_swap_from_body(swap_id, body.clone());
 
@@ -36,27 +34,16 @@ where
         .map_err(problem::from_anyhow)
         .map_err(warp::reject::custom)?;
 
-    facade
-        .init_communication(swap_id, swap)
-        .await
-        .map(|_| {
-            warp::reply::with_status(
-                warp::reply::with_header(reply, "Location", format!("/swaps/{}", swap_id)),
-                StatusCode::CREATED,
-            )
-        })
-        .map_err(problem::from_anyhow)
-        .map_err(into_rejection)
+    unimplemented!()
 }
 
 #[allow(clippy::needless_pass_by_value)]
 pub async fn post_herc20_hbit(
     body: serde_json::Value,
     facade: Facade,
-) -> Result<impl Reply, Rejection>
+) -> Result<warp::reply::Json, Rejection>
 where
-    Facade: Save<CreatedSwap<herc20::CreatedSwap, hbit::CreatedSwap>>
-        + InitCommunication<CreatedSwap<herc20::CreatedSwap, hbit::CreatedSwap>>,
+    Facade: Save<CreatedSwap<herc20::CreatedSwap, hbit::CreatedSwap>>,
 {
     let body = Body::<Herc20, Hbit>::deserialize(&body)
         .map_err(anyhow::Error::new)
@@ -64,7 +51,7 @@ where
         .map_err(warp::reject::custom)?;
 
     let swap_id = LocalSwapId::random();
-    let reply = warp::reply::reply();
+    let _reply = warp::reply::reply();
 
     let swap = herc20_hbit_created_swap_from_body(swap_id, body.clone());
 
@@ -74,17 +61,7 @@ where
         .map_err(problem::from_anyhow)
         .map_err(warp::reject::custom)?;
 
-    facade
-        .init_communication(swap_id, swap)
-        .await
-        .map(|_| {
-            warp::reply::with_status(
-                warp::reply::with_header(reply, "Location", format!("/swaps/{}", swap_id)),
-                StatusCode::CREATED,
-            )
-        })
-        .map_err(problem::from_anyhow)
-        .map_err(into_rejection)
+    unimplemented!()
 }
 
 fn hbit_herc20_created_swap_from_body(

--- a/cnd/src/network/comit/swaps.rs
+++ b/cnd/src/network/comit/swaps.rs
@@ -1,9 +1,9 @@
 use crate::{
-    swap_protocols::{Herc20HalightBitcoinCreateSwapParams, LocalSwapId, SharedSwapId},
+    network::comit::LocalData,
+    swap_protocols::{LocalSwapId, Role, SharedSwapId},
     timestamp::Timestamp,
 };
 use ::comit::network::protocols::announce::{protocol::ReplySubstream, SwapDigest};
-use digest::Digest;
 use libp2p::{swarm::NegotiatedSubstream, PeerId};
 use std::collections::HashMap;
 
@@ -21,7 +21,8 @@ pub enum Error {
     InternalFailure,
 }
 
-/// T is ReplySubstream<NegotiatedSubstream>
+/// Tracks the state of a swap in the communication phase, T is
+/// ReplySubstream<NegotiatedSubstream>
 #[derive(Debug)]
 pub struct Swaps<T> {
     /// In role of Alice; swaps exist in here once a swap is created by Alice
@@ -31,14 +32,18 @@ pub struct Swaps<T> {
     /// In role of Bob; swaps exist in here if Bob creates the swap _before_ an
     /// announce message is received from Alice (and up until the announce
     /// message arrives).
-    pending_announcement: HashMap<SwapDigest, LocalSwapId>,
+    pending_announcement: HashMap<SwapDigest, (LocalSwapId, PeerId)>,
+
     /// In role of Bob; swaps exist in here if Bob receives an announce message
     /// from Alice _before_ Bob creates the swap (and up until Bob creates the
     /// swap).
     pending_creation: HashMap<SwapDigest, (PeerId, T)>,
 
-    /// Stores the swap as soon as it is created
-    swaps: HashMap<LocalSwapId, Herc20HalightBitcoinCreateSwapParams>,
+    /// Stores the swap as soon as it is created.
+    swaps: HashMap<LocalSwapId, LocalData>,
+
+    /// Stores the swap role as soon as the swap is created.
+    roles: HashMap<LocalSwapId, Role>,
 
     /// Stores the shared swap id as soon as it is known.
     /// Bob defines the shared swap id when he confirms the swap by replying to
@@ -52,27 +57,33 @@ pub struct Swaps<T> {
 }
 
 impl<T> Swaps<T> {
+    pub fn get_local_swap_id(&self, shared_swap_id: SharedSwapId) -> Option<LocalSwapId> {
+        for (local, shared) in self.swap_ids.iter() {
+            if *shared == shared_swap_id {
+                return Some(*local);
+            }
+        }
+        None
+    }
+
     /// Gets a swap that was created
-    pub fn get_created_swap(
-        &self,
-        local_swap_id: &LocalSwapId,
-    ) -> Option<Herc20HalightBitcoinCreateSwapParams> {
+    pub fn get_local_data(&self, local_swap_id: &LocalSwapId) -> Option<LocalData> {
         self.swaps.get(local_swap_id).cloned()
     }
 
-    /// Alice created and announced it a swap and is waiting for a confirmation
-    /// from Bob
+    /// Alice created and announced the swap, it is now waiting for a
+    /// confirmation from Bob.
     pub fn create_as_pending_confirmation(
         &mut self,
         digest: SwapDigest,
         local_swap_id: LocalSwapId,
-        create_swap_params: Herc20HalightBitcoinCreateSwapParams,
+        data: LocalData,
     ) -> Result<(), Error> {
         if self.swaps.get(&local_swap_id).is_some() {
             return Err(Error::AlreadyExists);
         }
 
-        self.swaps.insert(local_swap_id, create_swap_params);
+        self.swaps.insert(local_swap_id, data);
 
         self.pending_confirmation
             .insert(digest.clone(), local_swap_id);
@@ -82,43 +93,44 @@ impl<T> Swaps<T> {
         Ok(())
     }
 
-    /// Alice moves a swap announced (pending confirmation) to communicate upon
-    /// receiving a confirmation from Bob
+    /// Alice moves an announced swap (pending confirmation) to communicate upon
+    /// receiving a confirmation from Bob.
     pub fn move_pending_confirmation_to_communicate(
         &mut self,
         digest: &SwapDigest,
         shared_swap_id: SharedSwapId,
-    ) -> Option<(LocalSwapId, Herc20HalightBitcoinCreateSwapParams)> {
+    ) -> Option<(LocalSwapId, LocalData)> {
         let local_swap_id = match self.pending_confirmation.remove(digest) {
             Some(local_swap_id) => local_swap_id,
             None => return None,
         };
 
-        let create_params = match self.swaps.get(&local_swap_id) {
+        let data = match self.swaps.get(&local_swap_id) {
             Some(create_params) => create_params,
             None => return None,
         };
 
         self.swap_ids.insert(local_swap_id, shared_swap_id);
 
-        Some((local_swap_id, create_params.clone()))
+        Some((local_swap_id, *data))
     }
 
-    /// Bob created a swap and it is pending announcement
+    /// Bob created a swap and it is pending announcement.
     pub fn create_as_pending_announcement(
         &mut self,
         digest: SwapDigest,
         local_swap_id: LocalSwapId,
-        create_swap_params: Herc20HalightBitcoinCreateSwapParams,
+        peer_id: PeerId,
+        data: LocalData,
     ) -> Result<(), Error> {
         if self.swaps.get(&local_swap_id).is_some() {
             return Err(Error::AlreadyExists);
         }
 
-        self.swaps.insert(local_swap_id, create_swap_params);
+        self.swaps.insert(local_swap_id, data);
 
         self.pending_announcement
-            .insert(digest.clone(), local_swap_id);
+            .insert(digest.clone(), (local_swap_id, peer_id));
 
         self.timestamps.insert(digest, Timestamp::now());
 
@@ -146,27 +158,30 @@ impl<T> Swaps<T> {
     }
 
     /// Bob: Move a swap from pending announcement (created) to communicate upon
-    /// receiving an announcement and replying to it
+    /// receiving an announcement and replying to it.
     pub fn move_pending_announcement_to_communicate(
         &mut self,
         digest: &SwapDigest,
         peer_id: &PeerId,
-    ) -> Result<(SharedSwapId, Herc20HalightBitcoinCreateSwapParams), Error> {
+    ) -> Result<(SharedSwapId, LocalData), Error> {
         let local_swap_id = match self.pending_announcement.get(&digest) {
-            Some(local_swap_id) => local_swap_id,
-            None => return Err(Error::NotFound),
+            Some((swap_id, pending_peer_id)) => {
+                if *peer_id != *pending_peer_id {
+                    return Err(Error::PeerIdMismatch);
+                }
+                swap_id
+            }
+            None => {
+                return Err(Error::NotFound);
+            }
         };
 
-        let create_params = match self.swaps.get(&local_swap_id) {
-            Some(create_params) => create_params,
+        let data = match self.swaps.get(&local_swap_id) {
+            Some(data) => data,
             None => return Err(Error::InternalFailure),
         };
 
-        if *peer_id != create_params.peer.peer_id {
-            return Err(Error::PeerIdMismatch);
-        }
-
-        let local_swap_id = self
+        let (local_swap_id, _) = self
             .pending_announcement
             .remove(digest)
             .expect("We did a `get` on the hashmap already.");
@@ -174,7 +189,7 @@ impl<T> Swaps<T> {
         let shared_swap_id = SharedSwapId::default();
         self.swap_ids.insert(local_swap_id, shared_swap_id.clone());
 
-        Ok((shared_swap_id, create_params.clone()))
+        Ok((shared_swap_id, *data))
     }
 
     /// Bob moves a swap that was announced and pending creation to communicate
@@ -183,32 +198,33 @@ impl<T> Swaps<T> {
         &mut self,
         digest: &SwapDigest,
         local_swap_id: LocalSwapId,
-        create_swap_params: Herc20HalightBitcoinCreateSwapParams,
+        peer_id: PeerId,
+        data: LocalData,
     ) -> Result<(SharedSwapId, PeerId, T), Error> {
         if self.swaps.get(&local_swap_id).is_some() {
             return Err(Error::AlreadyExists);
         }
 
-        let (peer, _) = match self.pending_creation.get(&digest) {
+        let (stored_peer_id, _) = match self.pending_creation.get(&digest) {
             Some(value) => value,
             None => return Err(Error::NotFound),
         };
 
-        if *peer != create_swap_params.peer.peer_id {
+        if *stored_peer_id != peer_id {
             return Err(Error::PeerIdMismatch);
         }
 
-        let (peer, io) = self
+        let (stored_peer_id, io) = self
             .pending_creation
             .remove(&digest)
-            .expect("Get already done");
+            .expect("should not fail because we just did a get on this hashmap");
 
-        self.swaps.insert(local_swap_id, create_swap_params);
+        self.swaps.insert(local_swap_id, data);
 
         let shared_swap_id = SharedSwapId::default();
         self.swap_ids.insert(local_swap_id, shared_swap_id.clone());
 
-        Ok((shared_swap_id, peer, io))
+        Ok((shared_swap_id, stored_peer_id, io))
     }
 
     /// Either role finalizes a swap that was in the communication phase
@@ -216,7 +232,7 @@ impl<T> Swaps<T> {
     pub fn finalize_swap(
         &mut self,
         shared_swap_id: &SharedSwapId,
-    ) -> Result<(LocalSwapId, Herc20HalightBitcoinCreateSwapParams), Error> {
+    ) -> Result<(LocalSwapId, LocalData), Error> {
         let local_swap_id = match self.swap_ids.iter().find_map(|(key, value)| {
             if *value == *shared_swap_id {
                 Some(key)
@@ -228,20 +244,12 @@ impl<T> Swaps<T> {
             None => return Err(Error::NotFound),
         };
 
-        let create_params = match self.swaps.get(&local_swap_id) {
+        let data = match self.swaps.get(&local_swap_id) {
             Some(create_params) => create_params,
             None => return Err(Error::NotFound),
         };
 
-        self.pending_announcement
-            .retain(|_, id| *id != *local_swap_id);
-
-        let finalized_digest = create_params.digest();
-
-        self.timestamps
-            .retain(|digest, _| *digest != finalized_digest);
-
-        Ok((*local_swap_id, create_params.clone()))
+        Ok((*local_swap_id, *data))
     }
 
     /// Remove all pending (not finalized) swap older than `older_than`
@@ -282,6 +290,7 @@ impl Default for Swaps<ReplySubstream<NegotiatedSubstream>> {
             pending_announcement: Default::default(),
             pending_creation: Default::default(),
             swaps: Default::default(),
+            roles: Default::default(),
             swap_ids: Default::default(),
             timestamps: Default::default(),
         }
@@ -296,6 +305,7 @@ impl Default for Swaps<()> {
             pending_announcement: Default::default(),
             pending_creation: Default::default(),
             swaps: Default::default(),
+            roles: Default::default(),
             swap_ids: Default::default(),
             timestamps: Default::default(),
         }
@@ -306,265 +316,58 @@ impl Default for Swaps<()> {
 mod tests {
     use super::*;
     use crate::{
-        asset, asset::ethereum::FromWei, identity, network::DialInformation, swap_protocols::Role,
+        asset::{self, ethereum::FromWei},
+        identity,
+        network::LocalData,
     };
+    use ::comit::network::{protocols::announce::SwapDigest, swap_digest::Herc20Halight};
     use digest::Digest;
 
-    impl<T> Swaps<T> {
-        /// Gets a swap that was announced
-        pub fn get_announced_swap(
-            &self,
-            local_swap_id: &LocalSwapId,
-        ) -> Option<(SharedSwapId, Herc20HalightBitcoinCreateSwapParams)> {
-            let create_params = match self.swaps.get(local_swap_id) {
-                Some(create_params) => create_params,
-                None => return None,
-            };
-
-            let shared_swap_id = match self.swap_ids.get(local_swap_id) {
-                Some(shared_swap_id) => shared_swap_id,
-                None => return None,
-            };
-
-            Some((*shared_swap_id, create_params.clone()))
-        }
-    }
-
-    fn create_params() -> Herc20HalightBitcoinCreateSwapParams {
-        Herc20HalightBitcoinCreateSwapParams {
-            role: Role::Alice,
-            peer: DialInformation {
-                peer_id: PeerId::random(),
-                address_hint: None,
-            },
-            ethereum_identity: identity::Ethereum::random(),
+    // Usage of this function relies on the fact that token_contract is
+    // random. We should use property based testing.
+    fn digest() -> SwapDigest {
+        Herc20Halight {
             ethereum_absolute_expiry: 12345.into(),
-            ethereum_amount: asset::Erc20Quantity::from_wei(9_001_000_000_000_000_000_000u128),
-            lightning_identity: identity::Lightning::random(),
+            erc20_amount: asset::Erc20Quantity::from_wei(9_001_000_000_000_000_000_000u128),
+            token_contract: identity::Ethereum::random(),
             lightning_cltv_expiry: 12345.into(),
             lightning_amount: asset::Bitcoin::from_sat(1_000_000_000),
-            token_contract: identity::Ethereum::random(),
         }
+        .digest()
     }
 
-    #[test]
-    fn created_swap_as_pending_confirmation_can_be_retrieved() {
-        let create_params = create_params();
-        let digest = create_params.digest();
-        let local_swap_id = LocalSwapId::default();
-        let mut swaps = Swaps::<()>::default();
-
-        let creation = swaps.create_as_pending_confirmation(
-            digest,
-            local_swap_id.clone(),
-            create_params.clone(),
-        );
-
-        assert!(creation.is_ok());
-        let created_swap = swaps.get_created_swap(&local_swap_id);
-        assert!(created_swap.is_some());
-        assert_eq!(created_swap.unwrap(), create_params)
-    }
-
-    #[test]
-    fn created_swap_as_pending_announcement_can_be_retrieved() {
-        let create_params = create_params();
-        let digest = create_params.digest();
-        let local_swap_id = LocalSwapId::default();
-        let mut swaps = Swaps::<()>::default();
-
-        let creation = swaps.create_as_pending_announcement(
-            digest,
-            local_swap_id.clone(),
-            create_params.clone(),
-        );
-
-        assert!(creation.is_ok());
-        let created_swap = swaps.get_created_swap(&local_swap_id);
-        assert!(created_swap.is_some());
-        assert_eq!(created_swap.unwrap(), create_params)
-    }
-
-    #[test]
-    fn given_alice_creates_dupe_swap_then_stored_params_are_unchanged() {
-        let first_create_params = create_params();
-        let mut second_create_params = first_create_params.clone();
-        // Ethereum identity is not part of the digest so both swaps should be
-        // considered the same
-        second_create_params.ethereum_identity = identity::Ethereum::random();
-
-        let digest = first_create_params.digest();
-        let second_digest = second_create_params.digest();
-
-        // The test is based on this assumption so making sure it's true
-        assert_eq!(digest, second_digest);
-
-        let local_swap_id = LocalSwapId::default();
-        let mut swaps = Swaps::<()>::default();
-
-        let _ = swaps.create_as_pending_confirmation(
-            digest.clone(),
-            local_swap_id.clone(),
-            first_create_params.clone(),
-        );
-
-        let stored_params = swaps.get_created_swap(&local_swap_id).unwrap();
-
-        assert_eq!(stored_params, first_create_params);
-
-        let creation =
-            swaps.create_as_pending_confirmation(digest, local_swap_id, second_create_params);
-
-        assert!(creation.is_err());
-        let stored_params = swaps.get_created_swap(&local_swap_id).unwrap();
-        assert_eq!(stored_params, first_create_params);
-    }
-
-    #[test]
-    fn given_bob_creates_dupe_swap_before_announcement_then_stored_params_are_unchanged() {
-        let first_create_params = create_params();
-        let mut second_create_params = first_create_params.clone();
-
-        // Ethereum identity is not part of the digest so both swaps should be
-        // considered the same
-        second_create_params.ethereum_identity = identity::Ethereum::random();
-
-        let digest = first_create_params.digest();
-        let second_digest = second_create_params.digest();
-
-        // The test is based on this assumption so making sure it's true
-        assert_eq!(digest, second_digest);
-
-        let local_swap_id = LocalSwapId::default();
-        let mut swaps = Swaps::<()>::default();
-
-        swaps
-            .create_as_pending_announcement(
-                digest.clone(),
-                local_swap_id.clone(),
-                first_create_params.clone(),
-            )
-            .unwrap();
-
-        let stored_params = swaps.get_created_swap(&local_swap_id).unwrap();
-
-        assert_eq!(stored_params, first_create_params);
-
-        let second_creation =
-            swaps.create_as_pending_announcement(digest, local_swap_id, second_create_params);
-
-        assert!(second_creation.is_err());
-        let stored_params = swaps.get_created_swap(&local_swap_id).unwrap();
-        assert_eq!(stored_params, first_create_params);
-    }
-
-    #[test]
-    fn from_creation_to_finalisation_for_alice() {
-        let create_params = create_params();
-        let digest = create_params.digest();
-        let local_swap_id = LocalSwapId::default();
-        let mut swaps = Swaps::<()>::default();
-
-        swaps
-            .create_as_pending_confirmation(digest.clone(), local_swap_id, create_params.clone())
-            .unwrap();
-
-        let shared_swap_id = SharedSwapId::default();
-        let (stored_local_swap_id, stored_create_params) = swaps
-            .move_pending_confirmation_to_communicate(&digest, shared_swap_id)
-            .unwrap();
-
-        assert_eq!(local_swap_id, stored_local_swap_id);
-        assert_eq!(create_params, stored_create_params);
-
-        let (stored_shared_swap_id, stored_create_params) =
-            swaps.get_announced_swap(&local_swap_id).unwrap();
-
-        assert_eq!(shared_swap_id, stored_shared_swap_id);
-        assert_eq!(create_params, stored_create_params);
-
-        let (_, stored_create_params) = swaps.finalize_swap(&shared_swap_id).unwrap();
-
-        assert_eq!(create_params, stored_create_params);
-        assert!(!swaps.swap_in_pending_hashmaps(&digest));
-    }
-
-    #[test]
-    fn from_creation_then_announcement_to_finalisation_for_bob() {
-        let create_params = create_params();
-        let digest = create_params.digest();
-        let local_swap_id = LocalSwapId::default();
-
-        let mut swaps = Swaps::<ReplySubstream<NegotiatedSubstream>>::default();
-
-        swaps
-            .create_as_pending_announcement(digest.clone(), local_swap_id, create_params.clone())
-            .unwrap();
-
-        let (shared_swap_id, stored_create_params) = swaps
-            .move_pending_announcement_to_communicate(&digest, &create_params.peer.peer_id)
-            .unwrap();
-
-        assert_eq!(create_params, stored_create_params);
-
-        let (stored_shared_swap_id, stored_create_params) =
-            swaps.get_announced_swap(&local_swap_id).unwrap();
-
-        assert_eq!(shared_swap_id, stored_shared_swap_id);
-        assert_eq!(create_params, stored_create_params);
-
-        let (_local_swap_id, stored_create_params) = swaps.finalize_swap(&shared_swap_id).unwrap();
-
-        assert_eq!(create_params, stored_create_params);
-        assert!(!swaps.swap_in_pending_hashmaps(&digest));
-    }
-
-    #[test]
-    fn from_announcement_then_creation_to_finalisation_for_bob() {
-        let create_params = create_params();
-        let digest = create_params.digest();
-        let local_swap_id = LocalSwapId::default();
-        let mut swaps = Swaps::default();
-
-        swaps
-            .insert_pending_creation(digest.clone(), create_params.peer.peer_id.clone(), ())
-            .unwrap();
-
-        let (shared_swap_id, _peer, _io) = swaps
-            .move_pending_creation_to_communicate(&digest, local_swap_id, create_params.clone())
-            .unwrap();
-
-        let (stored_shared_swap_id, stored_create_params) =
-            swaps.get_announced_swap(&local_swap_id).unwrap();
-
-        assert_eq!(shared_swap_id, stored_shared_swap_id);
-        assert_eq!(create_params, stored_create_params);
-
-        let (stored_local_swap_id, stored_create_params) =
-            swaps.finalize_swap(&shared_swap_id).unwrap();
-
-        assert_eq!(local_swap_id, stored_local_swap_id);
-        assert_eq!(create_params, stored_create_params);
-        assert!(!swaps.swap_in_pending_hashmaps(&digest));
+    // The same applies here as for digest() re property based testing.
+    fn local_data() -> LocalData {
+        LocalData {
+            secret_hash: None,
+            shared_swap_id: Some(SharedSwapId::default()),
+            ethereum_identity: Some(identity::Ethereum::random()),
+            lightning_identity: Some(identity::Lightning::random()),
+        }
     }
 
     #[test]
     fn old_pending_swaps_are_cleaned_up() {
         let mut swaps = Swaps::<()>::default();
 
-        let create_params1 = create_params();
-        let digest1 = create_params1.digest();
-        let create_params2 = create_params();
-        let digest2 = create_params2.digest();
-        let create_params3 = create_params();
-        let digest3 = create_params3.digest();
+        let digest1 = digest();
+        let digest2 = digest();
+        let digest3 = digest();
+
+        let data1 = local_data();
+        let data2 = local_data();
 
         swaps
-            .create_as_pending_confirmation(digest1.clone(), LocalSwapId::default(), create_params1)
+            .create_as_pending_confirmation(digest1.clone(), LocalSwapId::default(), data1)
             .unwrap();
 
         swaps
-            .create_as_pending_announcement(digest2.clone(), LocalSwapId::default(), create_params2)
+            .create_as_pending_announcement(
+                digest2.clone(),
+                LocalSwapId::default(),
+                PeerId::random(),
+                data2,
+            )
             .unwrap();
 
         swaps
@@ -573,7 +376,6 @@ mod tests {
 
         std::thread::sleep(std::time::Duration::from_secs(1));
         let time = Timestamp::now();
-
         swaps.clean_up_pending_swaps(time);
 
         assert!(!swaps.swap_in_pending_hashmaps(&digest1));
@@ -583,56 +385,65 @@ mod tests {
 
     #[test]
     fn old_finalized_swaps_are_not_cleaned_up() {
-        let create_params = create_params();
-        let digest = create_params.digest();
-        let local_swap_id = LocalSwapId::default();
-        let mut swaps = Swaps::<ReplySubstream<NegotiatedSubstream>>::default();
+        let mut swaps = Swaps::<()>::default();
+
+        let digest = digest();
+        let id = LocalSwapId::default();
+        let data = local_data();
+        let peer_id = PeerId::random();
 
         swaps
-            .create_as_pending_announcement(digest.clone(), local_swap_id, create_params.clone())
-            .unwrap();
-        let (shared_swap_id, _) = swaps
-            .move_pending_announcement_to_communicate(&digest, &create_params.peer.peer_id)
+            .create_as_pending_announcement(digest.clone(), id, peer_id.clone(), data.clone())
             .unwrap();
 
-        swaps.get_announced_swap(&local_swap_id).unwrap();
+        let (shared_swap_id, _) = swaps
+            .move_pending_announcement_to_communicate(&digest, &peer_id)
+            .unwrap();
 
         swaps.finalize_swap(&shared_swap_id).unwrap();
 
         std::thread::sleep(std::time::Duration::from_secs(1));
         let time = Timestamp::now();
-
         swaps.clean_up_pending_swaps(time);
 
-        assert!(swaps.get_announced_swap(&local_swap_id).is_some());
+        // assertions
+        swaps.swaps.get(&id).expect("swap to still be in swaps");
+        swaps
+            .swap_ids
+            .get(&id)
+            .expect("swap to still be in swap_ids");
     }
 
     #[test]
     fn young_pending_swaps_are_not_cleaned_up() {
         let mut swaps = Swaps::<()>::default();
 
-        let create_params1 = create_params();
-        let digest1 = create_params1.digest();
-        let create_params2 = create_params();
-        let digest2 = create_params2.digest();
-        let create_params3 = create_params();
-        let digest3 = create_params3.digest();
+        let digest1 = digest();
+        let digest2 = digest();
+        let digest3 = digest();
 
-        let time = Timestamp::now();
-        std::thread::sleep(std::time::Duration::from_secs(1));
+        let data1 = local_data();
+        let data2 = local_data();
 
         swaps
-            .create_as_pending_confirmation(digest1.clone(), LocalSwapId::default(), create_params1)
+            .create_as_pending_confirmation(digest1.clone(), LocalSwapId::default(), data1)
             .unwrap();
 
         swaps
-            .create_as_pending_announcement(digest2.clone(), LocalSwapId::default(), create_params2)
+            .create_as_pending_announcement(
+                digest2.clone(),
+                LocalSwapId::default(),
+                PeerId::random(),
+                data2,
+            )
             .unwrap();
 
         swaps
             .insert_pending_creation(digest3.clone(), PeerId::random(), ())
             .unwrap();
 
+        let time = Timestamp::now();
+        std::thread::sleep(std::time::Duration::from_secs(1));
         swaps.clean_up_pending_swaps(time);
 
         assert!(swaps.swap_in_pending_hashmaps(&digest1));
@@ -641,74 +452,19 @@ mod tests {
     }
 
     #[test]
-    fn given_bob_creates_dupe_swap_after_announcement_then_stored_params_are_unchanged() {
-        let first_create_params = create_params();
-        let mut second_create_params = first_create_params.clone();
-        second_create_params.ethereum_identity = identity::Ethereum::random();
-
-        let digest = first_create_params.digest();
-        let second_digest = second_create_params.digest();
-
-        assert_eq!(digest, second_digest);
-
-        let local_swap_id = LocalSwapId::default();
-        let mut swaps = Swaps::default();
-
-        swaps
-            .insert_pending_creation(digest.clone(), first_create_params.peer.peer_id.clone(), ())
-            .unwrap();
-
-        let (shared_swap_id, _peer, _io) = swaps
-            .move_pending_creation_to_communicate(
-                &digest,
-                local_swap_id,
-                first_create_params.clone(),
-            )
-            .unwrap();
-
-        let (stored_shared_swap_id, stored_create_params) =
-            swaps.get_announced_swap(&local_swap_id).unwrap();
-
-        assert_eq!(stored_shared_swap_id, shared_swap_id);
-        assert_eq!(stored_create_params, first_create_params);
-
-        let res = swaps.move_pending_creation_to_communicate(
-            &digest,
-            local_swap_id,
-            second_create_params,
-        );
-
-        assert!(res.is_err());
-        let (stored_shared_swap_id, stored_create_params) =
-            swaps.get_announced_swap(&local_swap_id).unwrap();
-        assert_eq!(stored_shared_swap_id, shared_swap_id);
-        assert_eq!(stored_create_params, first_create_params);
-    }
-
-    #[test]
-    fn given_move_pending_creation_to_communicate_errors_then_no_side_effects() {
-        let create_params = create_params();
-        let digest = create_params.digest();
-        let local_swap_id = LocalSwapId::default();
-        let mut swaps = Swaps::<()>::default();
-
-        let res = swaps.move_pending_creation_to_communicate(&digest, local_swap_id, create_params);
-
-        assert!(res.is_err());
-        let res = swaps.get_announced_swap(&local_swap_id);
-        assert!(res.is_none());
-    }
-
-    #[test]
     fn given_bob_receives_announcement_with_wrong_peer_id_then_error() {
-        let create_params = create_params();
-        let digest = create_params.digest();
-        let local_swap_id = LocalSwapId::default();
-
         let mut swaps = Swaps::<()>::default();
 
+        let data = local_data();
+        let digest = digest();
+
         swaps
-            .create_as_pending_announcement(digest.clone(), local_swap_id, create_params)
+            .create_as_pending_announcement(
+                digest.clone(),
+                LocalSwapId::default(),
+                PeerId::random(),
+                data,
+            )
             .unwrap();
 
         let res = swaps.move_pending_announcement_to_communicate(&digest, &PeerId::random());
@@ -718,15 +474,19 @@ mod tests {
 
     #[test]
     fn given_bob_receives_creation_with_different_peer_id_then_error() {
-        let create_params = create_params();
-        let digest = create_params.digest();
-        let local_swap_id = LocalSwapId::default();
-
         let mut swaps = Swaps::<()>::default();
 
-        let _ = swaps.insert_pending_creation(digest.clone(), PeerId::random(), ());
+        let data = local_data();
+        let digest = digest();
+        let local_swap_id = LocalSwapId::default();
 
-        let res = swaps.move_pending_creation_to_communicate(&digest, local_swap_id, create_params);
+        let _ = swaps.insert_pending_creation(digest.clone(), PeerId::random(), ());
+        let res = swaps.move_pending_creation_to_communicate(
+            &digest,
+            local_swap_id,
+            PeerId::random(),
+            data,
+        );
 
         assert_eq!(res, Err(Error::PeerIdMismatch));
     }

--- a/cnd/src/network/start_swap.rs
+++ b/cnd/src/network/start_swap.rs
@@ -1,0 +1,89 @@
+use crate::{
+    db::{ForSwap, Save, Swap},
+    network::comit::RemoteData,
+    protocol_spawner::{ProtocolSpawner, Spawn},
+    storage::{Load, Storage},
+    swap_protocols::{halight, herc20, LocalSwapId},
+};
+use ::comit::{
+    network::{WhatAliceLearnedFromBob, WhatBobLearnedFromAlice},
+    Protocol, Role, Side,
+};
+use chrono::offset::Utc;
+
+pub async fn start_swap(
+    storage: Storage,
+    spawner: ProtocolSpawner,
+    id: LocalSwapId,
+    data: RemoteData,
+) -> anyhow::Result<()>
+where
+    ProtocolSpawner: Spawn<herc20::Params> + Spawn<halight::Params>,
+{
+    let start_of_swap = Utc::now().naive_local();
+    let swap = storage.load(id).await?;
+
+    match (swap, data) {
+        (
+            Swap {
+                alpha: Protocol::Herc20,
+                beta: Protocol::Halight,
+                role: role @ Role::Alice,
+            },
+            RemoteData {
+                ethereum_identity: Some(ethereum_identity),
+                lightning_identity: Some(lightning_identity),
+                // Do not make this None, secret_hash is in the behaviour event for Alice.
+                secret_hash: _,
+            },
+        ) => {
+            storage
+                .save(ForSwap {
+                    local_swap_id: id,
+                    data: WhatAliceLearnedFromBob {
+                        redeem_ethereum_identity: ethereum_identity,
+                        refund_lightning_identity: lightning_identity,
+                    },
+                })
+                .await?;
+
+            let herc20_params: herc20::Params = storage.load(id).await?;
+            let halight_params: halight::Params = storage.load(id).await?;
+
+            spawner.spawn(id, herc20_params, start_of_swap, Side::Alpha, role);
+            spawner.spawn(id, halight_params, start_of_swap, Side::Beta, role);
+        }
+        (
+            Swap {
+                alpha: Protocol::Herc20,
+                beta: Protocol::Halight,
+                role: role @ Role::Bob,
+            },
+            RemoteData {
+                ethereum_identity: Some(ethereum_identity),
+                lightning_identity: Some(lightning_identity),
+                secret_hash: Some(secret_hash),
+            },
+        ) => {
+            storage
+                .save(ForSwap {
+                    local_swap_id: id,
+                    data: WhatBobLearnedFromAlice {
+                        secret_hash,
+                        refund_ethereum_identity: ethereum_identity,
+                        redeem_lightning_identity: lightning_identity,
+                    },
+                })
+                .await?;
+
+            let herc20_params: herc20::Params = storage.load(id).await?;
+            let halight_params: halight::Params = storage.load(id).await?;
+
+            spawner.spawn(id, herc20_params, start_of_swap, Side::Alpha, role);
+            spawner.spawn(id, halight_params, start_of_swap, Side::Beta, role);
+        }
+        _ => tracing::info!("attempting to start an unsupported swap"),
+    };
+
+    Ok(())
+}

--- a/cnd/src/protocol_spawner.rs
+++ b/cnd/src/protocol_spawner.rs
@@ -1,4 +1,7 @@
-use crate::swap_protocols::{halight, herc20, LocalSwapId};
+use crate::{
+    http_api::LedgerNotConfigured,
+    swap_protocols::{halight, herc20, LocalSwapId},
+};
 use chrono::NaiveDateTime;
 use comit::{
     btsieve,
@@ -10,7 +13,7 @@ use tokio::runtime::Handle;
 
 /// ProtocolSpawner acts as a bundle for all dependencies needed to spawn
 /// instances of a protocol.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ProtocolSpawner {
     ethereum_connector: Arc<btsieve::ethereum::Cache<btsieve::ethereum::Web3Connector>>,
     lnd_connector_params: Option<LndConnectorParams>,
@@ -47,6 +50,15 @@ impl ProtocolSpawner {
             runtime_handle,
             herc20_states,
             halight_states,
+        }
+    }
+
+    pub fn supports_halight(&self) -> anyhow::Result<()> {
+        match self.lnd_connector_params {
+            Some(_) => Ok(()),
+            None => Err(anyhow::Error::from(LedgerNotConfigured {
+                ledger: "lightning",
+            })),
         }
     }
 }

--- a/cnd/src/storage.rs
+++ b/cnd/src/storage.rs
@@ -3,8 +3,8 @@ use crate::{
         self,
         tables::{Halight, Herc20},
         wrapper_types::custom_sql_types::Text,
-        NoHalightRedeemIdentity, NoHalightRefundIdentity, NoHerc20RedeemIdentity,
-        NoHerc20RefundIdentity, NoSecretHash, Sqlite,
+        ForSwap, NoHalightRedeemIdentity, NoHalightRefundIdentity, NoHerc20RedeemIdentity,
+        NoHerc20RefundIdentity, NoSecretHash, Save, Sqlite,
     },
     http_api,
     http_api::{halight::HalightFinalized, herc20::Herc20Finalized},
@@ -14,9 +14,15 @@ use crate::{
 };
 use anyhow::Context;
 use async_trait::async_trait;
-use comit::{asset, Role};
+use comit::{
+    asset,
+    network::{WhatAliceLearnedFromBob, WhatBobLearnedFromAlice},
+    Protocol, Role,
+};
 use db::tables::{SecretHash, Swap};
-use diesel::{BelongingToDsl, ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl};
+use diesel::{
+    sql_types, BelongingToDsl, ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl,
+};
 use std::sync::Arc;
 
 /// Load data for a particular swap from the storage layer.
@@ -503,5 +509,211 @@ impl Load<http_api::BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc
                 beta_created: herc20_asset,
             }),
         }
+    }
+}
+
+#[async_trait::async_trait]
+impl Load<db::Swap> for Storage {
+    async fn load(&self, swap_id: LocalSwapId) -> anyhow::Result<db::Swap> {
+        #[derive(QueryableByName)]
+        struct Result {
+            #[sql_type = "sql_types::Text"]
+            role: Text<Role>,
+            #[sql_type = "sql_types::Text"]
+            alpha_protocol: Text<Protocol>,
+            #[sql_type = "sql_types::Text"]
+            beta_protocol: Text<Protocol>,
+        }
+
+        let Result { role, alpha_protocol, beta_protocol } = self.db.do_in_transaction(|connection| {
+            // Here is how this works:
+            // - COALESCE selects the first non-null value from a list of values
+            // - We use 3 sub-selects to select a static value (i.e. 'halight', etc) if that particular child table has a row with a foreign key to the parent table
+            // - We do this two times, once where we limit the results to rows that have `ledger` set to `Alpha` and once where `ledger` is set to `Beta`
+            //
+            // The result is a view with 3 columns: `role`, `alpha_protocol` and `beta_protocol` where the `*_protocol` columns have one of the values `halight`, `herc20` or `hbit`
+            diesel::sql_query(
+                r#"
+                SELECT
+                    role,
+                    COALESCE(
+                       (SELECT 'halight' from halights where halights.swap_id = swaps.id and halights.side = 'Alpha'),
+                       (SELECT 'herc20' from herc20s where herc20s.swap_id = swaps.id and herc20s.side = 'Alpha'),
+                       (SELECT 'hbit' from hbits where hbits.swap_id = swaps.id and hbits.side = 'Alpha')
+                    ) as alpha_protocol,
+                    COALESCE(
+                       (SELECT 'halight' from halights where halights.swap_id = swaps.id and halights.side = 'Beta'),
+                       (SELECT 'herc20' from herc20s where herc20s.swap_id = swaps.id and herc20s.side = 'Beta'),
+                       (SELECT 'hbit' from hbits where hbits.swap_id = swaps.id and hbits.side = 'Beta')
+                    ) as beta_protocol
+                from swaps
+                    where local_swap_id = ?
+            "#,
+            )
+                .bind::<sql_types::Text, _>(Text(swap_id))
+                .get_result(connection)
+        }).await.context(db::Error::SwapNotFound)?;
+
+        Ok(db::Swap {
+            role: role.0,
+            alpha: alpha_protocol.0,
+            beta: beta_protocol.0,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Load<halight::Params> for Storage {
+    async fn load(&self, id: LocalSwapId) -> anyhow::Result<halight::Params> {
+        use crate::db::schema::swaps;
+
+        let (swap, halight, secret_hash) = self
+            .db
+            .do_in_transaction::<_, _, anyhow::Error>(move |conn| {
+                let key = Text(id);
+
+                let swap: Swap = swaps::table
+                    .filter(swaps::local_swap_id.eq(key))
+                    .first(conn)?;
+
+                let halight = Halight::belonging_to(&swap).first::<Halight>(conn)?;
+                let secret_hash = SecretHash::belonging_to(&swap)
+                    .first::<SecretHash>(conn)
+                    .optional()?;
+
+                Ok((swap, halight, secret_hash))
+            })
+            .await
+            .context(db::Error::SwapNotFound)?;
+
+        let role = swap.role.0;
+        let secret_hash = match role {
+            Role::Alice => comit::SecretHash::new(self.seed.derive_swap_seed(id).derive_secret()),
+            Role::Bob => secret_hash.ok_or_else(|| NoSecretHash(id))?.secret_hash.0,
+        };
+
+        let params = halight::Params {
+            redeem_identity: halight
+                .redeem_identity
+                .ok_or_else(|| NoHalightRedeemIdentity(id))?
+                .0,
+            refund_identity: halight
+                .refund_identity
+                .ok_or_else(|| NoHalightRefundIdentity(id))?
+                .0,
+            cltv_expiry: halight.cltv_expiry.0.into(),
+            asset: halight.amount.0.into(),
+            secret_hash,
+        };
+
+        Ok(params)
+    }
+}
+
+#[async_trait::async_trait]
+impl Load<herc20::Params> for Storage {
+    async fn load(&self, id: LocalSwapId) -> anyhow::Result<herc20::Params> {
+        use crate::db::schema::swaps;
+
+        let (swap, herc20, secret_hash) = self
+            .db
+            .do_in_transaction::<_, _, anyhow::Error>(move |conn| {
+                let key = Text(id);
+
+                let swap: Swap = swaps::table
+                    .filter(swaps::local_swap_id.eq(key))
+                    .first(conn)?;
+
+                let herc20 = Herc20::belonging_to(&swap).first::<Herc20>(conn)?;
+                let secret_hash = SecretHash::belonging_to(&swap)
+                    .first::<SecretHash>(conn)
+                    .optional()?;
+
+                Ok((swap, herc20, secret_hash))
+            })
+            .await
+            .context(db::Error::SwapNotFound)?;
+
+        let role = swap.role.0;
+        let secret_hash = match role {
+            Role::Alice => comit::SecretHash::new(self.seed.derive_swap_seed(id).derive_secret()),
+            Role::Bob => secret_hash.ok_or_else(|| NoSecretHash(id))?.secret_hash.0,
+        };
+
+        let params = herc20::Params {
+            asset: asset::Erc20 {
+                quantity: herc20.amount.0.into(),
+                token_contract: herc20.token_contract.0.into(),
+            },
+            redeem_identity: herc20
+                .redeem_identity
+                .ok_or_else(|| NoHerc20RedeemIdentity(id))?
+                .0
+                .into(),
+            refund_identity: herc20
+                .refund_identity
+                .ok_or_else(|| NoHerc20RefundIdentity(id))?
+                .0
+                .into(),
+            expiry: herc20.expiry.0.into(),
+            secret_hash,
+        };
+
+        Ok(params)
+    }
+}
+
+#[async_trait::async_trait]
+impl Save<ForSwap<WhatAliceLearnedFromBob>> for Storage {
+    async fn save(&self, swap: ForSwap<WhatAliceLearnedFromBob>) -> anyhow::Result<()> {
+        let local_swap_id = swap.local_swap_id;
+        let refund_lightning_identity = swap.data.refund_lightning_identity;
+        let redeem_ethereum_identity = swap.data.redeem_ethereum_identity;
+
+        self.db
+            .do_in_transaction(|conn| {
+                self.db.update_halight_refund_identity(
+                    conn,
+                    local_swap_id,
+                    refund_lightning_identity,
+                )?;
+                self.db.update_herc20_redeem_identity(
+                    conn,
+                    local_swap_id,
+                    redeem_ethereum_identity,
+                )?;
+
+                Ok(())
+            })
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl Save<ForSwap<WhatBobLearnedFromAlice>> for Storage {
+    async fn save(&self, swap: ForSwap<WhatBobLearnedFromAlice>) -> anyhow::Result<()> {
+        let local_swap_id = swap.local_swap_id;
+        let redeem_lightning_identity = swap.data.redeem_lightning_identity;
+        let refund_ethereum_identity = swap.data.refund_ethereum_identity;
+        let secret_hash = swap.data.secret_hash;
+
+        self.db
+            .do_in_transaction(|conn| {
+                self.db.update_halight_redeem_identity(
+                    conn,
+                    local_swap_id,
+                    redeem_lightning_identity,
+                )?;
+                self.db.update_herc20_refund_identity(
+                    conn,
+                    local_swap_id,
+                    refund_ethereum_identity,
+                )?;
+                self.db
+                    .insert_secret_hash(conn, local_swap_id, secret_hash)?;
+
+                Ok(())
+            })
+            .await
     }
 }

--- a/comit/src/network.rs
+++ b/comit/src/network.rs
@@ -1,6 +1,7 @@
 pub mod oneshot_behaviour;
 pub mod oneshot_protocol;
 pub mod protocols;
+pub mod swap_digest;
 
 use crate::{identity, SecretHash};
 use libp2p::{Multiaddr, PeerId};

--- a/comit/src/network/swap_digest.rs
+++ b/comit/src/network/swap_digest.rs
@@ -1,0 +1,19 @@
+use crate::{asset, identity, network::protocols::announce::SwapDigest, RelativeTime, Timestamp};
+use digest::Digest;
+
+/// This represents the information that we use to create a swap digest for
+/// herc20 <-> halight swaps.
+#[derive(Clone, Digest, Debug)]
+#[digest(hash = "SwapDigest")]
+pub struct Herc20Halight {
+    #[digest(prefix = "2001")]
+    pub ethereum_absolute_expiry: Timestamp,
+    #[digest(prefix = "2002")]
+    pub erc20_amount: asset::Erc20Quantity,
+    #[digest(prefix = "2003")]
+    pub token_contract: identity::Ethereum,
+    #[digest(prefix = "3001")]
+    pub lightning_cltv_expiry: RelativeTime,
+    #[digest(prefix = "3002")]
+    pub lightning_amount: asset::Bitcoin,
+}


### PR DESCRIPTION
Builds on top of @D4nte's draft PR re-working the network module to make it easier to add more protocols.

The idea is to make the `Comit` (previously named `ComitLN`) `NetworkBehaviour` agnostic to the swap protocol that it is involved in i.e., within `Comit` there is no alpha/beta only data to be communicated with the peer node. One layer up, at the swarm (`ComitNode` `NetworkBehaviour`) the protocol and role are known.

All reads and writes to the database, which imply knowledge of the protocol, happen in the swarm. For this we add a reference to the new `Storage`.

Please note: This PR touches the network module, and call sites to the network module entry point `initiate_communication`, this includes the `Facade` and `index.rs`. Also, since this PR removes the now stale 'new' way to enter the network module `InitCommunication` added during the `hbit` module PR. We leave the endpoint code as 'untouched' as possible by simply removing the calls to `init_communication` and adding `unimplemeneted!()`.