### PR TITLE
Add a couple things to COMIT lib for Nectar

### DIFF
--- a/cnd/src/http_api/halbit_herc20/bob.rs
+++ b/cnd/src/http_api/halbit_herc20/bob.rs
@@ -83,9 +83,10 @@ impl FundAction for BobSwap<asset::Bitcoin, asset::Erc20, halbit::Finalized, her
                         state: herc20::State::Deployed { .. },
                         ..
                     },
+                secret_hash,
                 ..
             } => {
-                let fund_action = herc20.build_fund_action()?;
+                let fund_action = herc20.build_fund_action(*secret_hash)?;
                 Ok(fund_action)
             }
             _ => anyhow::bail!(ActionNotFound),
@@ -139,9 +140,10 @@ impl RefundAction for BobSwap<asset::Bitcoin, asset::Erc20, halbit::Finalized, h
                         state: herc20::State::Funded { .. },
                         ..
                     },
+                secret_hash,
                 ..
             } => {
-                let refund_action = herc20.build_refund_action()?;
+                let refund_action = herc20.build_refund_action(*secret_hash)?;
                 Ok(refund_action)
             }
             _ => anyhow::bail!(ActionNotFound),

--- a/cnd/src/http_api/hbit.rs
+++ b/cnd/src/http_api/hbit.rs
@@ -1,10 +1,12 @@
-use bitcoin::secp256k1::SecretKey;
-use comit::{
-    actions::bitcoin::{BroadcastSignedTransaction, SendToAddress, SpendOutput},
-    asset, ledger, Secret, SecretHash, Timestamp,
+use crate::{
+    actions::bitcoin::{BroadcastSignedTransaction, SendToAddress},
+    asset,
+    bitcoin::Address,
+    ledger, Secret, SecretHash, Timestamp,
 };
+use bitcoin::secp256k1::SecretKey;
 
-pub use crate::{actions::bitcoin::sign_with_fixed_rate, hbit::*};
+pub use crate::hbit::*;
 
 /// Data known by the party funding the HTLC in the Hbit protocol, after the
 /// swap has been finalized.
@@ -21,7 +23,7 @@ pub struct FinalizedAsFunder {
     pub asset: asset::Bitcoin,
     pub network: ledger::Bitcoin,
     pub transient_redeem_identity: identity::Bitcoin,
-    pub final_refund_identity: comit::bitcoin::Address,
+    pub final_refund_identity: Address,
     pub transient_refund_identity: SecretKey,
     pub expiry: Timestamp,
     pub state: State,
@@ -41,7 +43,7 @@ pub struct FinalizedAsFunder {
 pub struct FinalizedAsRedeemer {
     pub asset: asset::Bitcoin,
     pub network: ledger::Bitcoin,
-    pub final_redeem_identity: comit::bitcoin::Address,
+    pub final_redeem_identity: Address,
     pub transient_redeem_identity: SecretKey,
     pub transient_refund_identity: identity::Bitcoin,
     pub expiry: Timestamp,
@@ -50,67 +52,48 @@ pub struct FinalizedAsRedeemer {
 
 impl FinalizedAsFunder {
     pub fn build_fund_action(&self, secret_hash: SecretHash) -> SendToAddress {
-        let transient_refund_sk = self.transient_refund_identity;
-        let transient_refund_identity =
-            identity::Bitcoin::from_secret_key(&*crate::SECP, &transient_refund_sk);
-        let htlc = build_bitcoin_htlc(
-            self.transient_redeem_identity,
-            transient_refund_identity,
-            self.expiry,
-            secret_hash,
-        );
-        let network = bitcoin::Network::from(self.network);
-        let to = htlc.compute_address(network);
-        let amount = self.asset;
-
-        SendToAddress {
-            to,
-            amount,
-            network,
-        }
+        let params = self.build_params(secret_hash);
+        params.build_fund_action()
     }
 
     pub fn build_refund_action(
         &self,
         secret_hash: SecretHash,
     ) -> anyhow::Result<BroadcastSignedTransaction> {
-        let (htlc_location, fund_transaction) = match &self.state {
+        let (fund_amount, fund_location) = match &self.state {
             State::Funded {
-                htlc_location,
-                fund_transaction,
+                asset: fund_amount,
+                htlc_location: fund_location,
                 ..
-            } => (htlc_location, fund_transaction),
+            } => (fund_amount, fund_location),
             _ => anyhow::bail!("incorrect state"),
         };
 
-        let network = bitcoin::Network::from(self.network);
-        let spend_output = {
-            let transient_refund_sk = self.transient_refund_identity;
-            let transient_refund_identity =
-                identity::Bitcoin::from_secret_key(&*crate::SECP, &transient_refund_sk);
-            let htlc = build_bitcoin_htlc(
-                self.transient_redeem_identity,
-                transient_refund_identity,
-                self.expiry,
-                secret_hash,
-            );
+        let transient_refund_sk = self.transient_refund_identity;
+        let refund_address = self.final_refund_identity.clone().into();
+        let params = self.build_params(secret_hash);
+        params.build_refund_action(
+            &*crate::SECP,
+            *fund_amount,
+            *fund_location,
+            transient_refund_sk,
+            refund_address,
+        )
+    }
 
-            let previous_output = htlc_location;
-            let value = bitcoin::Amount::from_sat(
-                fund_transaction.output[htlc_location.vout as usize].value,
-            );
-            let input_parameters = htlc.unlock_after_timeout(&*crate::SECP, transient_refund_sk);
+    fn build_params(&self, secret_hash: SecretHash) -> Params {
+        let transient_refund_sk = self.transient_refund_identity;
+        let transient_refund_identity =
+            identity::Bitcoin::from_secret_key(&*crate::SECP, &transient_refund_sk);
 
-            SpendOutput::new(*previous_output, value, input_parameters, network)
-        };
-
-        let primed_transaction = spend_output.spend_to(self.final_refund_identity.clone().into());
-        let transaction = sign_with_fixed_rate(&*crate::SECP, primed_transaction)?;
-
-        Ok(BroadcastSignedTransaction {
-            transaction,
-            network,
-        })
+        Params {
+            network: self.network.into(),
+            asset: self.asset,
+            redeem_identity: self.transient_redeem_identity,
+            refund_identity: transient_refund_identity,
+            expiry: self.expiry,
+            secret_hash,
+        }
     }
 }
 
@@ -119,46 +102,42 @@ impl FinalizedAsRedeemer {
         &self,
         secret: Secret,
     ) -> anyhow::Result<BroadcastSignedTransaction> {
-        let (htlc_location, fund_transaction) = match &self.state {
+        let (fund_amount, fund_location) = match &self.state {
             State::Funded {
-                htlc_location,
-                fund_transaction,
+                asset: fund_amount,
+                htlc_location: fund_location,
                 ..
-            } => (htlc_location, fund_transaction),
+            } => (fund_amount, fund_location),
             _ => anyhow::bail!("incorrect state"),
         };
 
-        let network = bitcoin::Network::from(self.network);
-        let spend_output = {
-            let transient_redeem_sk = self.transient_redeem_identity;
-            let transient_redeem_identity =
-                identity::Bitcoin::from_secret_key(&*crate::SECP, &transient_redeem_sk);
-            let htlc = build_bitcoin_htlc(
-                transient_redeem_identity,
-                self.transient_refund_identity,
-                self.expiry,
-                SecretHash::new(secret),
-            );
+        let transient_redeem_sk = self.transient_redeem_identity;
+        let redeem_address = self.final_redeem_identity.clone().into();
 
-            let previous_output = htlc_location;
-            let value = bitcoin::Amount::from_sat(
-                fund_transaction.output[htlc_location.vout as usize].value,
-            );
-            let input_parameters = htlc.unlock_with_secret(
-                &*crate::SECP,
-                transient_redeem_sk,
-                secret.into_raw_secret(),
-            );
+        let secret_hash = SecretHash::new(secret);
+        let params = self.build_params(secret_hash);
+        params.build_redeem_action(
+            &*crate::SECP,
+            *fund_amount,
+            *fund_location,
+            transient_redeem_sk,
+            redeem_address,
+            secret,
+        )
+    }
 
-            SpendOutput::new(*previous_output, value, input_parameters, network)
-        };
+    fn build_params(&self, secret_hash: SecretHash) -> Params {
+        let transient_redeem_sk = self.transient_redeem_identity;
+        let transient_redeem_identity =
+            identity::Bitcoin::from_secret_key(&*crate::SECP, &transient_redeem_sk);
 
-        let primed_transaction = spend_output.spend_to(self.final_redeem_identity.clone().into());
-        let transaction = sign_with_fixed_rate(&*crate::SECP, primed_transaction)?;
-
-        Ok(BroadcastSignedTransaction {
-            transaction,
-            network,
-        })
+        Params {
+            network: self.network.into(),
+            asset: self.asset,
+            redeem_identity: transient_redeem_identity,
+            refund_identity: self.transient_refund_identity,
+            expiry: self.expiry,
+            secret_hash,
+        }
     }
 }

--- a/cnd/src/http_api/hbit_herc20/bob.rs
+++ b/cnd/src/http_api/hbit_herc20/bob.rs
@@ -63,9 +63,10 @@ impl FundAction
                         state: herc20::State::Deployed { .. },
                         ..
                     },
+                secret_hash,
                 ..
             } => {
-                let fund_action = herc20.build_fund_action()?;
+                let fund_action = herc20.build_fund_action(*secret_hash)?;
                 Ok(fund_action)
             }
             _ => anyhow::bail!(ActionNotFound),
@@ -118,9 +119,10 @@ impl RefundAction
                         state: herc20::State::Funded { .. },
                         ..
                     },
+                secret_hash,
                 ..
             } => {
-                let refund_action = herc20.build_refund_action()?;
+                let refund_action = herc20.build_refund_action(*secret_hash)?;
                 Ok(refund_action)
             }
             _ => anyhow::bail!(ActionNotFound),

