### PR TITLE
Orderbook order

### DIFF
--- a/api_tests/src/actors/order_factory.ts
+++ b/api_tests/src/actors/order_factory.ts
@@ -1,13 +1,13 @@
 export interface Herc20HbitOrder {
-    buy_quantity: string;
+    trade: string;
+    bitcoin_amount: string;
     bitcoin_ledger: string;
-    sell_token_contract: string;
-    sell_quantity: string;
+    ethereum_amount: string;
+    token_contract: string;
     ethereum_ledger: Ethereum;
     absolute_expiry: number;
     refund_identity: string;
     redeem_identity: string;
-    maker_addr: string;
 }
 
 interface Ethereum {
@@ -15,19 +15,19 @@ interface Ethereum {
 }
 
 export default class OrderFactory {
-    public static newHerc20HbitOrder(makerAddr: string): Herc20HbitOrder {
+    public static newHerc20HbitOrder(): Herc20HbitOrder {
         return {
-            buy_quantity: "100",
+            trade: "sell",
+            bitcoin_amount: "100000",
             bitcoin_ledger: "regtest",
-            sell_token_contract: "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280",
-            sell_quantity: "200",
+            ethereum_amount: "200",
+            token_contract: "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280",
             ethereum_ledger: {
                 chain_id: 1337,
             },
             absolute_expiry: 600,
             refund_identity: "1F1tAaz5x1HUXrCNLbtMDqcw6o5GNn4xqX",
             redeem_identity: "0x00a329c0648769a73afac7f9381e08fb43dbea72",
-            maker_addr: makerAddr,
         };
     }
 }

--- a/api_tests/tests/orderbook.ts
+++ b/api_tests/tests/orderbook.ts
@@ -20,11 +20,13 @@ it(
         // Bob dials alice
         // @ts-ignore
         await bob.cnd.client.post("dial", { addresses: aliceAddr });
+        // @ts-ignore
+        await alice.cnd.client.post("dial", { addresses: bobAddr });
 
         /// Wait for alice to accept an incoming connection from Bob
         await sleep(1000);
 
-        const bobMakeOrderBody = OrderFactory.newHerc20HbitOrder(bobAddr[0]);
+        const bobMakeOrderBody = OrderFactory.newHerc20HbitOrder();
         // @ts-ignore
         // make response contain url in the header to the created order
         // poll this order to see when when it has been converted to a swap

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -445,7 +445,7 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<OrderId, Response>> for O
 mod tests {
     use super::*;
     use crate::{
-        asset::{self, Erc20, Erc20Quantity},
+        asset::{self, Erc20Quantity},
         ledger,
         network::test::{await_events_or_timeout, new_connected_swarm_pair},
     };
@@ -457,13 +457,11 @@ mod tests {
             id: OrderId::random(),
             maker: MakerId::from(id),
             trade: Trade::Sell,
-            btc: asset::Bitcoin::from_sat(100),
+            bitcoin_amount: asset::Bitcoin::from_sat(100),
             bitcoin_ledger: ledger::Bitcoin::Regtest,
-            dai: Erc20 {
-                quantity: Erc20Quantity::max_value(),
-                // TODO: Use a more sane value?
-                token_contract: Default::default(),
-            },
+            // TODO: Use a more sane value?
+            ethereum_amount: Erc20Quantity::max_value(),
+            token_contract: Default::default(),
             ethereum_ledger: ledger::Ethereum::default(),
             absolute_expiry: 100,
         }
@@ -549,6 +547,7 @@ mod tests {
         }
     }
 
+    // TODO: Rename this - it should be maker_id_...
     #[test]
     fn peer_id_serializes_as_expected() {
         let given = "QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY".to_string();
@@ -561,6 +560,7 @@ mod tests {
         assert_that(&got).is_equal_to(want);
     }
 
+    // TODO: Rename this - it should be maker_id_...
     #[test]
     fn peer_id_serialization_roundtrip_test() {
         let s = "QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY".to_string();

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -1,8 +1,5 @@
-use crate::{
-    asset, ledger,
-    network::protocols::orderbook::{MakerId, SwapType, TradingPair},
-};
-use libp2p::{gossipsub::Topic, PeerId};
+use crate::{asset, ledger, network::protocols::orderbook::MakerId};
+use libp2p::gossipsub::Topic;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, str::FromStr};
 use uuid::Uuid;
@@ -45,12 +42,8 @@ pub struct Order {
 
 impl Order {
     pub fn topic(&self) -> Topic {
-        let peer_id = PeerId::from(self.maker.clone());
-        TradingPair {
-            buy: SwapType::Hbit,
-            sell: SwapType::Herc20,
-        }
-        .to_topic(&peer_id)
+        // TODO: Do we need this?
+        unimplemented!();
     }
 }
 

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -1,5 +1,7 @@
-use crate::{asset, ledger, network::protocols::orderbook::MakerId};
-use libp2p::gossipsub::Topic;
+use crate::{
+    asset, ledger,
+    network::protocols::orderbook::{MakerId, TradingPair, BTC_DAI},
+};
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, str::FromStr};
 use uuid::Uuid;
@@ -32,19 +34,31 @@ impl FromStr for OrderId {
 pub struct Order {
     pub id: OrderId,
     pub maker: MakerId,
+    pub trade: Trade,
     #[serde(with = "asset::bitcoin::sats_as_string")]
-    pub buy: asset::Bitcoin,
+    pub btc: asset::Bitcoin,
     pub bitcoin_ledger: ledger::Bitcoin,
-    pub sell: asset::Erc20,
+    pub dai: asset::Erc20,
     pub ethereum_ledger: ledger::Ethereum,
+    // TODO: Add both expiries
     pub absolute_expiry: u32,
 }
 
 impl Order {
-    pub fn topic(&self) -> Topic {
-        // TODO: Do we need this?
-        unimplemented!();
+    pub fn tp(&self) -> TradingPair {
+        TradingPair::BtcDai
     }
+
+    pub fn topic(&self) -> String {
+        BTC_DAI.to_string()
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum Trade {
+    Buy,
+    Sell,
 }
 
 #[cfg(test)]
@@ -61,12 +75,12 @@ mod tests {
     }
 
     #[test]
-    fn order_serialization_roundtrip() {
-        // TODO: Implement order_serialization_roundtrip()
+    fn btc_dai_order_serialization_roundtrip() {
+        // TODO: Implement btc_dai_order_serialization_roundtrip()
     }
 
     #[test]
-    fn order_serialization_stability() {
-        // TODO: Implement order_serialization_stability()
+    fn btc_dai_order_serialization_stability() {
+        // TODO: Implement btc_dai_order_serialization_stability()
     }
 }


### PR DESCRIPTION
Hold the phone - I'm way out of scope!

This is an idea for how to handle multiple orders of different types. We want to get as much help from the type system as we can while also keeping the code simple.

The idea presented here (in patch 2) adds an Abstract Data Type to hold `Order` trait objects. We convert the current concrete order type to a `BtcDaiOrder` and implement `Order` on it.

The ADT is unimplemented - posting a draft for early feedback.

Thanks