### PR TITLE
Make `Display` for Ethereum Address and Hash display hex

### DIFF
--- a/cnd/src/http_api/protocol.rs
+++ b/cnd/src/http_api/protocol.rs
@@ -112,7 +112,7 @@ impl From<herc20::State> for LedgerEvents {
                 deploy_transaction, ..
             } => {
                 let mut transactions = HashMap::new();
-                transactions.insert(ActionName::Deploy, format!("{:x}", deploy_transaction.hash));
+                transactions.insert(ActionName::Deploy, format!("{}", deploy_transaction.hash));
                 LedgerEvents::new(EscrowStatus::Deployed, transactions)
             }
             herc20::State::Funded {
@@ -121,8 +121,8 @@ impl From<herc20::State> for LedgerEvents {
                 ..
             } => {
                 let mut transactions = HashMap::new();
-                transactions.insert(ActionName::Deploy, format!("{:x}", deploy_transaction.hash));
-                transactions.insert(ActionName::Fund, format!("{:x}", fund_transaction.hash));
+                transactions.insert(ActionName::Deploy, format!("{}", deploy_transaction.hash));
+                transactions.insert(ActionName::Fund, format!("{}", fund_transaction.hash));
                 LedgerEvents::new(EscrowStatus::Funded, transactions)
             }
             herc20::State::IncorrectlyFunded {
@@ -131,8 +131,8 @@ impl From<herc20::State> for LedgerEvents {
                 ..
             } => {
                 let mut transactions = HashMap::new();
-                transactions.insert(ActionName::Deploy, format!("{:x}", deploy_transaction.hash));
-                transactions.insert(ActionName::Fund, format!("{:x}", fund_transaction.hash));
+                transactions.insert(ActionName::Deploy, format!("{}", deploy_transaction.hash));
+                transactions.insert(ActionName::Fund, format!("{}", fund_transaction.hash));
                 LedgerEvents::new(EscrowStatus::IncorrectlyFunded, transactions)
             }
             herc20::State::Redeemed {
@@ -142,9 +142,9 @@ impl From<herc20::State> for LedgerEvents {
                 ..
             } => {
                 let mut transactions = HashMap::new();
-                transactions.insert(ActionName::Deploy, format!("{:x}", deploy_transaction.hash));
-                transactions.insert(ActionName::Fund, format!("{:x}", fund_transaction.hash));
-                transactions.insert(ActionName::Redeem, format!("{:x}", redeem_transaction.hash));
+                transactions.insert(ActionName::Deploy, format!("{}", deploy_transaction.hash));
+                transactions.insert(ActionName::Fund, format!("{}", fund_transaction.hash));
+                transactions.insert(ActionName::Redeem, format!("{}", redeem_transaction.hash));
                 LedgerEvents::new(EscrowStatus::Redeemed, transactions)
             }
             herc20::State::Refunded {
@@ -154,9 +154,9 @@ impl From<herc20::State> for LedgerEvents {
                 ..
             } => {
                 let mut transactions = HashMap::new();
-                transactions.insert(ActionName::Deploy, format!("{:x}", deploy_transaction.hash));
-                transactions.insert(ActionName::Fund, format!("{:x}", fund_transaction.hash));
-                transactions.insert(ActionName::Refund, format!("{:x}", refund_transaction.hash));
+                transactions.insert(ActionName::Deploy, format!("{}", deploy_transaction.hash));
+                transactions.insert(ActionName::Fund, format!("{}", fund_transaction.hash));
+                transactions.insert(ActionName::Refund, format!("{}", refund_transaction.hash));
                 LedgerEvents::new(EscrowStatus::Refunded, transactions)
             }
         }

--- a/cnd/src/storage.rs
+++ b/cnd/src/storage.rs
@@ -222,18 +222,16 @@ impl IntoParams for herc20::Params {
         Ok(herc20::Params {
             asset: asset::Erc20 {
                 quantity: herc20.amount.0.into(),
-                token_contract: herc20.token_contract.0.into(),
+                token_contract: herc20.token_contract.0,
             },
             redeem_identity: herc20
                 .redeem_identity
                 .ok_or_else(|| NoHerc20RedeemIdentity(id))?
-                .0
-                .into(),
+                .0,
             refund_identity: herc20
                 .refund_identity
                 .ok_or_else(|| NoHerc20RefundIdentity(id))?
-                .0
-                .into(),
+                .0,
             expiry: herc20.expiry.0.into(),
             secret_hash,
             chain_id: herc20.chain_id.0.into(),

--- a/cnd/src/storage/db/integration_tests/serialization_format_stability.rs
+++ b/cnd/src/storage/db/integration_tests/serialization_format_stability.rs
@@ -41,7 +41,7 @@ fn bitcoin_public_key() {
 
 #[test]
 fn ethereum_address() {
-    roundtrip_test::<identity::Ethereum>("68917b35bacf71dbadf37628b3b7f290f6d88877");
+    roundtrip_test::<identity::Ethereum>("0x68917b35bacf71dbadf37628b3b7f290f6d88877");
 }
 
 #[test]

--- a/cnd/src/storage/db/integration_tests/serialization_format_stability.rs
+++ b/cnd/src/storage/db/integration_tests/serialization_format_stability.rs
@@ -4,7 +4,8 @@
 //! make sure we don't change the format accidentally!
 
 use crate::{
-    storage::db::wrapper_types::{Erc20Amount, Ether, EthereumAddress, Satoshis},
+    identity,
+    storage::db::wrapper_types::{Erc20Amount, Ether, Satoshis},
     Protocol, SecretHash,
 };
 use std::{fmt, str::FromStr};
@@ -40,7 +41,7 @@ fn bitcoin_public_key() {
 
 #[test]
 fn ethereum_address() {
-    roundtrip_test::<EthereumAddress>("68917b35bacf71dbadf37628b3b7f290f6d88877");
+    roundtrip_test::<identity::Ethereum>("68917b35bacf71dbadf37628b3b7f290f6d88877");
 }
 
 #[test]

--- a/cnd/src/storage/db/tables.rs
+++ b/cnd/src/storage/db/tables.rs
@@ -4,7 +4,7 @@ use crate::{
         schema::{address_book, halbits, hbits, herc20s, secret_hashes, swaps},
         wrapper_types::{
             custom_sql_types::{Text, U32},
-            BitcoinNetwork, Erc20Amount, EthereumAddress, Satoshis,
+            BitcoinNetwork, Erc20Amount, Satoshis,
         },
         Sqlite,
     },
@@ -86,9 +86,9 @@ pub struct Herc20 {
     pub amount: Text<Erc20Amount>,
     pub chain_id: U32,
     pub expiry: U32,
-    pub token_contract: Text<EthereumAddress>,
-    pub redeem_identity: Option<Text<EthereumAddress>>,
-    pub refund_identity: Option<Text<EthereumAddress>>,
+    pub token_contract: Text<identity::Ethereum>,
+    pub redeem_identity: Option<Text<identity::Ethereum>>,
+    pub refund_identity: Option<Text<identity::Ethereum>>,
     pub side: Text<Side>,
 }
 
@@ -99,9 +99,9 @@ pub struct InsertableHerc20 {
     pub amount: Text<Erc20Amount>,
     pub chain_id: U32,
     pub expiry: U32,
-    pub token_contract: Text<EthereumAddress>,
-    pub redeem_identity: Option<Text<EthereumAddress>>,
-    pub refund_identity: Option<Text<EthereumAddress>>,
+    pub token_contract: Text<identity::Ethereum>,
+    pub redeem_identity: Option<Text<identity::Ethereum>>,
+    pub refund_identity: Option<Text<identity::Ethereum>>,
     pub side: Text<Side>,
 }
 
@@ -109,7 +109,7 @@ impl From<Herc20> for asset::Erc20 {
     fn from(herc20: Herc20) -> asset::Erc20 {
         asset::Erc20 {
             quantity: herc20.amount.0.into(),
-            token_contract: herc20.token_contract.0.into(),
+            token_contract: herc20.token_contract.0,
         }
     }
 }
@@ -129,15 +129,11 @@ impl IntoInsertable for herc20::CreatedSwap {
 
     fn into_insertable(self, swap_id: i32, role: Role, side: Side) -> Self::Insertable {
         let redeem_identity = match (role, side) {
-            (Role::Alice, Side::Beta) | (Role::Bob, Side::Alpha) => {
-                Some(Text(EthereumAddress::from(self.identity)))
-            }
+            (Role::Alice, Side::Beta) | (Role::Bob, Side::Alpha) => Some(Text(self.identity)),
             _ => None,
         };
         let refund_identity = match (role, side) {
-            (Role::Alice, Side::Alpha) | (Role::Bob, Side::Beta) => {
-                Some(Text(EthereumAddress::from(self.identity)))
-            }
+            (Role::Alice, Side::Alpha) | (Role::Bob, Side::Beta) => Some(Text(self.identity)),
             _ => None,
         };
         assert!(redeem_identity.is_some() || refund_identity.is_some());
@@ -147,7 +143,7 @@ impl IntoInsertable for herc20::CreatedSwap {
             amount: Text(self.asset.quantity.into()),
             chain_id: U32(self.chain_id.into()),
             expiry: U32(self.absolute_expiry),
-            token_contract: Text(self.asset.token_contract.into()),
+            token_contract: Text(self.asset.token_contract),
             redeem_identity,
             refund_identity,
             side: Text(side),

--- a/cnd/src/storage/db/wrapper_types.rs
+++ b/cnd/src/storage/db/wrapper_types.rs
@@ -1,4 +1,4 @@
-use crate::{asset, identity, ledger};
+use crate::{asset, ledger};
 use std::{fmt, str::FromStr};
 
 pub mod custom_sql_types;
@@ -93,39 +93,6 @@ impl FromStr for Erc20Amount {
 impl fmt::Display for Erc20Amount {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0.to_wei_dec())
-    }
-}
-
-/// A wrapper type for ethereum addresses.
-///
-/// Together with the `Text` sql type, this will store an ethereum address in
-/// hex encoding.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct EthereumAddress(identity::Ethereum);
-
-impl FromStr for EthereumAddress {
-    type Err = <identity::Ethereum as FromStr>::Err;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        s.parse().map(EthereumAddress)
-    }
-}
-
-impl fmt::Display for EthereumAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:x}", self.0)
-    }
-}
-
-impl From<EthereumAddress> for identity::Ethereum {
-    fn from(address: EthereumAddress) -> Self {
-        address.0
-    }
-}
-
-impl From<identity::Ethereum> for EthereumAddress {
-    fn from(address: identity::Ethereum) -> Self {
-        EthereumAddress(address)
     }
 }
 

--- a/cnd/src/storage/http_api.rs
+++ b/cnd/src/storage/http_api.rs
@@ -351,14 +351,14 @@ impl IntoFinalized for Herc20 {
     fn into_finalized(self, state: Self::State) -> anyhow::Result<Self::Finalized> {
         let asset = asset::Erc20 {
             quantity: self.amount.0.into(),
-            token_contract: self.token_contract.0.into(),
+            token_contract: self.token_contract.0,
         };
 
         Ok(herc20::Finalized {
             asset,
             chain_id: self.chain_id.0.into(),
-            refund_identity: self.refund_identity.ok_or(NoRefundIdentity)?.0.into(),
-            redeem_identity: self.redeem_identity.ok_or(NoRedeemIdentity)?.0.into(),
+            refund_identity: self.refund_identity.ok_or(NoRefundIdentity)?.0,
+            redeem_identity: self.redeem_identity.ok_or(NoRedeemIdentity)?.0,
             expiry: self.expiry.0.into(),
             state,
         })

--- a/comit/src/btsieve/ethereum.rs
+++ b/comit/src/btsieve/ethereum.rs
@@ -141,7 +141,7 @@ where
         match block_generator.async_resume().await {
             GeneratorState::Yielded(block) => {
                 let span =
-                    tracing::trace_span!("new_block", blockhash = format_args!("{:x}", block.hash));
+                    tracing::trace_span!("new_block", blockhash = format_args!("{}", block.hash));
                 let _enter = span.enter();
 
                 tracing::trace!("checking {} transactions", block.transactions.len());
@@ -150,7 +150,7 @@ where
                     let tx_hash = transaction.hash;
                     let span = tracing::trace_span!(
                         "matching_transaction",
-                        txhash = format_args!("{:x}", tx_hash)
+                        txhash = format_args!("{}", tx_hash)
                     );
                     let _enter = span.enter();
 
@@ -192,7 +192,7 @@ where
         match block_generator.async_resume().await {
             GeneratorState::Yielded(block) => {
                 let span =
-                    tracing::trace_span!("new_block", blockhash = format_args!("{:x}", block.hash));
+                    tracing::trace_span!("new_block", blockhash = format_args!("{}", block.hash));
                 let _enter = span.enter();
 
                 let maybe_contains_transaction = topics.iter().all(|topic| {
@@ -221,7 +221,7 @@ where
 
                     let span = tracing::trace_span!(
                         "matching_transaction",
-                        txhash = format_args!("{:x}", tx_hash)
+                        txhash = format_args!("{}", tx_hash)
                     );
                     let _enter = span.enter();
 

--- a/comit/src/btsieve/ethereum/cache.rs
+++ b/comit/src/btsieve/ethereum/cache.rs
@@ -71,12 +71,12 @@ where
 
     async fn block_by_hash(&self, block_hash: Self::BlockHash) -> anyhow::Result<Self::Block> {
         if let Some(block) = self.block_cache.lock().await.get(&block_hash) {
-            tracing::trace!("Found block in cache: {:x}", block_hash);
+            tracing::trace!("Found block in cache: {}", block_hash);
             return Ok(block.clone());
         }
 
         let block = self.connector.block_by_hash(block_hash).await?;
-        tracing::trace!("Fetched block from connector: {:x}", block_hash);
+        tracing::trace!("Fetched block from connector: {}", block_hash);
 
         // We dropped the lock so at this stage the block may have been inserted by
         // another thread, no worries, inserting the same block twice does not hurt.
@@ -94,13 +94,13 @@ where
 {
     async fn receipt_by_hash(&self, transaction_hash: Hash) -> anyhow::Result<TransactionReceipt> {
         if let Some(receipt) = self.receipt_cache.lock().await.get(&transaction_hash) {
-            tracing::trace!("Found receipt in cache: {:x}", transaction_hash);
+            tracing::trace!("Found receipt in cache: {}", transaction_hash);
             return Ok(receipt.clone());
         }
 
         let receipt = self.connector.receipt_by_hash(transaction_hash).await?;
 
-        tracing::trace!("Fetched receipt from connector: {:x}", transaction_hash);
+        tracing::trace!("Fetched receipt from connector: {}", transaction_hash);
 
         // We dropped the lock so at this stage the receipt may have been inserted by
         // another thread, no worries, inserting the same receipt twice does not hurt.

--- a/comit/src/btsieve/ethereum/web3_connector.rs
+++ b/comit/src/btsieve/ethereum/web3_connector.rs
@@ -41,7 +41,7 @@ impl LatestBlock for Web3Connector {
             ]))
             .await?;
 
-        tracing::trace!("Fetched block from web3: {:x}", block.hash);
+        tracing::trace!("Fetched block from web3: {}", block.hash);
 
         Ok(block)
     }
@@ -61,7 +61,7 @@ impl BlockByHash for Web3Connector {
             ]))
             .await?;
 
-        tracing::trace!("Fetched block from web3: {:x}", block_hash);
+        tracing::trace!("Fetched block from web3: {}", block_hash);
 
         Ok(block)
     }
@@ -77,7 +77,7 @@ impl ReceiptByHash for Web3Connector {
             ]))
             .await?;
 
-        tracing::trace!("Fetched receipt from web3: {:x}", transaction_hash);
+        tracing::trace!("Fetched receipt from web3: {}", transaction_hash);
 
         Ok(receipt)
     }

--- a/comit/src/lib.rs
+++ b/comit/src/lib.rs
@@ -12,6 +12,8 @@ pub mod ledger;
 pub mod lightning;
 pub mod lnd;
 pub mod network;
+#[cfg(test)]
+pub mod proptest;
 mod secret;
 mod secret_hash;
 mod swap_id;

--- a/comit/src/proptest.rs
+++ b/comit/src/proptest.rs
@@ -1,0 +1,18 @@
+use proptest::prelude::*;
+
+pub mod ethereum {
+    use super::*;
+    use crate::ethereum::*;
+
+    prop_compose! {
+        pub fn address()(bytes in any::<[u8; 20]>()) -> Address {
+            bytes.into()
+        }
+    }
+
+    prop_compose! {
+        pub fn hash()(bytes in any::<[u8; 32]>()) -> Hash {
+            bytes.into()
+        }
+    }
+}


### PR DESCRIPTION
This allows us to:

- use to just use `{}` in `format!` macros
- remove the `EthereumAddress` wrapper
- delete the `LowerHex` implementation

Resolves #2413.