### PR TITLE
Recommend Unique Action (RUA)

### DIFF
--- a/api_tests/src/actors/swap_factory.ts
+++ b/api_tests/src/actors/swap_factory.ts
@@ -273,8 +273,8 @@ function defaultHerc20EthereumErc20RequestParams(
 }
 
 function defaultHalightHanHerc20Expiries() {
-    const alphaAbsoluteExpiry = Math.round(Date.now() / 1000) + 8;
-    const betaAbsoluteExpiry = Math.round(Date.now() / 1000) + 3;
+    const alphaAbsoluteExpiry = Math.round(Date.now() / 1000) + 120;
+    const betaAbsoluteExpiry = Math.round(Date.now() / 1000) + 60;
 
     return {
         alphaAbsoluteExpiry,

--- a/api_tests/src/actors/swap_factory.ts
+++ b/api_tests/src/actors/swap_factory.ts
@@ -273,8 +273,8 @@ function defaultHerc20EthereumErc20RequestParams(
 }
 
 function defaultHalightHanHerc20Expiries() {
-    const alphaAbsoluteExpiry = Math.round(Date.now() / 1000) + 120;
-    const betaAbsoluteExpiry = Math.round(Date.now() / 1000) + 60;
+    const alphaAbsoluteExpiry = Math.round(Date.now() / 1000) + 240;
+    const betaAbsoluteExpiry = Math.round(Date.now() / 1000) + 120;
 
     return {
         alphaAbsoluteExpiry,

--- a/cnd/src/http_api/herc20_halight/alice.rs
+++ b/cnd/src/http_api/herc20_halight/alice.rs
@@ -158,6 +158,7 @@ impl DeployAction
             AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
                 alpha_finalized:
                     herc20::Finalized {
+                        state: herc20::State::None,
                         asset: herc20_asset,
                         refund_identity: herc20_refund_identity,
                         redeem_identity: herc20_redeem_identity,

--- a/cnd/src/http_api/herc20_halight/alice.rs
+++ b/cnd/src/http_api/herc20_halight/alice.rs
@@ -5,7 +5,8 @@ use crate::{
         herc20,
         herc20::build_erc20_htlc,
         protocol::{
-            AlphaEvents, AlphaParams, BetaEvents, BetaParams, Halight, Herc20, LedgerEvents,
+            AlphaAbsoluteExpiry, AlphaBlockchain, AlphaEvents, AlphaParams, BetaAbsoluteExpiry,
+            BetaBlockchain, BetaEvents, BetaParams, Blockchain, Halight, Herc20, LedgerEvents,
         },
         ActionNotFound, AliceSwap,
     },
@@ -18,7 +19,7 @@ use blockchain_contracts::ethereum::rfc003::{Erc20Htlc, EtherHtlc};
 use comit::{
     asset,
     ethereum::{Bytes, ChainId},
-    SecretHash,
+    SecretHash, Timestamp,
 };
 
 impl From<AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>>
@@ -310,5 +311,43 @@ impl RefundAction
             }
             _ => anyhow::bail!(ActionNotFound),
         }
+    }
+}
+
+impl AlphaBlockchain
+    for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>
+{
+    fn alpha_blockchain(&self) -> Blockchain {
+        Blockchain::Ethereum
+    }
+}
+
+impl BetaBlockchain
+    for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>
+{
+    fn beta_blockchain(&self) -> Blockchain {
+        Blockchain::Bitcoin
+    }
+}
+
+impl AlphaAbsoluteExpiry
+    for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>
+{
+    fn alpha_absolute_expiry(&self) -> Option<Timestamp> {
+        match self {
+            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Created { .. } => None,
+            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
+                alpha_finalized: herc20::Finalized { expiry, .. },
+                ..
+            } => Some(*expiry)
+        }
+    }
+}
+
+impl BetaAbsoluteExpiry
+    for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>
+{
+    fn beta_absolute_expiry(&self) -> Option<Timestamp> {
+        None // No absolute expiry time for halight.
     }
 }

