### PR TITLE
Align Debug representation of identity messages

### DIFF
--- a/comit/src/network/protocols/ethereum_identity.rs
+++ b/comit/src/network/protocols/ethereum_identity.rs
@@ -1,9 +1,10 @@
 use crate::{identity, network::oneshot_protocol, SharedSwapId};
 use serde::{Deserialize, Serialize};
 use serde_hex::{SerHex, StrictPfx};
+use serdebug::SerDebug;
 
 /// The message for the Ethereum identity sharing protocol.
-#[derive(Clone, Copy, Deserialize, Debug, Serialize)]
+#[derive(Clone, Copy, Deserialize, SerDebug, Serialize)]
 pub struct Message {
     pub swap_id: SharedSwapId,
     /// An Ethereum address, serialized with a `0x` prefix as per convention in

--- a/comit/src/network/protocols/secret_hash.rs
+++ b/comit/src/network/protocols/secret_hash.rs
@@ -1,9 +1,10 @@
 use crate::{network::oneshot_protocol, SecretHash, SharedSwapId};
 use serde::{Deserialize, Serialize};
 use serde_hex::{SerHex, Strict};
+use serdebug::SerDebug;
 
 /// The message for the secret hash sharing protocol.
-#[derive(Clone, Copy, Deserialize, Debug, Serialize)]
+#[derive(Clone, Copy, Deserialize, SerDebug, Serialize)]
 pub struct Message {
     pub swap_id: SharedSwapId,
     /// A SHA-256 hash, serialized as hex without a `0x` prefix.


### PR DESCRIPTION
By using SerDebug for all of them, we get a nice hex-representation
instead of arrays of bytes in the logs.