### PR TITLE
Add facade 'can_refund' methods for layer 1 connectors

### DIFF
--- a/cnd/src/connectors.rs
+++ b/cnd/src/connectors.rs
@@ -1,0 +1,12 @@
+use crate::btsieve::{
+    bitcoin::{self, BitcoindConnector},
+    ethereum::{self, Web3Connector},
+};
+use std::sync::Arc;
+
+/// Blockchain connectors.
+#[derive(Debug, Clone)]
+pub struct Connectors {
+    pub bitcoin: Arc<bitcoin::Cache<BitcoindConnector>>,
+    pub ethereum: Arc<ethereum::Cache<Web3Connector>>,
+}

--- a/cnd/src/lib.rs
+++ b/cnd/src/lib.rs
@@ -40,6 +40,7 @@ pub mod spectral_ext;
 
 pub mod comit_api;
 pub mod config;
+pub mod connectors;
 pub mod file_lock;
 pub mod http_api;
 pub mod init_swap;

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -20,6 +20,7 @@ use cnd::{
         ethereum::{self, Web3Connector},
     },
     config::{self, validation::validate_connection_to_network, Settings},
+    connectors::Connectors,
     db::Sqlite,
     file_lock::TryLockExclusive,
     http_api::route_factory,
@@ -141,6 +142,11 @@ fn main() -> anyhow::Result<()> {
     })
     .ok();
 
+    let connectors = Connectors {
+        bitcoin: Arc::clone(&bitcoin_connector),
+        ethereum: Arc::clone(&ethereum_connector),
+    };
+
     // RCF003 protocol
     let rfc003_alpha_ledger_states = Arc::new(rfc003::LedgerStates::default());
     let rfc003_beta_ledger_states = Arc::new(rfc003::LedgerStates::default());
@@ -198,6 +204,7 @@ fn main() -> anyhow::Result<()> {
         swarm: swarm.clone(),
         db: database,
         storage: storage.clone(),
+        connectors,
     };
 
     let http_api_listener = runtime.block_on(bind_http_api_socket(&settings))?;

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -1,5 +1,6 @@
 use crate::{
     asset,
+    connectors::Connectors,
     db::{CreatedSwap, Save, Sqlite},
     identity,
     network::{DialInformation, Identities, Swarm},
@@ -8,6 +9,7 @@ use crate::{
     timestamp::Timestamp,
 };
 use ::comit::network::protocols::announce::SwapDigest;
+use comit::HasPassed;
 use digest::Digest;
 
 /// This represents the information available on a swap
@@ -108,6 +110,7 @@ pub struct Facade {
     pub swarm: Swarm,
     pub db: Sqlite,
     pub storage: Storage,
+    pub connectors: Connectors,
 }
 
 impl Facade {
@@ -122,6 +125,16 @@ impl Facade {
         self.swarm
             .initiate_communication(id, peer, role, digest, identities)
             .await
+    }
+
+    /// True if expiry time has elapsed according to the Bitcoin connector.
+    pub async fn can_refund_bitcoin(&self, expiry: Timestamp) -> bool {
+        self.connectors.bitcoin.has_passed(expiry).await
+    }
+
+    /// True if expiry time has elapsed according to the Ethereum connector.
+    pub async fn can_refund_ethereum(&self, expiry: Timestamp) -> bool {
+        self.connectors.ethereum.has_passed(expiry).await
     }
 }
 

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -128,12 +128,12 @@ impl Facade {
     }
 
     /// True if expiry time has elapsed according to the Bitcoin connector.
-    pub async fn can_refund_bitcoin(&self, expiry: Timestamp) -> bool {
+    pub async fn can_refund_bitcoin(&self, expiry: Timestamp) -> anyhow::Result<bool> {
         self.connectors.bitcoin.has_passed(expiry).await
     }
 
     /// True if expiry time has elapsed according to the Ethereum connector.
-    pub async fn can_refund_ethereum(&self, expiry: Timestamp) -> bool {
+    pub async fn can_refund_ethereum(&self, expiry: Timestamp) -> anyhow::Result<bool> {
         self.connectors.ethereum.has_passed(expiry).await
     }
 }

--- a/comit/src/btsieve/bitcoin/cache.rs
+++ b/comit/src/btsieve/bitcoin/cache.rs
@@ -103,13 +103,9 @@ impl<C> HasPassed for Cache<C>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash>,
 {
-    async fn has_passed(&self, timestamp: Timestamp) -> bool {
-        match self.median_time_past().await {
-            Err(e) => {
-                tracing::warn!("failed to get median time-past: {}", e);
-                false
-            }
-            Ok(time_past) => timestamp < time_past,
-        }
+    async fn has_passed(&self, timestamp: Timestamp) -> anyhow::Result<bool> {
+        let time_past = self.median_time_past().await?;
+        let has_passed = timestamp < time_past;
+        Ok(has_passed)
     }
 }

--- a/comit/src/btsieve/ethereum/cache.rs
+++ b/comit/src/btsieve/ethereum/cache.rs
@@ -4,10 +4,12 @@ use crate::{
         BlockByHash, LatestBlock,
     },
     ethereum::TransactionReceipt,
+    HasPassed, Timestamp,
 };
 use async_trait::async_trait;
 use derivative::Derivative;
 use lru::LruCache;
+pub use primitive_types::U256;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -110,5 +112,31 @@ where
         guard.put(transaction_hash, receipt.clone());
 
         Ok(receipt)
+    }
+}
+
+/// We define, for the Web3 connector, a timestamp to have passed if the
+/// connector has seen a block with a block-timestamp smaller than the
+/// timestamp.
+#[async_trait]
+impl<C> HasPassed for Cache<C>
+where
+    C: LatestBlock<Block = Block>,
+{
+    async fn has_passed(&self, timestamp: Timestamp) -> bool {
+        match self.latest_block().await {
+            Err(e) => {
+                tracing::warn!("failed to get block time: {}", e);
+                false
+            }
+            Ok(block) => U256::from(timestamp) < block.timestamp,
+        }
+    }
+}
+
+impl From<Timestamp> for U256 {
+    fn from(t: Timestamp) -> Self {
+        let u: u32 = t.into();
+        U256::from(u)
     }
 }

