### PR TITLE
Refactor order code

### DIFF
--- a/cnd/src/facade.rs
+++ b/cnd/src/facade.rs
@@ -1,13 +1,13 @@
 use crate::{
     btsieve::LatestBlock,
     connectors::Connectors,
-    network::{ComitPeers, Identities, ListenAddresses, LocalPeerId, SwapDigest, Swarm},
+    network::{ComitPeers, Identities, ListenAddresses, LocalPeerId, NewOrder, SwapDigest, Swarm},
     storage::{Load, LoadAll, Save, Storage},
     LocalSwapId, Role, Timestamp,
 };
 use comit::{
     bitcoin, identity,
-    network::{NewOrder, Order, OrderId, TradingPair},
+    network::{Order, OrderId, TradingPair},
 };
 use libp2p::{Multiaddr, PeerId};
 

--- a/cnd/src/http_api/orderbook.rs
+++ b/cnd/src/http_api/orderbook.rs
@@ -2,13 +2,14 @@ use crate::{
     asset, hbit, herc20,
     http_api::problem,
     identity, ledger,
+    network::NewOrder,
     storage::{CreatedSwap, Save},
     Facade, LocalSwapId, Role,
 };
 use chrono::Utc;
 use comit::{
     ethereum,
-    network::{NewOrder, Order, OrderId, SwapType},
+    network::{Order, OrderId, SwapType},
 };
 use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};

--- a/cnd/src/http_api/orderbook.rs
+++ b/cnd/src/http_api/orderbook.rs
@@ -12,7 +12,6 @@ use comit::{
 };
 use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 use warp::{http, http::StatusCode, Rejection, Reply};
 
 #[derive(Deserialize)]
