### PR TITLE
Add halight::Network type

### DIFF
--- a/cnd/src/db/tables.rs
+++ b/cnd/src/db/tables.rs
@@ -4,9 +4,9 @@ use crate::{
         schema::{address_book, halights, hbits, herc20s, secret_hashes, swaps},
         wrapper_types::{
             custom_sql_types::{Text, U32},
-            BitcoinNetwork, Erc20Amount, EthereumAddress, LightningNetwork, Satoshis,
+            BitcoinNetwork, Erc20Amount, EthereumAddress, Satoshis,
         },
-        Sqlite,
+        Db, Sqlite,
     },
     halight, hbit, herc20, identity, lightning, LocalSwapId, Role, Side,
 };
@@ -143,7 +143,7 @@ pub struct Halight {
     id: i32,
     swap_id: i32,
     pub amount: Text<Satoshis>,
-    pub network: Text<LightningNetwork>,
+    pub network: Text<Db<halight::Network>>,
     pub chain: String,
     pub cltv_expiry: U32,
     pub redeem_identity: Option<Text<lightning::PublicKey>>,
@@ -156,7 +156,7 @@ pub struct Halight {
 pub struct InsertableHalight {
     pub swap_id: i32,
     pub amount: Text<Satoshis>,
-    pub network: Text<LightningNetwork>,
+    pub network: Text<Db<halight::Network>>,
     pub chain: String,
     pub cltv_expiry: U32,
     pub redeem_identity: Option<Text<lightning::PublicKey>>,

--- a/cnd/src/db/wrapper_types.rs
+++ b/cnd/src/db/wrapper_types.rs
@@ -1,8 +1,6 @@
 use crate::{
     asset, identity,
-    swap_protocols::ledger::{
-        Lightning, {self},
-    },
+    swap_protocols::ledger::{self},
 };
 use std::{fmt, str::FromStr};
 
@@ -131,60 +129,6 @@ impl From<EthereumAddress> for identity::Ethereum {
 impl From<identity::Ethereum> for EthereumAddress {
     fn from(address: identity::Ethereum) -> Self {
         EthereumAddress(address)
-    }
-}
-
-/// A wrapper type for Lightning networks.
-///
-/// This is then wrapped in the db::custom_sql_types::Text to be stored in DB
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum LightningNetwork {
-    Mainnet,
-    Testnet,
-    Regtest,
-}
-
-impl From<Lightning> for LightningNetwork {
-    fn from(lightning: Lightning) -> Self {
-        match lightning {
-            Lightning::Mainnet => LightningNetwork::Mainnet,
-            Lightning::Testnet => LightningNetwork::Testnet,
-            Lightning::Regtest => LightningNetwork::Regtest,
-        }
-    }
-}
-
-impl From<LightningNetwork> for Lightning {
-    fn from(network: LightningNetwork) -> Self {
-        match network {
-            LightningNetwork::Mainnet => Lightning::Mainnet,
-            LightningNetwork::Testnet => Lightning::Testnet,
-            LightningNetwork::Regtest => Lightning::Regtest,
-        }
-    }
-}
-
-impl FromStr for LightningNetwork {
-    type Err = UnknownVariant;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "mainnet" => Ok(Self::Mainnet),
-            "testnet" => Ok(Self::Testnet),
-            "regtest" => Ok(Self::Regtest),
-            _ => Err(UnknownVariant),
-        }
-    }
-}
-
-impl fmt::Display for LightningNetwork {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = match self {
-            Self::Mainnet => "mainnet",
-            Self::Testnet => "testnet",
-            Self::Regtest => "regtest",
-        };
-        write!(f, "{}", s)
     }
 }
 

--- a/cnd/src/http_api.rs
+++ b/cnd/src/http_api.rs
@@ -175,30 +175,30 @@ impl Serialize for Http<PeerId> {
     }
 }
 
-impl Serialize for Http<ledger::Lightning> {
+impl Serialize for Http<halight::Network> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         let str = match self {
-            Http(ledger::Lightning::Mainnet) => "mainnet",
-            Http(ledger::Lightning::Testnet) => "testnet",
-            Http(ledger::Lightning::Regtest) => "regtest",
+            Http(halight::Network::Mainnet) => "mainnet",
+            Http(halight::Network::Testnet) => "testnet",
+            Http(halight::Network::Regtest) => "regtest",
         };
 
         serializer.serialize_str(str)
     }
 }
 
