### PR TITLE
Few fixes to migrations.sh

### DIFF
--- a/cnd/migrations.sh
+++ b/cnd/migrations.sh
@@ -4,7 +4,7 @@ function navigate_to_last_folder() {
   cd $(ls -d */|tail -n 1)
 }
 
-RELEASE_TAG=$(git describe --tags)
+RELEASE_TAG=$(git tag | tail -1)
 RELEASE_VERSION=$(echo $RELEASE_TAG | cut -d'-' -f 1)
 echo "Checking for current release version ${RELEASE_VERSION}"
 

--- a/cnd/migrations.sh
+++ b/cnd/migrations.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 function navigate_to_last_folder() {
   cd $(ls -d */|tail -n 1)


### PR DESCRIPTION
A few fixes to the `migrations.sh` script. The first minor the second fundamental, please review carefully to check I'm not missing something. 

- Patch one fixes the fact that the script does not run on Linux using `./migrations.sh`

- Patch two fixes the fact that the script does not get the current version correctly, it currently returns v0.7.3 and we are on v0.8.0