### PR TITLE
Rename struct name to Finalized

### DIFF
--- a/cnd/src/http_api/halight.rs
+++ b/cnd/src/http_api/halight.rs
@@ -1,11 +1,13 @@
 use crate::swap_protocols::halight;
 use comit::{asset, identity, RelativeTime};
 
+pub use crate::swap_protocols::halight::*;
+
 #[derive(Clone, Copy, Debug)]
-pub struct HalightFinalized {
-    pub halight_asset: asset::Bitcoin,
-    pub halight_refund_identity: identity::Lightning,
-    pub halight_redeem_identity: identity::Lightning,
+pub struct Finalized {
+    pub asset: asset::Bitcoin,
+    pub refund_identity: identity::Lightning,
+    pub redeem_identity: identity::Lightning,
     pub cltv_expiry: RelativeTime,
-    pub halight_state: halight::State,
+    pub state: halight::State,
 }

--- a/cnd/src/http_api/halight_herc20/alice.rs
+++ b/cnd/src/http_api/halight_herc20/alice.rs
@@ -1,7 +1,6 @@
 use crate::{
     http_api::{
-        halight::HalightFinalized,
-        herc20::Herc20Finalized,
+        halight, herc20,
         protocol::{
             AlphaEvents, AlphaParams, BetaEvents, BetaParams, Halight, Herc20, LedgerEvents,
         },
@@ -9,7 +8,7 @@ use crate::{
     },
     swap_protocols::{
         actions::{ethereum, lnd, lnd::Chain},
-        halight, herc20, DeployAction, FundAction, InitAction, RedeemAction, RefundAction,
+        DeployAction, FundAction, InitAction, RedeemAction, RefundAction,
     },
 };
 use blockchain_contracts::ethereum::rfc003::EtherHtlc;
@@ -19,17 +18,19 @@ use comit::{
     Never, SecretHash,
 };
 
-impl From<AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>> for Herc20 {
+impl From<AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>>
+    for Herc20
+{
     fn from(
-        from: AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>,
+        from: AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>,
     ) -> Self {
         match from {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Created {
+            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Created {
                 beta_created: herc20_asset,
                 ..
             }
-            | AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Finalized {
-                beta_finalized: Herc20Finalized { herc20_asset, .. },
+            | AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Finalized {
+                beta_finalized: herc20::Finalized { asset: herc20_asset, .. },
                 ..
             } => Self {
                 protocol: "herc20".to_owned(),
@@ -40,17 +41,19 @@ impl From<AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finali
     }
 }
 
-impl From<AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>> for Halight {
+impl From<AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>>
+    for Halight
+{
     fn from(
-        from: AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>,
+        from: AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>,
     ) -> Self {
         match from {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Created {
+            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Created {
                 alpha_created: halight_asset,
                 ..
             }
-            | AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Finalized {
-                alpha_finalized: HalightFinalized { halight_asset, .. },
+            | AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Finalized {
+                alpha_finalized: halight::Finalized { asset: halight_asset, .. },
                 ..
             } => Self {
                 protocol: "halight".to_owned(),
@@ -60,61 +63,65 @@ impl From<AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finali
     }
 }
 
-impl BetaParams for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl BetaParams for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
     type Output = Herc20;
     fn beta_params(&self) -> Self::Output {
         self.clone().into()
     }
 }
 
-impl BetaEvents for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl BetaEvents for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
     fn beta_events(&self) -> Option<LedgerEvents> {
         match self {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Created { .. } => None,
-            AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Finalized {
-                beta_finalized: Herc20Finalized { herc20_state, .. },
+            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Created { .. } => None,
+            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Finalized {
+                beta_finalized: herc20::Finalized { state: herc20_state, .. },
                 ..
             } => Some(From::<herc20::State>::from(herc20_state.clone())),
         }
     }
 }
 
-impl AlphaParams for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl AlphaParams
+    for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>
+{
     type Output = Halight;
     fn alpha_params(&self) -> Self::Output {
         self.clone().into()
     }
 }
 
-impl AlphaEvents for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl AlphaEvents
+    for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>
+{
     fn alpha_events(&self) -> Option<LedgerEvents> {
         match self {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Created { .. } => None,
-            AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Finalized {
-                alpha_finalized: HalightFinalized { halight_state, .. },
+            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Created { .. } => None,
+            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Finalized {
+                alpha_finalized: halight::Finalized { state: halight_state, .. },
                 ..
             } => Some(From::<halight::State>::from(*halight_state)),
         }
     }
 }
 
-impl FundAction for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl FundAction for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
     type Output = lnd::SendPayment;
 
     fn fund_action(&self) -> anyhow::Result<Self::Output> {
         match self {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Finalized {
+            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Finalized {
                 beta_finalized:
-                    Herc20Finalized {
-                        herc20_state: herc20::State::Funded { .. },
+                    herc20::Finalized {
+                        state: herc20::State::Funded { .. },
                         ..
                     },
                 alpha_finalized:
-                    HalightFinalized {
-                        halight_state: halight::State::Opened(_),
-                        halight_asset,
-                        halight_refund_identity,
-                        halight_redeem_identity,
+                    halight::Finalized {
+                        state: halight::State::Opened(_),
+                        asset: halight_asset,
+                        refund_identity: halight_refund_identity,
+                        redeem_identity: halight_redeem_identity,
                         cltv_expiry,
                     },
                 secret,
@@ -143,15 +150,17 @@ impl FundAction for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, He
     }
 }
 
-impl RedeemAction for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl RedeemAction
+    for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>
+{
     type Output = ethereum::CallContract;
 
     fn redeem_action(&self) -> anyhow::Result<Self::Output> {
         match self {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>::Finalized {
+            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Finalized {
                 beta_finalized:
-                    Herc20Finalized {
-                        herc20_state: herc20::State::Funded { htlc_location, .. },
+                    herc20::Finalized {
+                        state: herc20::State::Funded { htlc_location, .. },
                         ..
                     },
                 secret,
@@ -176,21 +185,25 @@ impl RedeemAction for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, 
     }
 }
 
-impl InitAction for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl InitAction for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
     type Output = Never;
     fn init_action(&self) -> anyhow::Result<Self::Output> {
         anyhow::bail!(ActionNotFound)
     }
 }
 
-impl DeployAction for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl DeployAction
+    for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>
+{
     type Output = Never;
     fn deploy_action(&self) -> anyhow::Result<Self::Output> {
         anyhow::bail!(ActionNotFound)
     }
 }
 
-impl RefundAction for AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl RefundAction
+    for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>
+{
     type Output = Never;
     fn refund_action(&self) -> anyhow::Result<Self::Output> {
         anyhow::bail!(ActionNotFound)

--- a/cnd/src/http_api/halight_herc20/bob.rs
+++ b/cnd/src/http_api/halight_herc20/bob.rs
@@ -1,7 +1,9 @@
 use crate::{
     http_api::{
-        halight::HalightFinalized,
-        herc20::Herc20Finalized,
+        halight,
+        halight::INVOICE_EXPIRY_SECS,
+        herc20,
+        herc20::build_erc20_htlc,
         protocol::{
             AlphaEvents, AlphaParams, BetaEvents, BetaParams, Halight, Herc20, LedgerEvents,
         },
@@ -9,10 +11,6 @@ use crate::{
     },
     swap_protocols::{
         actions::{ethereum, lnd, lnd::Chain},
-        halight,
-        halight::INVOICE_EXPIRY_SECS,
-        herc20,
-        herc20::build_erc20_htlc,
         DeployAction, FundAction, InitAction, RedeemAction, RefundAction,
     },
 };
@@ -22,17 +20,17 @@ use comit::{
     ethereum::{Bytes, ChainId},
 };
 
-impl InitAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl InitAction for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
     type Output = lnd::AddHoldInvoice;
 
     fn init_action(&self) -> anyhow::Result<Self::Output> {
         match self {
             BobSwap::Finalized {
                 alpha_finalized:
-                    HalightFinalized {
-                        halight_state: halight::State::None,
-                        halight_asset,
-                        halight_redeem_identity,
+                    halight::Finalized {
+                        state: halight::State::None,
+                        asset: halight_asset,
+                        redeem_identity: halight_redeem_identity,
                         cltv_expiry,
                         ..
                     },
@@ -62,23 +60,23 @@ impl InitAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc
     }
 }
 
-impl DeployAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl DeployAction for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
     type Output = ethereum::DeployContract;
 
     fn deploy_action(&self) -> anyhow::Result<Self::Output> {
         match self {
             BobSwap::Finalized {
                 alpha_finalized:
-                    HalightFinalized {
-                        halight_state: halight::State::Opened(_),
+                    halight::Finalized {
+                        state: halight::State::Opened(_),
                         ..
                     },
                 beta_finalized:
-                    Herc20Finalized {
-                        herc20_asset,
-                        herc20_refund_identity,
-                        herc20_redeem_identity,
-                        herc20_expiry,
+                    herc20::Finalized {
+                        asset: herc20_asset,
+                        refund_identity: herc20_refund_identity,
+                        redeem_identity: herc20_redeem_identity,
+                        expiry: herc20_expiry,
                         ..
                     },
                 secret_hash,
@@ -106,21 +104,21 @@ impl DeployAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, He
     }
 }
 
-impl FundAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl FundAction for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
     type Output = ethereum::CallContract;
 
     fn fund_action(&self) -> anyhow::Result<Self::Output> {
         match self {
             BobSwap::Finalized {
                 alpha_finalized:
-                    HalightFinalized {
-                        halight_state: halight::State::Opened(_),
+                    halight::Finalized {
+                        state: halight::State::Opened(_),
                         ..
                     },
                 beta_finalized:
-                    Herc20Finalized {
-                        herc20_asset,
-                        herc20_state: herc20::State::Deployed { htlc_location, .. },
+                    herc20::Finalized {
+                        asset: herc20_asset,
+                        state: herc20::State::Deployed { htlc_location, .. },
                         ..
                     },
                 ..
@@ -151,21 +149,21 @@ impl FundAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc
     }
 }
 
-impl RedeemAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl RedeemAction for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
     type Output = lnd::SettleInvoice;
 
     fn redeem_action(&self) -> anyhow::Result<Self::Output> {
         match self {
             BobSwap::Finalized {
                 alpha_finalized:
-                    HalightFinalized {
-                        halight_state: halight::State::Accepted(_),
-                        halight_redeem_identity,
+                    halight::Finalized {
+                        state: halight::State::Accepted(_),
+                        redeem_identity: halight_redeem_identity,
                         ..
                     },
                 beta_finalized:
-                    Herc20Finalized {
-                        herc20_state: herc20::State::Redeemed { secret, .. },
+                    herc20::Finalized {
+                        state: herc20::State::Redeemed { secret, .. },
                         ..
                     },
                 ..
@@ -187,21 +185,21 @@ impl RedeemAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, He
     }
 }
 
-impl RefundAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl RefundAction for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
     type Output = ethereum::CallContract;
 
     fn refund_action(&self) -> anyhow::Result<Self::Output> {
         match self {
             BobSwap::Finalized {
                 alpha_finalized:
-                    HalightFinalized {
-                        halight_state: halight::State::Accepted(_),
+                    halight::Finalized {
+                        state: halight::State::Accepted(_),
                         ..
                     },
                 beta_finalized:
-                    Herc20Finalized {
-                        herc20_state: herc20::State::Funded { htlc_location, .. },
-                        herc20_expiry,
+                    herc20::Finalized {
+                        state: herc20::State::Funded { htlc_location, .. },
+                        expiry: herc20_expiry,
                         ..
                     },
                 ..
@@ -225,47 +223,57 @@ impl RefundAction for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, He
     }
 }
 
-impl AlphaEvents for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl AlphaEvents for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
     fn alpha_events(&self) -> Option<LedgerEvents> {
         match self {
             BobSwap::Created { .. } => None,
             BobSwap::Finalized {
-                alpha_finalized: HalightFinalized { halight_state, .. },
+                alpha_finalized:
+                    halight::Finalized {
+                        state: halight_state,
+                        ..
+                    },
                 ..
             } => Some(From::<halight::State>::from(*halight_state)),
         }
     }
 }
 
-impl BetaEvents for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl BetaEvents for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
     fn beta_events(&self) -> Option<LedgerEvents> {
         match self {
             BobSwap::Created { .. } => None,
             BobSwap::Finalized {
-                beta_finalized: Herc20Finalized { herc20_state, .. },
+                beta_finalized:
+                    herc20::Finalized {
+                        state: herc20_state,
+                        ..
+                    },
                 ..
             } => Some(From::<herc20::State>::from(herc20_state.clone())),
         }
     }
 }
 
-impl AlphaParams for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl AlphaParams for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
     type Output = Herc20;
     fn alpha_params(&self) -> Self::Output {
         self.clone().into()
     }
 }
 
-impl BetaParams for BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> {
+impl BetaParams for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
     type Output = Halight;
     fn beta_params(&self) -> Self::Output {
         self.clone().into()
     }
 }
 
-impl From<BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>> for Halight {
+impl From<BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>>
+    for Halight
+{
     fn from(
-        from: BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>,
+        from: BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>,
     ) -> Self {
         match from {
             BobSwap::Created {
@@ -273,7 +281,11 @@ impl From<BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalize
                 ..
             }
             | BobSwap::Finalized {
-                alpha_finalized: HalightFinalized { halight_asset, .. },
+                alpha_finalized:
+                    halight::Finalized {
+                        asset: halight_asset,
+                        ..
+                    },
                 ..
             } => Self {
                 protocol: "halight".to_owned(),
@@ -283,9 +295,9 @@ impl From<BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalize
     }
 }
 
-impl From<BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>> for Herc20 {
+impl From<BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>> for Herc20 {
     fn from(
-        from: BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>,
+        from: BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>,
     ) -> Self {
         match from {
             BobSwap::Created {
@@ -293,7 +305,11 @@ impl From<BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalize
                 ..
             }
             | BobSwap::Finalized {
-                beta_finalized: Herc20Finalized { herc20_asset, .. },
+                beta_finalized:
+                    herc20::Finalized {
+                        asset: herc20_asset,
+                        ..
+                    },
                 ..
             } => Self {
                 protocol: "herc20".to_owned(),

--- a/cnd/src/http_api/herc20.rs
+++ b/cnd/src/http_api/herc20.rs
@@ -1,11 +1,13 @@
 use crate::swap_protocols::herc20;
 use comit::{asset, identity, Timestamp};
 
+pub use crate::swap_protocols::herc20::*;
+
 #[derive(Clone, Debug)]
-pub struct Herc20Finalized {
-    pub herc20_asset: asset::Erc20,
-    pub herc20_refund_identity: identity::Ethereum,
-    pub herc20_redeem_identity: identity::Ethereum,
-    pub herc20_expiry: Timestamp,
-    pub herc20_state: herc20::State,
+pub struct Finalized {
+    pub asset: asset::Erc20,
+    pub refund_identity: identity::Ethereum,
+    pub redeem_identity: identity::Ethereum,
+    pub expiry: Timestamp,
+    pub state: herc20::State,
 }

--- a/cnd/src/http_api/routes.rs
+++ b/cnd/src/http_api/routes.rs
@@ -6,9 +6,7 @@ pub mod rfc003;
 use crate::{
     http_api::{
         action::ActionResponseBody,
-        halight::HalightFinalized,
-        herc20::Herc20Finalized,
-        problem,
+        halight, herc20, problem,
         protocol::{AlphaEvents, AlphaParams, BetaEvents, BetaParams, GetRole},
         route_factory, ActionNotFound, AliceSwap, BobSwap, Http, Swap,
     },
@@ -47,8 +45,12 @@ pub async fn handle_get_swap(
             beta: Protocol::Halight,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
-                facade.load(swap_id).await?;
+            let swap: AliceSwap<
+                asset::Erc20,
+                asset::Bitcoin,
+                herc20::Finalized,
+                halight::Finalized,
+            > = facade.load(swap_id).await?;
             make_swap_entity(swap_id, swap)
         }
         Swap {
@@ -56,7 +58,7 @@ pub async fn handle_get_swap(
             beta: Protocol::Halight,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
+            let swap: BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> =
                 facade.load(swap_id).await?;
             make_swap_entity(swap_id, swap)
         }
@@ -65,8 +67,12 @@ pub async fn handle_get_swap(
             beta: Protocol::Herc20,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
-                facade.load(swap_id).await?;
+            let swap: AliceSwap<
+                asset::Bitcoin,
+                asset::Erc20,
+                halight::Finalized,
+                herc20::Finalized,
+            > = facade.load(swap_id).await?;
             make_swap_entity(swap_id, swap)
         }
         Swap {
@@ -74,7 +80,7 @@ pub async fn handle_get_swap(
             beta: Protocol::Herc20,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
+            let swap: BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> =
                 facade.load(swap_id).await?;
             make_swap_entity(swap_id, swap)
         }
@@ -253,8 +259,12 @@ async fn handle_action_init(id: LocalSwapId, facade: Facade) -> anyhow::Result<A
             beta: Protocol::Halight,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
-                facade.load(id).await?;
+            let swap: AliceSwap<
+                asset::Erc20,
+                asset::Bitcoin,
+                herc20::Finalized,
+                halight::Finalized,
+            > = facade.load(id).await?;
             swap.init_action()?
         }
         Swap {
@@ -262,7 +272,7 @@ async fn handle_action_init(id: LocalSwapId, facade: Facade) -> anyhow::Result<A
             beta: Protocol::Herc20,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
+            let swap: BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> =
                 facade.load(id).await?;
             swap.init_action()?
         }
@@ -294,8 +304,12 @@ async fn handle_action_deploy(
             beta: Protocol::Halight,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
-                facade.load(id).await?;
+            let swap: AliceSwap<
+                asset::Erc20,
+                asset::Bitcoin,
+                herc20::Finalized,
+                halight::Finalized,
+            > = facade.load(id).await?;
             swap.deploy_action()?
         }
         Swap {
@@ -303,7 +317,7 @@ async fn handle_action_deploy(
             beta: Protocol::Herc20,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
+            let swap: BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> =
                 facade.load(id).await?;
             swap.deploy_action()?
         }
@@ -332,8 +346,12 @@ async fn handle_action_fund(id: LocalSwapId, facade: Facade) -> anyhow::Result<A
             beta: Protocol::Halight,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
-                facade.load(id).await?;
+            let swap: AliceSwap<
+                asset::Erc20,
+                asset::Bitcoin,
+                herc20::Finalized,
+                halight::Finalized,
+            > = facade.load(id).await?;
             let action = swap.fund_action()?;
 
             ActionResponseBody::from(action)
@@ -343,7 +361,7 @@ async fn handle_action_fund(id: LocalSwapId, facade: Facade) -> anyhow::Result<A
             beta: Protocol::Halight,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
+            let swap: BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> =
                 facade.load(id).await?;
             let action = swap.fund_action()?;
 
@@ -354,8 +372,12 @@ async fn handle_action_fund(id: LocalSwapId, facade: Facade) -> anyhow::Result<A
             beta: Protocol::Herc20,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
-                facade.load(id).await?;
+            let swap: AliceSwap<
+                asset::Bitcoin,
+                asset::Erc20,
+                halight::Finalized,
+                herc20::Finalized,
+            > = facade.load(id).await?;
             let action = swap.fund_action()?;
 
             ActionResponseBody::from(action)
@@ -365,7 +387,7 @@ async fn handle_action_fund(id: LocalSwapId, facade: Facade) -> anyhow::Result<A
             beta: Protocol::Herc20,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
+            let swap: BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> =
                 facade.load(id).await?;
             let action = swap.fund_action()?;
 
@@ -397,8 +419,12 @@ async fn handle_action_redeem(
             beta: Protocol::Halight,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
-                facade.load(id).await?;
+            let swap: AliceSwap<
+                asset::Erc20,
+                asset::Bitcoin,
+                herc20::Finalized,
+                halight::Finalized,
+            > = facade.load(id).await?;
             let action = swap.redeem_action()?;
 
             ActionResponseBody::from(action)
@@ -408,7 +434,7 @@ async fn handle_action_redeem(
             beta: Protocol::Halight,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
+            let swap: BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> =
                 facade.load(id).await?;
             let action = swap.redeem_action()?;
 
@@ -419,8 +445,12 @@ async fn handle_action_redeem(
             beta: Protocol::Herc20,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
-                facade.load(id).await?;
+            let swap: AliceSwap<
+                asset::Bitcoin,
+                asset::Erc20,
+                halight::Finalized,
+                herc20::Finalized,
+            > = facade.load(id).await?;
             let action = swap.redeem_action()?;
 
             ActionResponseBody::from(action)
@@ -430,7 +460,7 @@ async fn handle_action_redeem(
             beta: Protocol::Herc20,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
+            let swap: BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> =
                 facade.load(id).await?;
             let action = swap.redeem_action()?;
 
@@ -462,8 +492,12 @@ async fn handle_action_refund(
             beta: Protocol::Halight,
             role: Role::Alice,
         } => {
-            let swap: AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized> =
-                facade.load(id).await?;
+            let swap: AliceSwap<
+                asset::Erc20,
+                asset::Bitcoin,
+                herc20::Finalized,
+                halight::Finalized,
+            > = facade.load(id).await?;
             let action = swap.refund_action()?;
             let response = ActionResponseBody::from(action);
 
@@ -474,7 +508,7 @@ async fn handle_action_refund(
             beta: Protocol::Herc20,
             role: Role::Bob,
         } => {
-            let swap: BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized> =
+            let swap: BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> =
                 facade.load(id).await?;
             let action = swap.refund_action()?;
             let response = ActionResponseBody::from(action);

--- a/cnd/src/storage.rs
+++ b/cnd/src/storage.rs
@@ -6,9 +6,7 @@ use crate::{
         ForSwap, NoHalightRedeemIdentity, NoHalightRefundIdentity, NoHerc20RedeemIdentity,
         NoHerc20RefundIdentity, NoSecretHash, Save, Sqlite,
     },
-    http_api,
-    http_api::{halight::HalightFinalized, herc20::Herc20Finalized},
-    identity, respawn,
+    http_api, identity, respawn,
     seed::{DeriveSwapSeed, RootSeed},
     swap_protocols::{halight, herc20, rfc003::DeriveSecret, state::Get, LocalSwapId},
 };
@@ -155,14 +153,26 @@ impl LoadAll<respawn::Swap<comit::Protocol, comit::Protocol>> for Storage {
 }
 
 #[async_trait::async_trait]
-impl Load<http_api::AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>>
-    for Storage
+impl
+    Load<
+        http_api::AliceSwap<
+            asset::Erc20,
+            asset::Bitcoin,
+            http_api::herc20::Finalized,
+            http_api::halight::Finalized,
+        >,
+    > for Storage
 {
     async fn load(
         &self,
         swap_id: LocalSwapId,
     ) -> anyhow::Result<
-        http_api::AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>,
+        http_api::AliceSwap<
+            asset::Erc20,
+            asset::Bitcoin,
+            http_api::herc20::Finalized,
+            http_api::halight::Finalized,
+        >,
     > {
         use crate::db::schema::swaps;
 
@@ -198,44 +208,38 @@ impl Load<http_api::AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, Hal
             (Some(alpha_state), Some(beta_state)) => Ok(http_api::AliceSwap::<
                 asset::Erc20,
                 asset::Bitcoin,
-                Herc20Finalized,
-                HalightFinalized,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
             >::Finalized {
-                alpha_finalized: Herc20Finalized {
-                    herc20_asset,
-                    herc20_refund_identity: herc20
+                alpha_finalized: http_api::herc20::Finalized {
+                    asset: herc20_asset,
+                    refund_identity: herc20
                         .refund_identity
                         .ok_or(db::Error::IdentityNotSet)?
                         .0
                         .into(),
-                    herc20_redeem_identity: herc20
+                    redeem_identity: herc20
                         .redeem_identity
                         .ok_or(db::Error::IdentityNotSet)?
                         .0
                         .into(),
-                    herc20_expiry: herc20.expiry.0.into(),
-                    herc20_state: alpha_state,
+                    expiry: herc20.expiry.0.into(),
+                    state: alpha_state,
                 },
-                beta_finalized: HalightFinalized {
-                    halight_asset,
-                    halight_refund_identity: halight
-                        .refund_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0,
-                    halight_redeem_identity: halight
-                        .redeem_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0,
+                beta_finalized: http_api::halight::Finalized {
+                    asset: halight_asset,
+                    refund_identity: halight.refund_identity.ok_or(db::Error::IdentityNotSet)?.0,
+                    redeem_identity: halight.redeem_identity.ok_or(db::Error::IdentityNotSet)?.0,
                     cltv_expiry: halight.cltv_expiry.0.into(),
-                    halight_state: beta_state,
+                    state: beta_state,
                 },
                 secret,
             }),
             _ => Ok(http_api::AliceSwap::<
                 asset::Erc20,
                 asset::Bitcoin,
-                Herc20Finalized,
-                HalightFinalized,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
             >::Created {
                 alpha_created: herc20_asset,
                 beta_created: halight_asset,
@@ -245,14 +249,26 @@ impl Load<http_api::AliceSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, Hal
 }
 
 #[async_trait::async_trait]
-impl Load<http_api::AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>>
-    for Storage
+impl
+    Load<
+        http_api::AliceSwap<
+            asset::Bitcoin,
+            asset::Erc20,
+            http_api::halight::Finalized,
+            http_api::herc20::Finalized,
+        >,
+    > for Storage
 {
     async fn load(
         &self,
         swap_id: LocalSwapId,
     ) -> anyhow::Result<
-        http_api::AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>,
+        http_api::AliceSwap<
+            asset::Bitcoin,
+            asset::Erc20,
+            http_api::halight::Finalized,
+            http_api::herc20::Finalized,
+        >,
     > {
         use crate::db::schema::swaps;
 
@@ -288,44 +304,38 @@ impl Load<http_api::AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, He
             (Some(alpha_state), Some(beta_state)) => Ok(http_api::AliceSwap::<
                 asset::Bitcoin,
                 asset::Erc20,
-                HalightFinalized,
-                Herc20Finalized,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
             >::Finalized {
-                beta_finalized: Herc20Finalized {
-                    herc20_asset,
-                    herc20_refund_identity: herc20
+                beta_finalized: http_api::herc20::Finalized {
+                    asset: herc20_asset,
+                    refund_identity: herc20
                         .refund_identity
                         .ok_or(db::Error::IdentityNotSet)?
                         .0
                         .into(),
-                    herc20_redeem_identity: herc20
+                    redeem_identity: herc20
                         .redeem_identity
                         .ok_or(db::Error::IdentityNotSet)?
                         .0
                         .into(),
-                    herc20_expiry: herc20.expiry.0.into(),
-                    herc20_state: alpha_state,
+                    expiry: herc20.expiry.0.into(),
+                    state: alpha_state,
                 },
-                alpha_finalized: HalightFinalized {
-                    halight_asset,
-                    halight_refund_identity: halight
-                        .refund_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0,
-                    halight_redeem_identity: halight
-                        .redeem_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0,
+                alpha_finalized: http_api::halight::Finalized {
+                    asset: halight_asset,
+                    refund_identity: halight.refund_identity.ok_or(db::Error::IdentityNotSet)?.0,
+                    redeem_identity: halight.redeem_identity.ok_or(db::Error::IdentityNotSet)?.0,
                     cltv_expiry: halight.cltv_expiry.0.into(),
-                    halight_state: beta_state,
+                    state: beta_state,
                 },
                 secret,
             }),
             _ => Ok(http_api::AliceSwap::<
                 asset::Bitcoin,
                 asset::Erc20,
-                HalightFinalized,
-                Herc20Finalized,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
             >::Created {
                 beta_created: herc20_asset,
                 alpha_created: halight_asset,
@@ -335,14 +345,26 @@ impl Load<http_api::AliceSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, He
 }
 
 #[async_trait::async_trait]
-impl Load<http_api::BobSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>>
-    for Storage
+impl
+    Load<
+        http_api::BobSwap<
+            asset::Erc20,
+            asset::Bitcoin,
+            http_api::herc20::Finalized,
+            http_api::halight::Finalized,
+        >,
+    > for Storage
 {
     async fn load(
         &self,
         swap_id: LocalSwapId,
     ) -> anyhow::Result<
-        http_api::BobSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, HalightFinalized>,
+        http_api::BobSwap<
+            asset::Erc20,
+            asset::Bitcoin,
+            http_api::herc20::Finalized,
+            http_api::halight::Finalized,
+        >,
     > {
         use crate::db::schema::swaps;
 
@@ -378,36 +400,30 @@ impl Load<http_api::BobSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, Halig
             (Some(alpha_state), Some(beta_state)) => Ok(http_api::BobSwap::<
                 asset::Erc20,
                 asset::Bitcoin,
-                Herc20Finalized,
-                HalightFinalized,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
             >::Finalized {
-                alpha_finalized: Herc20Finalized {
-                    herc20_asset,
-                    herc20_refund_identity: herc20
+                alpha_finalized: http_api::herc20::Finalized {
+                    asset: herc20_asset,
+                    refund_identity: herc20
                         .refund_identity
                         .ok_or(db::Error::IdentityNotSet)?
                         .0
                         .into(),
-                    herc20_redeem_identity: herc20
+                    redeem_identity: herc20
                         .redeem_identity
                         .ok_or(db::Error::IdentityNotSet)?
                         .0
                         .into(),
-                    herc20_expiry: herc20.expiry.0.into(),
-                    herc20_state: alpha_state,
+                    expiry: herc20.expiry.0.into(),
+                    state: alpha_state,
                 },
-                beta_finalized: HalightFinalized {
-                    halight_asset,
-                    halight_refund_identity: halight
-                        .refund_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0,
-                    halight_redeem_identity: halight
-                        .redeem_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0,
+                beta_finalized: http_api::halight::Finalized {
+                    asset: halight_asset,
+                    refund_identity: halight.refund_identity.ok_or(db::Error::IdentityNotSet)?.0,
+                    redeem_identity: halight.redeem_identity.ok_or(db::Error::IdentityNotSet)?.0,
                     cltv_expiry: halight.cltv_expiry.0.into(),
-                    halight_state: beta_state,
+                    state: beta_state,
                 },
                 secret_hash: secret_hash
                     .ok_or(db::Error::SecretHashNotSet)?
@@ -417,8 +433,8 @@ impl Load<http_api::BobSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, Halig
             _ => Ok(http_api::BobSwap::<
                 asset::Erc20,
                 asset::Bitcoin,
-                Herc20Finalized,
-                HalightFinalized,
+                http_api::herc20::Finalized,
+                http_api::halight::Finalized,
             >::Created {
                 alpha_created: herc20_asset,
                 beta_created: halight_asset,
@@ -428,14 +444,26 @@ impl Load<http_api::BobSwap<asset::Erc20, asset::Bitcoin, Herc20Finalized, Halig
 }
 
 #[async_trait::async_trait]
-impl Load<http_api::BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>>
-    for Storage
+impl
+    Load<
+        http_api::BobSwap<
+            asset::Bitcoin,
+            asset::Erc20,
+            http_api::halight::Finalized,
+            http_api::herc20::Finalized,
+        >,
+    > for Storage
 {
     async fn load(
         &self,
         swap_id: LocalSwapId,
     ) -> anyhow::Result<
-        http_api::BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc20Finalized>,
+        http_api::BobSwap<
+            asset::Bitcoin,
+            asset::Erc20,
+            http_api::halight::Finalized,
+            http_api::herc20::Finalized,
+        >,
     > {
         use crate::db::schema::swaps;
 
@@ -471,36 +499,30 @@ impl Load<http_api::BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc
             (Some(alpha_state), Some(beta_state)) => Ok(http_api::BobSwap::<
                 asset::Bitcoin,
                 asset::Erc20,
-                HalightFinalized,
-                Herc20Finalized,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
             >::Finalized {
-                alpha_finalized: HalightFinalized {
-                    halight_asset,
-                    halight_refund_identity: halight
-                        .refund_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0,
-                    halight_redeem_identity: halight
-                        .redeem_identity
-                        .ok_or(db::Error::IdentityNotSet)?
-                        .0,
+                alpha_finalized: http_api::halight::Finalized {
+                    asset: halight_asset,
+                    refund_identity: halight.refund_identity.ok_or(db::Error::IdentityNotSet)?.0,
+                    redeem_identity: halight.redeem_identity.ok_or(db::Error::IdentityNotSet)?.0,
                     cltv_expiry: halight.cltv_expiry.0.into(),
-                    halight_state: alpha_state,
+                    state: alpha_state,
                 },
-                beta_finalized: Herc20Finalized {
-                    herc20_asset,
-                    herc20_refund_identity: herc20
+                beta_finalized: http_api::herc20::Finalized {
+                    asset: herc20_asset,
+                    refund_identity: herc20
                         .refund_identity
                         .ok_or(db::Error::IdentityNotSet)?
                         .0
                         .into(),
-                    herc20_redeem_identity: herc20
+                    redeem_identity: herc20
                         .redeem_identity
                         .ok_or(db::Error::IdentityNotSet)?
                         .0
                         .into(),
-                    herc20_expiry: herc20.expiry.0.into(),
-                    herc20_state: beta_state,
+                    expiry: herc20.expiry.0.into(),
+                    state: beta_state,
                 },
                 secret_hash: secret_hash
                     .ok_or(db::Error::SecretHashNotSet)?
@@ -510,8 +532,8 @@ impl Load<http_api::BobSwap<asset::Bitcoin, asset::Erc20, HalightFinalized, Herc
             _ => Ok(http_api::BobSwap::<
                 asset::Bitcoin,
                 asset::Erc20,
-                HalightFinalized,
-                Herc20Finalized,
+                http_api::halight::Finalized,
+                http_api::herc20::Finalized,
             >::Created {
                 alpha_created: halight_asset,
                 beta_created: herc20_asset,


### PR DESCRIPTION
Re-export swap_protocols::{protocol} in http_api

Note: Bit weird now, because we always refer to what is in `swap_protocols` module as `http_api::{protocol}` - especially in the `db` I find that a bit awkward (there is no distinction between what is coming from `http_api` and what from the `swap_protocols` now...).