-impl<'de> Deserialize<'de> for Http<ledger::Lightning> {
-    fn deserialize<D>(deserializer: D) -> Result<Http<ledger::Lightning>, D::Error>
+impl<'de> Deserialize<'de> for Http<halight::Network> {
+    fn deserialize<D>(deserializer: D) -> Result<Http<halight::Network>, D::Error>
     where
         D: Deserializer<'de>,
     {
         let network = match String::deserialize(deserializer)?.as_str() {
-            "mainnet" => ledger::Lightning::Mainnet,
-            "testnet" => ledger::Lightning::Testnet,
-            "regtest" => ledger::Lightning::Regtest,
+            "mainnet" => halight::Network::Mainnet,
+            "testnet" => halight::Network::Testnet,
+            "regtest" => halight::Network::Regtest,
 
             network => {
                 return Err(<D as Deserializer<'de>>::Error::custom(format!(
@@ -551,6 +551,7 @@ pub struct ActionNotFound;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::{
         asset,
         asset::ethereum::FromWei,
@@ -757,5 +758,20 @@ mod tests {
             serialized,
             r#""QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY""#
         );
+    }
+
+    #[test]
+    fn http_halight_network_serializes_correctly_to_json() {
+        let network = Http(halight::Network::Mainnet);
+        let serialized = serde_json::to_string(&network).unwrap();
+        assert_eq!(serialized, r#""mainnet""#);
+
+        let network = Http(halight::Network::Testnet);
+        let serialized = serde_json::to_string(&network).unwrap();
+        assert_eq!(serialized, r#""testnet""#);
+
+        let network = Http(halight::Network::Regtest);
+        let serialized = serde_json::to_string(&network).unwrap();
+        assert_eq!(serialized, r#""regtest""#);
     }
 }

--- a/cnd/src/http_api/routes/index.rs
+++ b/cnd/src/http_api/routes/index.rs
@@ -6,7 +6,7 @@ use crate::{
     identity,
     network::{HalightHerc20, HbitHerc20, Herc20Halight, Herc20Hbit, Identities, ListenAddresses},
     storage::Load,
-    swap_protocols::{ledger, Rfc003Facade},
+    swap_protocols::Rfc003Facade,
     Facade, LocalSwapId, Role,
 };
 use digest::Digest;
@@ -388,7 +388,7 @@ impl ToCreatedSwap<hbit::CreatedSwap, herc20::CreatedSwap> for Body<Hbit, Herc20
 pub struct Halight {
     pub amount: Http<asset::Bitcoin>,
     pub identity: identity::Lightning,
-    pub network: Http<ledger::Lightning>,
+    pub network: Http<halight::Network>,
     pub cltv_expiry: u32,
 }
 

--- a/cnd/src/proptest.rs
+++ b/cnd/src/proptest.rs
@@ -106,14 +106,6 @@ pub mod ledger {
     use super::*;
     use comit::ledger;
 
-    pub fn lightning() -> impl Strategy<Value = ledger::Lightning> {
-        prop_oneof![
-            Just(ledger::Lightning::Mainnet),
-            Just(ledger::Lightning::Testnet),
-            Just(ledger::Lightning::Regtest)
-        ]
-    }
-
     pub fn bitcoin() -> impl Strategy<Value = ledger::Bitcoin> {
         prop_oneof![
             Just(ledger::Bitcoin::Mainnet),
@@ -170,7 +162,7 @@ pub mod halight {
         pub fn created_swap()(
             asset in asset::bitcoin(),
             identity in identity::lightning(),
-            network in ledger::lightning(),
+            network in network(),
             cltv_expiry in any::<u32>()
         ) -> halight::CreatedSwap {
             halight::CreatedSwap {
@@ -180,6 +172,14 @@ pub mod halight {
                 cltv_expiry
             }
         }
+    }
+
+    pub fn network() -> impl Strategy<Value = halight::Network> {
+        prop_oneof![
+            Just(halight::Network::Mainnet),
+            Just(halight::Network::Testnet),
+            Just(halight::Network::Regtest)
+        ]
     }
 }
 

--- a/comit/src/halight.rs
+++ b/comit/src/halight.rs
@@ -1,4 +1,4 @@
-use crate::{asset, identity, ledger, RelativeTime, Secret, SecretHash};
+use crate::{asset, identity, RelativeTime, Secret, SecretHash};
 use bitcoin::hashes::core::fmt::Formatter;
 use futures::{future, future::Either, Stream, TryFutureExt};
 use genawaiter::sync::Gen;
@@ -56,7 +56,7 @@ where
 pub struct CreatedSwap {
     pub asset: asset::Bitcoin,
     pub identity: identity::Lightning,
-    pub network: ledger::Lightning,
+    pub network: Network,
     pub cltv_expiry: u32,
 }
 
@@ -148,3 +148,11 @@ pub struct Settled {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Cancelled;
+
+/// Which layer 1 network we are running on (implicitly refers to the Bitcoin)
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Network {
+    Mainnet,
+    Testnet,
+    Regtest,
+}

--- a/comit/src/ledger.rs
+++ b/comit/src/ledger.rs
@@ -51,10 +51,3 @@ impl Default for Ethereum {
         }
     }
 }
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum Lightning {
-    Mainnet,
-    Testnet,
-    Regtest,
-}


### PR DESCRIPTION
We currently have a few problems that are all intertwined:
- non-uniform usage of the terms ledger/network
- non-uniform usage of modelling `hbit::CreatedSwap` vs `asset::Bitcoin`
- non-uniform serde code in http_api and the db i.e., how we wrap types

This PR resolves all there of these for the halight 'network' type. We
choose 'network' over 'ledger' because if its common usage throughout
the Ethereum and Bitcoin communities to refer to the specific network
in use (mainnet, testnet etc.). Arguably this could also have been
'ledger' since each network _is_ a separate network.

Do:

- Add `halight::Network` enum to model the three networks.

- Use `halight::Network` throughout `http_api` module.
- Add serialization stability test for `Http<halight::Netwok>` (Follow
the module example and only do serialization test not deserialization
test).

- Use `halight::Network` throughout `db` module.
- Add a `Db` wrapper type that controls ser/der (actually `FromStr`,
  `Display` in the db). (Mimics the `Http` wrapper.)
- Add serialization/deserialization stability tests to the `db` module.

- Remove `ledger::Lightning` in favour of the newly added type.