### PR TITLE
Actually do what the comment says

### DIFF
--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -4,8 +4,8 @@ pub mod start_swap;
 pub mod test_swarm;
 pub mod transport;
 
-// Export comit network types while maintaining the module abstraction.
 pub use self::comit::*;
+// Export comit network types while maintaining the module abstraction.
 pub use ::comit::network::*;
 pub use transport::ComitTransport;
 


### PR DESCRIPTION
During rebasing and merging 3 different PRs I managed to leave a line
of code in that was not intended, this is both wrong and is contrary
to what the code comment says.

This is a totally trivial oneline fix, first reviewer feel free to kick bors to save the next reviewer the time.