### PR TITLE
Move CreatedSwap to cnd

### DIFF
--- a/cnd/src/halbit.rs
+++ b/cnd/src/halbit.rs
@@ -1,6 +1,6 @@
 use crate::{
-    identity, state, state::Update, tracing_ext::InstrumentProtocol, LocalSwapId, Protocol,
-    RelativeTime, Role, Side,
+    asset, identity, ledger, state, state::Update, tracing_ext::InstrumentProtocol, LocalSwapId,
+    Protocol, RelativeTime, Role, Side,
 };
 use futures::TryStreamExt;
 use std::{
@@ -122,6 +122,16 @@ pub async fn new<C>(
     }
 
     tracing::info!("swap finished");
+}
+
+/// Data required to create a swap that involves bitcoin on the lightning
+/// network.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CreatedSwap {
+    pub asset: asset::Bitcoin,
+    pub identity: identity::Lightning,
+    pub network: ledger::Bitcoin,
+    pub cltv_expiry: u32,
 }
 
 /// Represents states that an invoice can be in.

--- a/cnd/src/hbit.rs
+++ b/cnd/src/hbit.rs
@@ -1,10 +1,11 @@
 use crate::{
     btsieve::{BlockByHash, LatestBlock},
+    ledger,
     swap_protocols::{state, state::Update},
     tracing_ext::InstrumentProtocol,
     LocalSwapId, Role, Side,
 };
-use bitcoin::{Block, BlockHash};
+use bitcoin::{Address, Block, BlockHash};
 use chrono::NaiveDateTime;
 use comit::{asset, htlc_location, transaction, Protocol, Secret};
 pub use comit::{hbit::*, identity};
@@ -41,6 +42,15 @@ pub async fn new<C>(
     }
 
     tracing::info!("swap finished");
+}
+
+/// Data required to create a swap that involves Bitcoin.
+#[derive(Clone, Debug)]
+pub struct CreatedSwap {
+    pub amount: asset::Bitcoin,
+    pub final_identity: Address,
+    pub network: ledger::Bitcoin,
+    pub absolute_expiry: u32,
 }
 
 #[derive(Default, Debug)]

--- a/cnd/src/herc20.rs
+++ b/cnd/src/herc20.rs
@@ -15,6 +15,7 @@ use std::{
 };
 use tokio::sync::Mutex;
 
+use crate::ethereum::ChainId;
 pub use comit::herc20::*;
 
 /// Creates a new instance of the herc20 protocol, annotated with tracing spans
@@ -43,6 +44,15 @@ pub async fn new<C>(
     }
 
     tracing::info!("swap finished");
+}
+
+/// Data required to create a swap that involves an ERC20 token.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CreatedSwap {
+    pub asset: asset::Erc20,
+    pub identity: identity::Ethereum,
+    pub chain_id: ChainId,
+    pub absolute_expiry: u32,
 }
 
 #[derive(Default, Debug)]

--- a/cnd/src/proptest.rs
+++ b/cnd/src/proptest.rs
@@ -148,7 +148,7 @@ pub mod asset {
 
 pub mod herc20 {
     use super::*;
-    use comit::herc20;
+    use crate::herc20;
 
     prop_compose! {
         pub fn created_swap()(
@@ -169,7 +169,7 @@ pub mod herc20 {
 
 pub mod halbit {
     use super::*;
-    use comit::halbit;
+    use crate::halbit;
 
     prop_compose! {
         pub fn created_swap()(
@@ -190,7 +190,7 @@ pub mod halbit {
 
 pub mod hbit {
     use super::*;
-    use comit::hbit;
+    use crate::hbit;
 
     prop_compose! {
         pub fn created_swap()(

--- a/comit/src/halbit.rs
+++ b/comit/src/halbit.rs
@@ -1,4 +1,4 @@
-use crate::{asset, identity, ledger, RelativeTime, Secret, SecretHash};
+use crate::{asset, identity, RelativeTime, Secret, SecretHash};
 use bitcoin::hashes::core::fmt::Formatter;
 use futures::{future, future::Either, Stream, TryFutureExt};
 use genawaiter::sync::Gen;
@@ -48,16 +48,6 @@ where
             }
         }
     })
-}
-
-/// Data required to create a swap that involves bitcoin on the lightning
-/// network.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct CreatedSwap {
-    pub asset: asset::Bitcoin,
-    pub identity: identity::Lightning,
-    pub network: ledger::Bitcoin,
-    pub cltv_expiry: u32,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/comit/src/hbit.rs
+++ b/comit/src/hbit.rs
@@ -9,7 +9,7 @@ use crate::{
         bitcoin::{watch_for_created_outpoint, watch_for_spent_outpoint},
         BlockByHash, LatestBlock,
     },
-    htlc_location, identity, ledger,
+    htlc_location, identity,
     timestamp::Timestamp,
     transaction, Secret, SecretHash,
 };
@@ -27,15 +27,6 @@ use futures::{
 use genawaiter::sync::{Co, Gen};
 use std::cmp::Ordering;
 use tracing_futures::Instrument;
-
-/// Data required to create a swap that involves Bitcoin.
-#[derive(Clone, Debug)]
-pub struct CreatedSwap {
-    pub amount: asset::Bitcoin,
-    pub final_identity: Address,
-    pub network: ledger::Bitcoin,
-    pub absolute_expiry: u32,
-}
 
 /// Represents the events in the hbit protocol.
 #[derive(Debug, Clone, PartialEq, strum_macros::Display)]

--- a/comit/src/herc20.rs
+++ b/comit/src/herc20.rs
@@ -28,15 +28,6 @@ lazy_static::lazy_static! {
     static ref TRANSFER_LOG_MSG: Hash = blockchain_contracts::ethereum::rfc003::ERC20_TRANSFER.parse().expect("to be valid hex");
 }
 
-/// Data required to create a swap that involves an ERC20 token.
-#[derive(Clone, Debug, PartialEq)]
-pub struct CreatedSwap {
-    pub asset: asset::Erc20,
-    pub identity: identity::Ethereum,
-    pub chain_id: ChainId,
-    pub absolute_expiry: u32,
-}
-
 /// Represents the events in the herc20 protocol.
 #[derive(Debug, Clone, PartialEq, strum_macros::Display)]
 pub enum Event {


### PR DESCRIPTION
The struct is purely a cnd construct, nothing in `comit` relies on it so it can be safely moved over.