--- a/cnd/src/http_api/herc20_halbit/alice.rs
+++ b/cnd/src/http_api/herc20_halbit/alice.rs
@@ -191,9 +191,11 @@ impl FundAction for AliceSwap<asset::Erc20, asset::Bitcoin, herc20::Finalized, h
                         state: halbit::State::Opened(_),
                         ..
                     },
+                secret,
                 ..
             } => {
-                let fund_action = herc20.build_fund_action()?;
+                let secret_hash = SecretHash::new(*secret);
+                let fund_action = herc20.build_fund_action(secret_hash)?;
                 Ok(fund_action)
             }
             _ => anyhow::bail!(ActionNotFound),
@@ -242,9 +244,11 @@ impl RefundAction
                         state: herc20::State::Funded { .. },
                         ..
                     },
+                secret,
                 ..
             } => {
-                let refund_action = herc20.build_refund_action()?;
+                let secret_hash = SecretHash::new(*secret);
+                let refund_action = herc20.build_refund_action(secret_hash)?;
                 Ok(refund_action)
             }
             _ => anyhow::bail!(ActionNotFound),

--- a/cnd/src/http_api/herc20_hbit/alice.rs
+++ b/cnd/src/http_api/herc20_hbit/alice.rs
@@ -64,9 +64,11 @@ impl FundAction
                         state: hbit::State::None,
                         ..
                     },
