### PR TITLE
Add serialization/deserialization for Bitcoin network

### DIFF
--- a/cnd/src/http_api.rs
+++ b/cnd/src/http_api.rs
@@ -174,43 +174,6 @@ impl Serialize for Http<PeerId> {
     }
 }
 
-impl Serialize for Http<ledger::Bitcoin> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let str = match self {
-            Http(ledger::Bitcoin::Mainnet) => "mainnet",
-            Http(ledger::Bitcoin::Testnet) => "testnet",
-            Http(ledger::Bitcoin::Regtest) => "regtest",
-        };
-
-        serializer.serialize_str(str)
-    }
-}
-
-impl<'de> Deserialize<'de> for Http<ledger::Bitcoin> {
-    fn deserialize<D>(deserializer: D) -> Result<Http<ledger::Bitcoin>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let network = match String::deserialize(deserializer)?.as_str() {
-            "mainnet" => ledger::Bitcoin::Mainnet,
-            "testnet" => ledger::Bitcoin::Testnet,
-            "regtest" => ledger::Bitcoin::Regtest,
-
-            network => {
-                return Err(<D as Deserializer<'de>>::Error::custom(format!(
-                    "not regtest: {}",
-                    network
-                )))
-            }
-        };
-
-        Ok(Http(network))
-    }
-}
-
 impl Serialize for Http<bitcoin::Network> {
     fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
     where

--- a/cnd/src/http_api/halbit.rs
+++ b/cnd/src/http_api/halbit.rs
@@ -1,7 +1,5 @@
 use crate::{
-    asset,
-    http_api::Http,
-    identity, ledger,
+    asset, identity, ledger,
     lnd::{AddHoldInvoice, Chain, SendPayment, SettleInvoice},
     RelativeTime, Secret, SecretHash,
 };
@@ -10,12 +8,12 @@ pub use crate::halbit::*;
 
 /// Data for the halbit protocol, wrapped where needed to control
 /// serialization/deserialization.
-#[derive(serde::Deserialize, Clone, Debug)]
+#[derive(serde::Deserialize, Clone, Copy, Debug)]
 pub struct Halbit {
     #[serde(with = "asset::bitcoin::sats_as_string")]
     pub amount: asset::Bitcoin,
     pub identity: identity::Lightning,
-    pub network: Http<ledger::Bitcoin>,
+    pub network: ledger::Bitcoin,
     pub cltv_expiry: u32,
 }
 
@@ -24,7 +22,7 @@ impl From<Halbit> for CreatedSwap {
         CreatedSwap {
             asset: p.amount,
             identity: p.identity,
-            network: *p.network,
+            network: p.network,
             cltv_expiry: p.cltv_expiry,
         }
     }


### PR DESCRIPTION
The bitcoin networks have canonical names (bitcoin, testnet, regtest). As such we can implement serialization/deserialization on them within COMIT and users can simply use these implementations.

Done in preparation for adding networks to the orderbook.

Based on information learned in @thomaseizinger recent post about serialization. If I have mis-understood you Thomas please say so.