### PR TITLE
Add alpha/beta identity generic types

### DIFF
--- a/cnd/src/network/start_swap.rs
+++ b/cnd/src/network/start_swap.rs
@@ -41,8 +41,8 @@ where
                 .save(ForSwap {
                     local_swap_id: id,
                     data: WhatAliceLearnedFromBob {
-                        redeem_ethereum_identity: ethereum_identity,
-                        refund_lightning_identity: lightning_identity,
+                        redeem_identity: ethereum_identity,
+                        refund_identity: lightning_identity,
                     },
                 })
                 .await?;
@@ -70,8 +70,8 @@ where
                     local_swap_id: id,
                     data: WhatBobLearnedFromAlice {
                         secret_hash,
-                        refund_ethereum_identity: ethereum_identity,
-                        redeem_lightning_identity: lightning_identity,
+                        refund_identity: ethereum_identity,
+                        redeem_identity: lightning_identity,
                     },
                 })
                 .await?;

--- a/cnd/src/storage.rs
+++ b/cnd/src/storage.rs
@@ -15,7 +15,7 @@ use crate::{
 use anyhow::Context;
 use async_trait::async_trait;
 use comit::{
-    asset,
+    asset, identity,
     network::{WhatAliceLearnedFromBob, WhatBobLearnedFromAlice},
     Protocol, Role,
 };
@@ -664,11 +664,14 @@ impl Load<herc20::Params> for Storage {
 }
 
 #[async_trait::async_trait]
-impl Save<ForSwap<WhatAliceLearnedFromBob>> for Storage {
-    async fn save(&self, swap: ForSwap<WhatAliceLearnedFromBob>) -> anyhow::Result<()> {
+impl Save<ForSwap<WhatAliceLearnedFromBob<identity::Ethereum, identity::Lightning>>> for Storage {
+    async fn save(
+        &self,
+        swap: ForSwap<WhatAliceLearnedFromBob<identity::Ethereum, identity::Lightning>>,
+    ) -> anyhow::Result<()> {
         let local_swap_id = swap.local_swap_id;
-        let refund_lightning_identity = swap.data.refund_lightning_identity;
-        let redeem_ethereum_identity = swap.data.redeem_ethereum_identity;
+        let refund_lightning_identity = swap.data.refund_identity;
+        let redeem_ethereum_identity = swap.data.redeem_identity;
 
         self.db
             .do_in_transaction(|conn| {
@@ -690,11 +693,14 @@ impl Save<ForSwap<WhatAliceLearnedFromBob>> for Storage {
 }
 
 #[async_trait::async_trait]
-impl Save<ForSwap<WhatBobLearnedFromAlice>> for Storage {
-    async fn save(&self, swap: ForSwap<WhatBobLearnedFromAlice>) -> anyhow::Result<()> {
+impl Save<ForSwap<WhatBobLearnedFromAlice<identity::Ethereum, identity::Lightning>>> for Storage {
+    async fn save(
+        &self,
+        swap: ForSwap<WhatBobLearnedFromAlice<identity::Ethereum, identity::Lightning>>,
+    ) -> anyhow::Result<()> {
         let local_swap_id = swap.local_swap_id;
-        let redeem_lightning_identity = swap.data.redeem_lightning_identity;
-        let refund_ethereum_identity = swap.data.refund_ethereum_identity;
+        let redeem_lightning_identity = swap.data.redeem_identity;
+        let refund_ethereum_identity = swap.data.refund_identity;
         let secret_hash = swap.data.secret_hash;
 
         self.db

--- a/comit/src/network.rs
+++ b/comit/src/network.rs
@@ -3,7 +3,7 @@ pub mod oneshot_protocol;
 pub mod protocols;
 pub mod swap_digest;
 
-use crate::{identity, SecretHash};
+use crate::SecretHash;
 use libp2p::{Multiaddr, PeerId};
 use std::fmt;
 
@@ -22,19 +22,17 @@ impl fmt::Display for DialInformation {
     }
 }
 
-/// All the data Alice learned from Bob during the communication phase of a
-/// herc20 <-> halight swap.
+/// Data Alice learned from Bob during the communication phase.
 #[derive(Clone, Copy, Debug)]
-pub struct WhatAliceLearnedFromBob {
-    pub redeem_ethereum_identity: identity::Ethereum,
-    pub refund_lightning_identity: identity::Lightning,
+pub struct WhatAliceLearnedFromBob<A, B> {
+    pub redeem_identity: A,
+    pub refund_identity: B,
 }
 
-/// All the data Bob learned from Alice during the communication phase of a
-/// herc20 <-> halight swap.
+/// Data Bob learned from Alice during the communication phase.
 #[derive(Clone, Copy, Debug)]
-pub struct WhatBobLearnedFromAlice {
+pub struct WhatBobLearnedFromAlice<A, B> {
     pub secret_hash: SecretHash,
-    pub refund_ethereum_identity: identity::Ethereum,
-    pub redeem_lightning_identity: identity::Lightning,
+    pub refund_identity: A,
+    pub redeem_identity: B,
 }


### PR DESCRIPTION
`WhatAliceLearnedFromBob` and `WhatBobLearnedFromAlice` are currently
typed to the herc<->halight swap. In order to use these structs for
other swaps we need the identities to be generic.