+                secret,
                 ..
             } => {
-                let fund_action = herc20.build_fund_action()?;
+                let secret_hash = SecretHash::new(*secret);
+                let fund_action = herc20.build_fund_action(secret_hash)?;
                 Ok(fund_action)
             }
             _ => anyhow::bail!(ActionNotFound),
@@ -116,9 +118,11 @@ impl RefundAction
                         ..
                     },
                 beta_finalized: hbit::FinalizedAsRedeemer { .. },
+                secret,
                 ..
             } => {
-                let refund_action = herc20.build_refund_action()?;
+                let secret_hash = SecretHash::new(*secret);
+                let refund_action = herc20.build_refund_action(secret_hash)?;
                 Ok(refund_action)
             }
             _ => anyhow::bail!(ActionNotFound),

--- a/cnd/src/storage.rs
+++ b/cnd/src/storage.rs
@@ -231,6 +231,7 @@ impl IntoParams for herc20::Params {
                 .into(),
             expiry: herc20.expiry.0.into(),
             secret_hash,
+            chain_id: herc20.chain_id.0.into(),
         })
     }
 }

--- a/comit/src/hbit.rs
+++ b/comit/src/hbit.rs
@@ -146,7 +146,7 @@ where
     Ok(())
 }
 
-async fn watch_for_funded<C>(
+pub async fn watch_for_funded<C>(
     connector: &C,
     params: &Params,
     start_of_swap: NaiveDateTime,
@@ -179,7 +179,7 @@ where
     Ok(event)
 }
 
-async fn watch_for_redeemed<C>(
+pub async fn watch_for_redeemed<C>(
     connector: &C,
     params: &Params,
     location: htlc_location::Bitcoin,
@@ -202,7 +202,7 @@ where
     })
 }
 
