### PR TITLE
Bump num from 0.2.1 to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
  "libp2p-comit",
  "libsqlite3-sys",
  "log 0.4.8",
- "num 0.2.1",
+ "num 0.3.0",
  "paste",
  "pem",
  "proptest",
@@ -581,7 +581,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.12.1",
- "bigdecimal",
  "bitcoin",
  "bitcoincore-rpc",
  "blockchain_contracts",
@@ -596,7 +595,7 @@ dependencies = [
  "levenshtein",
  "libp2p",
  "lru",
- "num 0.2.1",
+ "num 0.3.0",
  "primitive-types",
  "rand 0.7.3",
  "reqwest",
@@ -2167,15 +2166,15 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+checksum = "ab3e176191bc4faad357e3122c4747aa098ac880e88b168f106386128736cf4a"
 dependencies = [
- "num-bigint 0.2.6",
- "num-complex 0.2.4",
+ "num-bigint 0.3.0",
+ "num-complex 0.3.0",
  "num-integer",
  "num-iter",
- "num-rational 0.2.4",
+ "num-rational 0.3.0",
  "num-traits",
 ]
 
@@ -2203,6 +2202,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f3fc75e3697059fb1bc465e3d8cca6cf92f56854f201158b3f9c77d5a3cfa0"
+dependencies = [
+ "autocfg 1.0.0",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,19 +2224,18 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+checksum = "b05ad05bd8977050b171b3f6b48175fea6e0565b7981059b486075e1026a9fb5"
 dependencies = [
- "autocfg 1.0.0",
  "num-traits",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
  "autocfg 1.0.0",
  "num-traits",
@@ -2234,9 +2243,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00"
+checksum = "7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f"
 dependencies = [
  "autocfg 1.0.0",
  "num-integer",
@@ -2257,21 +2266,21 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+checksum = "a5b4d7360f362cfb50dde8143501e6940b22f644be75a4cc90b2d81968908138"
 dependencies = [
  "autocfg 1.0.0",
- "num-bigint 0.2.6",
+ "num-bigint 0.3.0",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg 1.0.0",
 ]

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -35,7 +35,7 @@ libp2p = { version = "0.18", default-features = false, features = ["tcp", "secio
 libp2p-comit = { path = "../libp2p-comit" }
 libsqlite3-sys = { version = ">=0.8.0, <0.13.0", features = ["bundled"] }
 log = { version = "0.4", features = ["serde"] }
-num = "0.2"
+num = "0.3"
 paste = "0.1"
 pem = "0.8"
 rand = "0.7"

--- a/comit/Cargo.toml
+++ b/comit/Cargo.toml
@@ -9,7 +9,6 @@ description = "Core components of the COMIT protocol"
 anyhow = "1"
 async-trait = "0.1"
 base64 = "0.12.1"
-bigdecimal = "0.1.2"
 bitcoin = { version = "0.23.0", features = ["rand"] }
 blockchain_contracts = "0.3.2"
 chrono = { version = "0.4", features = ["serde"] }
@@ -23,7 +22,7 @@ lazy_static = "1"
 levenshtein = "1"
 libp2p = { version = "0.18", default-features = false, features = ["tcp", "secio", "yamux", "mplex"] }
 lru = "0.5.1"
-num = "0.2"
+num = "0.3"
 primitive-types = { version = "0.7.2", features = ["serde"] }
 rand = "0.7"
 reqwest = { version = "0.10.6", default-features = false, features = ["json", "native-tls"] }

--- a/comit/src/asset/ethereum/ether.rs
+++ b/comit/src/asset/ethereum/ether.rs
@@ -2,22 +2,17 @@ use crate::{
     asset::ethereum::{Error, FromWei, TryFromWei},
     ethereum::U256,
 };
-use bigdecimal::BigDecimal;
 use lazy_static::lazy_static;
-use num::{bigint::Sign, pow::Pow, BigInt, BigUint, Num, Zero};
+use num::{pow::Pow, BigUint, Integer, Num, Zero};
 use serde::{
     de::{self, Deserialize, Deserializer},
     ser::{Serialize, Serializer},
 };
-use std::{fmt, ops::Div, str::FromStr};
+use std::{fmt, str::FromStr};
 
 lazy_static! {
     static ref WEI_IN_ETHER_U128: u128 = (10u128).pow(18);
     static ref WEI_IN_ETHER_BIGUINT: BigUint = BigUint::from(*WEI_IN_ETHER_U128);
-    static ref WEI_IN_ETHER_BIGDEC: BigDecimal = BigDecimal::from((
-        BigInt::from_biguint(Sign::Plus, WEI_IN_ETHER_BIGUINT.clone()),
-        0
-    ));
 }
 
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
@@ -53,10 +48,22 @@ impl Ether {
 
 impl fmt::Display for Ether {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        let big_int = BigInt::from_biguint(Sign::Plus, self.clone().0);
-        let dec = BigDecimal::from((big_int, 0));
-        let ether = dec.div(WEI_IN_ETHER_BIGDEC.clone());
-        write!(f, "{} ETH", ether)
+        let (ether, rem) = self.0.div_rem(&WEI_IN_ETHER_BIGUINT);
+
+        if rem.is_zero() {
+            write!(f, "{} ETH", ether)
+        } else {
+            // format number as base 10
+            let rem = rem.to_str_radix(10);
+
+            // prefix with 0 in the front until we have 18 chars
+            let rem = format!("{:0>18}", rem);
+
+            // trim unnecessary 0s from the back
+            let rem = rem.trim_end_matches('0');
+
+            write!(f, "{}.{} ETH", ether, rem)
+        }
     }
 }
 
@@ -172,6 +179,14 @@ mod tests {
         assert_eq!(
             Ether::from_wei(1_000_000_000_000_000u128).to_string(),
             "0.001 ETH"
+        );
+    }
+
+    #[test]
+    fn given_some_weird_wei_number_formats_correctly_as_eth() {
+        assert_eq!(
+            Ether::from_wei(1_003_564_412_000_000_000u128).to_string(),
+            "1.003564412 ETH"
         );
     }
 


### PR DESCRIPTION
Since the bigdecimal lib is not yet updated to num 0.3.0, we have
to implement Display for Ether ourselves.

Turns out to not be too complicated actually :)

This replaces #2844.