### PR TITLE
Simplify assertion of the side property of a table

### DIFF
--- a/cnd/src/storage.rs
+++ b/cnd/src/storage.rs
@@ -185,8 +185,21 @@ macro_rules! impl_load_tables {
                     .await
                     .context(NoSwapExists(id))?;
 
-                alpha.assert_side(Side::Alpha)?;
-                beta.assert_side(Side::Beta)?;
+                if alpha.side.0 != Side::Alpha {
+                    anyhow::bail!(
+                        "attempted to load {} as side Alpha but it was {}",
+                        stringify!($alpha),
+                        alpha.side.0
+                    );
+                }
+
+                if beta.side.0 != Side::Beta {
+                    anyhow::bail!(
+                        "attempted to load {} as side Beta but it was {}",
+                        stringify!($alpha),
+                        beta.side.0
+                    );
+                }
 
                 Ok(Tables {
                     swap,
@@ -203,11 +216,6 @@ impl_load_tables!(Herc20, Halbit);
 impl_load_tables!(Halbit, Herc20);
 impl_load_tables!(Herc20, Hbit);
 impl_load_tables!(Hbit, Herc20);
-
-/// Assert that a loaded data from a protocol table is for the correct side.
-pub trait AssertSide {
-    fn assert_side(&self, expected: Side) -> anyhow::Result<()>;
-}
 
 impl IntoParams for herc20::Params {
     type ProtocolTable = Herc20;

--- a/cnd/src/storage/db/tables.rs
+++ b/cnd/src/storage/db/tables.rs
@@ -8,7 +8,7 @@ use crate::{
         },
         Sqlite,
     },
-    AssertSide, LocalSwapId, Role, Side,
+    LocalSwapId, Role, Side,
 };
 use anyhow::Context;
 use chrono::NaiveDateTime;
@@ -314,27 +314,6 @@ macro_rules! swap_id_fk {
             .select(swaps::id)
     };
 }
-
-macro_rules! impl_assert_side {
-    ($target:tt) => {
-        impl AssertSide for $target {
-            fn assert_side(&self, expected: Side) -> anyhow::Result<()> {
-                let actual = self.side.0;
-                if actual != expected {
-                    anyhow::bail!(
-                        "side assertion failed: actual: {} expected: {}",
-                        actual,
-                        expected
-                    )
-                }
-                Ok(())
-            }
-        }
-    };
-}
-impl_assert_side!(Herc20);
-impl_assert_side!(Halbit);
-impl_assert_side!(Hbit);
 
 trait EnsureSingleRowAffected {
     fn ensure_single_row_affected(self) -> anyhow::Result<usize>;


### PR DESCRIPTION
We only use the provided trait in one place, there is no need for
this indirection.