### PR TITLE
Deduplicate serialization efforts without locking in one a specific one

### DIFF
--- a/cnd/src/http_api/action.rs
+++ b/cnd/src/http_api/action.rs
@@ -65,7 +65,8 @@ pub enum ActionResponseBody {
         min_block_timestamp: Option<Timestamp>,
     },
     LndAddHoldInvoice {
-        amount: Http<asset::Bitcoin>,
+        #[serde(with = "asset::bitcoin::sats_as_string")]
+        amount: asset::Bitcoin,
         secret_hash: SecretHash,
         expiry: RelativeTime,
         cltv_expiry: RelativeTime,
@@ -75,7 +76,8 @@ pub enum ActionResponseBody {
     },
     LndSendPayment {
         to_public_key: identity::Lightning,
-        amount: Http<asset::Bitcoin>,
+        #[serde(with = "asset::bitcoin::sats_as_string")]
+        amount: asset::Bitcoin,
         secret_hash: SecretHash,
         final_cltv_delta: RelativeTime,
         chain: Http<Chain>,
@@ -191,7 +193,7 @@ impl From<lnd::AddHoldInvoice> for ActionResponseBody {
         } = action;
 
         ActionResponseBody::LndAddHoldInvoice {
-            amount: Http(amount),
+            amount,
             secret_hash,
             expiry,
             cltv_expiry,
@@ -234,7 +236,7 @@ impl From<lnd::SendPayment> for ActionResponseBody {
 
         ActionResponseBody::LndSendPayment {
             to_public_key,
-            amount: amount.into(),
+            amount,
             secret_hash,
             network: network.into(),
             chain: chain.into(),

--- a/cnd/src/http_api/halbit.rs
+++ b/cnd/src/http_api/halbit.rs
@@ -12,7 +12,8 @@ pub use crate::halbit::*;
 /// serialization/deserialization.
 #[derive(serde::Deserialize, Clone, Debug)]
 pub struct Halbit {
-    pub amount: Http<asset::Bitcoin>,
+    #[serde(with = "asset::bitcoin::sats_as_string")]
+    pub amount: asset::Bitcoin,
     pub identity: identity::Lightning,
     pub network: Http<ledger::Bitcoin>,
     pub cltv_expiry: u32,
@@ -21,7 +22,7 @@ pub struct Halbit {
 impl From<Halbit> for CreatedSwap {
     fn from(p: Halbit) -> Self {
         CreatedSwap {
-            asset: *p.amount,
+            asset: p.amount,
             identity: p.identity,
             network: *p.network,
             cltv_expiry: p.cltv_expiry,

--- a/cnd/src/http_api/halbit_herc20.rs
+++ b/cnd/src/http_api/halbit_herc20.rs
@@ -54,7 +54,7 @@ impl From<PostBody<Halbit, Herc20>> for swap_digest::HalbitHerc20 {
     fn from(body: PostBody<Halbit, Herc20>) -> Self {
         Self {
             lightning_cltv_expiry: body.alpha.cltv_expiry.into(),
-            lightning_amount: body.alpha.amount.0,
+            lightning_amount: body.alpha.amount,
             ethereum_absolute_expiry: body.beta.absolute_expiry.into(),
             erc20_amount: body.beta.amount,
             token_contract: body.beta.token_contract,

--- a/cnd/src/http_api/hbit.rs
+++ b/cnd/src/http_api/hbit.rs
@@ -13,7 +13,8 @@ pub use crate::hbit::*;
 /// serialization/deserialization.
 #[derive(serde::Deserialize, Clone, Debug)]
 pub struct Hbit {
-    pub amount: Http<asset::Bitcoin>,
+    #[serde(with = "asset::bitcoin::sats_as_string")]
+    pub amount: asset::Bitcoin,
     pub final_identity: Http<bitcoin::Address>,
     pub network: Http<bitcoin::Network>,
     pub absolute_expiry: u32,
@@ -22,7 +23,7 @@ pub struct Hbit {
 impl From<Hbit> for CreatedSwap {
     fn from(p: Hbit) -> Self {
         CreatedSwap {
-            amount: *p.amount,
+            amount: p.amount,
             final_identity: p.final_identity.0,
             network: p.network.0.into(),
             absolute_expiry: p.absolute_expiry,

--- a/cnd/src/http_api/hbit_herc20.rs
+++ b/cnd/src/http_api/hbit_herc20.rs
@@ -58,7 +58,7 @@ impl From<PostBody<Hbit, Herc20>> for swap_digest::HbitHerc20 {
     fn from(body: PostBody<Hbit, Herc20>) -> Self {
         Self {
             bitcoin_expiry: body.alpha.absolute_expiry.into(),
-            bitcoin_amount: *body.alpha.amount,
+            bitcoin_amount: body.alpha.amount,
             ethereum_expiry: body.beta.absolute_expiry.into(),
             erc20_amount: body.beta.amount,
             token_contract: body.beta.token_contract,

--- a/cnd/src/http_api/herc20_halbit.rs
+++ b/cnd/src/http_api/herc20_halbit.rs
@@ -56,7 +56,7 @@ impl From<PostBody<Herc20, Halbit>> for swap_digest::Herc20Halbit {
             erc20_amount: body.alpha.amount,
             token_contract: body.alpha.token_contract,
             lightning_cltv_expiry: body.beta.cltv_expiry.into(),
-            lightning_amount: body.beta.amount.0,
+            lightning_amount: body.beta.amount,
         }
     }
 }

--- a/cnd/src/http_api/herc20_hbit.rs
+++ b/cnd/src/http_api/herc20_hbit.rs
@@ -62,7 +62,7 @@ impl From<PostBody<Herc20, Hbit>> for swap_digest::Herc20Hbit {
             erc20_amount: body.alpha.amount,
             token_contract: body.alpha.token_contract,
             bitcoin_expiry: body.beta.absolute_expiry.into(),
-            bitcoin_amount: *body.beta.amount,
+            bitcoin_amount: body.beta.amount,
         }
     }
 }

--- a/cnd/src/http_api/orderbook.rs
+++ b/cnd/src/http_api/orderbook.rs
@@ -19,6 +19,7 @@ use warp::{http, http::StatusCode, Rejection, Reply};
 
 #[derive(Deserialize)]
 struct MakeHerc20HbitOrderBody {
+    #[serde(with = "asset::bitcoin::sats_as_string")]
     pub buy_quantity: asset::Bitcoin,
     pub sell_token_contract: ethereum::Address,
     pub sell_quantity: asset::Erc20Quantity,
@@ -47,6 +48,7 @@ struct TakeHbitHerc20OrderBody {
 
 #[derive(Serialize)]
 struct Herc20HbitOrderResponse {
+    #[serde(with = "asset::bitcoin::sats_as_string")]
     pub buy_quantity: asset::Bitcoin,
     pub sell_token_contract: ethereum::Address,
     pub sell_quantity: asset::Erc20Quantity,

--- a/comit/src/asset.rs
+++ b/comit/src/asset.rs
@@ -1,4 +1,4 @@
-mod bitcoin;
+pub mod bitcoin;
 pub mod ethereum;
 
 pub use self::{


### PR DESCRIPTION
This patch is meant to set an example on how to effectively deal with the need for repeated serialization needs without locking a type into one a specific one.

In addition, this allows users of the `comit` library to reuse these serialization strategies.