### PR TITLE
Remove unused connectors and database from network

### DIFF
--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -147,7 +147,7 @@ fn main() -> anyhow::Result<()> {
     let hbit_states = Arc::new(hbit::States::default());
 
     let storage = Storage::new(
-        database.clone(),
+        database,
         seed,
         herc20_states.clone(),
         halbit_states.clone(),
@@ -167,9 +167,6 @@ fn main() -> anyhow::Result<()> {
     let swarm = Swarm::new(
         &settings,
         seed,
-        Arc::clone(&bitcoin_connector),
-        Arc::clone(&ethereum_connector),
-        &database,
         runtime.handle().clone(),
         storage.clone(),
         protocol_spawner.clone(),


### PR DESCRIPTION
When using the `Swarm` and `ComitNode` network behaviour for inspiration I noticed that the blockchain connectors and the database was never removed. 
With the concept of the `ProtocolSpawner` we don't need this anymore.

Since that is an easy quick fix I thought I just do it.