### PR TITLE
Fix Swap rename

### DIFF
--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -626,7 +626,7 @@ where
 {
     let id = swap_request.swap_id;
 
-    Save::save(&db, Swap::new(id, Role::Bob, counterparty)).await?;
+    Save::save(&db, Rfc003Swap::new(id, Role::Bob, counterparty)).await?;
     Save::save(&db, swap_request.clone()).await?;
 
     swap_communication_states


### PR DESCRIPTION
Recently we re-named the old `Swap` to `Rfc003Swap`, a call to the
constructor slipped passed me (tcharding) and the compiler some how.

Use the correct `Rfc003Swap::new()` constructor.