### PR TITLE
Add serialization tests for MakerId

### DIFF
--- a/cnd/src/http_api/orderbook.rs
+++ b/cnd/src/http_api/orderbook.rs
@@ -64,7 +64,7 @@ impl Herc20HbitOrderResponse {
             sell_token_contract: order.sell.token_contract,
             sell_quantity: order.sell.quantity.clone(),
             absolute_expiry: order.absolute_expiry,
-            maker: order.maker.peer_id().to_string(),
+            maker: order.maker.to_string(),
             id: order.id,
         }
     }
@@ -112,7 +112,7 @@ pub async fn post_take_herc20_hbit_order(
             network: ledger::Bitcoin::Regtest,
             absolute_expiry: order.absolute_expiry,
         },
-        peer: order.maker.peer_id(),
+        peer: order.maker.clone().into(),
         address_hint: None,
         role: Role::Alice,
         start_of_swap,

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -496,6 +496,7 @@ mod tests {
         network::test::{await_events_or_timeout, new_connected_swarm_pair},
     };
     use libp2p::Swarm;
+    use spectral::prelude::*;
 
     fn create_order(id: PeerId) -> Order {
         Order::new(id, NewOrder {
@@ -586,5 +587,17 @@ mod tests {
         while let Ok(event) = tokio::time::timeout(delay, swarm.next()).await {
             panic!("unexpected event emitted: {:?}", event)
         }
+    }
+
+    #[test]
+    fn peer_id_serializes_as_expected() {
+        let given = "QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY".to_string();
+        let peer_id = PeerId::from_str(&given).expect("failed to parse peer id");
+        let maker_id = MakerId(peer_id);
+
+        let want = format!("\"{}\"", given);
+        let got = serde_json::to_string(&maker_id).expect("failed to serialize peer id");
+
+        assert_that(&got).is_equal_to(want);
     }
 }

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -106,20 +106,18 @@ impl Orderbook {
     /// Take an order, called by Alice i.e., the taker.
     /// Does _not_ remove the order from the order book.
     pub fn take(&mut self, order_id: OrderId) -> anyhow::Result<()> {
-        let peer_id = self
-            .peer_id_for_order(order_id)
+        let maker_id = self
+            .maker_id(order_id)
             .ok_or_else(|| OrderbookError::OrderNotFound(order_id))?;
 
-        self.take_order.send_request(&peer_id, order_id);
+        self.take_order.send_request(&maker_id.into(), order_id);
 
         Ok(())
     }
 
-    /// Get the peer ID of the node that published this order.
-    pub fn peer_id_for_order(&self, order_id: OrderId) -> Option<PeerId> {
-        self.orders
-            .get(&order_id)
-            .map(|order| order.maker.clone().into())
+    /// Get the ID of the node that published this order.
+    fn maker_id(&self, order_id: OrderId) -> Option<MakerId> {
+        self.orders.get(&order_id).map(|order| order.maker.clone())
     }
 
     /// Confirm a take order request, called by Bob i.e., the maker.


### PR DESCRIPTION
The `MakerId` only exists so we can implement serialization/deserialization on it. 

- Adds stability test
- Adds a roundtrip test
- Adds `From` and `Display` impls (not so sure if we want these)?