### PR TITLE
Introduce clippy lints to comit lib

### DIFF
--- a/cnd/src/hbit.rs
+++ b/cnd/src/hbit.rs
@@ -181,7 +181,6 @@ impl state::Update<Event> for States {
 
 /// Represents states that an Bitcoin HTLC can be in.
 #[derive(Debug, Clone, strum_macros::Display)]
-#[allow(clippy::large_enum_variant)]
 pub enum State {
     None,
     Funded {

--- a/cnd/src/http_api/problem.rs
+++ b/cnd/src/http_api/problem.rs
@@ -11,8 +11,6 @@ pub struct LedgerNotConfigured {
     pub ledger: &'static str,
 }
 
-// tracing triggers clippy warning, issue reported: https://github.com/tokio-rs/tracing/issues/553
-#[allow(clippy::cognitive_complexity)]
 pub fn from_anyhow(e: anyhow::Error) -> HttpApiProblem {
     let e = match e.downcast::<HttpApiProblem>() {
         Ok(problem) => return problem,

--- a/cnd/src/http_api/protocol.rs
+++ b/cnd/src/http_api/protocol.rs
@@ -221,7 +221,6 @@ impl From<halbit::State> for LedgerEvents {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum AliceSwap<AC, BC, AF, BF> {
     Created {
@@ -235,7 +234,6 @@ pub enum AliceSwap<AC, BC, AF, BF> {
     },
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum BobSwap<AC, BC, AF, BF> {
     Created {

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -39,7 +39,6 @@ use tokio::{runtime::Handle, sync::Mutex};
 
 #[derive(Clone, derivative::Derivative)]
 #[derivative(Debug)]
-#[allow(clippy::type_complexity)]
 pub struct Swarm {
     #[derivative(Debug = "ignore")]
     inner: Arc<Mutex<libp2p::Swarm<ComitNode>>>,
@@ -47,7 +46,6 @@ pub struct Swarm {
 }
 
 impl Swarm {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         settings: &Settings,
         seed: RootSeed,
@@ -241,7 +239,6 @@ pub struct ComitNode {
 }
 
 impl ComitNode {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         seed: RootSeed,
         task_executor: Handle,

--- a/comit/src/btsieve/ethereum.rs
+++ b/comit/src/btsieve/ethereum.rs
@@ -256,12 +256,12 @@ impl Predates for Block {
     }
 }
 
-#[derive(Clone, Copy, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct Topic(pub Hash);
 
 /// Event works similar to web3 filters:
 /// https://web3js.readthedocs.io/en/1.0/web3-eth-subscribe.html?highlight=filter#subscribe-logs
-#[derive(Clone, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Event {
     pub address: Address,
     pub topics: Vec<Option<Topic>>,

--- a/comit/src/ethereum.rs
+++ b/comit/src/ethereum.rs
@@ -139,7 +139,7 @@ impl FromStr for Hash {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
 pub enum FromHexStrError {
     #[error("unable to decode string as hex")]
     InvalidHex(#[from] hex::FromHexError),

--- a/comit/src/lib.rs
+++ b/comit/src/lib.rs
@@ -1,3 +1,18 @@
+#![warn(
+    unused_extern_crates,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    rust_2018_idioms,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::fallible_impl_from,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_wrap,
+    clippy::print_stdout,
+    clippy::dbg_macro
+)]
+#![forbid(unsafe_code)]
+
 pub mod actions;
 pub mod asset;
 pub mod bitcoin;

--- a/comit/src/network/comit.rs
+++ b/comit/src/network/comit.rs
@@ -267,7 +267,6 @@ impl NetworkBehaviourEventProcess<orderbook::BehaviourOutEvent> for Comit {
 // CreatedSwapEvent pushed up to the ComitNode to let ComitNode know to save the
 // swap to the database. When a taker receives a TakeOrderResponse, the taker
 // converts the order into a swap.
-#[allow(clippy::cognitive_complexity)]
 impl NetworkBehaviourEventProcess<take_order::behaviour::BehaviourOutEvent> for Comit {
     fn inject_event(&mut self, event: take_order::behaviour::BehaviourOutEvent) {
         match event {

--- a/comit/src/network/protocols/announce.rs
+++ b/comit/src/network/protocols/announce.rs
@@ -25,6 +25,7 @@ use std::{
 /// us.
 #[derive(NetworkBehaviour)]
 #[behaviour(out_event = "BehaviourOutEvent", poll_method = "poll")]
+#[allow(missing_debug_implementations)]
 pub struct Announce {
     inner: RequestResponse<AnnounceCodec>,
 
@@ -276,7 +277,7 @@ pub enum BehaviourOutEvent {
     },
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct AnnounceProtocol;
 
 impl ProtocolName for AnnounceProtocol {
@@ -285,14 +286,14 @@ impl ProtocolName for AnnounceProtocol {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct AnnounceCodec;
 
 /// The different responses we can send back as part of an announcement.
 ///
 /// For now, this only includes a generic error variant in addition to the
 /// confirmation because we simply close the connection in case of an error.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum Response {
     Confirmation(SharedSwapId),
     Error,

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -18,7 +18,7 @@ use libp2p::{swarm::NetworkBehaviourEventProcess, PeerId};
 use serde::de::Error;
 use std::str::FromStr;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone, Copy)]
 pub enum OrderbookError {
     #[error("could not make order")]
     Make,
@@ -116,6 +116,7 @@ pub struct Order {
     pub absolute_expiry: u32,
 }
 
+#[derive(Debug)]
 pub struct OrderWithIdentities {
     pub id: OrderId,
     pub maker_id: Vec<u8>,
@@ -125,6 +126,7 @@ pub struct OrderWithIdentities {
     pub absolute_expiry: u32,
 }
 
+#[derive(Debug)]
 pub struct NewOrder {
     pub buy: asset::Bitcoin,
     pub sell: asset::Erc20,
@@ -155,6 +157,7 @@ impl Order {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
 pub struct DefaultMakerTopic;
 
 impl DefaultMakerTopic {
@@ -199,7 +202,7 @@ impl fmt::Debug for Orderbook {
     }
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct BehaviourOutEvent;
 
 impl NetworkBehaviourEventProcess<GossipsubEvent> for Orderbook {
@@ -308,8 +311,7 @@ impl Orderbook {
     }
 
     pub fn get_orders(&self) -> Vec<Order> {
-        #[allow(clippy::map_clone)]
-        self.orders.values().map(|order| order.clone()).collect()
+        self.orders.values().cloned().collect()
     }
 
     pub fn get_order(&self, order_id: &OrderId) -> Option<Order> {

--- a/comit/src/network/protocols/take_order/protocol.rs
+++ b/comit/src/network/protocols/take_order/protocol.rs
@@ -83,6 +83,7 @@ pub struct OrderConfirmed {
     pub swap_id: SharedSwapId,
 }
 
+#[derive(Debug)]
 pub struct InboundTakeOrderRequest<T> {
     pub order_id: OrderId,
     pub reply_substream: ReplySubstream<T>,
@@ -107,7 +108,7 @@ impl UpgradeInfo for InboundConfig {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct InboundMessage {
     order_id: OrderId,
     swap_digest: SwapDigest,


### PR DESCRIPTION
Noticed that we didn't have some of the lints enabled in the comit lib.