### PR TITLE
cnd: Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,17 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcf67bb7ba7797a081cd19009948ab533af7c355d5caf1d08c777582d351e9c"
 
 [[package]]
-name = "bigdecimal"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1374191e2dd25f9ae02e3aa95041ed5d747fc77b3c102b49fe2dd9a8117a6244"
-dependencies = [
- "num-bigint 0.2.6",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,7 +491,6 @@ dependencies = [
  "async-trait",
  "atty",
  "base64 0.12.2",
- "bigdecimal",
  "bitcoin",
  "bitcoincore-rpc",
  "blockchain_contracts",
@@ -515,19 +503,16 @@ dependencies = [
  "digest 0.1.0",
  "digest-macro-derive",
  "directories",
- "fern",
  "fs2",
  "futures",
  "genawaiter",
  "hex 0.4.2",
  "http-api-problem",
- "impl-template",
  "lazy_static",
  "libp2p",
  "libsqlite3-sys",
  "log 0.4.8",
  "num",
- "paste",
  "pem",
  "proptest",
  "rand 0.7.3",
@@ -559,17 +544,6 @@ dependencies = [
  "uuid",
  "void",
  "warp",
-]
-
-[[package]]
-name = "colored"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi 0.3.8",
 ]
 
 [[package]]
@@ -935,16 +909,6 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-
-[[package]]
-name = "fern"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9a4820f0ccc8a7afd67c39a0f1a0f4b07ca1725164271a64939d7aeb9af065"
-dependencies = [
- "colored",
- "log 0.4.8",
-]
 
 [[package]]
 name = "fixed-hash"
@@ -1491,18 +1455,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "impl-template"
-version = "1.0.0-alpha"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e20558cac9252437815e7231074926454f1d59d9797fff4840d135a30c930a49"
-dependencies = [
- "itertools",
- "proc-macro2 1.0.18",
- "quote 1.0.7",
- "syn 1.0.31",
 ]
 
 [[package]]
@@ -2115,22 +2067,11 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3e176191bc4faad357e3122c4747aa098ac880e88b168f106386128736cf4a"
 dependencies = [
- "num-bigint 0.3.0",
+ "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg 1.0.0",
- "num-integer",
  "num-traits",
 ]
 
@@ -2182,7 +2123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5b4d7360f362cfb50dde8143501e6940b22f644be75a4cc90b2d81968908138"
 dependencies = [
  "autocfg 1.0.0",
- "num-bigint 0.3.0",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -2335,25 +2276,6 @@ dependencies = [
  "redox_syscall",
  "smallvec 1.3.0",
  "winapi 0.3.8",
-]
-
-[[package]]
-name = "paste"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "026c63fe245362be0322bfec5a9656d458d13f9cfb1785d1b38458b9968e8080"
-dependencies = [
- "paste-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "paste-impl"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9281a268ec213237dcd2aa3c3d0f46681b04ced37c1616fd36567a9e6954b0"
-dependencies = [
- "proc-macro-hack",
 ]
 
 [[package]]

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -11,7 +11,6 @@ anyhow = "1"
 async-trait = "0.1"
 atty = "0.2"
 base64 = "0.12.2"
-bigdecimal = "0.1.2"
 bitcoin = { version = "0.23", features = ["use-serde"] }
 blockchain_contracts = "0.3.2"
 chrono = { version = "0.4", features = ["serde"] }
@@ -23,19 +22,16 @@ diesel_migrations = "1.4.0"
 digest = { path = "../digest" }
 digest-macro-derive = { path = "../digest-macro-derive" }
 directories = "2.0"
-fern = { version = "0.6", features = ["colored"] }
 fs2 = "0.4.3"
 futures = { version = "0.3", features = ["async-await"], default-features = false }
 genawaiter = { version = "0.99", features = ["futures03"] }
 hex = "0.4"
 http-api-problem = { version = "0.15", features = ["with_warp"] }
-impl-template = "1.0.0-alpha"
 lazy_static = "1"
 libp2p = { version = "0.18", default-features = false, features = ["tcp", "secio", "yamux", "mplex", "mdns", "dns"] }
 libsqlite3-sys = { version = ">=0.8.0, <0.13.0", features = ["bundled"] }
 log = { version = "0.4", features = ["serde"] }
 num = "0.3"
-paste = "0.1"
 pem = "0.8"
 rand = "0.7"
 reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }


### PR DESCRIPTION
We have a bunch of unused dependencies. Found using udeps.

````
cargo +nightly udeps
...
unused dependencies:
`cnd v0.8.0 (/home/tobin/SPOT/build/github.com/comit-network/comit-rs/cnd)`
└─── dependencies
     ├─── "bigdecimal"
     ├─── "fern"
     ├─── "impl-template"
     └─── "paste"
````

Remove the unused dependencies from cnd crate.