--- a/comit/src/btsieve/ethereum/cache.rs
+++ b/comit/src/btsieve/ethereum/cache.rs
@@ -123,14 +123,10 @@ impl<C> HasPassed for Cache<C>
 where
     C: LatestBlock<Block = Block>,
 {
-    async fn has_passed(&self, timestamp: Timestamp) -> bool {
-        match self.latest_block().await {
-            Err(e) => {
-                tracing::warn!("failed to get block time: {}", e);
-                false
-            }
-            Ok(block) => U256::from(timestamp) < block.timestamp,
-        }
+    async fn has_passed(&self, timestamp: Timestamp) -> anyhow::Result<bool> {
+        let block = self.latest_block().await?;
+        let has_passed = U256::from(timestamp) < block.timestamp;
+        Ok(has_passed)
     }
 }
 

--- a/comit/src/lib.rs
+++ b/comit/src/lib.rs
@@ -25,6 +25,7 @@ pub use self::{
     swap_id::SharedSwapId,
     timestamp::{RelativeTime, Timestamp},
 };
+use async_trait::async_trait;
 use digest::ToDigestInput;
 
 #[derive(
@@ -114,4 +115,13 @@ impl ToDigestInput for asset::Erc20Quantity {
     fn to_digest_input(&self) -> Vec<u8> {
         self.to_bytes()
     }
+}
+
+/// Returns true if time has passed according to self. Time is
+/// measured as a unix timestamp i.e., seconds since epoch.
+/// Implementers are free to define their own concept of a time being
+/// in the past and should document this when implementing this trait.
+#[async_trait]
+pub trait HasPassed {
+    async fn has_passed(&self, unix: Timestamp) -> bool;
 }

--- a/comit/src/lib.rs
+++ b/comit/src/lib.rs
@@ -123,5 +123,5 @@ impl ToDigestInput for asset::Erc20Quantity {
 /// in the past and should document this when implementing this trait.
 #[async_trait]
 pub trait HasPassed {
-    async fn has_passed(&self, unix: Timestamp) -> bool;
+    async fn has_passed(&self, unix: Timestamp) -> anyhow::Result<bool>;
 }

--- a/comit/src/timestamp.rs
+++ b/comit/src/timestamp.rs
@@ -1,4 +1,5 @@
 use bitcoin::hashes::core::fmt::Formatter;
+use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use std::{fmt, time::SystemTime};
 
@@ -50,6 +51,13 @@ impl From<Timestamp> for u32 {
 impl From<Timestamp> for i64 {
     fn from(item: Timestamp) -> Self {
         i64::from(item.0)
+    }
+}
+
+impl From<Timestamp> for NaiveDateTime {
+    fn from(t: Timestamp) -> Self {
+        let secs = i64::from(t);
+        NaiveDateTime::from_timestamp(secs, 0)
     }
 }
 


### PR DESCRIPTION
We would like to be able to determine whether an expiry time has elapsed i.e., whether a refund transaction would be accepted by the relevant blockchain.

In order to do this we add a trait `HasPassed` and then implement it for the layer 1 blockchain connectors.

We then add a new `Connectors` struct and add an instance of this to the `Facade`. Also add methods on the facade to call through to the appropriate connector to expose the required functionality.