@@ -57,7 +56,7 @@ struct Herc20HbitOrderResponse {
     sell_quantity: asset::Erc20Quantity,
     absolute_expiry: u32,
     maker: String,
-    id: Uuid,
+    id: OrderId,
 }
 
 impl Herc20HbitOrderResponse {

--- a/cnd/src/http_api/orderbook.rs
+++ b/cnd/src/http_api/orderbook.rs
@@ -61,9 +61,10 @@ struct Herc20HbitOrderResponse {
 }
 
 impl Herc20HbitOrderResponse {
+    // TODO: This should implement From
     fn from_order(order: &Order) -> Self {
         Herc20HbitOrderResponse {
-            buy_quantity: asset::Bitcoin::from_sat(order.buy),
+            buy_quantity: order.buy,
             sell_token_contract: order.sell.token_contract,
             sell_quantity: order.sell.quantity.clone(),
             absolute_expiry: order.absolute_expiry,
@@ -110,7 +111,7 @@ pub async fn post_take_herc20_hbit_order(
             absolute_expiry: order.absolute_expiry,
         },
         beta: hbit::CreatedSwap {
-            amount: asset::Bitcoin::from_sat(order.buy),
+            amount: asset::Bitcoin::from_sat(order.buy.as_sat()),
             final_identity: redeem_identity.clone(),
             network: ledger::Bitcoin::Regtest,
             absolute_expiry: order.absolute_expiry,

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -372,7 +372,7 @@ impl ComitNode {
         let order = Order {
             id: OrderId::random(),
             maker: MakerId::from(self.peer_id.clone()),
-            buy: new_order.buy.as_sat(),
+            buy: new_order.buy,
             bitcoin_ledger: new_order.bitcoin_ledger,
             sell: new_order.sell,
             ethereum_ledger: new_order.ethereum_ledger,
@@ -593,7 +593,7 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<orderbook::BehaviourOutEvent> f
                         absolute_expiry: order.absolute_expiry,
                     },
                     beta: hbit::CreatedSwap {
-                        amount: asset::Bitcoin::from_sat(order.buy),
+                        amount: asset::Bitcoin::from_sat(order.buy.as_sat()),
                         final_identity: final_identity.into(),
                         network: ledger::Bitcoin::Regtest,
                         absolute_expiry: order.absolute_expiry,

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -1,7 +1,7 @@
+mod order;
 mod take_order;
 
 use crate::{
-    asset, ledger,
     network::protocols::orderbook::take_order::{Response, TakeOrderCodec, TakeOrderProtocol},
     SharedSwapId,
 };
@@ -26,7 +26,8 @@ use std::{
     task::{Context, Poll},
     time::Duration,
 };
-use uuid::Uuid;
+
+pub use self::order::*;
 
 // We only support a single topic at the moment.
 const TOPIC: &str = "Herc20Hbit";
@@ -266,8 +267,6 @@ impl TradingPairTopic {
     }
 }
 
-pub type OrderId = Uuid;
-
 /// MakerId is a PeerId wrapper so we control serialization/deserialization.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MakerId(PeerId);
@@ -309,60 +308,6 @@ impl<'de> Deserialize<'de> for MakerId {
         let peer_id = PeerId::from_str(&string).map_err(D::Error::custom)?;
 
         Ok(MakerId(peer_id))
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct Order {
-    pub id: OrderId,
-    pub maker: MakerId,
-    pub buy: u64,
-    pub bitcoin_ledger: ledger::Bitcoin,
-    pub sell: asset::Erc20,
-    pub ethereum_ledger: ledger::Ethereum,
-    pub absolute_expiry: u32,
-}
-
-#[derive(Debug)]
-pub struct NewOrder {
-    pub buy: asset::Bitcoin,
-    pub bitcoin_ledger: ledger::Bitcoin,
-    pub sell: asset::Erc20,
-    pub ethereum_ledger: ledger::Ethereum,
-    pub absolute_expiry: u32,
-}
-
-impl Order {
-    pub fn new(peer_id: PeerId, new_order: NewOrder) -> Self {
-        Order {
-            id: Uuid::new_v4(),
-            maker: MakerId(peer_id),
-            buy: new_order.buy.as_sat(),
-            bitcoin_ledger: new_order.bitcoin_ledger,
-            sell: new_order.sell,
-            ethereum_ledger: new_order.ethereum_ledger,
-            absolute_expiry: new_order.absolute_expiry,
-        }
-    }
-
-    pub fn topic(&self, peer: &PeerId) -> Topic {
-        TradingPair {
-            buy: SwapType::Hbit,
-            sell: SwapType::Herc20,
-        }
-        .to_topic(peer)
-    }
-}
-
-impl NewOrder {
-    pub fn assert_valid_ledger_pair(&self) -> anyhow::Result<()> {
-        let a = self.bitcoin_ledger;
-        let b = self.ethereum_ledger;
-
-        if ledger::is_valid_ledger_pair(a, b) {
-            return Ok(());
-        }
-        Err(anyhow::anyhow!("invalid ledger pair {}/{}", a, b))
     }
 }
 
@@ -521,6 +466,7 @@ mod tests {
     use super::*;
     use crate::{
         asset::{self, Erc20, Erc20Quantity},
+        ledger,
         network::test::{await_events_or_timeout, new_connected_swarm_pair},
     };
     use libp2p::Swarm;

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -94,7 +94,7 @@ impl Orderbook {
     pub fn make(&mut self, order: Order) -> anyhow::Result<OrderId> {
         let order_id = order.id;
         let ser = bincode::serialize(&Message::CreateOrder(order.clone()))?;
-        let topic = order.topic(&self.peer_id);
+        let topic = order.topic();
 
         self.gossipsub.publish(&topic, ser);
         tracing::info!("published order: {}", order_id);
@@ -473,7 +473,9 @@ mod tests {
     use spectral::prelude::*;
 
     fn create_order(id: PeerId) -> Order {
-        Order::new(id, NewOrder {
+        Order {
+            id: OrderId::random(),
+            maker: MakerId::from(id),
             buy: asset::Bitcoin::from_sat(100),
             bitcoin_ledger: ledger::Bitcoin::Regtest,
             sell: Erc20 {
@@ -482,7 +484,7 @@ mod tests {
             },
             ethereum_ledger: ledger::Ethereum::default(),
             absolute_expiry: 100,
-        })
+        }
     }
 
     #[tokio::test]

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -4,9 +4,32 @@ use crate::{
 };
 use libp2p::{gossipsub::Topic, PeerId};
 use serde::{Deserialize, Serialize};
+use std::{fmt::Display, str::FromStr};
 use uuid::Uuid;
 
-pub type OrderId = Uuid;
+#[derive(Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrderId(Uuid);
+
+impl OrderId {
+    pub fn random() -> OrderId {
+        OrderId(Uuid::new_v4())
+    }
+}
+
+impl Display for OrderId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for OrderId {
+    type Err = uuid::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let uuid = Uuid::from_str(s)?;
+        Ok(OrderId(uuid))
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Order {
@@ -31,7 +54,7 @@ pub struct NewOrder {
 impl Order {
     pub fn new(peer_id: PeerId, new_order: NewOrder) -> Self {
         Order {
-            id: Uuid::new_v4(),
+            id: OrderId::random(),
             maker: MakerId(peer_id),
             buy: new_order.buy.as_sat(),
             bitcoin_ledger: new_order.bitcoin_ledger,
@@ -59,5 +82,19 @@ impl NewOrder {
             return Ok(());
         }
         Err(anyhow::anyhow!("invalid ledger pair {}/{}", a, b))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn order_id_serialization_roundtrip() {
+        // TODO: Implement order_id_serialization_roundtrip()
+    }
+
+    #[test]
+    fn order_id_serialization_stability() {
+        // TODO: Implement order_id_serialization_stability()
     }
 }

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -35,7 +35,8 @@ impl FromStr for OrderId {
 pub struct Order {
     pub id: OrderId,
     pub maker: MakerId,
-    pub buy: u64,
+    #[serde(with = "asset::bitcoin::sats_as_string")]
+    pub buy: asset::Bitcoin,
     pub bitcoin_ledger: ledger::Bitcoin,
     pub sell: asset::Erc20,
     pub ethereum_ledger: ledger::Ethereum,
@@ -64,5 +65,15 @@ mod tests {
     #[test]
     fn order_id_serialization_stability() {
         // TODO: Implement order_id_serialization_stability()
+    }
+
+    #[test]
+    fn order_serialization_roundtrip() {
+        // TODO: Implement order_serialization_roundtrip()
+    }
+
+    #[test]
+    fn order_serialization_stability() {
+        // TODO: Implement order_serialization_stability()
     }
 }

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -42,46 +42,14 @@ pub struct Order {
     pub absolute_expiry: u32,
 }
 
-#[derive(Debug)]
-pub struct NewOrder {
-    pub buy: asset::Bitcoin,
-    pub bitcoin_ledger: ledger::Bitcoin,
-    pub sell: asset::Erc20,
-    pub ethereum_ledger: ledger::Ethereum,
-    pub absolute_expiry: u32,
-}
-
 impl Order {
-    pub fn new(peer_id: PeerId, new_order: NewOrder) -> Self {
-        Order {
-            id: OrderId::random(),
-            maker: MakerId(peer_id),
-            buy: new_order.buy.as_sat(),
-            bitcoin_ledger: new_order.bitcoin_ledger,
-            sell: new_order.sell,
-            ethereum_ledger: new_order.ethereum_ledger,
-            absolute_expiry: new_order.absolute_expiry,
-        }
-    }
-
-    pub fn topic(&self, peer: &PeerId) -> Topic {
+    pub fn topic(&self) -> Topic {
+        let peer_id = PeerId::from(self.maker.clone());
         TradingPair {
             buy: SwapType::Hbit,
             sell: SwapType::Herc20,
         }
-        .to_topic(peer)
-    }
-}
-
-impl NewOrder {
-    pub fn assert_valid_ledger_pair(&self) -> anyhow::Result<()> {
-        let a = self.bitcoin_ledger;
-        let b = self.ethereum_ledger;
-
-        if ledger::is_valid_ledger_pair(a, b) {
-            return Ok(());
-        }
-        Err(anyhow::anyhow!("invalid ledger pair {}/{}", a, b))
+        .to_topic(&peer_id)
     }
 }
 

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -1,0 +1,63 @@
+use crate::{
+    asset, ledger,
+    network::protocols::orderbook::{MakerId, SwapType, TradingPair},
+};
+use libp2p::{gossipsub::Topic, PeerId};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+pub type OrderId = Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Order {
+    pub id: OrderId,
+    pub maker: MakerId,
+    pub buy: u64,
+    pub bitcoin_ledger: ledger::Bitcoin,
+    pub sell: asset::Erc20,
+    pub ethereum_ledger: ledger::Ethereum,
+    pub absolute_expiry: u32,
+}
+
+#[derive(Debug)]
+pub struct NewOrder {
+    pub buy: asset::Bitcoin,
+    pub bitcoin_ledger: ledger::Bitcoin,
+    pub sell: asset::Erc20,
+    pub ethereum_ledger: ledger::Ethereum,
+    pub absolute_expiry: u32,
+}
+
+impl Order {
+    pub fn new(peer_id: PeerId, new_order: NewOrder) -> Self {
+        Order {
+            id: Uuid::new_v4(),
+            maker: MakerId(peer_id),
+            buy: new_order.buy.as_sat(),
+            bitcoin_ledger: new_order.bitcoin_ledger,
+            sell: new_order.sell,
+            ethereum_ledger: new_order.ethereum_ledger,
+            absolute_expiry: new_order.absolute_expiry,
+        }
+    }
+
+    pub fn topic(&self, peer: &PeerId) -> Topic {
+        TradingPair {
+            buy: SwapType::Hbit,
+            sell: SwapType::Herc20,
+        }
+        .to_topic(peer)
+    }
+}
+
+impl NewOrder {
+    pub fn assert_valid_ledger_pair(&self) -> anyhow::Result<()> {
+        let a = self.bitcoin_ledger;
+        let b = self.ethereum_ledger;
+
+        if ledger::is_valid_ledger_pair(a, b) {
+            return Ok(());
+        }
+        Err(anyhow::anyhow!("invalid ledger pair {}/{}", a, b))
+    }
+}


### PR DESCRIPTION
Refactor the order code (`Order` and `NewOrder`) by doing:

- Patch 1: Add an `order` module to the orderbook (move `Order`, `NewOrder`, `OrderId` into it)
- Patch 2: Use a struct instead of a type alias for `OrderId`
- Patch 3: Move the `NewOrder` type to cnd (it is only used to interface between the controller and the network layer in cnd)
- Patch 4: Use `asset::Bitcoin` in the `Order` struct instead of a u64