### PR TITLE
Refactor swaps

### DIFF
--- a/cnd/src/http_api/halight_herc20/alice.rs
+++ b/cnd/src/http_api/halight_herc20/alice.rs
@@ -74,9 +74,13 @@ impl BetaParams for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, 
 impl BetaEvents for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
     fn beta_events(&self) -> Option<LedgerEvents> {
         match self {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Created { .. } => None,
-            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Finalized {
-                beta_finalized: herc20::Finalized { state: herc20_state, .. },
+            AliceSwap::Created { .. } => None,
+            AliceSwap::Finalized {
+                beta_finalized:
+                    herc20::Finalized {
+                        state: herc20_state,
+                        ..
+                    },
                 ..
             } => Some(From::<herc20::State>::from(herc20_state.clone())),
         }
@@ -97,9 +101,13 @@ impl AlphaEvents
 {
     fn alpha_events(&self) -> Option<LedgerEvents> {
         match self {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Created { .. } => None,
-            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Finalized {
-                alpha_finalized: halight::Finalized { state: halight_state, .. },
+            AliceSwap::Created { .. } => None,
+            AliceSwap::Finalized {
+                alpha_finalized:
+                    halight::Finalized {
+                        state: halight_state,
+                        ..
+                    },
                 ..
             } => Some(From::<halight::State>::from(*halight_state)),
         }
@@ -111,15 +119,15 @@ impl FundAction for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, 
 
     fn fund_action(&self) -> anyhow::Result<Self::Output> {
         match self {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Finalized {
+            AliceSwap::Finalized {
                 alpha_finalized:
-                halight::Finalized {
-                    state: halight::State::Opened(_),
-                    asset: halight_asset,
-                    refund_identity: halight_refund_identity,
-                    redeem_identity: halight_redeem_identity,
-                    cltv_expiry,
-                },
+                    halight::Finalized {
+                        state: halight::State::Opened(_),
+                        asset: halight_asset,
+                        refund_identity: halight_refund_identity,
+                        redeem_identity: halight_redeem_identity,
+                        cltv_expiry,
+                    },
                 beta_finalized:
                     herc20::Finalized {
                         state: herc20::State::None,
@@ -158,7 +166,7 @@ impl RedeemAction
 
     fn redeem_action(&self) -> anyhow::Result<Self::Output> {
         match self {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Finalized {
+            AliceSwap::Finalized {
                 beta_finalized:
                     herc20::Finalized {
                         state: herc20::State::Funded { htlc_location, .. },

--- a/cnd/src/http_api/halight_herc20/alice.rs
+++ b/cnd/src/http_api/halight_herc20/alice.rs
@@ -19,98 +19,19 @@ use comit::{
     Never, SecretHash, Timestamp,
 };
 
-impl From<AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>>
-    for Herc20
-{
-    fn from(
-        from: AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>,
-    ) -> Self {
-        match from {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Created {
-                beta_created: herc20_asset,
-                ..
-            }
-            | AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Finalized {
-                beta_finalized: herc20::Finalized { asset: herc20_asset, .. },
-                ..
-            } => Self {
-                protocol: "herc20".to_owned(),
-                quantity: herc20_asset.quantity.to_wei_dec(),
-                token_contract: herc20_asset.token_contract.to_string(),
-            },
-        }
+impl InitAction for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
+    type Output = Never;
+    fn init_action(&self) -> anyhow::Result<Self::Output> {
+        anyhow::bail!(ActionNotFound)
     }
 }
 
-impl From<AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>>
-    for Halight
-{
-    fn from(
-        from: AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>,
-    ) -> Self {
-        match from {
-            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Created {
-                alpha_created: halight_asset,
-                ..
-            }
-            | AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Finalized {
-                alpha_finalized: halight::Finalized { asset: halight_asset, .. },
-                ..
-            } => Self {
-                protocol: "halight".to_owned(),
-                quantity: halight_asset.as_sat().to_string(),
-            },
-        }
-    }
-}
-
-impl BetaParams for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
-    type Output = Herc20;
-    fn beta_params(&self) -> Self::Output {
-        self.clone().into()
-    }
-}
-
-impl BetaEvents for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
-    fn beta_events(&self) -> Option<LedgerEvents> {
-        match self {
-            AliceSwap::Created { .. } => None,
-            AliceSwap::Finalized {
-                beta_finalized:
-                    herc20::Finalized {
-                        state: herc20_state,
-                        ..
-                    },
-                ..
-            } => Some(From::<herc20::State>::from(herc20_state.clone())),
-        }
-    }
-}
-
-impl AlphaParams
+impl DeployAction
     for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>
 {
-    type Output = Halight;
-    fn alpha_params(&self) -> Self::Output {
-        self.clone().into()
-    }
-}
-
-impl AlphaEvents
-    for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>
-{
-    fn alpha_events(&self) -> Option<LedgerEvents> {
-        match self {
-            AliceSwap::Created { .. } => None,
-            AliceSwap::Finalized {
-                alpha_finalized:
-                    halight::Finalized {
-                        state: halight_state,
-                        ..
-                    },
-                ..
-            } => Some(From::<halight::State>::from(*halight_state)),
-        }
+    type Output = Never;
+    fn deploy_action(&self) -> anyhow::Result<Self::Output> {
+        anyhow::bail!(ActionNotFound)
     }
 }
 
@@ -194,28 +115,107 @@ impl RedeemAction
     }
 }
 
-impl InitAction for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
-    type Output = Never;
-    fn init_action(&self) -> anyhow::Result<Self::Output> {
-        anyhow::bail!(ActionNotFound)
-    }
-}
-
-impl DeployAction
-    for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>
-{
-    type Output = Never;
-    fn deploy_action(&self) -> anyhow::Result<Self::Output> {
-        anyhow::bail!(ActionNotFound)
-    }
-}
-
 impl RefundAction
     for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>
 {
     type Output = Never;
     fn refund_action(&self) -> anyhow::Result<Self::Output> {
         anyhow::bail!(ActionNotFound)
+    }
+}
+
+impl From<AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>>
+    for Herc20
+{
+    fn from(
+        from: AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>,
+    ) -> Self {
+        match from {
+            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Created {
+                beta_created: herc20_asset,
+                ..
+            }
+            | AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Finalized {
+                beta_finalized: herc20::Finalized { asset: herc20_asset, .. },
+                ..
+            } => Self {
+                protocol: "herc20".to_owned(),
+                quantity: herc20_asset.quantity.to_wei_dec(),
+                token_contract: herc20_asset.token_contract.to_string(),
+            },
+        }
+    }
+}
+
+impl From<AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>>
+    for Halight
+{
+    fn from(
+        from: AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>,
+    ) -> Self {
+        match from {
+            AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Created {
+                alpha_created: halight_asset,
+                ..
+            }
+            | AliceSwap::<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>::Finalized {
+                alpha_finalized: halight::Finalized { asset: halight_asset, .. },
+                ..
+            } => Self {
+                protocol: "halight".to_owned(),
+                quantity: halight_asset.as_sat().to_string(),
+            },
+        }
+    }
+}
+
+impl AlphaParams
+    for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>
+{
+    type Output = Halight;
+    fn alpha_params(&self) -> Self::Output {
+        self.clone().into()
+    }
+}
+
+impl BetaParams for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
+    type Output = Herc20;
+    fn beta_params(&self) -> Self::Output {
+        self.clone().into()
+    }
+}
+
+impl AlphaEvents
+    for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>
+{
+    fn alpha_events(&self) -> Option<LedgerEvents> {
+        match self {
+            AliceSwap::Created { .. } => None,
+            AliceSwap::Finalized {
+                alpha_finalized:
+                    halight::Finalized {
+                        state: halight_state,
+                        ..
+                    },
+                ..
+            } => Some(From::<halight::State>::from(*halight_state)),
+        }
+    }
+}
+
+impl BetaEvents for AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
+    fn beta_events(&self) -> Option<LedgerEvents> {
+        match self {
+            AliceSwap::Created { .. } => None,
+            AliceSwap::Finalized {
+                beta_finalized:
+                    herc20::Finalized {
+                        state: herc20_state,
+                        ..
+                    },
+                ..
+            } => Some(From::<herc20::State>::from(herc20_state.clone())),
+        }
     }
 }
 

--- a/cnd/src/http_api/halight_herc20/bob.rs
+++ b/cnd/src/http_api/halight_herc20/bob.rs
@@ -226,52 +226,6 @@ impl RefundAction for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, 
     }
 }
 
-impl AlphaEvents for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
-    fn alpha_events(&self) -> Option<LedgerEvents> {
-        match self {
-            BobSwap::Created { .. } => None,
-            BobSwap::Finalized {
-                alpha_finalized:
-                    halight::Finalized {
-                        state: halight_state,
-                        ..
-                    },
-                ..
-            } => Some(From::<halight::State>::from(*halight_state)),
-        }
-    }
-}
-
-impl BetaEvents for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
-    fn beta_events(&self) -> Option<LedgerEvents> {
-        match self {
-            BobSwap::Created { .. } => None,
-            BobSwap::Finalized {
-                beta_finalized:
-                    herc20::Finalized {
-                        state: herc20_state,
-                        ..
-                    },
-                ..
-            } => Some(From::<herc20::State>::from(herc20_state.clone())),
-        }
-    }
-}
-
-impl AlphaParams for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
-    type Output = Herc20;
-    fn alpha_params(&self) -> Self::Output {
-        self.clone().into()
-    }
-}
-
-impl BetaParams for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
-    type Output = Halight;
-    fn beta_params(&self) -> Self::Output {
-        self.clone().into()
-    }
-}
-
 impl From<BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>>
     for Halight
 {
@@ -319,6 +273,52 @@ impl From<BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Fina
                 quantity: herc20_asset.quantity.to_wei_dec(),
                 token_contract: herc20_asset.token_contract.to_string(),
             },
+        }
+    }
+}
+
+impl AlphaParams for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
+    type Output = Herc20;
+    fn alpha_params(&self) -> Self::Output {
+        self.clone().into()
+    }
+}
+
+impl BetaParams for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
+    type Output = Halight;
+    fn beta_params(&self) -> Self::Output {
+        self.clone().into()
+    }
+}
+
+impl AlphaEvents for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
+    fn alpha_events(&self) -> Option<LedgerEvents> {
+        match self {
+            BobSwap::Created { .. } => None,
+            BobSwap::Finalized {
+                alpha_finalized:
+                    halight::Finalized {
+                        state: halight_state,
+                        ..
+                    },
+                ..
+            } => Some(From::<halight::State>::from(*halight_state)),
+        }
+    }
+}
+
+impl BetaEvents for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
+    fn beta_events(&self) -> Option<LedgerEvents> {
+        match self {
+            BobSwap::Created { .. } => None,
+            BobSwap::Finalized {
+                beta_finalized:
+                    herc20::Finalized {
+                        state: herc20_state,
+                        ..
+                    },
+                ..
+            } => Some(From::<herc20::State>::from(herc20_state.clone())),
         }
     }
 }

