### PR TITLE
Reduce struct name and use fully qualified name `http_api::{protocol}::Finalized`

### DIFF
--- a/api_tests/tests/halight_erc20.ts
+++ b/api_tests/tests/halight_erc20.ts
@@ -1,6 +1,6 @@
 /**
- * @ledger ethereum
  * @ledger lightning
+ * @ledger ethereum
  */
 
 import SwapFactory from "../src/actors/swap_factory";
@@ -8,23 +8,23 @@ import { sleep } from "../src/utils";
 import { twoActorTest } from "../src/actor_test";
 
 it(
-    "herc20-ethereum-erc20-halight-lightning-bitcoin-alice-redeems-bob-redeems",
+    "halight-lightning-bitcoin-herc20-ethereum-erc20-alice-redeems-bob-redeems",
     twoActorTest(async ({ alice, bob }) => {
         const bodies = (await SwapFactory.newSwap(alice, bob))
-            .herc20EthereumErc20HalightLightningBitcoin;
+            .halightLightningBitcoinHerc20EthereumErc20;
 
-        await alice.createHerc20HalightSwap(bodies.alice);
+        await alice.createHalightHerc20Swap(bodies.alice);
         await sleep(500);
-        await bob.createHerc20HalightSwap(bodies.bob);
+        await bob.createHalightHerc20Swap(bodies.bob);
 
-        await alice.init();
-
-        await alice.deploy();
-        await alice.fund();
+        await bob.init();
 
         // we must not wait for bob's funding because `sendpayment` on a hold-invoice is a blocking call.
         // tslint:disable-next-line:no-floating-promises
-        bob.fund();
+        alice.fund();
+
+        await bob.deploy();
+        await bob.fund();
 
         await alice.redeem();
         await bob.redeem();

--- a/api_tests/tests/lightning_routes.ts
+++ b/api_tests/tests/lightning_routes.ts
@@ -37,21 +37,28 @@ describe("Lightning routes tests", () => {
     );
 
     it(
-        "create-halight-lightning-bitcoin-herc20-ethereum-erc20-returns-route-not-supported",
+        "create-halight-lightning-bitcoin-herc20-ethereum-erc20-returns-bad-request",
         twoActorTest(async ({ alice, bob }) => {
             const bodies = (await SwapFactory.newSwap(alice, bob, true))
                 .halightLightningBitcoinHerc20EthereumErc20;
+
+            const expectedProblem = {
+                status: 400,
+                title: "lightning is not configured.",
+                detail:
+                    "lightning ledger is not properly configured, swap involving this ledger are not available.",
+            };
 
             await expect(
                 alice.cnd.createHalightLightningBitcoinHerc20EthereumErc20(
                     bodies.alice
                 )
-            ).rejects.toThrow("Route not yet supported.");
+            ).rejects.toMatchObject(expectedProblem);
             await expect(
                 bob.cnd.createHalightLightningBitcoinHerc20EthereumErc20(
                     bodies.bob
                 )
-            ).rejects.toThrow("Route not yet supported.");
+            ).rejects.toMatchObject(expectedProblem);
         })
     );
 

--- a/cnd/src/db/tables.rs
+++ b/cnd/src/db/tables.rs
@@ -110,13 +110,17 @@ impl IntoInsertable for herc20::CreatedSwap {
     type Insertable = InsertableHerc20;
 
     fn into_insertable(self, swap_id: i32, role: Role, side: Side) -> Self::Insertable {
-        let redeem_identity = match role {
-            Role::Alice => None,
-            Role::Bob => Some(Text(EthereumAddress::from(self.identity))),
+        let redeem_identity = match (role, side) {
+            (Role::Alice, Side::Beta) | (Role::Bob, Side::Alpha) => {
+                Some(Text(EthereumAddress::from(self.identity)))
+            }
+            _ => None,
         };
-        let refund_identity = match role {
-            Role::Alice => Some(Text(EthereumAddress::from(self.identity))),
-            Role::Bob => None,
+        let refund_identity = match (role, side) {
+            (Role::Alice, Side::Alpha) | (Role::Bob, Side::Beta) => {
+                Some(Text(EthereumAddress::from(self.identity)))
+            }
+            _ => None,
         };
         assert!(redeem_identity.is_some() || refund_identity.is_some());
 
@@ -165,13 +169,13 @@ impl IntoInsertable for halight::CreatedSwap {
     type Insertable = InsertableHalight;
 
     fn into_insertable(self, swap_id: i32, role: Role, side: Side) -> Self::Insertable {
-        let redeem_identity = match role {
-            Role::Alice => Some(Text(self.identity)),
-            Role::Bob => None,
+        let redeem_identity = match (role, side) {
+            (Role::Alice, Side::Beta) | (Role::Bob, Side::Alpha) => Some(Text(self.identity)),
+            _ => None,
         };
-        let refund_identity = match role {
-            Role::Alice => None,
-            Role::Bob => Some(Text(self.identity)),
+        let refund_identity = match (role, side) {
+            (Role::Alice, Side::Alpha) | (Role::Bob, Side::Beta) => Some(Text(self.identity)),
+            _ => None,
         };
         assert!(redeem_identity.is_some() || refund_identity.is_some());
 

--- a/cnd/src/http_api/halight.rs
+++ b/cnd/src/http_api/halight.rs
@@ -2,10 +2,10 @@ use crate::swap_protocols::halight;
 use comit::{asset, identity, RelativeTime};
 
 #[derive(Clone, Copy, Debug)]
-pub struct HalightFinalized {
-    pub halight_asset: asset::Bitcoin,
-    pub halight_refund_identity: identity::Lightning,
-    pub halight_redeem_identity: identity::Lightning,
+pub struct Finalized {
+    pub asset: asset::Bitcoin,
+    pub refund_identity: identity::Lightning,
+    pub redeem_identity: identity::Lightning,
     pub cltv_expiry: RelativeTime,
-    pub halight_state: halight::State,
+    pub state: halight::State,
 }

--- a/cnd/src/http_api/halight_herc20/alice.rs
+++ b/cnd/src/http_api/halight_herc20/alice.rs
@@ -1,7 +1,6 @@
 use crate::{
+    http_api,
     http_api::{
-        halight::HalightFinalized,
-        herc20::Herc20Finalized,
         protocol::{
             GetAlphaEvents, GetAlphaParams, GetBetaEvents, GetBetaParams, Halight, Herc20,
             LedgerEvents,
@@ -20,17 +19,45 @@ use comit::{
     Never, SecretHash,
 };
 
-impl From<AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>> for Herc20 {
+impl
+    From<
+        AliceSwap<
+            asset::Bitcoin,
+            asset::Erc20,
+            http_api::halight::Finalized,
+            http_api::herc20::Finalized,
+        >,
+    > for Herc20
+{
     fn from(
-        from: AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>,
+        from: AliceSwap<
+            asset::Bitcoin,
+            asset::Erc20,
+            http_api::halight::Finalized,
+            http_api::herc20::Finalized,
+        >,
     ) -> Self {
         match from {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Created {
+            AliceSwap::<
+                asset::Bitcoin,
+                asset::Erc20,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
+            >::Created {
                 beta_created: herc20_asset,
                 ..
             }
-            | AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Finalized {
-                beta_finalized: Herc20Finalized { herc20_asset, .. },
+            | AliceSwap::<
+                asset::Bitcoin,
+                asset::Erc20,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
+            >::Finalized {
+                beta_finalized:
+                    http_api::herc20::Finalized {
+                        asset: herc20_asset,
+                        ..
+                    },
                 ..
             } => Self {
                 protocol: "herc20".to_owned(),
@@ -41,17 +68,45 @@ impl From<AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finali
     }
 }
 
-impl From<AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>> for Halight {
+impl
+    From<
+        AliceSwap<
+            asset::Bitcoin,
+            asset::Erc20,
+            http_api::halight::Finalized,
+            http_api::herc20::Finalized,
+        >,
+    > for Halight
+{
     fn from(
-        from: AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>,
+        from: AliceSwap<
+            asset::Bitcoin,
+            asset::Erc20,
+            http_api::halight::Finalized,
+            http_api::herc20::Finalized,
+        >,
     ) -> Self {
         match from {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Created {
+            AliceSwap::<
+                asset::Bitcoin,
+                asset::Erc20,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
+            >::Created {
                 alpha_created: halight_asset,
                 ..
             }
-            | AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Finalized {
-                alpha_finalized: HalightFinalized { halight_asset, .. },
+            | AliceSwap::<
+                asset::Bitcoin,
+                asset::Erc20,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
+            >::Finalized {
+                alpha_finalized:
+                    http_api::halight::Finalized {
+                        asset: halight_asset,
+                        ..
+                    },
                 ..
             } => Self {
                 protocol: "halight".to_owned(),
@@ -61,62 +116,134 @@ impl From<AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finali
     }
 }
 
-impl GetBetaParams for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl GetBetaParams
+    for AliceSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     type Output = Herc20;
     fn get_beta_params(&self) -> Self::Output {
         self.clone().into()
     }
 }
 
-impl GetBetaEvents for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl GetBetaEvents
+    for AliceSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     fn get_beta_events(&self) -> Option<LedgerEvents> {
         match self {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Created { .. } => None,
-            AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Finalized {
-                beta_finalized: Herc20Finalized { herc20_state, .. },
+            AliceSwap::<
+                asset::Bitcoin,
+                asset::Erc20,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
+            >::Created {
+                ..
+            } => None,
+            AliceSwap::<
+                asset::Bitcoin,
+                asset::Erc20,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
+            >::Finalized {
+                beta_finalized:
+                    http_api::herc20::Finalized {
+                        state: herc20_state,
+                        ..
+                    },
                 ..
             } => Some(From::<herc20::State>::from(herc20_state.clone())),
         }
     }
 }
 
-impl GetAlphaParams for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl GetAlphaParams
+    for AliceSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     type Output = Halight;
     fn get_alpha_params(&self) -> Self::Output {
         self.clone().into()
     }
 }
 
-impl GetAlphaEvents for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl GetAlphaEvents
+    for AliceSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     fn get_alpha_events(&self) -> Option<LedgerEvents> {
         match self {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Created { .. } => None,
-            AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Finalized {
-                alpha_finalized: HalightFinalized { halight_state, .. },
+            AliceSwap::<
+                asset::Bitcoin,
+                asset::Erc20,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
+            >::Created {
+                ..
+            } => None,
+            AliceSwap::<
+                asset::Bitcoin,
+                asset::Erc20,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
+            >::Finalized {
+                alpha_finalized:
+                    http_api::halight::Finalized {
+                        state: halight_state,
+                        ..
+                    },
                 ..
             } => Some(From::<halight::State>::from(*halight_state)),
         }
     }
 }
 
-impl FundAction for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl FundAction
+    for AliceSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     type Output = lnd::SendPayment;
 
     fn fund_action(&self) -> anyhow::Result<Self::Output> {
         match self {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Finalized {
-                beta_finalized:
-                    Herc20Finalized {
-                        herc20_state: herc20::State::Funded { .. },
-                        ..
-                    },
+            AliceSwap::<
+                asset::Bitcoin,
+                asset::Erc20,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
+            >::Finalized {
                 alpha_finalized:
-                    HalightFinalized {
-                        halight_state: halight::State::Opened(_),
-                        halight_asset,
-                        halight_refund_identity,
-                        halight_redeem_identity,
+                    http_api::halight::Finalized {
+                        state: halight::State::Opened(_),
+                        asset: halight_asset,
+                        refund_identity: halight_refund_identity,
+                        redeem_identity: halight_redeem_identity,
                         cltv_expiry,
+                    },
+                beta_finalized:
+                    http_api::herc20::Finalized {
+                        state: herc20::State::Funded { .. },
+                        ..
                     },
                 secret,
                 ..
@@ -144,15 +271,27 @@ impl FundAction for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, He
     }
 }
 
-impl RedeemAction for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl RedeemAction
+    for AliceSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     type Output = ethereum::CallContract;
 
     fn redeem_action(&self) -> anyhow::Result<Self::Output> {
         match self {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Finalized {
+            AliceSwap::<
+                asset::Bitcoin,
+                asset::Erc20,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
+            >::Finalized {
                 beta_finalized:
-                    Herc20Finalized {
-                        herc20_state: herc20::State::Funded { htlc_location, .. },
+                    http_api::herc20::Finalized {
+                        state: herc20::State::Funded { htlc_location, .. },
                         ..
                     },
                 secret,
@@ -177,21 +316,42 @@ impl RedeemAction for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, 
     }
 }
 
-impl InitAction for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl InitAction
+    for AliceSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     type Output = Never;
     fn init_action(&self) -> anyhow::Result<Self::Output> {
         anyhow::bail!(ActionNotFound)
     }
 }
 
-impl DeployAction for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl DeployAction
+    for AliceSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     type Output = Never;
     fn deploy_action(&self) -> anyhow::Result<Self::Output> {
         anyhow::bail!(ActionNotFound)
     }
 }
 
-impl RefundAction for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl RefundAction
+    for AliceSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     type Output = Never;
     fn refund_action(&self) -> anyhow::Result<Self::Output> {
         anyhow::bail!(ActionNotFound)

--- a/cnd/src/http_api/halight_herc20/bob.rs
+++ b/cnd/src/http_api/halight_herc20/bob.rs
@@ -1,7 +1,6 @@
 use crate::{
+    http_api,
     http_api::{
-        halight::HalightFinalized,
-        herc20::Herc20Finalized,
         protocol::{
             GetAlphaEvents, GetAlphaParams, GetBetaEvents, GetBetaParams, Halight, Herc20,
             LedgerEvents,
@@ -23,17 +22,24 @@ use comit::{
     ethereum::{Bytes, ChainId},
 };
 
-impl InitAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl InitAction
+    for BobSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     type Output = lnd::AddHoldInvoice;
 
     fn init_action(&self) -> anyhow::Result<Self::Output> {
         match self {
             BobSwap::Finalized {
                 alpha_finalized:
-                    HalightFinalized {
-                        halight_state: halight::State::None,
-                        halight_asset,
-                        halight_redeem_identity,
+                    http_api::halight::Finalized {
+                        state: halight::State::None,
+                        asset: halight_asset,
+                        redeem_identity: halight_redeem_identity,
                         cltv_expiry,
                         ..
                     },
@@ -63,23 +69,30 @@ impl InitAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc
     }
 }
 
-impl DeployAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl DeployAction
+    for BobSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     type Output = ethereum::DeployContract;
 
     fn deploy_action(&self) -> anyhow::Result<Self::Output> {
         match self {
             BobSwap::Finalized {
                 alpha_finalized:
-                    HalightFinalized {
-                        halight_state: halight::State::Opened(_),
+                    http_api::halight::Finalized {
+                        state: halight::State::Opened(_),
                         ..
                     },
                 beta_finalized:
-                    Herc20Finalized {
-                        herc20_asset,
-                        herc20_refund_identity,
-                        herc20_redeem_identity,
-                        herc20_expiry,
+                    http_api::herc20::Finalized {
+                        asset: herc20_asset,
+                        refund_identity: herc20_refund_identity,
+                        redeem_identity: herc20_redeem_identity,
+                        expiry: herc20_expiry,
                         ..
                     },
                 secret_hash,
@@ -107,21 +120,28 @@ impl DeployAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, He
     }
 }
 
-impl FundAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl FundAction
+    for BobSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     type Output = ethereum::CallContract;
 
     fn fund_action(&self) -> anyhow::Result<Self::Output> {
         match self {
             BobSwap::Finalized {
                 alpha_finalized:
-                    HalightFinalized {
-                        halight_state: halight::State::Opened(_),
+                    http_api::halight::Finalized {
+                        state: halight::State::Opened(_),
                         ..
                     },
                 beta_finalized:
-                    Herc20Finalized {
-                        herc20_asset,
-                        herc20_state: herc20::State::Deployed { htlc_location, .. },
+                    http_api::herc20::Finalized {
+                        asset: herc20_asset,
+                        state: herc20::State::Deployed { htlc_location, .. },
                         ..
                     },
                 ..
@@ -152,21 +172,28 @@ impl FundAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc
     }
 }
 
-impl RedeemAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl RedeemAction
+    for BobSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     type Output = lnd::SettleInvoice;
 
     fn redeem_action(&self) -> anyhow::Result<Self::Output> {
         match self {
             BobSwap::Finalized {
                 alpha_finalized:
-                    HalightFinalized {
-                        halight_state: halight::State::Accepted(_),
-                        halight_redeem_identity,
+                    http_api::halight::Finalized {
+                        state: halight::State::Accepted(_),
+                        redeem_identity: halight_redeem_identity,
                         ..
                     },
                 beta_finalized:
-                    Herc20Finalized {
-                        herc20_state: herc20::State::Redeemed { secret, .. },
+                    http_api::herc20::Finalized {
+                        state: herc20::State::Redeemed { secret, .. },
                         ..
                     },
                 ..
@@ -188,21 +215,28 @@ impl RedeemAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, He
     }
 }
 
-impl RefundAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl RefundAction
+    for BobSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     type Output = ethereum::CallContract;
 
     fn refund_action(&self) -> anyhow::Result<Self::Output> {
         match self {
             BobSwap::Finalized {
                 alpha_finalized:
-                    HalightFinalized {
-                        halight_state: halight::State::Accepted(_),
+                    http_api::halight::Finalized {
+                        state: halight::State::Accepted(_),
                         ..
                     },
                 beta_finalized:
-                    Herc20Finalized {
-                        herc20_state: herc20::State::Funded { htlc_location, .. },
-                        herc20_expiry,
+                    http_api::herc20::Finalized {
+                        state: herc20::State::Funded { htlc_location, .. },
+                        expiry: herc20_expiry,
                         ..
                     },
                 ..
@@ -226,47 +260,97 @@ impl RefundAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, He
     }
 }
 
-impl GetAlphaEvents for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl GetAlphaEvents
+    for BobSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     fn get_alpha_events(&self) -> Option<LedgerEvents> {
         match self {
             BobSwap::Created { .. } => None,
             BobSwap::Finalized {
-                alpha_finalized: HalightFinalized { halight_state, .. },
+                alpha_finalized:
+                    http_api::halight::Finalized {
+                        state: halight_state,
+                        ..
+                    },
                 ..
             } => Some(From::<halight::State>::from(*halight_state)),
         }
     }
 }
 
-impl GetBetaEvents for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl GetBetaEvents
+    for BobSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     fn get_beta_events(&self) -> Option<LedgerEvents> {
         match self {
             BobSwap::Created { .. } => None,
             BobSwap::Finalized {
-                beta_finalized: Herc20Finalized { herc20_state, .. },
+                beta_finalized:
+                    http_api::herc20::Finalized {
+                        state: herc20_state,
+                        ..
+                    },
                 ..
             } => Some(From::<herc20::State>::from(herc20_state.clone())),
         }
     }
 }
 
-impl GetAlphaParams for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl GetAlphaParams
+    for BobSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     type Output = Herc20;
     fn get_alpha_params(&self) -> Self::Output {
         self.clone().into()
     }
 }
 
-impl GetBetaParams for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl GetBetaParams
+    for BobSwap<
+        asset::Bitcoin,
+        asset::Erc20,
+        http_api::halight::Finalized,
+        http_api::herc20::Finalized,
+    >
+{
     type Output = Halight;
     fn get_beta_params(&self) -> Self::Output {
         self.clone().into()
     }
 }
 
-impl From<BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>> for Halight {
+impl
+    From<
+        BobSwap<
+            asset::Bitcoin,
+            asset::Erc20,
+            http_api::halight::Finalized,
+            http_api::herc20::Finalized,
+        >,
+    > for Halight
+{
     fn from(
-        from: BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>,
+        from: BobSwap<
+            asset::Bitcoin,
+            asset::Erc20,
+            http_api::halight::Finalized,
+            http_api::herc20::Finalized,
+        >,
     ) -> Self {
         match from {
             BobSwap::Created {
@@ -274,7 +358,11 @@ impl From<BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalize
                 ..
             }
             | BobSwap::Finalized {
-                alpha_finalized: HalightFinalized { halight_asset, .. },
+                alpha_finalized:
+                    http_api::halight::Finalized {
+                        asset: halight_asset,
+                        ..
+                    },
                 ..
             } => Self {
                 protocol: "halight".to_owned(),
@@ -284,9 +372,23 @@ impl From<BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalize
     }
 }
 
-impl From<BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>> for Herc20 {
+impl
+    From<
+        BobSwap<
+            asset::Bitcoin,
+            asset::Erc20,
+            http_api::halight::Finalized,
+            http_api::herc20::Finalized,
+        >,
+    > for Herc20
+{
     fn from(
-        from: BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>,
+        from: BobSwap<
+            asset::Bitcoin,
+            asset::Erc20,
+            http_api::halight::Finalized,
+            http_api::herc20::Finalized,
+        >,
     ) -> Self {
         match from {
             BobSwap::Created {
@@ -294,7 +396,11 @@ impl From<BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalize
                 ..
             }
             | BobSwap::Finalized {
-                beta_finalized: Herc20Finalized { herc20_asset, .. },
+                beta_finalized:
+                    http_api::herc20::Finalized {
+                        asset: herc20_asset,
+                        ..
+                    },
                 ..
             } => Self {
                 protocol: "herc20".to_owned(),

--- a/cnd/src/http_api/herc20.rs
+++ b/cnd/src/http_api/herc20.rs
@@ -2,10 +2,10 @@ use crate::swap_protocols::herc20;
 use comit::{asset, identity, Timestamp};
 
 #[derive(Clone, Debug)]
-pub struct Herc20Finalized {
-    pub herc20_asset: asset::Erc20,
-    pub herc20_refund_identity: identity::Ethereum,
-    pub herc20_redeem_identity: identity::Ethereum,
-    pub herc20_expiry: Timestamp,
-    pub herc20_state: herc20::State,
+pub struct Finalized {
+    pub asset: asset::Erc20,
+    pub refund_identity: identity::Ethereum,
+    pub redeem_identity: identity::Ethereum,
+    pub expiry: Timestamp,
+    pub state: herc20::State,
 }

--- a/cnd/src/http_api/herc20_halight/alice.rs
+++ b/cnd/src/http_api/herc20_halight/alice.rs
@@ -1,7 +1,6 @@
 use crate::{
+    http_api,
     http_api::{
-        halight::HalightFinalized,
-        herc20::Herc20Finalized,
         protocol::{
             GetAlphaEvents, GetAlphaParams, GetBetaEvents, GetBetaParams, Halight, Herc20,
             LedgerEvents,
@@ -24,17 +23,45 @@ use comit::{
     SecretHash,
 };
 
-impl From<AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>> for Herc20 {
+impl
+    From<
+        AliceSwap<
+            asset::Erc20,
+            asset::Bitcoin,
+            http_api::herc20::Finalized,
+            http_api::halight::Finalized,
+        >,
+    > for Herc20
+{
     fn from(
-        from: AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>,
+        from: AliceSwap<
+            asset::Erc20,
+            asset::Bitcoin,
+            http_api::herc20::Finalized,
+            http_api::halight::Finalized,
+        >,
     ) -> Self {
         match from {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>::Created {
+            AliceSwap::<
+                asset::Erc20,
+                asset::Bitcoin,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
+            >::Created {
                 alpha_created: herc20_asset,
                 ..
             }
-            | AliceSwap::<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>::Finalized {
-                alpha_finalized: Herc20Finalized { herc20_asset, .. },
+            | AliceSwap::<
+                asset::Erc20,
+                asset::Bitcoin,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
+            >::Finalized {
+                alpha_finalized:
+                    http_api::herc20::Finalized {
+                        asset: herc20_asset,
+                        ..
+                    },
                 ..
             } => Self {
                 protocol: "herc20".to_owned(),
@@ -45,17 +72,45 @@ impl From<AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinali
     }
 }
 
-impl From<AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>> for Halight {
+impl
+    From<
+        AliceSwap<
+            asset::Erc20,
+            asset::Bitcoin,
+            http_api::herc20::Finalized,
+            http_api::halight::Finalized,
+        >,
+    > for Halight
+{
     fn from(
-        from: AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>,
+        from: AliceSwap<
+            asset::Erc20,
+            asset::Bitcoin,
+            http_api::herc20::Finalized,
+            http_api::halight::Finalized,
+        >,
     ) -> Self {
         match from {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>::Created {
+            AliceSwap::<
+                asset::Erc20,
+                asset::Bitcoin,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
+            >::Created {
                 beta_created: halight_asset,
                 ..
             }
-            | AliceSwap::<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>::Finalized {
-                beta_finalized: HalightFinalized { halight_asset, .. },
+            | AliceSwap::<
+                asset::Erc20,
+                asset::Bitcoin,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
+            >::Finalized {
+                beta_finalized:
+                    http_api::halight::Finalized {
+                        asset: halight_asset,
+                        ..
+                    },
                 ..
             } => Self {
                 protocol: "halight".to_owned(),
@@ -65,55 +120,127 @@ impl From<AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinali
     }
 }
 
-impl GetAlphaParams for AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> {
+impl GetAlphaParams
+    for AliceSwap<
+        asset::Erc20,
+        asset::Bitcoin,
+        http_api::herc20::Finalized,
+        http_api::halight::Finalized,
+    >
+{
     type Output = Herc20;
     fn get_alpha_params(&self) -> Self::Output {
         self.clone().into()
     }
 }
 
-impl GetAlphaEvents for AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> {
+impl GetAlphaEvents
+    for AliceSwap<
+        asset::Erc20,
+        asset::Bitcoin,
+        http_api::herc20::Finalized,
+        http_api::halight::Finalized,
+    >
+{
     fn get_alpha_events(&self) -> Option<LedgerEvents> {
         match self {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>::Created { .. } => None,
-            AliceSwap::<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>::Finalized {
-                alpha_finalized: Herc20Finalized { herc20_state, .. },
+            AliceSwap::<
+                asset::Erc20,
+                asset::Bitcoin,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
+            >::Created {
+                ..
+            } => None,
+            AliceSwap::<
+                asset::Erc20,
+                asset::Bitcoin,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
+            >::Finalized {
+                alpha_finalized:
+                    http_api::herc20::Finalized {
+                        state: herc20_state,
+                        ..
+                    },
                 ..
             } => Some(From::<herc20::State>::from(herc20_state.clone())),
         }
     }
 }
 
-impl GetBetaParams for AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> {
+impl GetBetaParams
+    for AliceSwap<
+        asset::Erc20,
+        asset::Bitcoin,
+        http_api::herc20::Finalized,
+        http_api::halight::Finalized,
+    >
+{
     type Output = Halight;
     fn get_beta_params(&self) -> Self::Output {
         self.clone().into()
     }
 }
 
-impl GetBetaEvents for AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> {
+impl GetBetaEvents
+    for AliceSwap<
+        asset::Erc20,
+        asset::Bitcoin,
+        http_api::herc20::Finalized,
+        http_api::halight::Finalized,
+    >
+{
     fn get_beta_events(&self) -> Option<LedgerEvents> {
         match self {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>::Created { .. } => None,
-            AliceSwap::<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>::Finalized {
-                beta_finalized: HalightFinalized { halight_state, .. },
+            AliceSwap::<
+                asset::Erc20,
+                asset::Bitcoin,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
+            >::Created {
+                ..
+            } => None,
+            AliceSwap::<
+                asset::Erc20,
+                asset::Bitcoin,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
+            >::Finalized {
+                beta_finalized:
+                    http_api::halight::Finalized {
+                        state: halight_state,
+                        ..
+                    },
                 ..
             } => Some(From::<halight::State>::from(*halight_state)),
         }
     }
 }
 
-impl InitAction for AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> {
+impl InitAction
+    for AliceSwap<
+        asset::Erc20,
+        asset::Bitcoin,
+        http_api::herc20::Finalized,
+        http_api::halight::Finalized,
+    >
+{
     type Output = lnd::AddHoldInvoice;
 
     fn init_action(&self) -> anyhow::Result<Self::Output> {
         match self {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>::Finalized {
+            AliceSwap::<
+                asset::Erc20,
+                asset::Bitcoin,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
+            >::Finalized {
                 beta_finalized:
-                    HalightFinalized {
-                        halight_state: halight::State::None,
-                        halight_asset,
-                        halight_redeem_identity,
+                    http_api::halight::Finalized {
+                        state: halight::State::None,
+                        asset: halight_asset,
+                        redeem_identity: halight_redeem_identity,
                         cltv_expiry,
                         ..
                     },
@@ -143,23 +270,35 @@ impl InitAction for AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, Hal
     }
 }
 
-impl DeployAction for AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> {
+impl DeployAction
+    for AliceSwap<
+        asset::Erc20,
+        asset::Bitcoin,
+        http_api::herc20::Finalized,
+        http_api::halight::Finalized,
+    >
+{
     type Output = ethereum::DeployContract;
 
     fn deploy_action(&self) -> anyhow::Result<Self::Output> {
         match self {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>::Finalized {
-                beta_finalized:
-                    HalightFinalized {
-                        halight_state: halight::State::Opened(_),
+            AliceSwap::<
+                asset::Erc20,
+                asset::Bitcoin,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
+            >::Finalized {
+                alpha_finalized:
+                    http_api::herc20::Finalized {
+                        asset: herc20_asset,
+                        refund_identity: herc20_refund_identity,
+                        redeem_identity: herc20_redeem_identity,
+                        expiry: herc20_expiry,
                         ..
                     },
-                alpha_finalized:
-                    Herc20Finalized {
-                        herc20_asset,
-                        herc20_refund_identity,
-                        herc20_redeem_identity,
-                        herc20_expiry,
+                beta_finalized:
+                    http_api::halight::Finalized {
+                        state: halight::State::Opened(_),
                         ..
                     },
                 secret,
@@ -187,21 +326,33 @@ impl DeployAction for AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, H
     }
 }
 
-impl FundAction for AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> {
+impl FundAction
+    for AliceSwap<
+        asset::Erc20,
+        asset::Bitcoin,
+        http_api::herc20::Finalized,
+        http_api::halight::Finalized,
+    >
+{
     type Output = ethereum::CallContract;
 
     fn fund_action(&self) -> anyhow::Result<Self::Output> {
         match self {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>::Finalized {
-                beta_finalized:
-                    HalightFinalized {
-                        halight_state: halight::State::Opened(_),
+            AliceSwap::<
+                asset::Erc20,
+                asset::Bitcoin,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
+            >::Finalized {
+                alpha_finalized:
+                    http_api::herc20::Finalized {
+                        state: herc20::State::Deployed { htlc_location, .. },
+                        asset: herc20_asset,
                         ..
                     },
-                alpha_finalized:
-                    Herc20Finalized {
-                        herc20_state: herc20::State::Deployed { htlc_location, .. },
-                        herc20_asset,
+                beta_finalized:
+                    http_api::halight::Finalized {
+                        state: halight::State::Opened(_),
                         ..
                     },
                 ..
@@ -232,16 +383,28 @@ impl FundAction for AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, Hal
     }
 }
 
-impl RedeemAction for AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> {
+impl RedeemAction
+    for AliceSwap<
+        asset::Erc20,
+        asset::Bitcoin,
+        http_api::herc20::Finalized,
+        http_api::halight::Finalized,
+    >
+{
     type Output = lnd::SettleInvoice;
 
     fn redeem_action(&self) -> anyhow::Result<Self::Output> {
         match self {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>::Finalized {
+            AliceSwap::<
+                asset::Erc20,
+                asset::Bitcoin,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
+            >::Finalized {
                 beta_finalized:
-                    HalightFinalized {
-                        halight_state: halight::State::Accepted(_),
-                        halight_redeem_identity,
+                    http_api::halight::Finalized {
+                        state: halight::State::Accepted(_),
+                        redeem_identity: halight_redeem_identity,
                         ..
                     },
                 secret,
@@ -264,21 +427,33 @@ impl RedeemAction for AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, H
     }
 }
 
-impl RefundAction for AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> {
+impl RefundAction
+    for AliceSwap<
+        asset::Erc20,
+        asset::Bitcoin,
+        http_api::herc20::Finalized,
+        http_api::halight::Finalized,
+    >
+{
     type Output = ethereum::CallContract;
 
     fn refund_action(&self) -> anyhow::Result<Self::Output> {
         match self {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>::Finalized {
+            AliceSwap::<
+                asset::Erc20,
+                asset::Bitcoin,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
+            >::Finalized {
                 alpha_finalized:
-                    Herc20Finalized {
-                        herc20_state: herc20::State::Funded { htlc_location, .. },
-                        herc20_expiry,
+                    http_api::herc20::Finalized {
+                        state: herc20::State::Funded { htlc_location, .. },
+                        expiry: herc20_expiry,
                         ..
                     },
                 beta_finalized:
-                    HalightFinalized {
-                        halight_state: halight::State::Accepted(_),
+                    http_api::halight::Finalized {
+                        state: halight::State::Accepted(_),
                         ..
                     },
                 ..

--- a/cnd/src/http_api/routes.rs
+++ b/cnd/src/http_api/routes.rs
@@ -6,9 +6,7 @@ pub mod rfc003;
 use crate::{
     http_api::{
         action::ActionResponseBody,
-        halight::HalightFinalized,
-        herc20::Herc20Finalized,
-        problem,
+        halight, herc20, problem,
         protocol::{GetAlphaEvents, GetAlphaParams, GetBetaEvents, GetBetaParams, GetRole},
         route_factory, ActionNotFound, AliceSwap, BobSwap, Http, Swap,
     },
@@ -47,8 +45,12 @@ pub async fn handle_get_swap(
             beta: Protocol::Halight,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
-                facade.load(swap_id).await?;
+            let swap: AliceSwap<
+                asset::Erc20,
+                asset::Bitcoin,
+                herc20::Finalized,
+                halight::Finalized,
+            > = facade.load(swap_id).await?;
             make_swap_entity(swap_id, swap)
         }
         Swap {
@@ -56,7 +58,7 @@ pub async fn handle_get_swap(
             beta: Protocol::Halight,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
+            let swap: BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> =
                 facade.load(swap_id).await?;
             make_swap_entity(swap_id, swap)
         }
@@ -65,8 +67,12 @@ pub async fn handle_get_swap(
             beta: Protocol::Herc20,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
-                facade.load(swap_id).await?;
+            let swap: AliceSwap<
+                asset::Bitcoin,
+                asset::Erc20,
+                halight::Finalized,
+                herc20::Finalized,
+            > = facade.load(swap_id).await?;
             make_swap_entity(swap_id, swap)
         }
         Swap {
@@ -74,7 +80,7 @@ pub async fn handle_get_swap(
             beta: Protocol::Herc20,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
+            let swap: BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> =
                 facade.load(swap_id).await?;
             make_swap_entity(swap_id, swap)
         }
@@ -231,8 +237,12 @@ async fn handle_action_init(id: LocalSwapId, facade: Facade) -> anyhow::Result<A
             beta: Protocol::Halight,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
-                facade.load(id).await?;
+            let swap: AliceSwap<
+                asset::Erc20,
+                asset::Bitcoin,
+                herc20::Finalized,
+                halight::Finalized,
+            > = facade.load(id).await?;
             swap.init_action()?
         }
         Swap {
@@ -240,7 +250,7 @@ async fn handle_action_init(id: LocalSwapId, facade: Facade) -> anyhow::Result<A
             beta: Protocol::Herc20,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
+            let swap: BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> =
                 facade.load(id).await?;
             swap.init_action()?
         }
@@ -272,8 +282,12 @@ async fn handle_action_deploy(
             beta: Protocol::Halight,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
-                facade.load(id).await?;
+            let swap: AliceSwap<
+                asset::Erc20,
+                asset::Bitcoin,
+                herc20::Finalized,
+                halight::Finalized,
+            > = facade.load(id).await?;
             swap.deploy_action()?
         }
         Swap {
@@ -281,7 +295,7 @@ async fn handle_action_deploy(
             beta: Protocol::Herc20,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
+            let swap: BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> =
                 facade.load(id).await?;
             swap.deploy_action()?
         }
@@ -310,8 +324,12 @@ async fn handle_action_fund(id: LocalSwapId, facade: Facade) -> anyhow::Result<A
             beta: Protocol::Halight,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
-                facade.load(id).await?;
+            let swap: AliceSwap<
+                asset::Erc20,
+                asset::Bitcoin,
+                herc20::Finalized,
+                halight::Finalized,
+            > = facade.load(id).await?;
             let action = swap.fund_action()?;
 
             ActionResponseBody::from(action)
@@ -321,7 +339,7 @@ async fn handle_action_fund(id: LocalSwapId, facade: Facade) -> anyhow::Result<A
             beta: Protocol::Halight,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
+            let swap: BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> =
                 facade.load(id).await?;
             let action = swap.fund_action()?;
 
@@ -332,8 +350,12 @@ async fn handle_action_fund(id: LocalSwapId, facade: Facade) -> anyhow::Result<A
             beta: Protocol::Herc20,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
-                facade.load(id).await?;
+            let swap: AliceSwap<
+                asset::Bitcoin,
+                asset::Erc20,
+                halight::Finalized,
+                herc20::Finalized,
+            > = facade.load(id).await?;
             let action = swap.fund_action()?;
 
             ActionResponseBody::from(action)
@@ -343,7 +365,7 @@ async fn handle_action_fund(id: LocalSwapId, facade: Facade) -> anyhow::Result<A
             beta: Protocol::Herc20,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
+            let swap: BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> =
                 facade.load(id).await?;
             let action = swap.fund_action()?;
 
@@ -375,8 +397,12 @@ async fn handle_action_redeem(
             beta: Protocol::Halight,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
-                facade.load(id).await?;
+            let swap: AliceSwap<
+                asset::Erc20,
+                asset::Bitcoin,
+                herc20::Finalized,
+                halight::Finalized,
+            > = facade.load(id).await?;
             let action = swap.redeem_action()?;
 
             ActionResponseBody::from(action)
@@ -386,7 +412,7 @@ async fn handle_action_redeem(
             beta: Protocol::Halight,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
+            let swap: BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> =
                 facade.load(id).await?;
             let action = swap.redeem_action()?;
 
@@ -397,8 +423,12 @@ async fn handle_action_redeem(
             beta: Protocol::Herc20,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
-                facade.load(id).await?;
+            let swap: AliceSwap<
+                asset::Bitcoin,
+                asset::Erc20,
+                halight::Finalized,
+                herc20::Finalized,
+            > = facade.load(id).await?;
             let action = swap.redeem_action()?;
 
             ActionResponseBody::from(action)
@@ -408,7 +438,7 @@ async fn handle_action_redeem(
             beta: Protocol::Herc20,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
+            let swap: BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> =
                 facade.load(id).await?;
             let action = swap.redeem_action()?;
 
@@ -440,8 +470,12 @@ async fn handle_action_refund(
             beta: Protocol::Halight,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
-                facade.load(id).await?;
+            let swap: AliceSwap<
+                asset::Erc20,
+                asset::Bitcoin,
+                herc20::Finalized,
+                halight::Finalized,
+            > = facade.load(id).await?;
             let action = swap.refund_action()?;
             let response = ActionResponseBody::from(action);
 
@@ -452,7 +486,7 @@ async fn handle_action_refund(
             beta: Protocol::Herc20,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
+            let swap: BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> =
                 facade.load(id).await?;
             let action = swap.refund_action()?;
             let response = ActionResponseBody::from(action);

--- a/cnd/src/storage.rs
+++ b/cnd/src/storage.rs
@@ -6,9 +6,7 @@ use crate::{
         ForSwap, NoHalightRedeemIdentity, NoHalightRefundIdentity, NoHerc20RedeemIdentity,
         NoHerc20RefundIdentity, NoSecretHash, Save, Sqlite,
     },
-    http_api,
-    http_api::{halight::HalightFinalized, herc20::Herc20Finalized},
-    identity, respawn,
+    http_api, identity, respawn,
     seed::{DeriveSwapSeed, RootSeed},
     swap_protocols::{halight, herc20, rfc003::DeriveSecret, state::Get, LocalSwapId},
 };
@@ -155,14 +153,26 @@ impl LoadAll<respawn::Swap<comit::Protocol, comit::Protocol>> for Storage {
 }
 
 #[async_trait::async_trait]
-impl Load<http_api::AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>>
-    for Storage
+impl
+    Load<
+        http_api::AliceSwap<
+            asset::Erc20,
+            asset::Bitcoin,
+            http_api::herc20::Finalized,
+            http_api::halight::Finalized,
+        >,
+    > for Storage
 {
     async fn load(
         &self,
         swap_id: LocalSwapId,
     ) -> anyhow::Result<
-        http_api::AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>,
+        http_api::AliceSwap<
+            asset::Erc20,
+            asset::Bitcoin,
+            http_api::herc20::Finalized,
+            http_api::halight::Finalized,
+        >,
     > {
         use crate::db::schema::swaps;
 
@@ -198,44 +208,38 @@ impl Load<http_api::AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, Hal
             (Some(alpha_state), Some(beta_state)) => Ok(http_api::AliceSwap::<
                 asset::Erc20,
                 asset::Bitcoin,
-                Herc20Finalized,
-                HalightFinalized,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
             >::Finalized {
-                alpha_finalized: Herc20Finalized {
-                    herc20_asset,
-                    herc20_refund_identity: herc20
+                alpha_finalized: http_api::herc20::Finalized {
+                    asset: herc20_asset,
+                    refund_identity: herc20
                         .refund_identity
                         .ok_or(db::Error::IdentityNotSet)?
                         .0
                         .into(),
-                    herc20_redeem_identity: herc20
+                    redeem_identity: herc20
                         .redeem_identity
                         .ok_or(db::Error::IdentityNotSet)?
                         .0
                         .into(),
-                    herc20_expiry: herc20.expiry.0.into(),
-                    herc20_state: alpha_state,
+                    expiry: herc20.expiry.0.into(),
+                    state: alpha_state,
                 },
-                beta_finalized: HalightFinalized {
-                    halight_asset,
-                    halight_refund_identity: halight
-                        .refund_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0,
-                    halight_redeem_identity: halight
-                        .redeem_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0,
+                beta_finalized: http_api::halight::Finalized {
+                    asset: halight_asset,
+                    refund_identity: halight.refund_identity.ok_or(db::Error::IdentityNotSet)?.0,
+                    redeem_identity: halight.redeem_identity.ok_or(db::Error::IdentityNotSet)?.0,
                     cltv_expiry: halight.cltv_expiry.0.into(),
-                    halight_state: beta_state,
+                    state: beta_state,
                 },
                 secret,
             }),
             _ => Ok(http_api::AliceSwap::<
                 asset::Erc20,
                 asset::Bitcoin,
-                Herc20Finalized,
-                HalightFinalized,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
             >::Created {
                 alpha_created: herc20_asset,
                 beta_created: halight_asset,
@@ -245,14 +249,26 @@ impl Load<http_api::AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, Hal
 }
 
 #[async_trait::async_trait]
-impl Load<http_api::AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>>
-    for Storage
+impl
+    Load<
+        http_api::AliceSwap<
+            asset::Bitcoin,
+            asset::Erc20,
+            http_api::halight::Finalized,
+            http_api::herc20::Finalized,
+        >,
+    > for Storage
 {
     async fn load(
         &self,
         swap_id: LocalSwapId,
     ) -> anyhow::Result<
-        http_api::AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>,
+        http_api::AliceSwap<
+            asset::Bitcoin,
+            asset::Erc20,
+            http_api::halight::Finalized,
+            http_api::herc20::Finalized,
+        >,
     > {
         use crate::db::schema::swaps;
 
@@ -288,44 +304,38 @@ impl Load<http_api::AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, He
             (Some(alpha_state), Some(beta_state)) => Ok(http_api::AliceSwap::<
                 asset::Bitcoin,
                 asset::Erc20,
-                HalightFinalized,
-                Herc20Finalized,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
             >::Finalized {
-                beta_finalized: Herc20Finalized {
-                    herc20_asset,
-                    herc20_refund_identity: herc20
-                        .refund_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0
-                        .into(),
-                    herc20_redeem_identity: herc20
-                        .redeem_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0
-                        .into(),
-                    herc20_expiry: herc20.expiry.0.into(),
-                    herc20_state: alpha_state,
-                },
-                alpha_finalized: HalightFinalized {
-                    halight_asset,
-                    halight_refund_identity: halight
-                        .refund_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0,
-                    halight_redeem_identity: halight
-                        .redeem_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0,
+                alpha_finalized: http_api::halight::Finalized {
+                    asset: halight_asset,
+                    refund_identity: halight.refund_identity.ok_or(db::Error::IdentityNotSet)?.0,
+                    redeem_identity: halight.redeem_identity.ok_or(db::Error::IdentityNotSet)?.0,
                     cltv_expiry: halight.cltv_expiry.0.into(),
-                    halight_state: beta_state,
+                    state: beta_state,
+                },
+                beta_finalized: http_api::herc20::Finalized {
+                    asset: herc20_asset,
+                    refund_identity: herc20
+                        .refund_identity
+                        .ok_or(db::Error::IdentityNotSet)?
+                        .0
+                        .into(),
+                    redeem_identity: herc20
+                        .redeem_identity
+                        .ok_or(db::Error::IdentityNotSet)?
+                        .0
+                        .into(),
+                    expiry: herc20.expiry.0.into(),
+                    state: alpha_state,
                 },
                 secret,
             }),
             _ => Ok(http_api::AliceSwap::<
                 asset::Bitcoin,
                 asset::Erc20,
-                HalightFinalized,
-                Herc20Finalized,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
             >::Created {
                 beta_created: herc20_asset,
                 alpha_created: halight_asset,
@@ -335,14 +345,26 @@ impl Load<http_api::AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, He
 }
 
 #[async_trait::async_trait]
-impl Load<http_api::BobSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>>
-    for Storage
+impl
+    Load<
+        http_api::BobSwap<
+            asset::Erc20,
+            asset::Bitcoin,
+            http_api::herc20::Finalized,
+            http_api::halight::Finalized,
+        >,
+    > for Storage
 {
     async fn load(
         &self,
         swap_id: LocalSwapId,
     ) -> anyhow::Result<
-        http_api::BobSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>,
+        http_api::BobSwap<
+            asset::Erc20,
+            asset::Bitcoin,
+            http_api::herc20::Finalized,
+            http_api::halight::Finalized,
+        >,
     > {
         use crate::db::schema::swaps;
 
@@ -377,44 +399,38 @@ impl Load<http_api::BobSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, Halig
             (Some(alpha_state), Some(beta_state)) => Ok(http_api::BobSwap::<
                 asset::Erc20,
                 asset::Bitcoin,
-                Herc20Finalized,
-                HalightFinalized,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
             >::Finalized {
-                alpha_finalized: Herc20Finalized {
-                    herc20_asset,
-                    herc20_refund_identity: herc20
+                alpha_finalized: http_api::herc20::Finalized {
+                    asset: herc20_asset,
+                    refund_identity: herc20
                         .refund_identity
                         .ok_or(db::Error::IdentityNotSet)?
                         .0
                         .into(),
-                    herc20_redeem_identity: herc20
+                    redeem_identity: herc20
                         .redeem_identity
                         .ok_or(db::Error::IdentityNotSet)?
                         .0
                         .into(),
-                    herc20_expiry: herc20.expiry.0.into(),
-                    herc20_state: alpha_state,
+                    expiry: herc20.expiry.0.into(),
+                    state: alpha_state,
                 },
-                beta_finalized: HalightFinalized {
-                    halight_asset,
-                    halight_refund_identity: halight
-                        .refund_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0,
-                    halight_redeem_identity: halight
-                        .redeem_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0,
+                beta_finalized: http_api::halight::Finalized {
+                    asset: halight_asset,
+                    refund_identity: halight.refund_identity.ok_or(db::Error::IdentityNotSet)?.0,
+                    redeem_identity: halight.redeem_identity.ok_or(db::Error::IdentityNotSet)?.0,
                     cltv_expiry: halight.cltv_expiry.0.into(),
-                    halight_state: beta_state,
+                    state: beta_state,
                 },
                 secret_hash: secret_hash.0,
             }),
             _ => Ok(http_api::BobSwap::<
                 asset::Erc20,
                 asset::Bitcoin,
-                Herc20Finalized,
-                HalightFinalized,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
             >::Created {
                 alpha_created: herc20_asset,
                 beta_created: halight_asset,
@@ -424,14 +440,26 @@ impl Load<http_api::BobSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, Halig
 }
 
 #[async_trait::async_trait]
-impl Load<http_api::BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>>
-    for Storage
+impl
+    Load<
+        http_api::BobSwap<
+            asset::Bitcoin,
+            asset::Erc20,
+            http_api::halight::Finalized,
+            http_api::herc20::Finalized,
+        >,
+    > for Storage
 {
     async fn load(
         &self,
         swap_id: LocalSwapId,
     ) -> anyhow::Result<
-        http_api::BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>,
+        http_api::BobSwap<
+            asset::Bitcoin,
+            asset::Erc20,
+            http_api::halight::Finalized,
+            http_api::herc20::Finalized,
+        >,
     > {
         use crate::db::schema::swaps;
 
@@ -466,44 +494,38 @@ impl Load<http_api::BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc
             (Some(alpha_state), Some(beta_state)) => Ok(http_api::BobSwap::<
                 asset::Bitcoin,
                 asset::Erc20,
-                HalightFinalized,
-                Herc20Finalized,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
             >::Finalized {
-                alpha_finalized: HalightFinalized {
-                    halight_asset,
-                    halight_refund_identity: halight
-                        .refund_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0,
-                    halight_redeem_identity: halight
-                        .redeem_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0,
+                alpha_finalized: http_api::halight::Finalized {
+                    asset: halight_asset,
+                    refund_identity: halight.refund_identity.ok_or(db::Error::IdentityNotSet)?.0,
+                    redeem_identity: halight.redeem_identity.ok_or(db::Error::IdentityNotSet)?.0,
                     cltv_expiry: halight.cltv_expiry.0.into(),
-                    halight_state: alpha_state,
+                    state: alpha_state,
                 },
-                beta_finalized: Herc20Finalized {
-                    herc20_asset,
-                    herc20_refund_identity: herc20
+                beta_finalized: http_api::herc20::Finalized {
+                    asset: herc20_asset,
+                    refund_identity: herc20
                         .refund_identity
                         .ok_or(db::Error::IdentityNotSet)?
                         .0
                         .into(),
-                    herc20_redeem_identity: herc20
+                    redeem_identity: herc20
                         .redeem_identity
                         .ok_or(db::Error::IdentityNotSet)?
                         .0
                         .into(),
-                    herc20_expiry: herc20.expiry.0.into(),
-                    herc20_state: beta_state,
+                    expiry: herc20.expiry.0.into(),
+                    state: beta_state,
                 },
                 secret_hash: secret_hash.0,
             }),
             _ => Ok(http_api::BobSwap::<
                 asset::Bitcoin,
                 asset::Erc20,
-                HalightFinalized,
-                Herc20Finalized,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
             >::Created {
                 alpha_created: halight_asset,
                 beta_created: herc20_asset,

--- a/comit/src/lnd.rs
+++ b/comit/src/lnd.rs
@@ -351,6 +351,7 @@ impl LndConnectorAsReceiver {
 
         // Need to shortcut here until https://github.com/hyperium/hyper/issues/2171 or https://github.com/lightningnetwork/lnd/issues/4135 is resolved
         if response.status() == StatusCode::INTERNAL_SERVER_ERROR {
+            tracing::debug!("invoice not found");
             return Ok(None);
         }
 

--- a/comit/src/network.rs
+++ b/comit/src/network.rs
@@ -3,7 +3,7 @@ pub mod oneshot_protocol;
 pub mod protocols;
 pub mod swap_digest;
 
-use crate::{identity, SecretHash};
+use crate::SecretHash;
 use libp2p::{Multiaddr, PeerId};
 use std::fmt;
 
@@ -22,19 +22,17 @@ impl fmt::Display for DialInformation {
     }
 }
 
-/// All the data Alice learned from Bob during the communication phase of a
-/// herc20 <-> halight swap.
+/// Data Alice learned from Bob during the communication phase.
 #[derive(Clone, Copy, Debug)]
-pub struct WhatAliceLearnedFromBob {
-    pub redeem_ethereum_identity: identity::Ethereum,
-    pub refund_lightning_identity: identity::Lightning,
+pub struct WhatAliceLearnedFromBob<A, B> {
+    pub alpha_redeem_identity: A,
+    pub beta_refund_identity: B,
 }
 
-/// All the data Bob learned from Alice during the communication phase of a
-/// herc20 <-> halight swap.
+/// Data Bob learned from Alice during the communication phase.
 #[derive(Clone, Copy, Debug)]
-pub struct WhatBobLearnedFromAlice {
+pub struct WhatBobLearnedFromAlice<A, B> {
     pub secret_hash: SecretHash,
-    pub refund_ethereum_identity: identity::Ethereum,
-    pub redeem_lightning_identity: identity::Lightning,
+    pub alpha_refund_identity: A,
+    pub beta_redeem_identity: B,
 }


### PR DESCRIPTION
Import by fully qualified name (due to same protocol module names)

This is for you @tcharding - I have to say I am not really a fan of it. Due to having to use the fully qualified name most lines break. I don't think this patch really helps, but if the others feel strong about it we can merge it.