### PR TITLE
Remove the ethereum::Bytes wrapper

### DIFF
--- a/comit/src/actions.rs
+++ b/comit/src/actions.rs
@@ -77,15 +77,11 @@ pub mod bitcoin {
 }
 
 pub mod ethereum {
-    use crate::{
-        asset,
-        ethereum::{Bytes, ChainId},
-        identity, Timestamp,
-    };
+    use crate::{asset, ethereum::ChainId, identity, Timestamp};
 
     #[derive(Debug, Clone, PartialEq)]
     pub struct DeployContract {
-        pub data: Bytes,
+        pub data: Vec<u8>,
         pub amount: asset::Ether,
         pub gas_limit: u64,
         pub chain_id: ChainId,
@@ -94,7 +90,7 @@ pub mod ethereum {
     #[derive(Debug, Clone, PartialEq)]
     pub struct CallContract {
         pub to: identity::Ethereum,
-        pub data: Option<Bytes>,
+        pub data: Option<Vec<u8>>,
         pub gas_limit: u64,
         pub chain_id: ChainId,
         pub min_block_timestamp: Option<Timestamp>,

--- a/comit/src/ethereum.rs
+++ b/comit/src/ethereum.rs
@@ -182,7 +182,8 @@ pub struct Transaction {
     /// Transfered value
     pub value: U256,
     /// Input data
-    pub input: Bytes,
+    #[serde(with = "SerHexSeq::<StrictPfx>")]
+    pub input: Vec<u8>,
 }
 
 /// A log produced by a transaction.
@@ -193,7 +194,8 @@ pub struct Log {
     /// Topics
     pub topics: Vec<Hash>,
     /// Data
-    pub data: Bytes,
+    #[serde(with = "SerHexSeq::<StrictPfx>")]
+    pub data: Vec<u8>,
 }
 
 /// The block returned from RPC calls.
@@ -213,22 +215,6 @@ pub struct Block {
     pub timestamp: U256,
     /// Transactions
     pub transactions: Vec<Transaction>,
-}
-
-/// Raw bytes wrapper
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct Bytes(#[serde(with = "SerHexSeq::<StrictPfx>")] pub Vec<u8>);
-
-impl AsRef<[u8]> for Bytes {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-}
-
-impl<T: Into<Vec<u8>>> From<T> for Bytes {
-    fn from(data: T) -> Self {
-        Bytes(data.into())
-    }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]


### PR DESCRIPTION
The main purpose of this wrapper was serialization to and from hex.
This is a concern of the respective API layer and should hence be
co-located with the consuming code in the REST API.

Resolves #2416.