### PR TITLE
Make SwapContext query a view

### DIFF
--- a/cnd/migrations/2020-07-06-053142_release_0_9_0/down.sql
+++ b/cnd/migrations/2020-07-06-053142_release_0_9_0/down.sql
@@ -6,3 +6,5 @@ CREATE TABLE address_book
     peer_id                     NOT NULL,
     multi_address                NOT NULL
 );
+
+DROP VIEW swap_contexts;

--- a/cnd/migrations/2020-07-06-053142_release_0_9_0/up.sql
+++ b/cnd/migrations/2020-07-06-053142_release_0_9_0/up.sql
@@ -1,0 +1,24 @@
+-- Your SQL goes here
+
+DROP TABLE address_book;
+
+-- Here is how this works:
+-- * COALESCE selects the first non-null value from a list of values
+-- * We use 3 sub-selects to select a static value (i.e. 'halbit', etc) if that particular child table has a row with a foreign key to the parent table
+-- * We do this two times, once where we limit the results to rows that have `side` set to `Alpha` and once where `side` is set to `Beta`
+-- The result is a view with 5 columns: `id`, `local_swap_id`, `role`, `alpha` and `beta` where the `alpha` and `beta` columns have one of the values `halbit`, `herc20` or `hbit`
+CREATE VIEW swap_contexts AS
+SELECT id,
+       local_swap_id,
+       role,
+       COALESCE(
+               (SELECT 'halbit' from halbits where halbits.swap_id = swaps.id and halbits.side = 'Alpha'),
+               (SELECT 'herc20' from herc20s where herc20s.swap_id = swaps.id and herc20s.side = 'Alpha'),
+               (SELECT 'hbit' from hbits where hbits.swap_id = swaps.id and hbits.side = 'Alpha')
+           ) as alpha,
+       COALESCE(
+               (SELECT 'halbit' from halbits where halbits.swap_id = swaps.id and halbits.side = 'Beta'),
+               (SELECT 'herc20' from herc20s where herc20s.swap_id = swaps.id and herc20s.side = 'Beta'),
+               (SELECT 'hbit' from hbits where hbits.swap_id = swaps.id and hbits.side = 'Beta')
+           ) as beta
+FROM swaps

--- a/cnd/migrations/2020-07-06-053142_remove_address_book/up.sql
+++ b/cnd/migrations/2020-07-06-053142_remove_address_book/up.sql
@@ -1,3 +1,0 @@
--- Your SQL goes here
-
-DROP TABLE address_book;