--- a/cnd/src/http_api/herc20_halight/alice.rs
+++ b/cnd/src/http_api/herc20_halight/alice.rs
@@ -114,6 +114,10 @@ impl InitAction for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, h
     fn init_action(&self) -> anyhow::Result<Self::Output> {
         match self {
             AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
+                alpha_finalized: herc20::Finalized {
+                    state: herc20::State::None,
+                    ..
+                },
                 beta_finalized:
                     halight::Finalized {
                         state: halight::State::None,

--- a/cnd/src/http_api/protocol.rs
+++ b/cnd/src/http_api/protocol.rs
@@ -1,5 +1,5 @@
 use crate::swap_protocols::{halight, herc20, Role, Secret};
-use comit::SecretHash;
+use comit::{SecretHash, Timestamp};
 use serde::Serialize;
 use std::collections::HashMap;
 
@@ -34,6 +34,33 @@ pub trait AlphaEvents {
 
 pub trait BetaEvents {
     fn beta_events(&self) -> Option<LedgerEvents>;
+}
+
+/// Get the underlying blockchain used by the alpha protocol.
+pub trait AlphaBlockchain {
+    fn alpha_blockchain(&self) -> Blockchain;
+}
+
+/// Get the underlying blockchain used by the beta protocol.
+pub trait BetaBlockchain {
+    fn beta_blockchain(&self) -> Blockchain;
+}
+
+/// Get the absolute expiry time for the alpha protocol.
+pub trait AlphaAbsoluteExpiry {
+    fn alpha_absolute_expiry(&self) -> Option<Timestamp>;
+}
+
+/// Get the absolute expiry time for the beta protocol.
+pub trait BetaAbsoluteExpiry {
+    fn beta_absolute_expiry(&self) -> Option<Timestamp>;
+}
+
+/// Blockchains we currently support swaps on top of.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Blockchain {
+    Bitcoin,
+    Ethereum,
 }
 
 pub trait GetRole {

--- a/cnd/src/swap_protocols/facade.rs
+++ b/cnd/src/swap_protocols/facade.rs
@@ -9,7 +9,6 @@ use crate::{
     timestamp::Timestamp,
 };
 use ::comit::network::protocols::announce::SwapDigest;
-use comit::HasPassed;
 use digest::Digest;
 
 /// This represents the information available on a swap
@@ -127,14 +126,15 @@ impl Facade {
             .await
     }
 
-    /// True if expiry time has elapsed according to the Bitcoin connector.
-    pub async fn can_refund_bitcoin(&self, expiry: Timestamp) -> anyhow::Result<bool> {
-        self.connectors.bitcoin.has_passed(expiry).await
+    /// Returns the Bitcoin median time past, used for nLockTime and
+    /// CheckLockTimeVerify.
+    pub async fn bitcoin_median_time_past(&self) -> anyhow::Result<Timestamp> {
+        self.connectors.bitcoin.median_time_past().await
     }
 
-    /// True if expiry time has elapsed according to the Ethereum connector.
-    pub async fn can_refund_ethereum(&self, expiry: Timestamp) -> anyhow::Result<bool> {
-        self.connectors.ethereum.has_passed(expiry).await
+    /// Returns the timestamp of the latest Ethereum block.
+    pub async fn ethereum_latest_time(&self) -> anyhow::Result<Timestamp> {
+        self.connectors.ethereum.latest_timestamp().await
     }
 }
 

--- a/comit/src/lib.rs
+++ b/comit/src/lib.rs
@@ -25,7 +25,6 @@ pub use self::{
     swap_id::SharedSwapId,
     timestamp::{RelativeTime, Timestamp},
 };
-use async_trait::async_trait;
 use digest::ToDigestInput;
 
 #[derive(
@@ -115,13 +114,4 @@ impl ToDigestInput for asset::Erc20Quantity {
     fn to_digest_input(&self) -> Vec<u8> {
         self.to_bytes()
     }
-}
-
-/// Returns true if time has passed according to self. Time is
-/// measured as a unix timestamp i.e., seconds since epoch.
-/// Implementers are free to define their own concept of a time being
-/// in the past and should document this when implementing this trait.
-#[async_trait]
-pub trait HasPassed {
-    async fn has_passed(&self, unix: Timestamp) -> anyhow::Result<bool>;
 }

--- a/comit/src/timestamp.rs
+++ b/comit/src/timestamp.rs
@@ -61,6 +61,12 @@ impl From<Timestamp> for NaiveDateTime {
     }
 }
 
+impl From<crate::ethereum::U256> for Timestamp {
+    fn from(value: crate::ethereum::U256) -> Self {
+        value.low_u32().into()
+    }
+}
+
 /// A duration used to represent a relative timelock
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
 #[serde(transparent)]


### PR DESCRIPTION
We want to recommend to the user what is the next action to take for a swap during the COMIT protocol.

Refund (and only refund) is returned once it is possible to refund, meaning that the HTLC has expired. This is done by checking the blockchain.

This PR is the result of the RUA shape up (@tcharding and @D4nte).

- Patch 1 and 2 are bug fixes to the actions logic
- Patch 3 fixes the e2e tests so that expiries are correct
- Patch 4 adds the RUA logic
- Patch 5 refactors the whole thing

Patch 5 is left separate to assist review, if this is not the case please say and we can squash 4 and 5 together.

This is v2 (total re-write) of https://github.com/comit-network/comit-rs/pull/2736.  Sorry for breaking the thread of context, seems we _still_ don't know how to use GitHub :)

This work is not tested any more than the current testing provided by the e2e tests. In particular, regression tests for this work are not added. There is a [tracking issue](https://github.com/comit-network/comit-rs/issues/2753) for adding testing (or fixing the API), we would like to merge this PR separately before starting work on that ticket.