### PR TITLE
Follow-up to PR #2776

### DIFF
--- a/cnd/src/db/errors.rs
+++ b/cnd/src/db/errors.rs
@@ -33,4 +33,4 @@ pub struct NoHbitRefundIdentity(pub LocalSwapId);
 
 #[derive(thiserror::Error, Debug, Clone, Copy)]
 #[error("no hbit redeem identity found in database for swap {0}")]
-pub struct NoHbit20RedeemIdentity(pub LocalSwapId);
+pub struct NoHbitRedeemIdentity(pub LocalSwapId);

--- a/cnd/src/db/integration_tests/load_protocol_combination.rs
+++ b/cnd/src/db/integration_tests/load_protocol_combination.rs
@@ -3,9 +3,8 @@ use crate::{
         tables::{Insert, IntoInsertable},
         CreatedSwap, Save, Sqlite,
     },
-    http_api,
     proptest::*,
-    Protocol,
+    Protocol, SwapContext,
 };
 use proptest::prelude::*;
 use tokio::runtime::Runtime;
@@ -41,7 +40,7 @@ proptest! {
     }
 }
 
-async fn save_and_load<A, B>(db: &Sqlite, swap: &CreatedSwap<A, B>) -> http_api::SwapContext
+async fn save_and_load<A, B>(db: &Sqlite, swap: &CreatedSwap<A, B>) -> SwapContext
 where
     A: Clone + IntoInsertable + Send + 'static,
     B: Clone + IntoInsertable + Send + 'static,

--- a/cnd/src/db/save_load_impls.rs
+++ b/cnd/src/db/save_load_impls.rs
@@ -5,7 +5,7 @@ use crate::{
         wrapper_types::custom_sql_types::Text,
         CreatedSwap, Save, Sqlite,
     },
-    http_api, LocalSwapId, Protocol, Role, Side, SwapContext,
+    LocalSwapId, Protocol, Role, Side, SwapContext,
 };
 use anyhow::Context;
 use diesel::{sql_types, RunQueryDsl};