--- a/cnd/src/http_api/herc20_halight/alice.rs
+++ b/cnd/src/http_api/herc20_halight/alice.rs
@@ -81,9 +81,13 @@ impl AlphaEvents
 {
     fn alpha_events(&self) -> Option<LedgerEvents> {
         match self {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Created { .. } => None,
-            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
-                alpha_finalized: herc20::Finalized { state: herc20_state, .. },
+            AliceSwap::Created { .. } => None,
+            AliceSwap::Finalized {
+                alpha_finalized:
+                    herc20::Finalized {
+                        state: herc20_state,
+                        ..
+                    },
                 ..
             } => Some(From::<herc20::State>::from(herc20_state.clone())),
         }
@@ -100,9 +104,13 @@ impl BetaParams for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, h
 impl BetaEvents for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
     fn beta_events(&self) -> Option<LedgerEvents> {
         match self {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Created { .. } => None,
-            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
-                beta_finalized: halight::Finalized { state: halight_state, .. },
+            AliceSwap::Created { .. } => None,
+            AliceSwap::Finalized {
+                beta_finalized:
+                    halight::Finalized {
+                        state: halight_state,
+                        ..
+                    },
                 ..
             } => Some(From::<halight::State>::from(*halight_state)),
         }
@@ -114,11 +122,12 @@ impl InitAction for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, h
 
     fn init_action(&self) -> anyhow::Result<Self::Output> {
         match self {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
-                alpha_finalized: herc20::Finalized {
-                    state: herc20::State::None,
-                    ..
-                },
+            AliceSwap::Finalized {
+                alpha_finalized:
+                    herc20::Finalized {
+                        state: herc20::State::None,
+                        ..
+                    },
                 beta_finalized:
                     halight::Finalized {
                         state: halight::State::None,
@@ -160,7 +169,7 @@ impl DeployAction
 
     fn deploy_action(&self) -> anyhow::Result<Self::Output> {
         match self {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
+            AliceSwap::Finalized {
                 alpha_finalized:
                     herc20::Finalized {
                         state: herc20::State::None,
@@ -205,7 +214,7 @@ impl FundAction for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, h
 
     fn fund_action(&self) -> anyhow::Result<Self::Output> {
         match self {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
+            AliceSwap::Finalized {
                 alpha_finalized:
                     herc20::Finalized {
                         state: herc20::State::Deployed { htlc_location, .. },
@@ -252,7 +261,7 @@ impl RedeemAction
 
     fn redeem_action(&self) -> anyhow::Result<Self::Output> {
         match self {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
+            AliceSwap::Finalized {
                 beta_finalized:
                     halight::Finalized {
                         state: halight::State::Accepted(_),
@@ -286,7 +295,7 @@ impl RefundAction
 
     fn refund_action(&self) -> anyhow::Result<Self::Output> {
         match self {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
+            AliceSwap::Finalized {
                 alpha_finalized:
                     herc20::Finalized {
                         state: herc20::State::Funded { htlc_location, .. },
@@ -333,11 +342,11 @@ impl AlphaAbsoluteExpiry
 {
     fn alpha_absolute_expiry(&self) -> Option<Timestamp> {
         match self {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Created { .. } => None,
-            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
+            AliceSwap::Created { .. } => None,
+            AliceSwap::Finalized {
                 alpha_finalized: herc20::Finalized { expiry, .. },
                 ..
-            } => Some(*expiry)
+            } => Some(*expiry),
         }
     }
 }

--- a/cnd/src/http_api/herc20_halight/alice.rs
+++ b/cnd/src/http_api/herc20_halight/alice.rs
@@ -22,101 +22,6 @@ use comit::{
     SecretHash, Timestamp,
 };
 
-impl From<AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>>
-    for Herc20
-{
-    fn from(
-        from: AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>,
-    ) -> Self {
-        match from {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Created {
-                alpha_created: herc20_asset,
-                ..
-            }
-            | AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
-                alpha_finalized: herc20::Finalized { asset: herc20_asset, .. },
-                ..
-            } => Self {
-                protocol: "herc20".to_owned(),
-                quantity: herc20_asset.quantity.to_wei_dec(),
-                token_contract: herc20_asset.token_contract.to_string(),
-            },
-        }
-    }
-}
-
-impl From<AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>>
-    for Halight
-{
-    fn from(
-        from: AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>,
-    ) -> Self {
-        match from {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Created {
-                beta_created: halight_asset,
-                ..
-            }
-            | AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
-                beta_finalized: halight::Finalized { asset: halight_asset, .. },
-                ..
-            } => Self {
-                protocol: "halight".to_owned(),
-                quantity: halight_asset.as_sat().to_string(),
-            },
-        }
-    }
-}
-
-impl AlphaParams
-    for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>
-{
-    type Output = Herc20;
-    fn alpha_params(&self) -> Self::Output {
-        self.clone().into()
-    }
-}
-
-impl AlphaEvents
-    for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>
-{
-    fn alpha_events(&self) -> Option<LedgerEvents> {
-        match self {
-            AliceSwap::Created { .. } => None,
-            AliceSwap::Finalized {
-                alpha_finalized:
-                    herc20::Finalized {
-                        state: herc20_state,
-                        ..
-                    },
-                ..
-            } => Some(From::<herc20::State>::from(herc20_state.clone())),
-        }
-    }
-}
-
-impl BetaParams for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
-    type Output = Halight;
-    fn beta_params(&self) -> Self::Output {
-        self.clone().into()
-    }
-}
-
-impl BetaEvents for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
-    fn beta_events(&self) -> Option<LedgerEvents> {
-        match self {
-            AliceSwap::Created { .. } => None,
-            AliceSwap::Finalized {
-                beta_finalized:
-                    halight::Finalized {
-                        state: halight_state,
-                        ..
-                    },
-                ..
-            } => Some(From::<halight::State>::from(*halight_state)),
-        }
-    }
-}
-
 impl InitAction for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
     type Output = lnd::AddHoldInvoice;
 
@@ -319,6 +224,101 @@ impl RefundAction
                 })
             }
             _ => anyhow::bail!(ActionNotFound),
+        }
+    }
+}
+
+impl From<AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>>
+    for Herc20
+{
+    fn from(
+        from: AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>,
+    ) -> Self {
+        match from {
+            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Created {
+                alpha_created: herc20_asset,
+                ..
+            }
+            | AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
+                alpha_finalized: herc20::Finalized { asset: herc20_asset, .. },
+                ..
+            } => Self {
+                protocol: "herc20".to_owned(),
+                quantity: herc20_asset.quantity.to_wei_dec(),
+                token_contract: herc20_asset.token_contract.to_string(),
+            },
+        }
+    }
+}
+
+impl From<AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>>
+    for Halight
+{
+    fn from(
+        from: AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>,
+    ) -> Self {
+        match from {
+            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Created {
+                beta_created: halight_asset,
+                ..
+            }
+            | AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
+                beta_finalized: halight::Finalized { asset: halight_asset, .. },
+                ..
+            } => Self {
+                protocol: "halight".to_owned(),
+                quantity: halight_asset.as_sat().to_string(),
+            },
+        }
+    }
+}
+
+impl AlphaParams
+    for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>
+{
+    type Output = Herc20;
+    fn alpha_params(&self) -> Self::Output {
+        self.clone().into()
+    }
+}
+
+impl BetaParams for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
+    type Output = Halight;
+    fn beta_params(&self) -> Self::Output {
+        self.clone().into()
+    }
+}
+
+impl AlphaEvents
+    for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>
+{
+    fn alpha_events(&self) -> Option<LedgerEvents> {
+        match self {
+            AliceSwap::Created { .. } => None,
+            AliceSwap::Finalized {
+                alpha_finalized:
+                    herc20::Finalized {
+                        state: herc20_state,
+                        ..
+                    },
+                ..
+            } => Some(From::<herc20::State>::from(herc20_state.clone())),
+        }
+    }
+}
+
+impl BetaEvents for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
+    fn beta_events(&self) -> Option<LedgerEvents> {
+        match self {
+            AliceSwap::Created { .. } => None,
+            AliceSwap::Finalized {
+                beta_finalized:
+                    halight::Finalized {
+                        state: halight_state,
+                        ..
+                    },
+                ..
+            } => Some(From::<halight::State>::from(*halight_state)),
         }
     }
 }

--- a/cnd/src/http_api/herc20_halight/bob.rs
+++ b/cnd/src/http_api/herc20_halight/bob.rs
@@ -236,11 +236,11 @@ impl AlphaAbsoluteExpiry
 {
     fn alpha_absolute_expiry(&self) -> Option<Timestamp> {
         match self {
-            BobSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Created { .. } => None,
-            BobSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
+            BobSwap::Created { .. } => None,
+            BobSwap::Finalized {
                 alpha_finalized: herc20::Finalized { expiry, .. },
                 ..
-            } => Some(*expiry)
+            } => Some(*expiry),
         }
     }
 }

--- a/cnd/src/http_api/herc20_halight/bob.rs
+++ b/cnd/src/http_api/herc20_halight/bob.rs
@@ -20,6 +20,20 @@ use comit::{
     Never, Timestamp,
 };
 
+impl InitAction for BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
+    type Output = Never;
+    fn init_action(&self) -> anyhow::Result<Self::Output> {
+        anyhow::bail!(ActionNotFound)
+    }
+}
+
+impl DeployAction for BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
+    type Output = Never;
+    fn deploy_action(&self) -> anyhow::Result<Self::Output> {
+        anyhow::bail!(ActionNotFound)
+    }
+}
+
 impl FundAction for BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
     type Output = lnd::SendPayment;
 
@@ -101,66 +115,6 @@ impl RedeemAction for BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, h
     }
 }
 
-impl AlphaEvents for BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
-    fn alpha_events(&self) -> Option<LedgerEvents> {
-        match self {
-            BobSwap::Created { .. } => None,
-            BobSwap::Finalized {
-                alpha_finalized:
-                    herc20::Finalized {
-                        state: herc20_state,
-                        ..
-                    },
-                ..
-            } => Some(From::<herc20::State>::from(herc20_state.clone())),
-        }
-    }
-}
-
-impl BetaEvents for BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
-    fn beta_events(&self) -> Option<LedgerEvents> {
-        match self {
-            BobSwap::Created { .. } => None,
-            BobSwap::Finalized {
-                beta_finalized:
-                    halight::Finalized {
-                        state: halight_state,
-                        ..
-                    },
-                ..
-            } => Some(From::<halight::State>::from(*halight_state)),
-        }
-    }
-}
-
-impl AlphaParams for BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
-    type Output = Herc20;
-    fn alpha_params(&self) -> Self::Output {
-        self.clone().into()
-    }
-}
-
-impl BetaParams for BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
-    type Output = Halight;
-    fn beta_params(&self) -> Self::Output {
-        self.clone().into()
-    }
-}
-
-impl DeployAction for BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
-    type Output = Never;
-    fn deploy_action(&self) -> anyhow::Result<Self::Output> {
-        anyhow::bail!(ActionNotFound)
-    }
-}
-
-impl InitAction for BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
-    type Output = Never;
-    fn init_action(&self) -> anyhow::Result<Self::Output> {
-        anyhow::bail!(ActionNotFound)
-    }
-}
-
 impl RefundAction for BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
     type Output = Never;
     fn refund_action(&self) -> anyhow::Result<Self::Output> {
@@ -215,6 +169,52 @@ impl From<BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Fina
                 protocol: "halight".to_owned(),
                 quantity: halight_asset.as_sat().to_string(),
             },