-async fn watch_for_refunded<C>(
+pub async fn watch_for_refunded<C>(
     connector: &C,
     params: &Params,
     location: htlc_location::Bitcoin,

--- a/comit/src/hbit.rs
+++ b/comit/src/hbit.rs
@@ -1,6 +1,9 @@
 //! Htlc Bitcoin atomic swap protocol.
 
 use crate::{
+    actions::bitcoin::{
+        sign_with_fixed_rate, BroadcastSignedTransaction, SendToAddress, SpendOutput,
+    },
     asset,
     btsieve::{
         bitcoin::{watch_for_created_outpoint, watch_for_spent_outpoint},
@@ -12,9 +15,10 @@ use crate::{
 };
 use bitcoin::{
     hashes::{hash160, Hash},
-    Address, Block, BlockHash, Transaction,
+    secp256k1::{Secp256k1, SecretKey, Signing},
+    Address, Block, BlockHash, Network, Transaction,
 };
-use blockchain_contracts::bitcoin::rfc003::bitcoin_htlc::BitcoinHtlc;
+use blockchain_contracts::bitcoin::{rfc003::bitcoin_htlc::BitcoinHtlc, witness::UnlockParameters};
 use chrono::NaiveDateTime;
 use futures::{
     future::{self, Either},
@@ -28,7 +32,7 @@ use tracing_futures::Instrument;
 #[derive(Clone, Debug)]
 pub struct CreatedSwap {
     pub amount: asset::Bitcoin,
-    pub final_identity: bitcoin::Address,
+    pub final_identity: Address,
     pub network: ledger::Bitcoin,
     pub absolute_expiry: u32,
 }
@@ -221,12 +225,102 @@ where
 
 #[derive(Clone, Copy, Debug)]
 pub struct Params {
-    pub network: bitcoin::Network,
+    pub network: Network,
     pub asset: asset::Bitcoin,
     pub redeem_identity: identity::Bitcoin,
     pub refund_identity: identity::Bitcoin,
     pub expiry: Timestamp,
     pub secret_hash: SecretHash,
+}
+
+impl Params {
+    pub fn build_fund_action(&self) -> SendToAddress {
+        let network = self.network;
+        let to = self.compute_address();
+        let amount = self.asset;
+
+        SendToAddress {
+            to,
+            amount,
+            network,
+        }
+    }
+
+    pub fn build_refund_action<C>(
+        &self,
+        secp: &Secp256k1<C>,
+        fund_amount: asset::Bitcoin,
+        fund_location: htlc_location::Bitcoin,
+        transient_refund_sk: SecretKey,
+        refund_address: Address,
+    ) -> anyhow::Result<BroadcastSignedTransaction>
+    where
+        C: Signing,
+    {
+        self.build_spend_action(
+            &secp,
+            fund_amount,
+            fund_location,
+            refund_address,
+            |htlc: BitcoinHtlc| htlc.unlock_after_timeout(&secp, transient_refund_sk),
+        )
+    }
+
+    pub fn build_redeem_action<C>(
+        &self,
+        secp: &Secp256k1<C>,
+        fund_amount: asset::Bitcoin,
+        fund_location: htlc_location::Bitcoin,
+        transient_redeem_sk: SecretKey,
+        redeem_address: Address,
+        secret: Secret,
+    ) -> anyhow::Result<BroadcastSignedTransaction>
+    where
+        C: Signing,
+    {
+        self.build_spend_action(
+            &secp,
+            fund_amount,
+            fund_location,
+            redeem_address,
+            |htlc: BitcoinHtlc| {
+                htlc.unlock_with_secret(secp, transient_redeem_sk, secret.into_raw_secret())
+            },
+        )
+    }
+
+    fn build_spend_action<C>(
+        &self,
+        secp: &Secp256k1<C>,
+        fund_amount: asset::Bitcoin,
+        fund_location: htlc_location::Bitcoin,
+        spend_address: Address,
+        unlock_fn: impl Fn(BitcoinHtlc) -> UnlockParameters,
+    ) -> anyhow::Result<BroadcastSignedTransaction>
+    where
+        C: Signing,
+    {
+        let network = self.network;
+        let primed_transaction = {
+            let htlc = build_bitcoin_htlc(
+                self.redeem_identity,
+                self.refund_identity,
+                self.expiry,
+                self.secret_hash,
+            );
+            let input_parameters = unlock_fn(htlc);
+            let spend_output =
+                SpendOutput::new(fund_location, fund_amount.into(), input_parameters, network);
+
+            spend_output.spend_to(spend_address)
+        };
+        let transaction = sign_with_fixed_rate(&secp, primed_transaction)?;
+
+        Ok(BroadcastSignedTransaction {
+            transaction,
+            network,
+        })
+    }
 }
 
 impl From<Params> for BitcoinHtlc {

--- a/comit/src/herc20.rs
+++ b/comit/src/herc20.rs
@@ -148,7 +148,7 @@ where
     Ok(())
 }
 
-async fn watch_for_deployed<C>(
+pub async fn watch_for_deployed<C>(
     connector: &C,
     params: Params,
     start_of_swap: NaiveDateTime,
@@ -172,7 +172,7 @@ where
     })
 }
 
-async fn watch_for_funded<C>(
+pub async fn watch_for_funded<C>(
     connector: &C,
     params: Params,
     start_of_swap: NaiveDateTime,
@@ -209,7 +209,7 @@ where
     Ok(event)
 }
 
-async fn watch_for_redeemed<C>(
+pub async fn watch_for_redeemed<C>(
     connector: &C,
     start_of_swap: NaiveDateTime,
     deployed: Deployed,
@@ -238,7 +238,7 @@ where
     })
 }
 
-async fn watch_for_refunded<C>(
+pub async fn watch_for_refunded<C>(
     connector: &C,
     start_of_swap: NaiveDateTime,
     deployed: Deployed,


### PR DESCRIPTION
I think none of this should be contentious.

It turns out that, in Nectar, using the low-level API `watch_for_EVENT` enables better code composition than if we used `watch_ledger`. I don't think making it public could enable harmful patterns by consumers of the library. It appears to be a very useful building block.

Before patches https://github.com/comit-network/comit-rs/commit/45df400b8a6b39d6b91caf76cdf24ddf9e060d84 and https://github.com/comit-network/comit-rs/commit/6dd9fd48ca7b82e17d80a47ce678ee93847ffdb6, the action building logic lived in the HTTP API module of cnd (the only place where it was needed). Other applications will need this code, so moving it to the COMIT library is needed.

We don't need to get this merged soon, because we're just building against the branch anyway, but I want to know if there is consensus that these are good, correctly implemented changes.