### PR TITLE
Only automatically merge PRs that target dev

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -31,6 +31,7 @@ pull_request_rules:
       - label!=blocked
       - label!=no-mergify
       - head~=^(?!release.*).*$
+      - base=dev
     actions:
       comment:
         message: "bors r+"


### PR DESCRIPTION
GitHub recently released a feature called PR retargeting: https://github.blog/changelog/2020-05-19-pull-request-retargeting.

To use that efficiently, we tell mergify to only merge PRs that target `dev`.

Let's see if this works :)