### PR TITLE
Re-export rust-bitcoin from COMIT lib

### DIFF
--- a/comit/src/lib.rs
+++ b/comit/src/lib.rs
@@ -18,6 +18,9 @@ mod swap_id;
 mod timestamp;
 pub mod transaction;
 
+// Re-export rust-bitcoin to make our consumer's life easier.
+pub use ::bitcoin as bitcoin_lib;
+
 pub use self::{
     network::DialInformation,
     secret::Secret,
@@ -25,6 +28,7 @@ pub use self::{
     swap_id::{LocalSwapId, SharedSwapId},
     timestamp::{RelativeTime, Timestamp},
 };
+
 use digest::ToDigestInput;
 
 #[derive(


### PR DESCRIPTION
All current swaps involve Bitcoin and depend on the `rust-bitcoin` library. Consumers of COMIT lib can now rely on a specific version of `rust-bitcoin` through this re-exported dependency, avoiding problems with version incompatibility.

Is this all that needs to be done? Did I completely miss the point? :stuck_out_tongue: 