+        }
+    }
+}
+
+impl AlphaParams for BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
+    type Output = Herc20;
+    fn alpha_params(&self) -> Self::Output {
+        self.clone().into()
+    }
+}
+
+impl BetaParams for BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
+    type Output = Halight;
+    fn beta_params(&self) -> Self::Output {
+        self.clone().into()
+    }
+}
+
+impl AlphaEvents for BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
+    fn alpha_events(&self) -> Option<LedgerEvents> {
+        match self {
+            BobSwap::Created { .. } => None,
+            BobSwap::Finalized {
+                alpha_finalized:
+                    herc20::Finalized {
+                        state: herc20_state,
+                        ..
+                    },
+                ..
+            } => Some(From::<herc20::State>::from(herc20_state.clone())),
+        }
+    }
+}
+
+impl BetaEvents for BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized> {
+    fn beta_events(&self) -> Option<LedgerEvents> {
+        match self {
+            BobSwap::Created { .. } => None,
+            BobSwap::Finalized {
+                beta_finalized:
+                    halight::Finalized {
+                        state: halight_state,
+                        ..
+                    },
+                ..
+            } => Some(From::<halight::State>::from(*halight_state)),
         }
     }
 }


### PR DESCRIPTION
Clean up and simplify swaps a little bit. Changes in this PR are rather trivial.

- Patch 1 removes unnecessary type annotations when the compiler can infer the types. 
- Patch 2 is just moving code around within the swaps files (alice.rs/bob.rs) to make the files uniform and make the code look like we care :)