@@ -55,10 +55,7 @@ where
 }
 
 impl Sqlite {
-    pub async fn load_swap_context(
-        &self,
-        swap_id: LocalSwapId,
-    ) -> anyhow::Result<http_api::SwapContext> {
+    pub async fn load_swap_context(&self, swap_id: LocalSwapId) -> anyhow::Result<SwapContext> {
         #[derive(QueryableByName)]
         struct Result {
             #[sql_type = "sql_types::Text"]
@@ -98,7 +95,8 @@ impl Sqlite {
                 .get_result(connection)
         }).await.context(db::Error::SwapNotFound)?;
 
-        Ok(http_api::SwapContext {
+        Ok(SwapContext {
+            id: swap_id,
             role: role.0,
             alpha: alpha_protocol.0,
             beta: beta_protocol.0,

--- a/cnd/src/db/with_swap_types.rs
+++ b/cnd/src/db/with_swap_types.rs
@@ -22,7 +22,7 @@ macro_rules! _match_role {
 }
 
 #[macro_export]
-macro_rules! with_swap_types {
+macro_rules! rfc003_with_swap_types {
     ($swap_types:expr, $fn:expr) => {{
         use crate::{
             asset,

--- a/cnd/src/http_api.rs
+++ b/cnd/src/http_api.rs
@@ -28,7 +28,7 @@ use crate::{
     ethereum::ChainId,
     htlc_location, identity,
     swap_protocols::{ledger, rfc003::SwapId, SwapProtocol},
-    transaction, Protocol, Role,
+    transaction, Role,
 };
 use libp2p::{Multiaddr, PeerId};
 use serde::{
@@ -39,13 +39,6 @@ use std::{
     ops::Deref,
     str::FromStr,
 };
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct SwapContext {
-    pub role: Role,
-    pub alpha: Protocol,
-    pub beta: Protocol,
-}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Http<I>(pub I);

--- a/cnd/src/http_api/action.rs
+++ b/cnd/src/http_api/action.rs
@@ -277,6 +277,12 @@ impl From<ethereum::CallContract> for ActionResponseBody {
     }
 }
 
+impl From<comit::Never> for ActionResponseBody {
+    fn from(_: comit::Never) -> Self {
+        unreachable!("impl should be removed once ! type is stabilised")
+    }
+}
+
 impl ListRequiredFields for SendToAddress {
     fn list_required_fields() -> Vec<siren::Field> {
         vec![]

--- a/cnd/src/http_api/halight.rs
+++ b/cnd/src/http_api/halight.rs
@@ -1,5 +1,8 @@
-use crate::{asset, identity, RelativeTime};
-use comit::ledger;
+use crate::{
+    asset, identity, ledger,
+    lnd::{AddHoldInvoice, Chain, SendPayment, SettleInvoice},
+    RelativeTime, Secret, SecretHash,
+};
 
 pub use crate::halight::*;
 
@@ -11,4 +14,57 @@ pub struct Finalized {
     pub redeem_identity: identity::Lightning,
     pub cltv_expiry: RelativeTime,
     pub state: State,
+}
+
+impl Finalized {
+    pub fn build_init_action(&self, secret_hash: SecretHash) -> AddHoldInvoice {
+        let amount = self.asset;
+        let expiry = INVOICE_EXPIRY_SECS;
+        let cltv_expiry = self.cltv_expiry;
+        let chain = Chain::Bitcoin;
+        let network = bitcoin::Network::from(self.network);
+        let self_public_key = self.redeem_identity;
+
+        AddHoldInvoice {
+            amount,
+            secret_hash,
+            expiry,
+            cltv_expiry,
+            chain,
+            network,
+            self_public_key,
+        }
+    }
+
+    pub fn build_fund_action(&self, secret_hash: SecretHash) -> SendPayment {
+        let to_public_key = self.redeem_identity;
+        let amount = self.asset;
+        let final_cltv_delta = self.cltv_expiry;
+        let chain = Chain::Bitcoin;
+        let network = bitcoin::Network::from(self.network);
+        let self_public_key = self.refund_identity;
+
+        SendPayment {
+            to_public_key,
+            amount,
+            secret_hash,
+            final_cltv_delta,
+            chain,
+            network,
+            self_public_key,
+        }
+    }
+
+    pub fn build_redeem_action(&self, secret: Secret) -> SettleInvoice {
+        let chain = Chain::Bitcoin;
+        let network = bitcoin::Network::from(self.network);
+        let self_public_key = self.redeem_identity;
+
+        SettleInvoice {
+            secret,
+            chain,
+            network,
+            self_public_key,
+        }
+    }
 }

--- a/cnd/src/http_api/halight_herc20/bob.rs
+++ b/cnd/src/http_api/halight_herc20/bob.rs
@@ -1,21 +1,16 @@
 use crate::{
     asset,
-    ethereum::Bytes,
     http_api::{
-        halight,
-        halight::INVOICE_EXPIRY_SECS,
-        herc20,
-        herc20::build_erc20_htlc,
+        halight, herc20,
         protocol::{
             AlphaAbsoluteExpiry, AlphaEvents, AlphaLedger, AlphaParams, BetaAbsoluteExpiry,
             BetaEvents, BetaLedger, BetaParams, Halight, Herc20, Ledger, LedgerEvents,
         },
         ActionNotFound, BobSwap,
     },
-    swap_protocols::actions::{ethereum, lnd, lnd::Chain},
+    swap_protocols::actions::{ethereum, lnd},
     DeployAction, FundAction, InitAction, RedeemAction, RefundAction, Timestamp,
 };
-use blockchain_contracts::ethereum::rfc003::{Erc20Htlc, EtherHtlc};
 
 impl InitAction for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized> {
     type Output = lnd::AddHoldInvoice;
@@ -24,34 +19,17 @@ impl InitAction for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, he
         match self {
             BobSwap::Finalized {
                 alpha_finalized:
+                    halight
+                    @
                     halight::Finalized {
-                        asset: halight_asset,
-                        network,
-                        redeem_identity: halight_redeem_identity,
-                        cltv_expiry,
                         state: halight::State::None,
                         ..
                     },
                 secret_hash,
                 ..
             } => {
-                let amount = *halight_asset;
-                let secret_hash = *secret_hash;
-                let expiry = INVOICE_EXPIRY_SECS;
-                let cltv_expiry = *cltv_expiry;
-                let chain = Chain::Bitcoin;
-                let network = bitcoin::Network::from(*network);
-                let self_public_key = *halight_redeem_identity;
-
-                Ok(lnd::AddHoldInvoice {
-                    amount,
-                    secret_hash,
-                    expiry,
-                    cltv_expiry,
-                    chain,
-                    network,
-                    self_public_key,
-                })
+                let init_action = halight.build_init_action(*secret_hash);
+                Ok(init_action)
             }
             _ => anyhow::bail!(ActionNotFound),
         }
@@ -70,33 +48,17 @@ impl DeployAction for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, 
                         ..
                     },
                 beta_finalized:
+                    herc20
+                    @
                     herc20::Finalized {
-                        asset: herc20_asset,
-                        chain_id,
-                        refund_identity: herc20_refund_identity,
-                        redeem_identity: herc20_redeem_identity,
-                        expiry: herc20_expiry,
                         state: herc20::State::None,
                         ..
                     },
                 secret_hash,
                 ..
             } => {
-                let htlc = build_erc20_htlc(
-                    herc20_asset.clone(),
-                    *herc20_redeem_identity,
-                    *herc20_refund_identity,
-                    *herc20_expiry,
-                    *secret_hash,
-                );
-                let gas_limit = Erc20Htlc::deploy_tx_gas_limit();
-
-                Ok(ethereum::DeployContract {
-                    data: htlc.into(),
-                    amount: asset::Ether::zero(),
-                    gas_limit,
-                    chain_id: *chain_id,
-                })
+                let deploy_action = herc20.build_deploy_action(*secret_hash);
+                Ok(deploy_action)
             }
             _ => anyhow::bail!(ActionNotFound),
         }
@@ -115,33 +77,16 @@ impl FundAction for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, he
                         ..
                     },
                 beta_finalized:
+                    herc20
+                    @
                     herc20::Finalized {
-                        asset: herc20_asset,
-                        chain_id,
-                        state: herc20::State::Deployed { htlc_location, .. },
+                        state: herc20::State::Deployed { .. },
                         ..
                     },
                 ..
             } => {
-                let herc20_asset = herc20_asset.clone();
-                let to = herc20_asset.token_contract;
-                let htlc_address = blockchain_contracts::ethereum::Address((*htlc_location).into());
-                let data = Erc20Htlc::transfer_erc20_tx_payload(
-                    herc20_asset.quantity.into(),
-                    htlc_address,
-                );
-                let data = Some(Bytes(data));
-
-                let gas_limit = Erc20Htlc::fund_tx_gas_limit();
-                let min_block_timestamp = None;
-
-                Ok(ethereum::CallContract {
-                    to,
-                    data,
-                    gas_limit,
-                    chain_id: *chain_id,
-                    min_block_timestamp,
-                })
+                let fund_action = herc20.build_fund_action()?;
+                Ok(fund_action)
             }
             _ => anyhow::bail!(ActionNotFound),
         }
@@ -155,9 +100,9 @@ impl RedeemAction for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, 
         match self {
             BobSwap::Finalized {
                 alpha_finalized:
+                    halight
+                    @
                     halight::Finalized {
-                        network,
-                        redeem_identity: halight_redeem_identity,
                         state: halight::State::Accepted(_),
                         ..
                     },
@@ -168,17 +113,8 @@ impl RedeemAction for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, 
                     },
                 ..
             } => {
-                let secret = *secret;
-                let chain = Chain::Bitcoin;
-                let network = bitcoin::Network::from(*network);
-                let self_public_key = *halight_redeem_identity;
-
-                Ok(lnd::SettleInvoice {
-                    secret,
-                    chain,
-                    network,
-                    self_public_key,
-                })
+                let redeem_action = halight.build_redeem_action(*secret);
+                Ok(redeem_action)
             }
             _ => anyhow::bail!(ActionNotFound),
         }
@@ -197,26 +133,16 @@ impl RefundAction for BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, 
                         ..
                     },
                 beta_finalized:
+                    herc20
+                    @
                     herc20::Finalized {
-                        chain_id,
-                        expiry: herc20_expiry,
-                        state: herc20::State::Funded { htlc_location, .. },
+                        state: herc20::State::Funded { .. },
                         ..
                     },
                 ..
             } => {
-                let to = *htlc_location;
-                let data = None;
-                let gas_limit = EtherHtlc::refund_tx_gas_limit();
-                let min_block_timestamp = Some(*herc20_expiry);
-
-                Ok(ethereum::CallContract {
-                    to,
-                    data,
-                    gas_limit,
-                    chain_id: *chain_id,
-                    min_block_timestamp,
-                })
+                let refund_action = herc20.build_refund_action()?;
+                Ok(refund_action)
             }
             _ => anyhow::bail!(ActionNotFound),
         }

--- a/cnd/src/http_api/hbit.rs
+++ b/cnd/src/http_api/hbit.rs
@@ -1,7 +1,7 @@
+use bitcoin::secp256k1::SecretKey;
 use comit::{asset, ledger, Timestamp};
 
 pub use crate::hbit::*;
-use bitcoin::secp256k1::SecretKey;
 
 #[derive(Clone, Debug)]
 pub struct FinalizedAsFunder {

--- a/cnd/src/http_api/hbit.rs
+++ b/cnd/src/http_api/hbit.rs
@@ -3,6 +3,16 @@ use comit::{asset, ledger, Timestamp};
 
 pub use crate::hbit::*;
 
+/// Data known by the party funding the HTLC in the Hbit protocol, after the
+/// swap has been finalized.
+///
+/// The funder of the HTLC knows the following identities:
+/// - `transient_redeem_identity`: the public identity of the redeemer.
+/// - `transient_refund_identity`: their own secret identity, from which their
+///   public identity can be derived, and which can be used to produce a
+///   signature that will enable the refund action.
+/// -`final_refund_identity`: the address where the HTLC funds will go if the
+///   refund action is executed.
 #[derive(Clone, Debug)]
 pub struct FinalizedAsFunder {
     pub asset: asset::Bitcoin,
@@ -14,6 +24,16 @@ pub struct FinalizedAsFunder {
     pub state: State,
 }
 
+/// Data known by the party redeeming the HTLC in the Hbit protocol, after the
+/// swap has been finalized.
+///
+/// The redeemer of the HTLC knows the following identities:
+/// - `transient_refund_identity`: the public identity of the funder.
+/// - `transient_redeem_identity`: their own secret identity, from which their
+///   public identity can be derived, and which can be used to produce a
+///   signature that will enable the redeem action.
+/// -`final_refund_identity`: the address where the HTLC funds will go if the
+///   redeem action is executed.
 #[derive(Clone, Debug)]
 pub struct FinalizedAsRedeemer {
     pub asset: asset::Bitcoin,

--- a/cnd/src/http_api/hbit.rs
+++ b/cnd/src/http_api/hbit.rs
@@ -1,7 +1,10 @@
 use bitcoin::secp256k1::SecretKey;
-use comit::{asset, ledger, Timestamp};
+use comit::{
+    actions::bitcoin::{BroadcastSignedTransaction, SendToAddress, SpendOutput},
+    asset, ledger, Secret, SecretHash, Timestamp,
+};
 
-pub use crate::hbit::*;
+pub use crate::{actions::bitcoin::sign_with_fixed_rate, hbit::*};
 
 /// Data known by the party funding the HTLC in the Hbit protocol, after the
 /// swap has been finalized.
@@ -43,4 +46,119 @@ pub struct FinalizedAsRedeemer {
     pub transient_refund_identity: identity::Bitcoin,
     pub expiry: Timestamp,
     pub state: State,
+}
+
+impl FinalizedAsFunder {
+    pub fn build_fund_action(&self, secret_hash: SecretHash) -> SendToAddress {
+        let transient_refund_sk = self.transient_refund_identity;
+        let transient_refund_identity =
+            identity::Bitcoin::from_secret_key(&*crate::SECP, &transient_refund_sk);
+        let htlc = build_bitcoin_htlc(
+            self.transient_redeem_identity,
+            transient_refund_identity,
+            self.expiry,
+            secret_hash,
+        );
+        let network = bitcoin::Network::from(self.network);
+        let to = htlc.compute_address(network);
+        let amount = self.asset;
+
+        SendToAddress {
+            to,
+            amount,
+            network,
+        }
+    }
+
+    pub fn build_refund_action(
+        &self,
+        secret_hash: SecretHash,
+    ) -> anyhow::Result<BroadcastSignedTransaction> {
+        let (htlc_location, fund_transaction) = match &self.state {
+            State::Funded {
+                htlc_location,
+                fund_transaction,
+                ..
+            } => (htlc_location, fund_transaction),
+            _ => anyhow::bail!("incorrect state"),
+        };
+
+        let network = bitcoin::Network::from(self.network);
+        let spend_output = {
+            let transient_refund_sk = self.transient_refund_identity;
+            let transient_refund_identity =
+                identity::Bitcoin::from_secret_key(&*crate::SECP, &transient_refund_sk);
+            let htlc = build_bitcoin_htlc(
+                self.transient_redeem_identity,
+                transient_refund_identity,
+                self.expiry,
+                secret_hash,
+            );
+
+            let previous_output = htlc_location;
+            let value = bitcoin::Amount::from_sat(
+                fund_transaction.output[htlc_location.vout as usize].value,
+            );
+            let input_parameters = htlc.unlock_after_timeout(&*crate::SECP, transient_refund_sk);
+
+            SpendOutput::new(*previous_output, value, input_parameters, network)
+        };
+
+        let primed_transaction = spend_output.spend_to(self.final_refund_identity.clone().into());
+        let transaction = sign_with_fixed_rate(&*crate::SECP, primed_transaction)?;
+
+        Ok(BroadcastSignedTransaction {
+            transaction,
+            network,
+        })
+    }
+}
+
+impl FinalizedAsRedeemer {
+    pub fn build_redeem_action(
+        &self,
+        secret: Secret,
+    ) -> anyhow::Result<BroadcastSignedTransaction> {
+        let (htlc_location, fund_transaction) = match &self.state {
+            State::Funded {
+                htlc_location,
+                fund_transaction,
+                ..
+            } => (htlc_location, fund_transaction),
+            _ => anyhow::bail!("incorrect state"),
+        };
+
+        let network = bitcoin::Network::from(self.network);
+        let spend_output = {
+            let transient_redeem_sk = self.transient_redeem_identity;
+            let transient_redeem_identity =
+                identity::Bitcoin::from_secret_key(&*crate::SECP, &transient_redeem_sk);
+            let htlc = build_bitcoin_htlc(
+                transient_redeem_identity,
+                self.transient_refund_identity,
+                self.expiry,
+                SecretHash::new(secret),
+            );
+
+            let previous_output = htlc_location;
+            let value = bitcoin::Amount::from_sat(
+                fund_transaction.output[htlc_location.vout as usize].value,
+            );
+            let input_parameters = htlc.unlock_with_secret(
+                &*crate::SECP,
+                transient_redeem_sk,
+                secret.into_raw_secret(),
+            );
+
+            SpendOutput::new(*previous_output, value, input_parameters, network)
+        };
+
+        let primed_transaction = spend_output.spend_to(self.final_redeem_identity.clone().into());
+        let transaction = sign_with_fixed_rate(&*crate::SECP, primed_transaction)?;
+
+        Ok(BroadcastSignedTransaction {
+            transaction,
+            network,
+        })
+    }
 }

--- a/cnd/src/http_api/hbit_herc20/alice.rs
+++ b/cnd/src/http_api/hbit_herc20/alice.rs
@@ -1,7 +1,5 @@
 use crate::{
-    actions::bitcoin::{
-        sign_with_fixed_rate, BroadcastSignedTransaction, SendToAddress, SpendOutput,
-    },
+    actions::bitcoin::{BroadcastSignedTransaction, SendToAddress},
     http_api::{
         hbit, herc20,
         protocol::{
@@ -10,12 +8,9 @@ use crate::{
         },
         ActionNotFound, AliceSwap,
     },
-    identity, DeployAction, FundAction, InitAction, RedeemAction, RefundAction, Timestamp,
+    DeployAction, FundAction, InitAction, RedeemAction, RefundAction, Timestamp,
 };
-use blockchain_contracts::ethereum::rfc003::EtherHtlc;
-use comit::{
-    actions::ethereum, asset, ethereum::Bytes, hbit::build_bitcoin_htlc, Never, SecretHash,
-};
+use comit::{actions::ethereum, asset, Never, SecretHash};
 
 impl FundAction
     for AliceSwap<asset::Bitcoin, asset::Erc20, hbit::FinalizedAsFunder, herc20::Finalized>
@@ -26,35 +21,18 @@ impl FundAction
         match self {
             AliceSwap::Finalized {
                 alpha_finalized:
+                    hbit
+                    @
                     hbit::FinalizedAsFunder {
-                        asset,
-                        network,
-                        transient_redeem_identity: redeem_identity,
-                        transient_refund_identity: transient_refund_sk,
-                        expiry,
                         state: hbit::State::None,
                         ..
                     },
                 secret,
                 ..
             } => {
-                let refund_identity =
-                    identity::Bitcoin::from_secret_key(&*crate::SECP, &transient_refund_sk);
-                let htlc = build_bitcoin_htlc(
-                    *redeem_identity,
-                    refund_identity,
-                    *expiry,
-                    SecretHash::new(*secret),
-                );
-                let network = bitcoin::Network::from(*network);
-                let to = htlc.compute_address(network);
-                let amount = *asset;
-
-                Ok(SendToAddress {
-                    to,
-                    amount,
-                    network,
-                })
+                let secret_hash = SecretHash::new(*secret);
+                let fund_action = hbit.build_fund_action(secret_hash);
+                Ok(fund_action)
             }
             _ => anyhow::bail!(ActionNotFound),
         }
@@ -70,26 +48,17 @@ impl RedeemAction
         match self {
             AliceSwap::Finalized {
                 beta_finalized:
+                    herc20
+                    @
                     herc20::Finalized {
-                        chain_id,
-                        state: herc20::State::Funded { htlc_location, .. },
+                        state: herc20::State::Funded { .. },
                         ..
                     },
                 secret,
                 ..
             } => {
-                let to = *htlc_location;
-                let data = Some(Bytes::from(secret.into_raw_secret().to_vec()));
-                let gas_limit = EtherHtlc::redeem_tx_gas_limit();
-                let min_block_timestamp = None;
-
-                Ok(ethereum::CallContract {
-                    to,
-                    data,
-                    gas_limit,
-                    chain_id: *chain_id,
-                    min_block_timestamp,
-                })
+                let redeem_action = herc20.build_redeem_action(*secret)?;
+                Ok(redeem_action)
             }
             _ => anyhow::bail!(ActionNotFound),
         }
@@ -105,52 +74,18 @@ impl RefundAction
         match self {
             AliceSwap::Finalized {
                 alpha_finalized:
+                    hbit
+                    @
                     hbit::FinalizedAsFunder {
-                        network,
-                        transient_redeem_identity,
-                        transient_refund_identity: transient_refund_sk,
-                        final_refund_identity,
-                        expiry,
-                        state:
-                            hbit::State::Funded {
-                                htlc_location,
-                                fund_transaction,
-                                ..
-                            },
+                        state: hbit::State::Funded { .. },
                         ..
                     },
                 secret,
                 ..
             } => {
-                let network = bitcoin::Network::from(*network);
-                let spend_output = {
-                    let transient_refund_identity =
-                        identity::Bitcoin::from_secret_key(&*crate::SECP, &transient_refund_sk);
-                    let htlc = build_bitcoin_htlc(
-                        *transient_redeem_identity,
-                        transient_refund_identity,
-                        *expiry,
-                        SecretHash::new(*secret),
-                    );
-
-                    let previous_output = *htlc_location;
-                    let value = bitcoin::Amount::from_sat(
-                        fund_transaction.output[htlc_location.vout as usize].value,
-                    );
-                    let input_parameters =
-                        htlc.unlock_after_timeout(&*crate::SECP, *transient_refund_sk);
-
-                    SpendOutput::new(previous_output, value, input_parameters, network)
-                };
-
-                let primed_transaction =
-                    spend_output.spend_to(final_refund_identity.clone().into());
-                let transaction = sign_with_fixed_rate(&*crate::SECP, primed_transaction)?;
-
-                Ok(BroadcastSignedTransaction {
-                    transaction,
-                    network,
-                })
+                let secret_hash = SecretHash::new(*secret);
+                let refund_action = hbit.build_refund_action(secret_hash)?;
+                Ok(refund_action)
             }
             _ => anyhow::bail!(ActionNotFound),
         }

--- a/cnd/src/http_api/hbit_herc20/bob.rs
+++ b/cnd/src/http_api/hbit_herc20/bob.rs
@@ -1,18 +1,16 @@
 use crate::{
-    actions::bitcoin::{sign_with_fixed_rate, BroadcastSignedTransaction, SpendOutput},
+    actions::bitcoin::BroadcastSignedTransaction,
     http_api::{
         hbit, herc20,
-        herc20::build_erc20_htlc,
         protocol::{
             AlphaAbsoluteExpiry, AlphaEvents, AlphaLedger, AlphaParams, BetaAbsoluteExpiry,
             BetaEvents, BetaLedger, BetaParams, Hbit, Herc20, Ledger, LedgerEvents,
         },
         ActionNotFound, BobSwap,
     },
-    identity, DeployAction, FundAction, InitAction, RedeemAction, RefundAction, Timestamp,
+    DeployAction, FundAction, InitAction, RedeemAction, RefundAction, Timestamp,
 };
-use blockchain_contracts::ethereum::rfc003::{Erc20Htlc, EtherHtlc};
-use comit::{actions::ethereum, asset, ethereum::Bytes, hbit::build_bitcoin_htlc, Never};
+use comit::{actions::ethereum, asset, Never};
 
 impl DeployAction
     for BobSwap<asset::Bitcoin, asset::Erc20, hbit::FinalizedAsRedeemer, herc20::Finalized>
@@ -28,32 +26,17 @@ impl DeployAction
                         ..
                     },
                 beta_finalized:
+                    herc20
+                    @
                     herc20::Finalized {
-                        asset: herc20_asset,
-                        chain_id,
-                        refund_identity: herc20_refund_identity,
-                        redeem_identity: herc20_redeem_identity,
-                        expiry: herc20_expiry,
                         state: herc20::State::None,
+                        ..
                     },
                 secret_hash,
                 ..
             } => {
-                let htlc = build_erc20_htlc(
-                    herc20_asset.clone(),
-                    *herc20_redeem_identity,
-                    *herc20_refund_identity,
-                    *herc20_expiry,
-                    *secret_hash,
-                );
-                let gas_limit = Erc20Htlc::deploy_tx_gas_limit();
-
-                Ok(ethereum::DeployContract {
-                    data: htlc.into(),
-                    amount: asset::Ether::zero(),
-                    gas_limit,
-                    chain_id: *chain_id,
-                })
+                let deploy_action = herc20.build_deploy_action(*secret_hash);
+                Ok(deploy_action)
             }
             _ => anyhow::bail!(ActionNotFound),
         }
@@ -74,33 +57,16 @@ impl FundAction
                         ..
                     },
                 beta_finalized:
+                    herc20
+                    @
                     herc20::Finalized {
-                        asset: herc20_asset,
-                        chain_id,
-                        state: herc20::State::Deployed { htlc_location, .. },
+                        state: herc20::State::Deployed { .. },
                         ..
                     },
                 ..
             } => {
-                let herc20_asset = herc20_asset.clone();
-                let to = herc20_asset.token_contract;
-                let htlc_address = blockchain_contracts::ethereum::Address((*htlc_location).into());
-                let data = Erc20Htlc::transfer_erc20_tx_payload(
-                    herc20_asset.quantity.into(),
-                    htlc_address,
-                );
-                let data = Some(Bytes(data));
-
-                let gas_limit = Erc20Htlc::fund_tx_gas_limit();
-                let min_block_timestamp = None;
-
-                Ok(ethereum::CallContract {
-                    to,
-                    data,
-                    gas_limit,
-                    chain_id: *chain_id,
-                    min_block_timestamp,
-                })
+                let fund_action = herc20.build_fund_action()?;
+                Ok(fund_action)
             }
             _ => anyhow::bail!(ActionNotFound),
         }
@@ -116,18 +82,10 @@ impl RedeemAction
         match self {
             BobSwap::Finalized {
                 alpha_finalized:
+                    hbit
+                    @
                     hbit::FinalizedAsRedeemer {
-                        network,
-                        final_redeem_identity,
-                        transient_redeem_identity: transient_redeem_sk,
-                        transient_refund_identity,
-                        expiry,
-                        state:
-                            hbit::State::Funded {
-                                htlc_location,
-                                fund_transaction,
-                                ..
-                            },
+                        state: hbit::State::Funded { .. },
                         ..
                     },
                 beta_finalized:
@@ -135,41 +93,10 @@ impl RedeemAction
                         state: herc20::State::Redeemed { secret, .. },
                         ..
                     },
-                secret_hash,
                 ..
             } => {
-                let network = bitcoin::Network::from(*network);
-                let spend_output = {
-                    let transient_redeem_identity =
-                        identity::Bitcoin::from_secret_key(&*crate::SECP, &transient_redeem_sk);
-                    let htlc = build_bitcoin_htlc(
-                        transient_redeem_identity,
-                        *transient_refund_identity,
-                        *expiry,
-                        *secret_hash,
-                    );
-
-                    let previous_output = *htlc_location;
-                    let value = bitcoin::Amount::from_sat(
-                        fund_transaction.output[htlc_location.vout as usize].value,
-                    );
-                    let input_parameters = htlc.unlock_with_secret(
-                        &*crate::SECP,
-                        *transient_redeem_sk,
-                        secret.into_raw_secret(),
-                    );
-
-                    SpendOutput::new(previous_output, value, input_parameters, network)
-                };
-
-                let primed_transaction =
-                    spend_output.spend_to(final_redeem_identity.clone().into());
-                let transaction = sign_with_fixed_rate(&*crate::SECP, primed_transaction)?;
-
-                Ok(BroadcastSignedTransaction {
-                    transaction,
-                    network,
-                })
+                let redeem_action = hbit.build_redeem_action(*secret)?;
+                Ok(redeem_action)
             }
             _ => anyhow::bail!(ActionNotFound),
         }
@@ -185,26 +112,16 @@ impl RefundAction
         match self {
             BobSwap::Finalized {
                 beta_finalized:
+                    herc20
+                    @
                     herc20::Finalized {
-                        chain_id,
-                        expiry: herc20_expiry,
-                        state: herc20::State::Funded { htlc_location, .. },
+                        state: herc20::State::Funded { .. },
                         ..
                     },
                 ..
             } => {
-                let to = *htlc_location;
-                let data = None;
-                let gas_limit = EtherHtlc::refund_tx_gas_limit();
-                let min_block_timestamp = Some(*herc20_expiry);
-
-                Ok(ethereum::CallContract {
-                    to,
-                    data,
-                    gas_limit,
-                    chain_id: *chain_id,
-                    min_block_timestamp,
-                })
+                let refund_action = herc20.build_refund_action()?;
+                Ok(refund_action)
             }
             _ => anyhow::bail!(ActionNotFound),
         }

--- a/cnd/src/http_api/herc20.rs
+++ b/cnd/src/http_api/herc20.rs
@@ -1,4 +1,10 @@
-use crate::{asset, ethereum::ChainId, identity, Timestamp};
+use crate::{
+    actions::ethereum::{CallContract, DeployContract},
+    asset,
+    ethereum::{Bytes, ChainId},
+    identity, Secret, SecretHash, Timestamp,
+};
+use blockchain_contracts::ethereum::rfc003::{Erc20Htlc, EtherHtlc};
 
 pub use crate::herc20::*;
 
@@ -10,4 +16,84 @@ pub struct Finalized {
     pub redeem_identity: identity::Ethereum,
     pub expiry: Timestamp,
     pub state: State,
+}
+
+impl Finalized {
+    pub fn build_deploy_action(&self, secret_hash: SecretHash) -> DeployContract {
+        let htlc = build_erc20_htlc(
+            self.asset.clone(),
+            self.redeem_identity,
+            self.refund_identity,
+            self.expiry,
+            secret_hash,
+        );
+        let gas_limit = Erc20Htlc::deploy_tx_gas_limit();
+
+        DeployContract {
+            data: htlc.into(),
+            amount: asset::Ether::zero(),
+            gas_limit,
+            chain_id: self.chain_id,
+        }
+    }
+
+    pub fn build_fund_action(&self) -> anyhow::Result<CallContract> {
+        let htlc_location = match self.state {
+            State::Deployed { htlc_location, .. } => htlc_location,
+            _ => anyhow::bail!("incorrect state"),
+        };
+
+        let to = self.asset.token_contract;
+        let htlc_address = blockchain_contracts::ethereum::Address(htlc_location.into());
+        let data =
+            Erc20Htlc::transfer_erc20_tx_payload(self.asset.clone().quantity.into(), htlc_address);
+        let data = Some(Bytes(data));
+
+        let gas_limit = Erc20Htlc::fund_tx_gas_limit();
+        let min_block_timestamp = None;
+
+        Ok(CallContract {
+            to,
+            data,
+            gas_limit,
+            chain_id: self.chain_id,
+            min_block_timestamp,
+        })
+    }
+
+    pub fn build_refund_action(&self) -> anyhow::Result<CallContract> {
+        let to = match self.state {
+            State::Funded { htlc_location, .. } => htlc_location,
+            _ => anyhow::bail!("incorrect state"),
+        };
+        let data = None;
+        let gas_limit = EtherHtlc::refund_tx_gas_limit();
+        let min_block_timestamp = Some(self.expiry);
+
+        Ok(CallContract {
+            to,
+            data,
+            gas_limit,
+            chain_id: self.chain_id,
+            min_block_timestamp,
+        })
+    }
+
+    pub fn build_redeem_action(&self, secret: Secret) -> anyhow::Result<CallContract> {
+        let to = match self.state {
+            State::Funded { htlc_location, .. } => htlc_location,
+            _ => anyhow::bail!("incorrect state"),
+        };
+        let data = Some(Bytes::from(secret.into_raw_secret().to_vec()));
+        let gas_limit = EtherHtlc::redeem_tx_gas_limit();
+        let min_block_timestamp = None;
+
+        Ok(CallContract {
+            to,
+            data,
+            gas_limit,
+            chain_id: self.chain_id,
+            min_block_timestamp,
+        })
+    }
 }

--- a/cnd/src/http_api/herc20_halight/alice.rs
+++ b/cnd/src/http_api/herc20_halight/alice.rs
@@ -275,11 +275,11 @@ impl AlphaAbsoluteExpiry
 {
     fn alpha_absolute_expiry(&self) -> Option<Timestamp> {
         match self {
-            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Created { .. } => None,
-            AliceSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
+            AliceSwap::Created { .. } => None,
+            AliceSwap::Finalized {
                 alpha_finalized: herc20::Finalized { expiry, .. },
                 ..
-            } => Some(*expiry)
+            } => Some(*expiry),
         }
     }
 }

--- a/cnd/src/http_api/herc20_halight/bob.rs
+++ b/cnd/src/http_api/herc20_halight/bob.rs
@@ -198,11 +198,11 @@ impl AlphaAbsoluteExpiry
 {
     fn alpha_absolute_expiry(&self) -> Option<Timestamp> {
         match self {
-            BobSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Created { .. } => None,
-            BobSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>::Finalized {
+            BobSwap::Created { .. } => None,
+            BobSwap::Finalized {
                 alpha_finalized: herc20::Finalized { expiry, .. },
                 ..
-            } => Some(*expiry)
+            } => Some(*expiry),
         }
     }
 }

--- a/cnd/src/http_api/herc20_hbit/alice.rs
+++ b/cnd/src/http_api/herc20_hbit/alice.rs
@@ -263,20 +263,8 @@ impl AlphaAbsoluteExpiry
 {
     fn alpha_absolute_expiry(&self) -> Option<Timestamp> {
         match self {
-            AliceSwap::<
-                asset::Erc20,
-                asset::Bitcoin,
-                herc20::Finalized,
-                hbit::FinalizedAsRedeemer,
-            >::Created {
-                ..
-            } => None,
-            AliceSwap::<
-                asset::Erc20,
-                asset::Bitcoin,
-                herc20::Finalized,
-                hbit::FinalizedAsRedeemer,
-            >::Finalized {
+            AliceSwap::Created { .. } => None,
+            AliceSwap::Finalized {
                 alpha_finalized: herc20::Finalized { expiry, .. },
                 ..
             } => Some(*expiry),
@@ -289,20 +277,8 @@ impl BetaAbsoluteExpiry
 {
     fn beta_absolute_expiry(&self) -> Option<Timestamp> {
         match self {
-            AliceSwap::<
-                asset::Erc20,
-                asset::Bitcoin,
-                herc20::Finalized,
-                hbit::FinalizedAsRedeemer,
-            >::Created {
-                ..
-            } => None,
-            AliceSwap::<
-                asset::Erc20,
-                asset::Bitcoin,
-                herc20::Finalized,
-                hbit::FinalizedAsRedeemer,
-            >::Finalized {
+            AliceSwap::Created { .. } => None,
+            AliceSwap::Finalized {
                 beta_finalized: hbit::FinalizedAsRedeemer { expiry, .. },
                 ..
             } => Some(*expiry),

--- a/cnd/src/http_api/herc20_hbit/alice.rs
+++ b/cnd/src/http_api/herc20_hbit/alice.rs
@@ -1,20 +1,16 @@
 use crate::{
-    actions::bitcoin::{sign_with_fixed_rate, BroadcastSignedTransaction, SpendOutput},
+    actions::bitcoin::BroadcastSignedTransaction,
     http_api::{
         hbit, herc20,
-        herc20::build_erc20_htlc,
         protocol::{
             AlphaAbsoluteExpiry, AlphaEvents, AlphaLedger, AlphaParams, BetaAbsoluteExpiry,
             BetaEvents, BetaLedger, BetaParams, Hbit, Herc20, Ledger, LedgerEvents,
         },
         ActionNotFound, AliceSwap,
     },
-    identity, DeployAction, FundAction, InitAction, RedeemAction, RefundAction, Timestamp,
+    DeployAction, FundAction, InitAction, RedeemAction, RefundAction, Timestamp,
 };
-use blockchain_contracts::ethereum::rfc003::{Erc20Htlc, EtherHtlc};
-use comit::{
-    actions::ethereum, asset, ethereum::Bytes, hbit::build_bitcoin_htlc, Never, SecretHash,
-};
+use comit::{actions::ethereum, asset, Never, SecretHash};
 
 impl DeployAction
     for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, hbit::FinalizedAsRedeemer>
@@ -25,13 +21,10 @@ impl DeployAction
         match self {
             AliceSwap::Finalized {
                 alpha_finalized:
+                    herc20
+                    @
                     herc20::Finalized {
                         state: herc20::State::None,
-                        asset: herc20_asset,
-                        chain_id,
-                        refund_identity: herc20_refund_identity,
-                        redeem_identity: herc20_redeem_identity,
-                        expiry: herc20_expiry,
                         ..
                     },
                 beta_finalized:
@@ -42,21 +35,9 @@ impl DeployAction
                 secret,
                 ..
             } => {
-                let htlc = build_erc20_htlc(
-                    herc20_asset.clone(),
-                    *herc20_redeem_identity,
-                    *herc20_refund_identity,
-                    *herc20_expiry,
-                    SecretHash::new(*secret),
-                );
-                let gas_limit = Erc20Htlc::deploy_tx_gas_limit();
-
-                Ok(ethereum::DeployContract {
-                    data: htlc.into(),
-                    amount: asset::Ether::zero(),
-                    gas_limit,
-                    chain_id: *chain_id,
-                })
+                let secret_hash = SecretHash::new(*secret);
+                let deploy_action = herc20.build_deploy_action(secret_hash);
+                Ok(deploy_action)
             }
             _ => anyhow::bail!(ActionNotFound),
         }
@@ -72,10 +53,10 @@ impl FundAction
         match self {
             AliceSwap::Finalized {
                 alpha_finalized:
+                    herc20
+                    @
                     herc20::Finalized {
-                        state: herc20::State::Deployed { htlc_location, .. },
-                        asset: herc20_asset,
-                        chain_id,
+                        state: herc20::State::Deployed { .. },
                         ..
                     },
                 beta_finalized:
@@ -85,25 +66,8 @@ impl FundAction
                     },
                 ..
             } => {
-                let herc20_asset = herc20_asset.clone();
-                let to = herc20_asset.token_contract;
-                let htlc_address = blockchain_contracts::ethereum::Address((*htlc_location).into());
-                let data = Erc20Htlc::transfer_erc20_tx_payload(
-                    herc20_asset.quantity.into(),
-                    htlc_address,
-                );
-                let data = Some(Bytes(data));
-
-                let gas_limit = Erc20Htlc::fund_tx_gas_limit();
-                let min_block_timestamp = None;
-
-                Ok(ethereum::CallContract {
-                    to,
-                    data,
-                    gas_limit,
-                    chain_id: *chain_id,
-                    min_block_timestamp,
-                })
+                let fund_action = herc20.build_fund_action()?;
+                Ok(fund_action)
             }
             _ => anyhow::bail!(ActionNotFound),
         }
@@ -119,55 +83,17 @@ impl RedeemAction
         match self {
             AliceSwap::Finalized {
                 beta_finalized:
+                    hbit
+                    @
                     hbit::FinalizedAsRedeemer {
-                        network,
-                        final_redeem_identity,
-                        transient_redeem_identity: transient_redeem_sk,
-                        transient_refund_identity,
-                        expiry,
-                        state:
-                            hbit::State::Funded {
-                                htlc_location,
-                                fund_transaction,
-                                ..
-                            },
+                        state: hbit::State::Funded { .. },
                         ..
                     },
                 secret,
                 ..
             } => {
-                let network = bitcoin::Network::from(*network);
-                let spend_output = {
-                    let transient_redeem_identity =
-                        identity::Bitcoin::from_secret_key(&*crate::SECP, &transient_redeem_sk);
-                    let htlc = build_bitcoin_htlc(
-                        transient_redeem_identity,
-                        *transient_refund_identity,
-                        *expiry,
-                        SecretHash::new(*secret),
-                    );
-
-                    let previous_output = *htlc_location;
-                    let value = bitcoin::Amount::from_sat(
-                        fund_transaction.output[htlc_location.vout as usize].value,
-                    );
-                    let input_parameters = htlc.unlock_with_secret(
-                        &*crate::SECP,
-                        *transient_redeem_sk,
-                        secret.into_raw_secret(),
-                    );
-
-                    SpendOutput::new(previous_output, value, input_parameters, network)
-                };
-
-                let primed_transaction =
-                    spend_output.spend_to(final_redeem_identity.clone().into());
-                let transaction = sign_with_fixed_rate(&*crate::SECP, primed_transaction)?;
-
-                Ok(BroadcastSignedTransaction {
-                    transaction,
-                    network,
-                })
+                let redeem_action = hbit.build_redeem_action(*secret)?;
+                Ok(redeem_action)
             }
             _ => anyhow::bail!(ActionNotFound),
         }
@@ -183,27 +109,17 @@ impl RefundAction
         match self {
             AliceSwap::Finalized {
                 alpha_finalized:
+                    herc20
+                    @
                     herc20::Finalized {
-                        state: herc20::State::Funded { htlc_location, .. },
-                        expiry: herc20_expiry,
-                        chain_id,
+                        state: herc20::State::Funded { .. },
                         ..
                     },
                 beta_finalized: hbit::FinalizedAsRedeemer { .. },
                 ..
             } => {
-                let to = *htlc_location;
-                let data = None;
-                let gas_limit = EtherHtlc::refund_tx_gas_limit();
-                let min_block_timestamp = Some(*herc20_expiry);
-
-                Ok(ethereum::CallContract {
-                    to,
-                    data,
-                    gas_limit,
-                    chain_id: *chain_id,
-                    min_block_timestamp,
-                })
+                let refund_action = herc20.build_refund_action()?;
+                Ok(refund_action)
             }
             _ => anyhow::bail!(ActionNotFound),
         }

--- a/cnd/src/http_api/herc20_hbit/bob.rs
+++ b/cnd/src/http_api/herc20_hbit/bob.rs
@@ -235,11 +235,11 @@ impl AlphaAbsoluteExpiry
 {
     fn alpha_absolute_expiry(&self) -> Option<Timestamp> {
         match self {
-            BobSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, hbit::FinalizedAsFunder>::Created { .. } => None,
-            BobSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, hbit::FinalizedAsFunder>::Finalized {
+            BobSwap::Created { .. } => None,
+            BobSwap::Finalized {
                 alpha_finalized: herc20::Finalized { expiry, .. },
                 ..
-            } => Some(*expiry)
+            } => Some(*expiry),
         }
     }
 }
@@ -249,11 +249,11 @@ impl BetaAbsoluteExpiry
 {
     fn beta_absolute_expiry(&self) -> Option<Timestamp> {
         match self {
-            BobSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, hbit::FinalizedAsFunder>::Created { .. } => None,
-            BobSwap::<asset::Erc20, asset::Bitcoin, herc20::Finalized, hbit::FinalizedAsFunder>::Finalized {
+            BobSwap::Created { .. } => None,
+            BobSwap::Finalized {
                 beta_finalized: hbit::FinalizedAsFunder { expiry, .. },
                 ..
-            } => Some(*expiry)
+            } => Some(*expiry),
         }
     }
 }

--- a/cnd/src/http_api/routes/rfc003/handlers/action.rs
+++ b/cnd/src/http_api/routes/rfc003/handlers/action.rs
@@ -43,7 +43,7 @@ pub async fn handle_action(
 ) -> anyhow::Result<ActionResponseBody> {
     let types = dependencies.determine_types(&swap_id).await?;
 
-    with_swap_types!(types, {
+    rfc003_with_swap_types!(types, {
         let swap_communication: SwapCommunication<AL, BL, AA, BA, AI, BI> = dependencies
             .get(&swap_id)
             .await?

--- a/cnd/src/http_api/swap_resource.rs
+++ b/cnd/src/http_api/swap_resource.rs
@@ -90,7 +90,7 @@ pub async fn build_rfc003_siren_entity(
 ) -> anyhow::Result<siren::Entity> {
     let id = swap.swap_id;
 
-    with_swap_types!(types, {
+    rfc003_with_swap_types!(types, {
         let swap_has_failed = dependencies.swap_error_states.has_failed(&id).await;
 
         if swap_has_failed && on_fail == OnFail::Error {

--- a/cnd/src/lib.rs
+++ b/cnd/src/lib.rs
@@ -37,6 +37,8 @@ pub mod quickcheck;
 mod seed;
 #[cfg(test)]
 pub mod spectral_ext;
+#[macro_use]
+pub mod with_swap_types;
 
 mod actions;
 pub mod comit_api;

--- a/cnd/src/load_swaps.rs
+++ b/cnd/src/load_swaps.rs
@@ -13,7 +13,7 @@ pub async fn load_swaps_from_database(facade: Rfc003Facade) -> anyhow::Result<()
 
         let types = DetermineTypes::determine_types(&facade, &swap_id).await?;
 
-        with_swap_types!(types, {
+        rfc003_with_swap_types!(types, {
             let accepted =
                 LoadAcceptedSwap::<AL, BL, AA, BA, AI, BI>::load_accepted_swap(&facade, &swap_id)
                     .await;

--- a/cnd/src/network/comit.rs
+++ b/cnd/src/network/comit.rs
@@ -663,10 +663,10 @@ mod tests {
         .digest();
 
         let want_alice_to_learn_from_bob = RemoteData {
+            // This is not exactly 'learned' but it is in the behaviour out event for both roles.
             secret_hash: alice_local_data.secret_hash,
             ethereum_identity: bob_local_data.ethereum_identity,
             lightning_identity: bob_local_data.lightning_identity,
-            // This is not exactly 'learned' but it is in the behaviour out event for both roles.
             bitcoin_identity: None,
         };
 

--- a/cnd/src/spawn.rs
+++ b/cnd/src/spawn.rs
@@ -1,15 +1,5 @@
-use crate::{
-    halight, hbit, herc20, Load, LocalSwapId, Protocol, ProtocolSpawner, Role, Side, Spawn, Storage,
-};
+use crate::{Load, ProtocolSpawner, Role, Side, Spawn, Storage, SwapContext};
 use chrono::NaiveDateTime;
-
-#[derive(Clone, Copy, Debug)]
-pub struct SwapContext {
-    pub id: LocalSwapId,
-    pub role: Role,
-    pub alpha: Protocol,
-    pub beta: Protocol,
-}
 
 #[derive(Clone, Copy, Debug)]
 pub struct Swap<A, B> {
@@ -24,100 +14,23 @@ pub async fn spawn(
     storage: &Storage,
     swap_context: SwapContext,
 ) -> anyhow::Result<()> {
-    match swap_context {
-        SwapContext {
-            alpha: Protocol::Herc20,
-            beta: Protocol::Halight,
-            ..
-        } => {
-            let swap =
-                Load::<Swap<herc20::Params, halight::Params>>::load(storage, swap_context.id)
-                    .await?;
-            spawner.spawn(
-                swap_context.id,
-                swap.alpha,
-                swap.start_of_swap,
-                Side::Alpha,
-                swap.role,
-            );
-            spawner.spawn(
-                swap_context.id,
-                swap.beta,
-                swap.start_of_swap,
-                Side::Beta,
-                swap.role,
-            );
-        }
-        SwapContext {
-            alpha: Protocol::Halight,
-            beta: Protocol::Herc20,
-            ..
-        } => {
-            let swap =
-                Load::<Swap<halight::Params, herc20::Params>>::load(storage, swap_context.id)
-                    .await?;
-            spawner.spawn(
-                swap_context.id,
-                swap.alpha,
-                swap.start_of_swap,
-                Side::Alpha,
-                swap.role,
-            );
-            spawner.spawn(
-                swap_context.id,
-                swap.beta,
-                swap.start_of_swap,
-                Side::Beta,
-                swap.role,
-            );
-        }
-        SwapContext {
-            alpha: Protocol::Herc20,
-            beta: Protocol::Hbit,
-            ..
-        } => {
-            let swap =
-                Load::<Swap<herc20::Params, hbit::Params>>::load(storage, swap_context.id).await?;
-            spawner.spawn(
-                swap_context.id,
-                swap.alpha,
-                swap.start_of_swap,
-                Side::Alpha,
-                swap.role,
-            );
-            spawner.spawn(
-                swap_context.id,
-                swap.beta,
-                swap.start_of_swap,
-                Side::Beta,
-                swap.role,
-            );
-        }
-
-        SwapContext {
-            alpha: Protocol::Hbit,
-            beta: Protocol::Herc20,
-            ..
-        } => {
-            let swap =
-                Load::<Swap<hbit::Params, herc20::Params>>::load(storage, swap_context.id).await?;
-            spawner.spawn(
-                swap_context.id,
-                swap.alpha,
-                swap.start_of_swap,
-                Side::Alpha,
-                swap.role,
-            );
-            spawner.spawn(
-                swap_context.id,
-                swap.beta,
-                swap.start_of_swap,
-                Side::Beta,
-                swap.role,
-            );
-        }
-        _ => tracing::info!("attempting to start an unsupported swap"),
-    };
+    within_swap_context!(swap_context, {
+        let swap = Load::<Swap<AlphaParams, BetaParams>>::load(storage, swap_context.id).await?;
+        spawner.spawn(
+            swap_context.id,
+            swap.alpha,
+            swap.start_of_swap,
+            Side::Alpha,
+            swap.role,
+        );
+        spawner.spawn(
+            swap_context.id,
+            swap.beta,
+            swap.start_of_swap,
+            Side::Beta,
+            swap.role,
+        );
+    });
 
     Ok(())
 }

--- a/cnd/src/storage.rs
+++ b/cnd/src/storage.rs
@@ -320,12 +320,7 @@ impl
         let secret = self.seed.derive_swap_seed(swap_id).derive_secret();
 
         match (alpha_state, beta_state) {
-            (Some(alpha_state), Some(beta_state)) => Ok(http_api::AliceSwap::<
-                asset::Erc20,
-                asset::Bitcoin,
-                http_api::herc20::Finalized,
-                http_api::halight::Finalized,
-            >::Finalized {
+            (Some(alpha_state), Some(beta_state)) => Ok(http_api::AliceSwap::Finalized {
                 alpha_finalized: http_api::herc20::Finalized {
                     asset: herc20_asset,
                     chain_id: herc20.chain_id.0.into(),
@@ -352,12 +347,7 @@ impl
                 },
                 secret,
             }),
-            _ => Ok(http_api::AliceSwap::<
-                asset::Erc20,
-                asset::Bitcoin,
-                http_api::herc20::Finalized,
-                http_api::halight::Finalized,
-            >::Created {
+            _ => Ok(http_api::AliceSwap::Created {
                 alpha_created: herc20_asset,
                 beta_created: halight_asset,
             }),
@@ -418,12 +408,7 @@ impl
         let secret = self.seed.derive_swap_seed(swap_id).derive_secret();
 
         match (alpha_state, beta_state) {
-            (Some(alpha_state), Some(beta_state)) => Ok(http_api::AliceSwap::<
-                asset::Bitcoin,
-                asset::Erc20,
-                http_api::halight::Finalized,
-                http_api::herc20::Finalized,
-            >::Finalized {
+            (Some(alpha_state), Some(beta_state)) => Ok(http_api::AliceSwap::Finalized {
                 beta_finalized: http_api::herc20::Finalized {
                     asset: herc20_asset,
                     chain_id: herc20.chain_id.0.into(),
@@ -450,12 +435,7 @@ impl
                 },
                 secret,
             }),
-            _ => Ok(http_api::AliceSwap::<
-                asset::Bitcoin,
-                asset::Erc20,
-                http_api::halight::Finalized,
-                http_api::herc20::Finalized,
-            >::Created {
+            _ => Ok(http_api::AliceSwap::Created {
                 beta_created: herc20_asset,
                 alpha_created: halight_asset,
             }),
@@ -516,12 +496,7 @@ impl
         let halight_asset = halight.amount.0.into();
 
         match (alpha_state, beta_state) {
-            (Some(alpha_state), Some(beta_state)) => Ok(http_api::BobSwap::<
-                asset::Erc20,
-                asset::Bitcoin,
-                http_api::herc20::Finalized,
-                http_api::halight::Finalized,
-            >::Finalized {
+            (Some(alpha_state), Some(beta_state)) => Ok(http_api::BobSwap::Finalized {
                 alpha_finalized: http_api::herc20::Finalized {
                     asset: herc20_asset,
                     chain_id: herc20.chain_id.0.into(),
@@ -551,12 +526,7 @@ impl
                     .secret_hash
                     .0,
             }),
-            _ => Ok(http_api::BobSwap::<
-                asset::Erc20,
-                asset::Bitcoin,
-                http_api::herc20::Finalized,
-                http_api::halight::Finalized,
-            >::Created {
+            _ => Ok(http_api::BobSwap::Created {
                 alpha_created: herc20_asset,
                 beta_created: halight_asset,
             }),
@@ -617,12 +587,7 @@ impl
         let halight_asset = halight.amount.0.into();
 
         match (alpha_state, beta_state) {
-            (Some(alpha_state), Some(beta_state)) => Ok(http_api::BobSwap::<
-                asset::Bitcoin,
-                asset::Erc20,
-                http_api::halight::Finalized,
-                http_api::herc20::Finalized,
-            >::Finalized {
+            (Some(alpha_state), Some(beta_state)) => Ok(http_api::BobSwap::Finalized {
                 alpha_finalized: http_api::halight::Finalized {
                     asset: halight_asset,
                     network: halight.network.0.into(),
@@ -652,12 +617,7 @@ impl
                     .secret_hash
                     .0,
             }),
-            _ => Ok(http_api::BobSwap::<
-                asset::Bitcoin,
-                asset::Erc20,
-                http_api::halight::Finalized,
-                http_api::herc20::Finalized,
-            >::Created {
+            _ => Ok(http_api::BobSwap::Created {
                 alpha_created: halight_asset,
                 beta_created: herc20_asset,
             }),

--- a/cnd/src/with_swap_types.rs
+++ b/cnd/src/with_swap_types.rs
@@ -1,0 +1,156 @@
+#[macro_export]
+macro_rules! within_swap_context {
+    ($swap_context:expr, $fn:expr) => {{
+        use crate::{
+            asset,
+            http_api::{halight, hbit, herc20, AliceSwap, BobSwap},
+            Protocol, Role, SwapContext,
+        };
+
+        let swap_context: SwapContext = $swap_context;
+
+        match swap_context {
+            SwapContext {
+                alpha: Protocol::Herc20,
+                beta: Protocol::Halight,
+                role: Role::Alice,
+                ..
+            } => {
+                #[allow(dead_code)]
+                type ActorSwap =
+                    AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>;
+                #[allow(dead_code)]
+                type AlphaParams = herc20::Params;
+                #[allow(dead_code)]
+                type BetaParams = halight::Params;
+                $fn
+            }
+            SwapContext {
+                alpha: Protocol::Herc20,
+                beta: Protocol::Halight,
+                role: Role::Bob,
+                ..
+            } => {
+                #[allow(dead_code)]
+                type ActorSwap =
+                    BobSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, halight::Finalized>;
+                #[allow(dead_code)]
+                type AlphaParams = herc20::Params;
+                #[allow(dead_code)]
+                type BetaParams = halight::Params;
+                $fn
+            }
+            SwapContext {
+                alpha: Protocol::Halight,
+                beta: Protocol::Herc20,
+                role: Role::Alice,
+                ..
+            } => {
+                #[allow(dead_code)]
+                type ActorSwap =
+                    AliceSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>;
+                #[allow(dead_code)]
+                type AlphaParams = halight::Params;
+                #[allow(dead_code)]
+                type BetaParams = herc20::Params;
+                $fn
+            }
+            SwapContext {
+                alpha: Protocol::Halight,
+                beta: Protocol::Herc20,
+                role: Role::Bob,
+                ..
+            } => {
+                #[allow(dead_code)]
+                type ActorSwap =
+                    BobSwap<asset::Bitcoin, asset::Erc20, halight::Finalized, herc20::Finalized>;
+                #[allow(dead_code)]
+                type AlphaParams = halight::Params;
+                #[allow(dead_code)]
+                type BetaParams = herc20::Params;
+                $fn
+            }
+            SwapContext {
+                alpha: Protocol::Herc20,
+                beta: Protocol::Hbit,
+                role: Role::Alice,
+                ..
+            } => {
+                #[allow(dead_code)]
+                type ActorSwap = AliceSwap<
+                    asset::Erc20,
+                    asset::Bitcoin,
+                    herc20::Finalized,
+                    hbit::FinalizedAsRedeemer,
+                >;
+                #[allow(dead_code)]
+                type AlphaParams = herc20::Params;
+                #[allow(dead_code)]
+                type BetaParams = hbit::Params;
+
+                $fn
+            }
+            SwapContext {
+                alpha: Protocol::Herc20,
+                beta: Protocol::Hbit,
+                role: Role::Bob,
+                ..
+            } => {
+                #[allow(dead_code)]
+                type ActorSwap = BobSwap<
+                    asset::Erc20,
+                    asset::Bitcoin,
+                    herc20::Finalized,
+                    hbit::FinalizedAsFunder,
+                >;
+                #[allow(dead_code)]
+                type AlphaParams = herc20::Params;
+                #[allow(dead_code)]
+                type BetaParams = hbit::Params;
+
+                $fn
+            }
+            SwapContext {
+                alpha: Protocol::Hbit,
+                beta: Protocol::Herc20,
+                role: Role::Alice,
+                ..
+            } => {
+                #[allow(dead_code)]
+                type ActorSwap = AliceSwap<
+                    asset::Bitcoin,
+                    asset::Erc20,
+                    hbit::FinalizedAsFunder,
+                    herc20::Finalized,
+                >;
+                #[allow(dead_code)]
+                type AlphaParams = hbit::Params;
+                #[allow(dead_code)]
+                type BetaParams = herc20::Params;
+
+                $fn
+            }
+            SwapContext {
+                alpha: Protocol::Hbit,
+                beta: Protocol::Herc20,
+                role: Role::Bob,
+                ..
+            } => {
+                #[allow(dead_code)]
+                type ActorSwap = BobSwap<
+                    asset::Bitcoin,
+                    asset::Erc20,
+                    hbit::FinalizedAsRedeemer,
+                    herc20::Finalized,
+                >;
+                #[allow(dead_code)]
+                type AlphaParams = hbit::Params;
+                #[allow(dead_code)]
+                type BetaParams = herc20::Params;
+
+                $fn
+            }
+            _ => unimplemented!("protocol combination not supported: {:?}", swap_context),
+        }
+    }};
+}

--- a/comit/src/bitcoin.rs
+++ b/comit/src/bitcoin.rs
@@ -10,7 +10,7 @@ use crate::{
     btsieve::{BlockByHash, LatestBlock},
     Timestamp,
 };
-use bitcoin::{hashes::core::fmt::Formatter, secp256k1};
+use bitcoin::secp256k1;
 use serde::{
     de::{self, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
@@ -45,7 +45,7 @@ impl fmt::Display for PublicKey {
 }
 
 impl fmt::Display for Address {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }


### PR DESCRIPTION
Tackling most of @thomaseizinger's suggestions from his review of PR #2776.

Patch af9643e could either be squashed with 2a44449 or reverted and replaced with the introduction of another macro for spawning swaps. This depends on your reviews.