### PR TITLE
Add configurable ledger to ordebook

### DIFF
--- a/api_tests/src/actors/order_factory.ts
+++ b/api_tests/src/actors/order_factory.ts
@@ -1,19 +1,29 @@
 export interface Herc20HbitOrder {
     buy_quantity: string;
+    bitcoin_ledger: string;
     sell_token_contract: string;
     sell_quantity: string;
+    ethereum_ledger: Ethereum;
     absolute_expiry: number;
     refund_identity: string;
     redeem_identity: string;
     maker_addr: string;
 }
 
+interface Ethereum {
+    chain_id: number;
+}
+
 export default class OrderFactory {
     public static newHerc20HbitOrder(makerAddr: string): Herc20HbitOrder {
         return {
             buy_quantity: "100",
+            bitcoin_ledger: "regtest",
             sell_token_contract: "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280",
             sell_quantity: "200",
+            ethereum_ledger: {
+                chain_id: 1337,
+            },
             absolute_expiry: 600,
             refund_identity: "1F1tAaz5x1HUXrCNLbtMDqcw6o5GNn4xqX",
             redeem_identity: "0x00a329c0648769a73afac7f9381e08fb43dbea72",

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -1,7 +1,7 @@
 mod take_order;
 
 use crate::{
-    asset,
+    asset, ledger,
     network::protocols::orderbook::take_order::{Response, TakeOrderCodec, TakeOrderProtocol},
     SharedSwapId,
 };
@@ -307,14 +307,18 @@ pub struct Order {
     pub id: OrderId,
     pub maker: MakerId,
     pub buy: u64,
+    pub bitcoin_ledger: ledger::Bitcoin,
     pub sell: asset::Erc20,
+    pub ethereum_ledger: ledger::Ethereum,
     pub absolute_expiry: u32,
 }
 
 #[derive(Debug)]
 pub struct NewOrder {
     pub buy: asset::Bitcoin,
+    pub bitcoin_ledger: ledger::Bitcoin,
     pub sell: asset::Erc20,
+    pub ethereum_ledger: ledger::Ethereum,
     pub absolute_expiry: u32,
 }
 
@@ -324,7 +328,9 @@ impl Order {
             id: Uuid::new_v4(),
             maker: MakerId(peer_id),
             buy: new_order.buy.as_sat(),
+            bitcoin_ledger: new_order.bitcoin_ledger,
             sell: new_order.sell,
+            ethereum_ledger: new_order.ethereum_ledger,
             absolute_expiry: new_order.absolute_expiry,
         }
     }
@@ -335,6 +341,18 @@ impl Order {
             sell: SwapType::Herc20,
         }
         .to_topic(peer)
+    }
+}
+
+impl NewOrder {
+    pub fn assert_valid_ledger_pair(&self) -> anyhow::Result<()> {
+        let a = self.bitcoin_ledger;
+        let b = self.ethereum_ledger;
+
+        if ledger::is_valid_ledger_pair(a, b) {
+            return Ok(());
+        }
+        Err(anyhow::anyhow!("invalid ledger pair {}/{}", a, b))
     }
 }
 
@@ -500,10 +518,12 @@ mod tests {
     fn create_order(id: PeerId) -> Order {
         Order::new(id, NewOrder {
             buy: asset::Bitcoin::from_sat(100),
+            bitcoin_ledger: ledger::Bitcoin::Regtest,
             sell: Erc20 {
                 token_contract: Default::default(),
                 quantity: Erc20Quantity::max_value(),
             },
+            ethereum_ledger: ledger::Ethereum::default(),
             absolute_expiry: 100,
         })
     }


### PR DESCRIPTION
Currently we hardcode regtest in the orderbook. We would like to somehow be able to configure the network so this works on mainnet.

Support mainnet by doing:
- Add a field for both bitcoin and ethereum ledgers on the cnd order creation endpoint.
- Add the ledgers to the orderbook within comit crate.
- Add an assertion method on `NewOrder` to assert a valid ledger pair, defined as the 'same' network kind. Add infrastructure for this assertion.
- Add ser/deser tests for the `ledger` module.