### PR TITLE
Move time-related methods from cache to dedicated modules

### DIFF
--- a/comit/src/btsieve/bitcoin/cache.rs
+++ b/comit/src/btsieve/bitcoin/cache.rs
@@ -1,7 +1,4 @@
-use crate::{
-    btsieve::{BlockByHash, LatestBlock},
-    Timestamp,
-};
+use crate::btsieve::{BlockByHash, LatestBlock};
 use async_trait::async_trait;
 use bitcoin::{util::hash::BitcoinHash, Block, BlockHash as Hash, BlockHash};
 use derivative::Derivative;
@@ -70,29 +67,5 @@ where
         guard.put(block_hash, block.clone());
 
         Ok(block)
-    }
-}
-
-impl<C> Cache<C>
-where
-    C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash>,
-{
-    /// Median time past is defined as the median of the blocktimes from the
-    /// last 11 blocks.
-    pub async fn median_time_past(&self) -> anyhow::Result<Timestamp> {
-        let mut block_times = vec![];
-
-        let mut current = self.latest_block().await?;
-        block_times.push(current.header.time);
-
-        for _ in 0..10 {
-            let prev = current.header.prev_blockhash;
-            current = self.block_by_hash(prev).await?;
-            block_times.push(current.header.time);
-        }
-
-        block_times.sort();
-        let median = block_times[5];
-        Ok(Timestamp::from(median))
     }
 }

--- a/comit/src/btsieve/ethereum/cache.rs
+++ b/comit/src/btsieve/ethereum/cache.rs
@@ -4,7 +4,6 @@ use crate::{
         BlockByHash, LatestBlock,
     },
     ethereum::TransactionReceipt,
-    Timestamp,
 };
 use async_trait::async_trait;
 use derivative::Derivative;
@@ -40,17 +39,6 @@ impl<C> Cache<C> {
             block_cache,
             receipt_cache,
         }
-    }
-}
-
-impl<C> Cache<C>
-where
-    C: LatestBlock<Block = Block>,
-{
-    /// Timestamp of the latest block on the Ethereum chain.
-    pub async fn latest_timestamp(&self) -> anyhow::Result<Timestamp> {
-        let block = self.latest_block().await?;
-        Ok(block.timestamp.into())
     }
 }
 


### PR DESCRIPTION
The `Cache` components are designed to be proxies. Hence, they
must not expose any APIs other than the ones from the component
they are proxying.

We achieve that by moving the calculation of Bitcoin's median-time
to the `bitcoin` module in the `comit` crate.

For Ethereum, the impl is so trivial that we just do it inline in
the facade.