### PR TITLE
Don't repeat ourselves for loading a single or all swap contexts

### DIFF
--- a/cnd/src/db/integration_tests/load_protocol_combination.rs
+++ b/cnd/src/db/integration_tests/load_protocol_combination.rs
@@ -1,4 +1,4 @@
-use crate::{db::CreatedSwap, proptest::*, Load, Protocol, Save, Storage, SwapContext};
+use crate::{db::CreatedSwap, proptest::*, storage::SwapContext, Load, Protocol, Save, Storage};
 use proptest::prelude::*;
 use tokio::runtime::Runtime;
 

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -23,7 +23,7 @@ use crate::{
     protocol_spawner::ProtocolSpawner,
     seed::RootSeed,
     spawn::spawn,
-    storage::Storage,
+    storage::{Storage, SwapContext},
     swap_protocols::{
         rfc003::{
             self,
@@ -33,7 +33,7 @@ use crate::{
         },
         HashFunction, SwapProtocol,
     },
-    transaction, Load, LocalSwapId, Protocol, Role, SecretHash, SharedSwapId, SwapContext,
+    transaction, Load, LocalSwapId, Protocol, Role, SecretHash, SharedSwapId,
 };
 use anyhow::Context;
 use async_trait::async_trait;

--- a/cnd/src/spawn.rs
+++ b/cnd/src/spawn.rs
@@ -1,4 +1,4 @@
-use crate::{Load, ProtocolSpawner, Role, Side, Spawn, Storage, SwapContext};
+use crate::{storage::SwapContext, Load, ProtocolSpawner, Role, Side, Spawn, Storage};
 use chrono::NaiveDateTime;
 
 #[derive(Clone, Copy, Debug)]

--- a/cnd/src/with_swap_types.rs
+++ b/cnd/src/with_swap_types.rs
@@ -4,7 +4,8 @@ macro_rules! within_swap_context {
         use crate::{
             asset,
             http_api::{halbit, hbit, herc20, AliceSwap, BobSwap},
-            Protocol, Role, SwapContext,
+            storage::SwapContext,
+            Protocol, Role,
         };
 
         let swap_context: SwapContext = $swap_context;


### PR DESCRIPTION
We can simply filter the list in-memory for desired swap id. Unless
we have A LOT of entries, this should not be an issue.
In case we do, nothing else in the codebase currently deals with this
problem properly.

Draft until https://github.com/comit-network/comit-rs/pull/2829 merges to see if we our mergify configuration and the PR targeting works nicely :)