### PR TITLE
Rename Swap -> Rfc003Swap

### DIFF
--- a/cnd/src/db/integration_tests/db_roundtrips.rs
+++ b/cnd/src/db/integration_tests/db_roundtrips.rs
@@ -3,7 +3,7 @@ use crate::{
     db::{
         load_swaps::LoadAcceptedSwap,
         swap_types::{DetermineTypes, SwapTypes},
-        AssetKind, LedgerKind, Retrieve, Save, Sqlite, Swap,
+        AssetKind, LedgerKind, Retrieve, Rfc003Swap, Save, Sqlite,
     },
     identity,
     quickcheck::Quickcheck,
@@ -19,20 +19,20 @@ macro_rules! db_roundtrip_test {
             #[test]
             #[allow(non_snake_case, clippy::redundant_closure_call)]
             fn [<roundtrip_test_ $alpha_ledger _ $beta_ledger _ $alpha_asset _ $beta_asset>]() {
-                fn prop(swap: Quickcheck<Swap>,
+                fn prop(swap: Quickcheck<Rfc003Swap>,
                         request: Quickcheck<Request<$alpha_ledger, $beta_ledger, $alpha_asset, $beta_asset, $alpha_identity, $beta_identity>>,
                         accept: Quickcheck<Accept<$alpha_identity, $beta_identity>>,
                 ) -> anyhow::Result<bool> {
 
                     // unpack the swap from the generic newtype
-                    let Swap { swap_id, role, counterparty } = swap.0;
+                    let Rfc003Swap { swap_id, role, counterparty } = swap.0;
 
                     // construct the expected swap types from the function we get passed in order to enrich it with the role
                     let expected_swap_types = ($expected_swap_types_fn)(role);
 
                     let db = Sqlite::test();
 
-                    let saved_swap = Swap {
+                    let saved_swap = Rfc003Swap {
                         swap_id,
                         role,
                         counterparty
@@ -69,7 +69,7 @@ macro_rules! db_roundtrip_test {
                 }
 
                 quickcheck::quickcheck(prop as fn(
-                    Quickcheck<Swap>,
+                    Quickcheck<Rfc003Swap>,
                     Quickcheck<Request<$alpha_ledger, $beta_ledger, $alpha_asset, $beta_asset, $alpha_identity, $beta_identity>>,
                     Quickcheck<Accept<$alpha_identity, $beta_identity>>,
                 ) -> anyhow::Result<bool>);

--- a/cnd/src/db/save_load_impls/rfc003.rs
+++ b/cnd/src/db/save_load_impls/rfc003.rs
@@ -6,7 +6,7 @@ use crate::{
             custom_sql_types::{Text, U32},
             BitcoinNetwork, Erc20Amount, Ether, EthereumAddress, Satoshis,
         },
-        Save, Sqlite, Swap,
+        Rfc003Swap, Save, Sqlite,
     },
     identity,
     swap_protocols::{
@@ -20,8 +20,8 @@ use diesel::RunQueryDsl;
 use libp2p::{self, PeerId};
 
 #[async_trait]
-impl Save<Swap> for Sqlite {
-    async fn save(&self, swap: Swap) -> anyhow::Result<()> {
+impl Save<Rfc003Swap> for Sqlite {
+    async fn save(&self, swap: Rfc003Swap) -> anyhow::Result<()> {
         let insertable = InsertableRfc003Swap::from(swap);
 
         self.do_in_transaction(|connection| {
@@ -43,8 +43,8 @@ struct InsertableRfc003Swap {
     pub counterparty: Text<PeerId>,
 }
 
-impl From<Swap> for InsertableRfc003Swap {
-    fn from(swap: Swap) -> Self {
+impl From<Rfc003Swap> for InsertableRfc003Swap {
+    fn from(swap: Rfc003Swap) -> Self {
         InsertableRfc003Swap {
             swap_id: Text(swap.swap_id),
             role: Text(swap.role),

--- a/cnd/src/db/swap.rs
+++ b/cnd/src/db/swap.rs
@@ -11,20 +11,20 @@ use libp2p::{self, PeerId};
 #[async_trait]
 #[ambassador::delegatable_trait]
 pub trait Retrieve: Send + Sync + 'static {
-    async fn get(&self, key: &SwapId) -> anyhow::Result<Swap>;
-    async fn all(&self) -> anyhow::Result<Vec<Swap>>;
+    async fn get(&self, key: &SwapId) -> anyhow::Result<Rfc003Swap>;
+    async fn all(&self) -> anyhow::Result<Vec<Rfc003Swap>>;
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Swap {
+pub struct Rfc003Swap {
     pub swap_id: SwapId,
     pub role: Role,
     pub counterparty: PeerId,
 }
 
-impl Swap {
-    pub fn new(swap_id: SwapId, role: Role, counterparty: PeerId) -> Swap {
-        Swap {
+impl Rfc003Swap {
+    pub fn new(swap_id: SwapId, role: Role, counterparty: PeerId) -> Rfc003Swap {
+        Rfc003Swap {
             swap_id,
             role,
             counterparty,
@@ -34,7 +34,7 @@ impl Swap {
 
 #[async_trait]
 impl Retrieve for Sqlite {
-    async fn get(&self, key: &SwapId) -> anyhow::Result<Swap> {
+    async fn get(&self, key: &SwapId) -> anyhow::Result<Rfc003Swap> {
         use self::rfc003_schema::rfc003_swaps::dsl::*;
 
         let record: QueryableSwap = self
@@ -49,10 +49,10 @@ impl Retrieve for Sqlite {
             .await?
             .ok_or(Error::SwapNotFound)?;
 
-        Ok(Swap::from(record))
+        Ok(Rfc003Swap::from(record))
     }
 
-    async fn all(&self) -> anyhow::Result<Vec<Swap>> {
+    async fn all(&self) -> anyhow::Result<Vec<Rfc003Swap>> {
         use self::rfc003_schema::rfc003_swaps::dsl::*;
 
         let records: Vec<QueryableSwap> = self
@@ -71,9 +71,9 @@ struct QueryableSwap {
     pub counterparty: Text<PeerId>,
 }
 
-impl From<QueryableSwap> for Swap {
-    fn from(swap: QueryableSwap) -> Swap {
-        Swap {
+impl From<QueryableSwap> for Rfc003Swap {
+    fn from(swap: QueryableSwap) -> Rfc003Swap {
+        Rfc003Swap {
             swap_id: *swap.swap_id,
             role: *swap.role,
             counterparty: (*swap.counterparty).clone(),

--- a/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/post_swap.rs
@@ -1,5 +1,5 @@
 use crate::{
-    db::{LoadAcceptedSwap, Save, Sqlite, Swap},
+    db::{LoadAcceptedSwap, Rfc003Swap, Save, Sqlite},
     htlc_location,
     http_api::{DialInformation, HttpAsset, HttpLedger},
     identity,
@@ -33,8 +33,10 @@ async fn initiate_request<AL, BL, AA, BA, AH, BH, AI, BI, AT, BT>(
     swap_request: rfc003::Request<AL, BL, AA, BA, AI, BI>,
 ) -> anyhow::Result<()>
 where
-    Sqlite:
-        Save<Request<AL, BL, AA, BA, AI, BI>> + Save<Accept<AI, BI>> + Save<Swap> + Save<Decline>,
+    Sqlite: Save<Request<AL, BL, AA, BA, AI, BI>>
+        + Save<Accept<AI, BI>>
+        + Save<Rfc003Swap>
+        + Save<Decline>,
     AL: Clone + Send + Sync + 'static,
     BL: Clone + Send + Sync + 'static,
     AA: Clone + Ord + Send + Sync + 'static,
@@ -63,7 +65,11 @@ where
 
     let counterparty = PeerId::from(peer.clone());
 
-    Save::save(&dependencies, Swap::new(id, Role::Alice, counterparty)).await?;
+    Save::save(
+        &dependencies,
+        Rfc003Swap::new(id, Role::Alice, counterparty),
+    )
+    .await?;
     Save::save(&dependencies, swap_request.clone()).await?;
 
     dependencies

--- a/cnd/src/http_api/swap_resource.rs
+++ b/cnd/src/http_api/swap_resource.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::type_repetition_in_bounds)]
 
 use crate::{
-    db::{Swap, SwapTypes},
+    db::{Rfc003Swap, SwapTypes},
     http_api::{
         action::rfc003::ToSirenAction,
         route_factory,
@@ -83,7 +83,7 @@ pub enum OnFail {
 #[allow(clippy::cognitive_complexity)]
 pub async fn build_rfc003_siren_entity(
     dependencies: &Rfc003Facade,
-    swap: Swap,
+    swap: Rfc003Swap,
     types: SwapTypes,
     include_state: IncludeState,
     on_fail: OnFail,

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     comit_api::LedgerKind,
     config::Settings,
-    db::{CreatedSwap, ForSwap, Save, Sqlite, Swap},
+    db::{CreatedSwap, ForSwap, Rfc003Swap, Save, Sqlite},
     htlc_location,
     http_api::LedgerNotConfigured,
     libp2p_comit_ext::{FromHeader, ToHeader},
@@ -623,12 +623,12 @@ where
     BI: Send + 'static,
     AT: Send + 'static,
     BT: Send + 'static,
-    DB: Save<Request<AL, BL, AA, BA, AI, BI>> + Save<Swap>,
+    DB: Save<Request<AL, BL, AA, BA, AI, BI>> + Save<Rfc003Swap>,
     Request<AL, BL, AA, BA, AI, BI>: Clone,
 {
     let id = swap_request.swap_id;
 
-    Save::save(&db, Swap::new(id, Role::Bob, counterparty)).await?;
+    Save::save(&db, Rfc003Swap::new(id, Role::Bob, counterparty)).await?;
     Save::save(&db, swap_request.clone()).await?;
 
     swap_communication_states

--- a/cnd/src/quickcheck.rs
+++ b/cnd/src/quickcheck.rs
@@ -1,7 +1,7 @@
 use crate::{
     asset,
     asset::ethereum::FromWei,
-    db::Swap,
+    db::Rfc003Swap,
     ethereum::{Address, Bytes, ChainId},
     identity,
     swap_protocols::{
@@ -295,9 +295,9 @@ impl Arbitrary for Quickcheck<PeerId> {
     }
 }
 
-impl Arbitrary for Quickcheck<Swap> {
+impl Arbitrary for Quickcheck<Rfc003Swap> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        Quickcheck(Swap {
+        Quickcheck(Rfc003Swap {
             swap_id: *Quickcheck::<SwapId>::arbitrary(g),
             role: *Quickcheck::<Role>::arbitrary(g),
             counterparty: Quickcheck::<PeerId>::arbitrary(g).0,

--- a/cnd/src/swap_protocols/rfc003_facade.rs
+++ b/cnd/src/swap_protocols/rfc003_facade.rs
@@ -5,7 +5,10 @@ use crate::{
         bitcoin::BitcoindConnector,
         ethereum::{self, Web3Connector},
     },
-    db::{AcceptedSwap, DetermineTypes, LoadAcceptedSwap, Retrieve, Save, Sqlite, Swap, SwapTypes},
+    db::{
+        AcceptedSwap, DetermineTypes, LoadAcceptedSwap, Retrieve, Rfc003Swap, Save, Sqlite,
+        SwapTypes,
+    },
     htlc_location, identity,
     network::{
         ComitPeers, DialInformation, ListenAddresses, LocalPeerId, PendingRequestFor, RequestError,


### PR DESCRIPTION
The identifier `Swap` is in high demand, lets not waste it on rfc003 code.

Rename the rfc003 `Swap` to `Rfc003Swap`.