### PR TITLE
Upgrade bitcoind to 0.20.0

### DIFF
--- a/api_tests/src/ledgers/bitcoind_instance.ts
+++ b/api_tests/src/ledgers/bitcoind_instance.ts
@@ -42,7 +42,7 @@ export class BitcoindInstance implements LedgerInstance {
     ) {}
 
     public async start() {
-        const bin = await this.findBinary("0.19.1");
+        const bin = await this.findBinary("0.20.0");
 
         this.logger.info("Using binary", bin);
 
@@ -164,6 +164,7 @@ rest=1
 acceptnonstdtxn=0
 zmqpubrawblock=tcp://127.0.0.1:${this.zmqPubRawBlockPort}
 zmqpubrawtx=tcp://127.0.0.1:${this.zmqPubRawTxPort}
+fallbackfee=0.0002
 
 [regtest]
 bind=0.0.0.0:${this.p2pPort}


### PR DESCRIPTION
Due to the lack of transactions on the local blockchain, bitcoind cannot
estimate a fee. Hence, fallback fee should be set.

See bitcoind 0.20.0 Release notes for details.