### PR TITLE
Remove hard coded regtest network

### DIFF
--- a/cnd/src/db/tables.rs
+++ b/cnd/src/db/tables.rs
@@ -126,7 +126,7 @@ impl IntoInsertable for herc20::CreatedSwap {
         InsertableHerc20 {
             swap_id,
             amount: Text(self.asset.quantity.into()),
-            chain_id: U32(self.chain_id),
+            chain_id: U32(self.chain_id.into()),
             expiry: U32(self.absolute_expiry),
             token_contract: Text(self.asset.token_contract.into()),
             redeem_identity,

--- a/cnd/src/db/tables.rs
+++ b/cnd/src/db/tables.rs
@@ -4,7 +4,7 @@ use crate::{
         schema::{address_book, halights, hbits, herc20s, secret_hashes, swaps},
         wrapper_types::{
             custom_sql_types::{Text, U32},
-            BitcoinNetwork, Erc20Amount, EthereumAddress, LightningNetwork, Satoshis,
+            BitcoinNetwork, Erc20Amount, EthereumAddress, Satoshis,
         },
         Sqlite,
     },
@@ -143,7 +143,7 @@ pub struct Halight {
     id: i32,
     swap_id: i32,
     pub amount: Text<Satoshis>,
-    pub network: Text<LightningNetwork>,
+    pub network: Text<BitcoinNetwork>,
     pub chain: String,
     pub cltv_expiry: U32,
     pub redeem_identity: Option<Text<lightning::PublicKey>>,
@@ -156,7 +156,7 @@ pub struct Halight {
 pub struct InsertableHalight {
     pub swap_id: i32,
     pub amount: Text<Satoshis>,
-    pub network: Text<LightningNetwork>,
+    pub network: Text<BitcoinNetwork>,
     pub chain: String,
     pub cltv_expiry: U32,
     pub redeem_identity: Option<Text<lightning::PublicKey>>,

--- a/cnd/src/db/wrapper_types.rs
+++ b/cnd/src/db/wrapper_types.rs
@@ -1,9 +1,4 @@
-use crate::{
-    asset, identity,
-    swap_protocols::ledger::{
-        Lightning, {self},
-    },
-};
+use crate::{asset, identity, swap_protocols::ledger};
 use std::{fmt, str::FromStr};
 
 pub mod custom_sql_types;
@@ -131,60 +126,6 @@ impl From<EthereumAddress> for identity::Ethereum {
 impl From<identity::Ethereum> for EthereumAddress {
     fn from(address: identity::Ethereum) -> Self {
         EthereumAddress(address)
-    }
-}
-
-/// A wrapper type for Lightning networks.
-///
-/// This is then wrapped in the db::custom_sql_types::Text to be stored in DB
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum LightningNetwork {
-    Mainnet,
-    Testnet,
-    Regtest,
-}
-
-impl From<Lightning> for LightningNetwork {
-    fn from(lightning: Lightning) -> Self {
-        match lightning {
-            Lightning::Mainnet => LightningNetwork::Mainnet,
-            Lightning::Testnet => LightningNetwork::Testnet,
-            Lightning::Regtest => LightningNetwork::Regtest,
-        }
-    }
-}
-
-impl From<LightningNetwork> for Lightning {
-    fn from(network: LightningNetwork) -> Self {
-        match network {
-            LightningNetwork::Mainnet => Lightning::Mainnet,
-            LightningNetwork::Testnet => Lightning::Testnet,
-            LightningNetwork::Regtest => Lightning::Regtest,
-        }
-    }
-}
-
-impl FromStr for LightningNetwork {
-    type Err = UnknownVariant;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "mainnet" => Ok(Self::Mainnet),
-            "testnet" => Ok(Self::Testnet),
-            "regtest" => Ok(Self::Regtest),
-            _ => Err(UnknownVariant),
-        }
-    }
-}
-
-impl fmt::Display for LightningNetwork {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = match self {
-            Self::Mainnet => "mainnet",
-            Self::Testnet => "testnet",
-            Self::Regtest => "regtest",
-        };
-        write!(f, "{}", s)
     }
 }
 

--- a/cnd/src/http_api.rs
+++ b/cnd/src/http_api.rs
@@ -175,30 +175,30 @@ impl Serialize for Http<PeerId> {
     }
 }
 
-impl Serialize for Http<ledger::Lightning> {
+impl Serialize for Http<ledger::Bitcoin> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         let str = match self {
-            Http(ledger::Lightning::Mainnet) => "mainnet",
-            Http(ledger::Lightning::Testnet) => "testnet",
-            Http(ledger::Lightning::Regtest) => "regtest",
+            Http(ledger::Bitcoin::Mainnet) => "mainnet",
+            Http(ledger::Bitcoin::Testnet) => "testnet",
+            Http(ledger::Bitcoin::Regtest) => "regtest",
         };
 
         serializer.serialize_str(str)
     }
 }
 
-impl<'de> Deserialize<'de> for Http<ledger::Lightning> {
-    fn deserialize<D>(deserializer: D) -> Result<Http<ledger::Lightning>, D::Error>
+impl<'de> Deserialize<'de> for Http<ledger::Bitcoin> {
+    fn deserialize<D>(deserializer: D) -> Result<Http<ledger::Bitcoin>, D::Error>
     where
         D: Deserializer<'de>,
     {
         let network = match String::deserialize(deserializer)?.as_str() {
-            "mainnet" => ledger::Lightning::Mainnet,
-            "testnet" => ledger::Lightning::Testnet,
-            "regtest" => ledger::Lightning::Regtest,
+            "mainnet" => ledger::Bitcoin::Mainnet,
+            "testnet" => ledger::Bitcoin::Testnet,
+            "regtest" => ledger::Bitcoin::Regtest,
 
             network => {
                 return Err(<D as Deserializer<'de>>::Error::custom(format!(

--- a/cnd/src/http_api/halight.rs
+++ b/cnd/src/http_api/halight.rs
@@ -1,10 +1,12 @@
 use crate::{asset, identity, RelativeTime};
+use comit::ledger;
 
 pub use crate::halight::*;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Finalized {
     pub asset: asset::Bitcoin,
+    pub network: ledger::Bitcoin,
     pub refund_identity: identity::Lightning,
     pub redeem_identity: identity::Lightning,
     pub cltv_expiry: RelativeTime,

--- a/cnd/src/http_api/hbit.rs
+++ b/cnd/src/http_api/hbit.rs
@@ -1,4 +1,4 @@
-use comit::{asset, Timestamp};
+use comit::{asset, ledger, Timestamp};
 
 pub use crate::hbit::*;
 use bitcoin::secp256k1::SecretKey;
@@ -6,6 +6,7 @@ use bitcoin::secp256k1::SecretKey;
 #[derive(Clone, Debug)]
 pub struct FinalizedAsFunder {
     pub asset: asset::Bitcoin,
+    pub network: ledger::Bitcoin,
     pub transient_redeem_identity: identity::Bitcoin,
     pub final_refund_identity: comit::bitcoin::Address,
     pub transient_refund_identity: SecretKey,
@@ -16,6 +17,7 @@ pub struct FinalizedAsFunder {
 #[derive(Clone, Debug)]
 pub struct FinalizedAsRedeemer {
     pub asset: asset::Bitcoin,
+    pub network: ledger::Bitcoin,
     pub final_redeem_identity: comit::bitcoin::Address,
     pub transient_redeem_identity: SecretKey,
     pub transient_refund_identity: identity::Bitcoin,

--- a/cnd/src/http_api/herc20.rs
+++ b/cnd/src/http_api/herc20.rs
@@ -1,10 +1,11 @@
-use crate::{asset, identity, Timestamp};
+use crate::{asset, ethereum::ChainId, identity, Timestamp};
 
 pub use crate::herc20::*;
 
 #[derive(Clone, Debug)]
 pub struct Finalized {
     pub asset: asset::Erc20,
+    pub chain_id: ChainId,
     pub refund_identity: identity::Ethereum,
     pub redeem_identity: identity::Ethereum,
     pub expiry: Timestamp,

--- a/cnd/src/http_api/routes/index.rs
+++ b/cnd/src/http_api/routes/index.rs
@@ -1,6 +1,7 @@
 use crate::{
     asset,
     db::{CreatedSwap, Save},
+    ethereum::ChainId,
     halight, hbit, herc20,
     http_api::{problem, routes::into_rejection, DialInformation, Http},
     identity,
@@ -398,7 +399,7 @@ pub struct Halight {
 pub struct Herc20 {
     pub amount: asset::Erc20Quantity,
     pub identity: identity::Ethereum,
-    pub chain_id: u32,
+    pub chain_id: ChainId,
     // This should re-named to token_contract but doing so is a breaking API change.
     pub contract_address: identity::Ethereum,
     pub absolute_expiry: u32,

--- a/cnd/src/http_api/routes/index.rs
+++ b/cnd/src/http_api/routes/index.rs
@@ -388,7 +388,7 @@ impl ToCreatedSwap<hbit::CreatedSwap, herc20::CreatedSwap> for Body<Hbit, Herc20
 pub struct Halight {
     pub amount: Http<asset::Bitcoin>,
     pub identity: identity::Lightning,
-    pub network: Http<ledger::Lightning>,
+    pub network: Http<ledger::Bitcoin>,
     pub cltv_expiry: u32,
 }
 

--- a/cnd/src/lib.rs
+++ b/cnd/src/lib.rs
@@ -65,7 +65,7 @@ use std::{
 
 pub use self::{actions::*, facade::Facade, seed::*, swap_id::*};
 // Export comit types so we do not need to worry about where they come from.
-pub use comit::{Never, Protocol, RelativeTime, Role, Secret, SecretHash, Side, Timestamp};
+pub use comit::{ledger, Never, Protocol, RelativeTime, Role, Secret, SecretHash, Side, Timestamp};
 
 lazy_static::lazy_static! {
     pub static ref SECP: ::bitcoin::secp256k1::Secp256k1<::bitcoin::secp256k1::All> =

--- a/cnd/src/proptest.rs
+++ b/cnd/src/proptest.rs
@@ -6,7 +6,7 @@
 //! `crate::identity::Bitcoin` is defined at
 //! `crate::proptest::identity::bitcoin()`.
 
-use crate::{LocalSwapId, Role, Side};
+use crate::{ethereum::ChainId, LocalSwapId, Role, Side};
 use proptest::prelude::*;
 use uuid::Uuid;
 
@@ -20,6 +20,10 @@ pub fn side() -> impl Strategy<Value = Side> {
 
 pub fn local_swap_id() -> impl Strategy<Value = LocalSwapId> {
     prop::num::u128::ANY.prop_map(|v| LocalSwapId::from(Uuid::from_u128(v)))
+}
+
+pub fn chain_id() -> impl Strategy<Value = ChainId> {
+    prop::num::u32::ANY.prop_map(ChainId::from)
 }
 
 pub mod libp2p {
@@ -141,7 +145,7 @@ pub mod herc20 {
         pub fn created_swap()(
             asset in asset::erc20(),
             identity in identity::ethereum(),
-            chain_id in any::<u32>(),
+            chain_id in chain_id(),
             absolute_expiry in any::<u32>()
         ) -> herc20::CreatedSwap {
             herc20::CreatedSwap {

--- a/cnd/src/proptest.rs
+++ b/cnd/src/proptest.rs
@@ -106,14 +106,6 @@ pub mod ledger {
     use super::*;
     use comit::ledger;
 
-    pub fn lightning() -> impl Strategy<Value = ledger::Lightning> {
-        prop_oneof![
-            Just(ledger::Lightning::Mainnet),
-            Just(ledger::Lightning::Testnet),
-            Just(ledger::Lightning::Regtest)
-        ]
-    }
-
     pub fn bitcoin() -> impl Strategy<Value = ledger::Bitcoin> {
         prop_oneof![
             Just(ledger::Bitcoin::Mainnet),
@@ -170,7 +162,7 @@ pub mod halight {
         pub fn created_swap()(
             asset in asset::bitcoin(),
             identity in identity::lightning(),
-            network in ledger::lightning(),
+            network in ledger::bitcoin(),
             cltv_expiry in any::<u32>()
         ) -> halight::CreatedSwap {
             halight::CreatedSwap {

--- a/cnd/src/storage.rs
+++ b/cnd/src/storage.rs
@@ -321,6 +321,7 @@ impl
             >::Finalized {
                 alpha_finalized: http_api::herc20::Finalized {
                     asset: herc20_asset,
+                    chain_id: herc20.chain_id.0.into(),
                     refund_identity: herc20
                         .refund_identity
                         .ok_or(db::Error::IdentityNotSet)?
@@ -336,6 +337,7 @@ impl
                 },
                 beta_finalized: http_api::halight::Finalized {
                     asset: halight_asset,
+                    network: halight.network.0.into(),
                     refund_identity: halight.refund_identity.ok_or(db::Error::IdentityNotSet)?.0,
                     redeem_identity: halight.redeem_identity.ok_or(db::Error::IdentityNotSet)?.0,
                     cltv_expiry: halight.cltv_expiry.0.into(),
@@ -417,6 +419,7 @@ impl
             >::Finalized {
                 beta_finalized: http_api::herc20::Finalized {
                     asset: herc20_asset,
+                    chain_id: herc20.chain_id.0.into(),
                     refund_identity: herc20
                         .refund_identity
                         .ok_or(db::Error::IdentityNotSet)?
@@ -432,6 +435,7 @@ impl
                 },
                 alpha_finalized: http_api::halight::Finalized {
                     asset: halight_asset,
+                    network: halight.network.0.into(),
                     refund_identity: halight.refund_identity.ok_or(db::Error::IdentityNotSet)?.0,
                     redeem_identity: halight.redeem_identity.ok_or(db::Error::IdentityNotSet)?.0,
                     cltv_expiry: halight.cltv_expiry.0.into(),
@@ -513,6 +517,7 @@ impl
             >::Finalized {
                 alpha_finalized: http_api::herc20::Finalized {
                     asset: herc20_asset,
+                    chain_id: herc20.chain_id.0.into(),
                     refund_identity: herc20
                         .refund_identity
                         .ok_or(db::Error::IdentityNotSet)?
@@ -528,6 +533,7 @@ impl
                 },
                 beta_finalized: http_api::halight::Finalized {
                     asset: halight_asset,
+                    network: halight.network.0.into(),
                     refund_identity: halight.refund_identity.ok_or(db::Error::IdentityNotSet)?.0,
                     redeem_identity: halight.redeem_identity.ok_or(db::Error::IdentityNotSet)?.0,
                     cltv_expiry: halight.cltv_expiry.0.into(),
@@ -612,6 +618,7 @@ impl
             >::Finalized {
                 alpha_finalized: http_api::halight::Finalized {
                     asset: halight_asset,
+                    network: halight.network.0.into(),
                     refund_identity: halight.refund_identity.ok_or(db::Error::IdentityNotSet)?.0,
                     redeem_identity: halight.redeem_identity.ok_or(db::Error::IdentityNotSet)?.0,
                     cltv_expiry: halight.cltv_expiry.0.into(),
@@ -619,6 +626,7 @@ impl
                 },
                 beta_finalized: http_api::herc20::Finalized {
                     asset: herc20_asset,
+                    chain_id: herc20.chain_id.0.into(),
                     refund_identity: herc20
                         .refund_identity
                         .ok_or(db::Error::IdentityNotSet)?
@@ -706,6 +714,7 @@ impl
             (Some(alpha_state), Some(beta_state)) => Ok(http_api::AliceSwap::Finalized {
                 alpha_finalized: http_api::herc20::Finalized {
                     asset: herc20_asset,
+                    chain_id: herc20.chain_id.0.into(),
                     refund_identity: herc20
                         .refund_identity
                         .ok_or(db::Error::IdentityNotSet)?
@@ -721,6 +730,7 @@ impl
                 },
                 beta_finalized: http_api::hbit::FinalizedAsRedeemer {
                     asset: hbit_asset,
+                    network: hbit.network.0.into(),
                     transient_refund_identity: hbit
                         .transient_identity
                         .ok_or(db::Error::IdentityNotSet)?
@@ -799,6 +809,7 @@ impl
             (Some(alpha_state), Some(beta_state)) => Ok(http_api::BobSwap::Finalized {
                 alpha_finalized: http_api::herc20::Finalized {
                     asset: herc20_asset,
+                    chain_id: herc20.chain_id.0.into(),
                     refund_identity: herc20
                         .refund_identity
                         .ok_or(db::Error::IdentityNotSet)?
@@ -814,6 +825,7 @@ impl
                 },
                 beta_finalized: http_api::hbit::FinalizedAsFunder {
                     asset: hbit_asset,
+                    network: hbit.network.0.into(),
                     transient_redeem_identity: hbit
                         .transient_identity
                         .ok_or(db::Error::IdentityNotSet)?
@@ -895,6 +907,7 @@ impl
             (Some(alpha_state), Some(beta_state)) => Ok(http_api::AliceSwap::Finalized {
                 alpha_finalized: http_api::hbit::FinalizedAsFunder {
                     asset: hbit_asset,
+                    network: hbit.network.0.into(),
                     transient_refund_identity: self
                         .seed
                         .derive_swap_seed(swap_id)
@@ -909,6 +922,7 @@ impl
                 },
                 beta_finalized: http_api::herc20::Finalized {
                     asset: herc20_asset,
+                    chain_id: herc20.chain_id.0.into(),
                     refund_identity: herc20
                         .refund_identity
                         .ok_or(db::Error::IdentityNotSet)?
@@ -988,6 +1002,7 @@ impl
             (Some(alpha_state), Some(beta_state)) => Ok(http_api::BobSwap::Finalized {
                 alpha_finalized: http_api::hbit::FinalizedAsRedeemer {
                     asset: hbit_asset,
+                    network: hbit.network.0.into(),
                     transient_redeem_identity: self
                         .seed
                         .derive_swap_seed(swap_id)
@@ -1002,6 +1017,7 @@ impl
                 },
                 beta_finalized: http_api::herc20::Finalized {
                     asset: herc20_asset,
+                    chain_id: herc20.chain_id.0.into(),
                     refund_identity: herc20
                         .refund_identity
                         .ok_or(db::Error::IdentityNotSet)?

--- a/comit/src/halight.rs
+++ b/comit/src/halight.rs
@@ -56,7 +56,7 @@ where
 pub struct CreatedSwap {
     pub asset: asset::Bitcoin,
     pub identity: identity::Lightning,
-    pub network: ledger::Lightning,
+    pub network: ledger::Bitcoin,
     pub cltv_expiry: u32,
 }
 

--- a/comit/src/herc20.rs
+++ b/comit/src/herc20.rs
@@ -33,7 +33,7 @@ lazy_static::lazy_static! {
 pub struct CreatedSwap {
     pub asset: asset::Erc20,
     pub identity: identity::Ethereum,
-    pub chain_id: u32,
+    pub chain_id: u32, // FIXME: Why is this not a ChainId?
     pub absolute_expiry: u32,
 }
 

--- a/comit/src/herc20.rs
+++ b/comit/src/herc20.rs
@@ -7,7 +7,7 @@ use crate::{
         ethereum::{watch_for_contract_creation, watch_for_event, ReceiptByHash, Topic},
         BlockByHash, LatestBlock,
     },
-    ethereum::{Block, Bytes, Hash, U256},
+    ethereum::{Block, Bytes, ChainId, Hash, U256},
     htlc_location, identity,
     timestamp::Timestamp,
     transaction, Secret, SecretHash,
@@ -33,7 +33,7 @@ lazy_static::lazy_static! {
 pub struct CreatedSwap {
     pub asset: asset::Erc20,
     pub identity: identity::Ethereum,
-    pub chain_id: u32, // FIXME: Why is this not a ChainId?
+    pub chain_id: ChainId,
     pub absolute_expiry: u32,
 }
 

--- a/comit/src/ledger.rs
+++ b/comit/src/ledger.rs
@@ -51,10 +51,3 @@ impl Default for Ethereum {
         }
     }
 }
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum Lightning {
-    Mainnet,
-    Testnet,
-    Regtest,
-}

--- a/comit/src/ledger.rs
+++ b/comit/src/ledger.rs
@@ -44,6 +44,12 @@ impl Ethereum {
     }
 }
 
+impl From<u32> for Ethereum {
+    fn from(chain_id: u32) -> Self {
+        Ethereum::new(chain_id.into())
+    }
+}
+
 impl Default for Ethereum {
     fn default() -> Self {
         Ethereum {


### PR DESCRIPTION
We have a bunch of places where we hard code the regtest network, for all three ledgers. We already have this network information in the database, all we need to do is expose it via the `Finalized` structs.

Add 'network' field, ether `ledger::Bitcoin` for Bitcoin and Lightning swaps or `ChainId` for Ethereum, to the `Finalized` family of structs.

Use new fields and remove hard code ledger types.

- Patch 1 is clean up; removes the `ledger::Lightning` struct.
- Patch 2 is the PR content described above.
