### PR TITLE
http_api: Remove unnecessary generics from Swap

### DIFF
--- a/cnd/src/db/integration_tests/load_protocol_combination.rs
+++ b/cnd/src/db/integration_tests/load_protocol_combination.rs
@@ -12,7 +12,7 @@ use tokio::runtime::Runtime;
 
 proptest! {
     /// Test strategy:
-    /// To be sure that Load<http_api::Swap<Protocol, Protocol>> works as expected, we insert several(!) swaps into the DB.
+    /// To be sure that Load<http_api::Swap> works as expected, we insert several(!) swaps into the DB.
     /// With only a single swap, we would not be sure that the custom SQL query actually outputs the correct combination.
     #[test]
     fn given_several_swaps_can_correctly_load_protocol_combinations(
@@ -41,10 +41,7 @@ proptest! {
     }
 }
 
-async fn save_and_load<A, B>(
-    db: &Sqlite,
-    swap: &CreatedSwap<A, B>,
-) -> http_api::Swap<Protocol, Protocol>
+async fn save_and_load<A, B>(db: &Sqlite, swap: &CreatedSwap<A, B>) -> http_api::Swap
 where
     A: Clone + IntoInsertable + Send + 'static,
     B: Clone + IntoInsertable + Send + 'static,

--- a/cnd/src/db/save_load_impls.rs
+++ b/cnd/src/db/save_load_impls.rs
@@ -51,10 +51,7 @@ where
 }
 
 impl Sqlite {
-    pub async fn load_meta_swap(
-        &self,
-        swap_id: LocalSwapId,
-    ) -> anyhow::Result<http_api::Swap<Protocol, Protocol>> {
+    pub async fn load_meta_swap(&self, swap_id: LocalSwapId) -> anyhow::Result<http_api::Swap> {
         #[derive(QueryableByName)]
         struct Result {
             #[sql_type = "sql_types::Text"]

--- a/cnd/src/http_api.rs
+++ b/cnd/src/http_api.rs
@@ -28,7 +28,7 @@ use crate::{
     ethereum::ChainId,
     htlc_location, identity,
     swap_protocols::{ledger, rfc003::SwapId, SwapProtocol},
-    transaction, Role,
+    transaction, Protocol, Role,
 };
 use libp2p::{Multiaddr, PeerId};
 use serde::{
@@ -40,11 +40,11 @@ use std::{
     str::FromStr,
 };
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct Swap<A, B> {
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Swap {
     pub role: Role,
-    pub alpha: A,
-    pub beta: B,
+    pub alpha: Protocol,
+    pub beta: Protocol,
     /* pub status: SwapStatus (if you want to have this, you need to save ledger state to the
      * database) */
 }

--- a/cnd/src/storage.rs
+++ b/cnd/src/storage.rs
@@ -65,11 +65,8 @@ impl Storage {
 }
 
 #[async_trait::async_trait]
-impl Load<http_api::Swap<comit::Protocol, comit::Protocol>> for Storage {
-    async fn load(
-        &self,
-        swap_id: LocalSwapId,
-    ) -> anyhow::Result<http_api::Swap<comit::Protocol, comit::Protocol>> {
+impl Load<http_api::Swap> for Storage {
+    async fn load(&self, swap_id: LocalSwapId) -> anyhow::Result<http_api::Swap> {
         self.db.load_meta_swap(swap_id).await
     }
 }
@@ -1221,7 +1218,7 @@ impl Load<hbit::Params> for Storage {
 #[async_trait::async_trait]
 impl Load<identity::Bitcoin> for Storage {
     async fn load(&self, swap_id: LocalSwapId) -> anyhow::Result<identity::Bitcoin> {
-        let swap: http_api::Swap<comit::Protocol, comit::Protocol> = self.load(swap_id).await?;
+        let swap: http_api::Swap = self.load(swap_id).await?;
 
         let sk = match swap {
             http_api::Swap {


### PR DESCRIPTION
We have generic types alpha/beta on the http_api `Swap` type. These
are always set to `Protocol`, therefore the generics are unnecessary.

Overly generic code is harder to reason about and maintain.

Remove unnecessary generics from `http_api::Swap<comit::Protocol,
comit::Protocol>` so we have plain old `http_api::Swap`.