### PR TITLE
Only cache target dir on ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
 
       - name: Cache target directory
         uses: actions/cache@v2
+        if: ${{ matrix.os }} == 'ubuntu-latest'
         with:
           path: target
           # The target directory is only useful with the same Rust version, dependencies and operating system.


### PR DESCRIPTION
Our caches are so big that they invalidate them constantly. Ubuntu
takes the longest to run with the e2e tests, so it would benefit
the most from caching.