### PR TITLE
Do not panic on unexpected messages

### DIFF
--- a/cnd/src/network/comit.rs
+++ b/cnd/src/network/comit.rs
@@ -357,7 +357,7 @@ impl NetworkBehaviourEventProcess<announce::behaviour::BehaviourOutEvent> for Co
                 swap_digest,
                 swap_id: shared_swap_id,
             } => {
-                if let Some((_local_swap_id, data)) = self
+                if let Some(data) = self
                     .swaps
                     .move_pending_confirmation_to_communicate(&swap_digest, shared_swap_id)
                 {

--- a/cnd/src/network/comit/swaps.rs
+++ b/cnd/src/network/comit/swaps.rs
@@ -229,10 +229,7 @@ impl<T> Swaps<T> {
 
     /// Either role finalizes a swap that was in the communication phase
     /// This also proceeds with clean up from the various _pending_ stores.
-    pub fn finalize_swap(
-        &mut self,
-        shared_swap_id: &SharedSwapId,
-    ) -> Result<(LocalSwapId, LocalData), Error> {
+    pub fn finalize_swap(&mut self, shared_swap_id: &SharedSwapId) -> Result<LocalSwapId, Error> {
         let local_swap_id = match self.swap_ids.iter().find_map(|(key, value)| {
             if *value == *shared_swap_id {
                 Some(key)
@@ -244,12 +241,7 @@ impl<T> Swaps<T> {
             None => return Err(Error::NotFound),
         };
 
-        let data = match self.swaps.get(&local_swap_id) {
-            Some(create_params) => create_params,
-            None => return Err(Error::NotFound),
-        };
-
-        Ok((*local_swap_id, *data))
+        Ok(*local_swap_id)
     }
 
     /// Remove all pending (not finalized) swap older than `older_than`

--- a/cnd/src/network/comit/swaps.rs
+++ b/cnd/src/network/comit/swaps.rs
@@ -99,7 +99,7 @@ impl<T> Swaps<T> {
         &mut self,
         digest: &SwapDigest,
         shared_swap_id: SharedSwapId,
-    ) -> Option<(LocalSwapId, LocalData)> {
+    ) -> Option<LocalData> {
         let local_swap_id = match self.pending_confirmation.remove(digest) {
             Some(local_swap_id) => local_swap_id,
             None => return None,
@@ -112,7 +112,7 @@ impl<T> Swaps<T> {
 
         self.swap_ids.insert(local_swap_id, shared_swap_id);
 
-        Some((local_swap_id, *data))
+        Some(*data)
     }
 
     /// Bob created a swap and it is pending announcement.


### PR DESCRIPTION
The `expect` was called on received events, meaning a malicious party could send a message with an unknown shared swap id and panic our node.
Also little clean up where a tuple was returned but only one value used.