--- a/cnd/src/facade.rs
+++ b/cnd/src/facade.rs
@@ -2,8 +2,8 @@ use crate::{
     btsieve::LatestBlock,
     connectors::Connectors,
     network::{ComitPeers, Identities, ListenAddresses, LocalPeerId, SwapDigest, Swarm},
-    storage::{Load, LoadAll, Storage},
-    LocalSwapId, Role, Save, Timestamp,
+    storage::{Load, LoadAll, Save, Storage},
+    LocalSwapId, Role, Timestamp,
 };
 use comit::{
     bitcoin, identity,

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -80,8 +80,7 @@ use self::{
     protocol_spawner::{ProtocolSpawner, *},
     respawn::respawn,
     spawn::*,
-    storage::{Sqlite, Storage, *},
-    RootSeed,
+    storage::{RootSeed, Sqlite, Storage},
 };
 use anyhow::Context;
 use comit::{

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -12,9 +12,8 @@ use crate::{
     identity,
     network::{peer_tracker::PeerTracker, Comit, LocalData},
     spawn,
-    storage::{ForSwap, Save},
-    CreatedSwap, Load, LocalSwapId, Never, Protocol, ProtocolSpawner, Role, RootSeed, SecretHash,
-    SharedSwapId, Storage, SwapContext,
+    storage::{CreatedSwap, ForSwap, Load, RootSeed, Save, SwapContext},
+    LocalSwapId, Never, Protocol, ProtocolSpawner, Role, SecretHash, SharedSwapId, Storage,
 };
 use ::comit::asset;
 use anyhow::Context;

--- a/cnd/src/spawn.rs
+++ b/cnd/src/spawn.rs
@@ -1,4 +1,7 @@
-use crate::{storage::SwapContext, Load, ProtocolSpawner, Role, Side, Spawn, Storage};
+use crate::{
+    storage::{Load, SwapContext},
+    ProtocolSpawner, Role, Side, Spawn, Storage,
+};
 use chrono::NaiveDateTime;
 
 #[derive(Clone, Copy, Debug)]

--- a/cnd/src/storage/db.rs
+++ b/cnd/src/storage/db.rs
@@ -9,9 +9,9 @@ embed_migrations!("./migrations");
 pub use self::{errors::*, tables::*, wrapper_types::custom_sql_types::Text};
 pub use crate::storage::{ForSwap, Save};
 
-use crate::{LocalSwapId, Protocol, Role};
+use crate::{LocalSwapId, Role};
 use chrono::NaiveDateTime;
-use diesel::{self, prelude::*, sql_types, sqlite::SqliteConnection};
+use diesel::{self, prelude::*, sqlite::SqliteConnection};
 use libp2p::PeerId;
 use std::{
     ffi::OsStr,
@@ -27,18 +27,6 @@ use tokio::sync::Mutex;
 pub struct Sqlite {
     #[derivative(Debug = "ignore")]
     connection: Arc<Mutex<SqliteConnection>>,
-}
-
-#[derive(Clone, Copy, Debug, QueryableByName)]
-pub struct SwapContextRow {
-    #[sql_type = "sql_types::Text"]
-    pub id: Text<LocalSwapId>,
-    #[sql_type = "sql_types::Text"]
-    pub role: Text<Role>,
-    #[sql_type = "sql_types::Text"]
-    pub alpha: Text<Protocol>,
-    #[sql_type = "sql_types::Text"]
-    pub beta: Text<Protocol>,
 }
 
 impl Sqlite {
@@ -85,37 +73,6 @@ impl Sqlite {
         let result = connection.transaction(|| f(&connection))?;
 
         Ok(result)
-    }
-
-    pub async fn swap_contexts(&self) -> anyhow::Result<Vec<SwapContextRow>> {
-        let contexts = self.do_in_transaction(|connection| {
-            // Here is how this works:
-            // - COALESCE selects the first non-null value from a list of values
-            // - We use 3 sub-selects to select a static value (i.e. 'halbit', etc) if that particular child table has a row with a foreign key to the parent table
-            // - We do this two times, once where we limit the results to rows that have `ledger` set to `Alpha` and once where `ledger` is set to `Beta`
-            //
-            // The result is a view with 4 columns: `id`, `role`, `alpha` and `beta` where the `alpha` and `beta` columns have one of the values `halbit`, `herc20` or `hbit`
-            diesel::sql_query(
-                r#"
-                        SELECT
-                            local_swap_id as id,
-                            role,
-                            COALESCE(
-                               (SELECT 'halbit' from halbits where halbits.swap_id = swaps.id and halbits.side = 'Alpha'),
-                               (SELECT 'herc20' from herc20s where herc20s.swap_id = swaps.id and herc20s.side = 'Alpha'),
-                               (SELECT 'hbit' from hbits where hbits.swap_id = swaps.id and hbits.side = 'Alpha')
-                            ) as alpha,
-                            COALESCE(
-                               (SELECT 'halbit' from halbits where halbits.swap_id = swaps.id and halbits.side = 'Beta'),
-                               (SELECT 'herc20' from herc20s where herc20s.swap_id = swaps.id and herc20s.side = 'Beta'),
-                               (SELECT 'hbit' from hbits where hbits.swap_id = swaps.id and hbits.side = 'Beta')
-                            ) as beta
-                        FROM swaps
-                    "#,
-            ).get_results::<SwapContextRow>(connection)
-        }).await?;
-
-        Ok(contexts)
     }
 }
 

--- a/cnd/src/storage/db/integration_tests.rs
+++ b/cnd/src/storage/db/integration_tests.rs
@@ -1,2 +1,2 @@
-mod load_protocol_combination;
 mod serialization_format_stability;
+mod swap_context;

--- a/cnd/src/storage/db/integration_tests/swap_context.rs
+++ b/cnd/src/storage/db/integration_tests/swap_context.rs
@@ -1,7 +1,7 @@
 use crate::{
     proptest::*,
-    storage::{db::CreatedSwap, SwapContext},
-    Load, Protocol, Save, Storage,
+    storage::{CreatedSwap, Load, Save, SwapContext},
+    Protocol, Storage,
 };
 use proptest::prelude::*;
 use tokio::runtime::Runtime;

--- a/cnd/src/storage/db/schema.rs
+++ b/cnd/src/storage/db/schema.rs
@@ -60,6 +60,16 @@ table! {
     }
 }
 
+table! {
+    swap_contexts {
+        id -> Integer,
+        local_swap_id -> Text,
+        role -> Text,
+        alpha -> Text,
+        beta -> Text,
+    }
+}
+
 allow_tables_to_appear_in_same_query!(swaps, halbits);
 allow_tables_to_appear_in_same_query!(swaps, herc20s);
 allow_tables_to_appear_in_same_query!(swaps, hbits);

--- a/cnd/src/storage/db/tables.rs
+++ b/cnd/src/storage/db/tables.rs
@@ -1,14 +1,14 @@
 use crate::{
     asset, bitcoin, halbit, hbit, herc20, identity, lightning,
     storage::db::{
-        schema::{halbits, hbits, herc20s, secret_hashes, swaps},
+        schema::{halbits, hbits, herc20s, secret_hashes, swap_contexts, swaps},
         wrapper_types::{
             custom_sql_types::{Text, U32},
             BitcoinNetwork, Erc20Amount, Satoshis,
         },
         Sqlite,
     },
-    LocalSwapId, Role, Side,
+    LocalSwapId, Protocol, Role, Side,
 };
 use anyhow::Context;
 use chrono::NaiveDateTime;
@@ -59,6 +59,16 @@ impl InsertableSwap {
             start_of_swap,
         }
     }
+}
+
+#[derive(Associations, Clone, Copy, Debug, Identifiable, Queryable, PartialEq)]
+#[table_name = "swap_contexts"]
+pub struct SwapContext {
+    id: i32,
+    pub local_swap_id: Text<LocalSwapId>,
+    pub role: Text<Role>,
+    pub alpha: Text<Protocol>,
+    pub beta: Text<Protocol>,
 }
 
 #[derive(Associations, Clone, Copy, Debug, Identifiable, Queryable, PartialEq)]

--- a/cnd/src/storage/http_api.rs
+++ b/cnd/src/storage/http_api.rs
@@ -4,10 +4,10 @@ use crate::{
     http_api::{halbit, hbit, herc20, AliceSwap, BobSwap},
     state::Get,
     storage::{
-        db::{Halbit, Hbit, Herc20, NoRedeemIdentity, NoRefundIdentity, NoSecretHash},
-        LoadTables, RootSeed, Tables,
+        Halbit, Hbit, Herc20, Load, LoadTables, NoRedeemIdentity, NoRefundIdentity, NoSecretHash,
+        RootSeed, Tables,
     },
-    Load, LocalSwapId, Storage,
+    LocalSwapId, Storage,
 };
 use async_trait::async_trait;
 


### PR DESCRIPTION
This allows us to avoid inline SQL and instead use diesel's built-in abstractions to query and deal with this query.

Initially, I thought the benefit we would be getting out of this is that sqlite would complain if we make a mistake in the SQL query, for example, when a column is misspelled.

Unfortunately, that is not the case but I only realized after the change was done so I thought I put it up anyway :D