### PR TITLE
Pass Storage to respawn

### DIFF
--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -180,7 +180,7 @@ fn main() -> anyhow::Result<()> {
     let facade = Facade {
         swarm: swarm.clone(),
         db: database,
-        storage,
+        storage: storage.clone(),
     };
 
     let protocol_spawner = ProtocolSpawner::new(
@@ -193,7 +193,7 @@ fn main() -> anyhow::Result<()> {
 
     let http_api_listener = runtime.block_on(bind_http_api_socket(&settings))?;
     runtime.block_on(load_swaps::load_swaps_from_database(rfc003_facade.clone()))?;
-    match runtime.block_on(respawn(facade.clone(), protocol_spawner)) {
+    match runtime.block_on(respawn(storage, protocol_spawner)) {
         Ok(()) => {}
         Err(e) => tracing::warn!("failed to respawn swaps: {:?}", e),
     };

--- a/cnd/src/respawn.rs
+++ b/cnd/src/respawn.rs
@@ -6,8 +6,8 @@
 
 use crate::{
     protocol_spawner::{ProtocolSpawner, Spawn},
-    storage::{Load, LoadAll},
-    swap_protocols::{halight, herc20, Facade, LocalSwapId, Side},
+    storage::{Load, LoadAll, Storage},
+    swap_protocols::{halight, herc20, LocalSwapId, Side},
 };
 use chrono::Utc;
 use comit::{Protocol, Role};
@@ -26,8 +26,8 @@ pub struct Swap<A, B> {
 }
 
 /// Respawn the protocols for all swaps that are not yet done.
-pub async fn respawn(facade: Facade, protocol_spawner: ProtocolSpawner) -> anyhow::Result<()> {
-    let swaps = facade.load_all().await?;
+pub async fn respawn(storage: Storage, protocol_spawner: ProtocolSpawner) -> anyhow::Result<()> {
+    let swaps = storage.load_all().await?;
 
     for swap in swaps {
         match swap {
@@ -37,7 +37,7 @@ pub async fn respawn(facade: Facade, protocol_spawner: ProtocolSpawner) -> anyho
                 alpha: Protocol::Herc20,
                 beta: Protocol::Halight,
             } => {
-                let swap: Swap<herc20::Params, halight::Params> = match facade.load(id).await {
+                let swap: Swap<herc20::Params, halight::Params> = match storage.load(id).await {
                     Ok(swap) => swap,
                     Err(e) => {
                         tracing::warn!("failed to load data for swap {}: {:?}", id, e);


### PR DESCRIPTION
We do not need access to the `Facade` when respawning, `Storage` is a
top level type, no need to call through to it via the facade.

Pass `Storage` directly to the `respawn()` function instead of
delegating to the `Facade`.