### PR TITLE
ordebook: field names and position

### DIFF
--- a/api_tests/src/actors/actor.ts
+++ b/api_tests/src/actors/actor.ts
@@ -256,6 +256,20 @@ export class Actor {
         );
     }
 
+    /**
+     * Makes a BtcDai sell order (herc20-hbit Swap)
+     */
+    public async makeOrder(_payload: Herc20HbitPayload) {
+        // TODO: Implement makeOrder()
+    }
+
+    /**
+     * Takes a BtcDai sell order (herc20-hbit Swap)
+     */
+    public async takeOrder(_payload: Herc20HbitPayload) {
+        // TODO: Implement takeOrder()
+    }
+
     private async setStartingBalances() {
         switch (this.name) {
             case "alice": {

--- a/api_tests/src/actors/order_factory.ts
+++ b/api_tests/src/actors/order_factory.ts
@@ -1,13 +1,13 @@
 export interface Herc20HbitOrder {
-    buy_quantity: string;
+    trade: string;
+    bitcoin_amount: string;
     bitcoin_ledger: string;
-    sell_token_contract: string;
-    sell_quantity: string;
+    ethereum_amount: string;
+    token_contract: string;
     ethereum_ledger: Ethereum;
     absolute_expiry: number;
     refund_identity: string;
     redeem_identity: string;
-    maker_addr: string;
 }
 
 interface Ethereum {
@@ -15,19 +15,19 @@ interface Ethereum {
 }
 
 export default class OrderFactory {
-    public static newHerc20HbitOrder(makerAddr: string): Herc20HbitOrder {
+    public static newHerc20HbitOrder(): Herc20HbitOrder {
         return {
-            buy_quantity: "100",
+            trade: "sell",
+            bitcoin_amount: "100000",
             bitcoin_ledger: "regtest",
-            sell_token_contract: "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280",
-            sell_quantity: "200",
+            ethereum_amount: "200",
+            token_contract: "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280",
             ethereum_ledger: {
                 chain_id: 1337,
             },
             absolute_expiry: 600,
             refund_identity: "1F1tAaz5x1HUXrCNLbtMDqcw6o5GNn4xqX",
             redeem_identity: "0x00a329c0648769a73afac7f9381e08fb43dbea72",
-            maker_addr: makerAddr,
         };
     }
 }

--- a/api_tests/tests/orderbook.ts
+++ b/api_tests/tests/orderbook.ts
@@ -20,11 +20,13 @@ it(
         // Bob dials alice
         // @ts-ignore
         await bob.cnd.client.post("dial", { addresses: aliceAddr });
+        // @ts-ignore
+        await alice.cnd.client.post("dial", { addresses: bobAddr });
 
         /// Wait for alice to accept an incoming connection from Bob
         await sleep(1000);
 
-        const bobMakeOrderBody = OrderFactory.newHerc20HbitOrder(bobAddr[0]);
+        const bobMakeOrderBody = OrderFactory.newHerc20HbitOrder();
         // @ts-ignore
         // make response contain url in the header to the created order
         // poll this order to see when when it has been converted to a swap

--- a/api_tests/tests/orderbook.ts
+++ b/api_tests/tests/orderbook.ts
@@ -3,102 +3,39 @@
  * @ledger bitcoin
  */
 
-import OrderFactory from "../src/actors/order_factory";
+import SwapFactory from "../src/actors/swap_factory";
 import { twoActorTest } from "../src/actor_test";
-import { Entity, Link } from "comit-sdk/dist/src/cnd/siren";
-import { sleep } from "../src/utils";
+// import { sleep } from "../src/utils";
 
-it(
-    "orderbook_bob_makes_order_alice_takes_order",
-    twoActorTest(async ({ alice, bob }) => {
-        // Get alice's listen address
-        const aliceAddr = await alice.cnd.getPeerListenAddresses();
+describe("orderbook", () => {
+    it(
+        "btc_dai_sell_order",
+        twoActorTest(async ({ alice, bob }) => {
+            const bodies = (
+                await SwapFactory.newSwap(alice, bob, {
+                    ledgers: {
+                        alpha: "ethereum",
+                        beta: "bitcoin",
+                    },
+                })
+            ).herc20Hbit;
 
-        // Get bobs's listen address
-        const bobAddr = await bob.cnd.getPeerListenAddresses();
+            await bob.makeOrder(bodies.bob);
+            await alice.takeOrder(bodies.alice);
 
-        // Bob dials alice
-        // @ts-ignore
-        await bob.cnd.client.post("dial", { addresses: aliceAddr });
-        // @ts-ignore
-        await alice.cnd.client.post("dial", { addresses: bobAddr });
+            // await alice.assertAndExecuteNextAction("deploy");
+            // await alice.assertAndExecuteNextAction("fund");
 
-        /// Wait for alice to accept an incoming connection from Bob
-        await sleep(1000);
+            // await bob.assertAndExecuteNextAction("fund");
 
-        const bobMakeOrderBody = OrderFactory.newHerc20HbitOrder();
-        // @ts-ignore
-        // make response contain url in the header to the created order
-        // poll this order to see when when it has been converted to a swap
-        // "POST /orders"
-        const bobMakeOrderResponse = await bob.cnd.client.post(
-            "orders",
-            bobMakeOrderBody
-        );
+            // await alice.assertAndExecuteNextAction("redeem");
+            // await bob.assertAndExecuteNextAction("redeem");
 
-        // Poll until Alice receives an order. The order must be the one that Bob created above.
-        // @ts-ignore
-        const aliceOrdersResponse = await alice.pollCndUntil<Entity>(
-            "orders",
-            (entity) => entity.entities.length > 0
-        );
-        const aliceOrderResponse: Entity = aliceOrdersResponse.entities[0];
+            // // Wait until the wallet sees the new balance.
+            // await sleep(2000);
 
-        // Alice extracts the siren action to take the order
-        const aliceOrderTakeAction = aliceOrderResponse.actions.find(
-            (action: any) => action.name === "take"
-        );
-        // Alice executes the siren take action extracted in the previous line
-        // The resolver function fills the refund and redeem address fields required
-        // "POST /orders/63c0f8bd-beb2-4a9c-8591-a46f65913b0a/take"
-        // Alice receives a url to the swap that was created as a result of taking the order
-        // @ts-ignore
-        const aliceTakeOrderResponse = await alice.cnd.executeSirenAction(
-            aliceOrderTakeAction,
-            async (field) => {
-                //                const classes = field.class;
-
-                if (field.name === "refund_identity") {
-                    // @ts-ignore
-                    return Promise.resolve(
-                        "0x00a329c0648769a73afac7f9381e08fb43dbea72"
-                    );
-                }
-
-                if (field.name === "redeem_identity") {
-                    // @ts-ignore
-                    return Promise.resolve(
-                        "1F1tAaz5x1HUXrCNLbtMDqcw6o5GNn4xqX"
-                    );
-                }
-            }
-        );
-
-        // Wait for bob to acknowledge that Alice has taken the order he created
-        await sleep(1000);
-
-        // @ts-ignore
-        const aliceSwapResponse = await alice.cnd.client.get(
-            aliceTakeOrderResponse.headers.location
-        );
-        expect(aliceSwapResponse.status).toEqual(200);
-
-        // Since Alice has taken the swap, the order created by Bob should have an associated swap in the navigational link
-        const bobGetOrderResponse = await bob.cnd.fetch<Entity>(
-            bobMakeOrderResponse.headers.location
-        );
-
-        expect(bobGetOrderResponse.status).toEqual(200);
-        const linkToBobSwap = bobGetOrderResponse.data.links.find(
-            (link: Link) => link.rel.includes("swap")
-        );
-        expect(linkToBobSwap).toBeDefined();
-
-        // The link the Bobs swap should return 200
-        // "GET /swaps/934dd090-f8eb-4244-9aba-78e23d3f79eb HTTP/1.1"
-        const bobSwapResponse = await bob.cnd.fetch<Entity>(linkToBobSwap.href);
-        expect(bobSwapResponse.status).toEqual(200);
-
-        // Bob and Alice both have a swap created from the order that Bob made and alice took.
-    })
-);
+            // await alice.assertBalancesAfterSwap();
+            // await bob.assertBalancesAfterSwap();
+        })
+    );
+});

--- a/cnd/src/http_api/orderbook.rs
+++ b/cnd/src/http_api/orderbook.rs
@@ -324,10 +324,11 @@ mod tests {
             "position": "sell",
             "bitcoin_amount": "300",
             "bitcoin_ledger": "regtest",
+            "bitcoin_absolute_expiry": 600,
             "ethereum_amount": "200",
             "token_contract": "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280",
             "ethereum_ledger": {"chain_id":2},
-            "absolute_expiry": 600,
+            "ethereum_absolute_expiry": 600,
             "refund_identity": "1F1tAaz5x1HUXrCNLbtMDqcw6o5GNn4xqX",
             "redeem_identity": "0x00a329c0648769a73afac7f9381e08fb43dbea72"
         }"#;

--- a/cnd/src/http_api/orderbook.rs
+++ b/cnd/src/http_api/orderbook.rs
@@ -10,7 +10,7 @@ use crate::{
 use chrono::Utc;
 use comit::{
     ethereum,
-    network::{MakerId, Order, OrderId, Trade},
+    network::{MakerId, Order, OrderId, Position},
 };
 use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
@@ -195,7 +195,7 @@ pub async fn get_orders(facade: Facade) -> Result<impl Reply, Rejection> {
 
 #[derive(Clone, Debug, Deserialize)]
 struct MakeHerc20HbitOrderBody {
-    trade: Trade,
+    position: Position,
     #[serde(with = "asset::bitcoin::sats_as_string")]
     bitcoin_amount: asset::Bitcoin,
     bitcoin_ledger: ledger::Bitcoin,
@@ -210,7 +210,7 @@ struct MakeHerc20HbitOrderBody {
 impl From<MakeHerc20HbitOrderBody> for NewOrder {
     fn from(body: MakeHerc20HbitOrderBody) -> Self {
         NewOrder {
-            trade: body.trade,
+            position: body.position,
             bitcoin_amount: body.bitcoin_amount,
             bitcoin_ledger: body.bitcoin_ledger,
             ethereum_amount: body.ethereum_amount,
@@ -231,7 +231,7 @@ struct TakeHerc20HbitOrderBody {
 struct Herc20HbitOrderResponse {
     id: OrderId,
     maker: MakerId,
-    trade: Trade,
+    position: Position,
     #[serde(with = "asset::bitcoin::sats_as_string")]
     bitcoin_amount: asset::Bitcoin,
     bitcoin_ledger: ledger::Bitcoin,
@@ -246,7 +246,7 @@ impl From<Order> for Herc20HbitOrderResponse {
         Herc20HbitOrderResponse {
             id: order.id,
             maker: order.maker,
-            trade: order.trade,
+            position: order.position,
             bitcoin_amount: order.bitcoin_amount,
             bitcoin_ledger: order.bitcoin_ledger,
             ethereum_amount: order.ethereum_amount,
@@ -317,7 +317,7 @@ mod tests {
     fn test_make_order_deserialization() {
         let json = r#"
         {
-            "trade": "sell",
+            "position": "sell",
             "bitcoin_amount": "300",
             "bitcoin_ledger": "regtest",
             "ethereum_amount": "200",

--- a/cnd/src/http_api/orderbook.rs
+++ b/cnd/src/http_api/orderbook.rs
@@ -53,13 +53,13 @@ pub async fn post_take_herc20_hbit_order(
             },
             identity: refund_identity,
             chain_id: order.ethereum_ledger.chain_id,
-            absolute_expiry: order.absolute_expiry,
+            absolute_expiry: order.ethereum_absolute_expiry,
         },
         beta: hbit::CreatedSwap {
             amount: order.bitcoin_amount,
             final_identity: redeem_identity.clone(),
             network: order.bitcoin_ledger,
-            absolute_expiry: order.absolute_expiry,
+            absolute_expiry: order.bitcoin_absolute_expiry,
         },
         peer: order.maker.clone().into(),
         address_hint: None,
@@ -199,10 +199,11 @@ struct MakeHerc20HbitOrderBody {
     #[serde(with = "asset::bitcoin::sats_as_string")]
     bitcoin_amount: asset::Bitcoin,
     bitcoin_ledger: ledger::Bitcoin,
+    bitcoin_absolute_expiry: u32,
     ethereum_amount: asset::Erc20Quantity,
     token_contract: identity::Ethereum,
     ethereum_ledger: ledger::Ethereum,
-    absolute_expiry: u32,
+    ethereum_absolute_expiry: u32,
     refund_identity: bitcoin::Address,
     redeem_identity: identity::Ethereum,
 }
@@ -213,10 +214,11 @@ impl From<MakeHerc20HbitOrderBody> for NewOrder {
             position: body.position,
             bitcoin_amount: body.bitcoin_amount,
             bitcoin_ledger: body.bitcoin_ledger,
+            bitcoin_absolute_expiry: body.bitcoin_absolute_expiry,
             ethereum_amount: body.ethereum_amount,
             token_contract: body.token_contract,
             ethereum_ledger: body.ethereum_ledger,
-            absolute_expiry: body.absolute_expiry,
+            ethereum_absolute_expiry: body.ethereum_absolute_expiry,
         }
     }
 }
@@ -235,10 +237,11 @@ struct Herc20HbitOrderResponse {
     #[serde(with = "asset::bitcoin::sats_as_string")]
     bitcoin_amount: asset::Bitcoin,
     bitcoin_ledger: ledger::Bitcoin,
+    bitcoin_absolute_expiry: u32,
     ethereum_amount: asset::Erc20Quantity,
     token_contract: ethereum::Address,
     ethereum_ledger: ledger::Ethereum,
-    absolute_expiry: u32,
+    ethereum_absolute_expiry: u32,
 }
 
 impl From<Order> for Herc20HbitOrderResponse {
@@ -249,10 +252,11 @@ impl From<Order> for Herc20HbitOrderResponse {
             position: order.position,
             bitcoin_amount: order.bitcoin_amount,
             bitcoin_ledger: order.bitcoin_ledger,
+            bitcoin_absolute_expiry: order.bitcoin_absolute_expiry,
             ethereum_amount: order.ethereum_amount,
             token_contract: order.token_contract,
             ethereum_ledger: order.ethereum_ledger,
-            absolute_expiry: order.absolute_expiry,
+            ethereum_absolute_expiry: order.ethereum_absolute_expiry,
         }
     }
 }

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -655,7 +655,6 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<orderbook::BehaviourOutEvent> f
                 order_id,
                 shared_swap_id,
             } => {
-                // TODO: Re-evaluate all the hashmap access
                 let local_swap_id = self.local_swap_ids.get(&shared_swap_id).unwrap();
                 let &data = match self.local_data.get(local_swap_id) {
                     Some(data) => data,
@@ -667,8 +666,6 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<orderbook::BehaviourOutEvent> f
                         return;
                     }
                 };
-
-                // TODO: Consider creating/saving the swap here.
 
                 let peer_id = self
                     .confirmed_order_peers

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -371,7 +371,7 @@ impl ComitNode {
         let order = Order {
             id: OrderId::random(),
             maker: MakerId::from(self.peer_id.clone()),
-            trade: new_order.trade,
+            position: new_order.position,
             bitcoin_amount: new_order.bitcoin_amount,
             bitcoin_ledger: new_order.bitcoin_ledger,
             ethereum_amount: new_order.ethereum_amount,
@@ -452,7 +452,7 @@ impl ListenAddresses for Swarm {
 /// Used by the controller to pass in parameters for a new order.
 #[derive(Debug)]
 pub struct NewOrder {
-    pub trade: Trade,
+    pub position: Position,
     pub bitcoin_amount: asset::Bitcoin,
     pub bitcoin_ledger: ledger::Bitcoin,
     pub ethereum_amount: asset::Erc20Quantity,

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -151,9 +151,7 @@ impl Swarm {
 
     pub async fn dial_addr(&mut self, addr: Multiaddr) -> anyhow::Result<()> {
         let mut guard = self.inner.lock().await;
-        // todo: log error
-        libp2p::Swarm::dial_addr(&mut *guard, addr).unwrap();
-        // guard.dial_addr(addr);
+        let _ = libp2p::Swarm::dial_addr(&mut *guard, addr)?;
         Ok(())
     }
 

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -374,10 +374,11 @@ impl ComitNode {
             position: new_order.position,
             bitcoin_amount: new_order.bitcoin_amount,
             bitcoin_ledger: new_order.bitcoin_ledger,
+            bitcoin_absolute_expiry: new_order.bitcoin_absolute_expiry,
             ethereum_amount: new_order.ethereum_amount,
             token_contract: new_order.token_contract,
             ethereum_ledger: new_order.ethereum_ledger,
-            absolute_expiry: new_order.absolute_expiry,
+            ethereum_absolute_expiry: new_order.ethereum_absolute_expiry,
         };
         let order_id = self.orderbook.make(order)?;
         self.order_swap_ids.insert(order_id, swap_id);
@@ -449,17 +450,17 @@ impl ListenAddresses for Swarm {
     }
 }
 
-/// Used by the controller to pass in parameters for a new order.
+/// Used by the controller to pass in data for a new order.
 #[derive(Debug)]
 pub struct NewOrder {
     pub position: Position,
     pub bitcoin_amount: asset::Bitcoin,
     pub bitcoin_ledger: ledger::Bitcoin,
+    pub bitcoin_absolute_expiry: u32,
     pub ethereum_amount: asset::Erc20Quantity,
     pub token_contract: identity::Ethereum,
     pub ethereum_ledger: ledger::Ethereum,
-    // TODO: Add both expiries
-    pub absolute_expiry: u32,
+    pub ethereum_absolute_expiry: u32,
 }
 
 impl NewOrder {
@@ -597,13 +598,13 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<orderbook::BehaviourOutEvent> f
                         },
                         identity: redeem_identity,
                         chain_id: order.ethereum_ledger.chain_id,
-                        absolute_expiry: order.absolute_expiry,
+                        absolute_expiry: order.ethereum_absolute_expiry,
                     },
                     beta: hbit::CreatedSwap {
                         amount: order.bitcoin_amount,
                         final_identity: final_identity.into(),
                         network: order.bitcoin_ledger,
-                        absolute_expiry: order.absolute_expiry,
+                        absolute_expiry: order.bitcoin_absolute_expiry,
                     },
                     peer: peer_id.clone(),
                     address_hint: None,

--- a/comit/src/asset/bitcoin.rs
+++ b/comit/src/asset/bitcoin.rs
@@ -16,6 +16,11 @@ impl Bitcoin {
     pub fn to_le_bytes(self) -> [u8; 8] {
         self.0.as_sat().to_le_bytes()
     }
+
+    #[cfg(test)]
+    pub fn meaningless_test_value() -> Self {
+        Bitcoin::from_sat(1_000u64)
+    }
 }
 
 impl From<Bitcoin> for Amount {

--- a/comit/src/asset/ethereum/erc20.rs
+++ b/comit/src/asset/ethereum/erc20.rs
@@ -35,6 +35,11 @@ impl Erc20Quantity {
     pub fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes_le()
     }
+
+    #[cfg(test)]
+    pub fn meaningless_test_value() -> Self {
+        Erc20Quantity::from_wei(1_000u32)
+    }
 }
 
 impl FromWei<U256> for Erc20Quantity {

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -419,36 +419,16 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<OrderId, Response>> for O
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        asset::{self, Erc20Quantity},
-        ledger,
-        network::test::{await_events_or_timeout, new_connected_swarm_pair},
-    };
+    use crate::network::test::{await_events_or_timeout, new_connected_swarm_pair};
     use libp2p::Swarm;
     use spectral::prelude::*;
-
-    fn create_order(id: PeerId) -> Order {
-        Order {
-            id: OrderId::random(),
-            maker: MakerId::from(id),
-            position: Position::Sell,
-            bitcoin_amount: asset::Bitcoin::from_sat(100),
-            bitcoin_ledger: ledger::Bitcoin::Regtest,
-            bitcoin_absolute_expiry: 100, // TODO: Use more meaningful value.
-            // TODO: Use a more sane value?
-            ethereum_amount: Erc20Quantity::max_value(),
-            token_contract: Default::default(),
-            ethereum_ledger: ledger::Ethereum::default(),
-            ethereum_absolute_expiry: 100, // TODO: Use more meaningful value.
-        }
-    }
 
     #[tokio::test]
     async fn take_order_request_confirmation() {
         // arrange
 
         let (mut alice, mut bob) = new_connected_swarm_pair(Orderbook::new).await;
-        let bob_order = create_order(bob.peer_id.clone());
+        let bob_order = order::meaningless_test_order(MakerId::from(bob.peer_id.clone()));
 
         // act
 

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -32,8 +32,6 @@ pub use self::order::*;
 /// String representing the BTC/DAI trading pair.
 const BTC_DAI: &str = "BTC/DAI";
 
-// We only support a single topic at the moment.
-const TOPIC: &str = "Herc20Hbit";
 /// The time we wait for a take order request to be confirmed or denied.
 const REQUEST_TIMEOUT_SECS: u64 = 10;
 
@@ -85,7 +83,9 @@ impl Orderbook {
         orderbook.gossipsub.subscribe(Makers::topic());
 
         // Since we only support a single trading pair topic just subscribe to it now.
-        orderbook.gossipsub.subscribe(Topic::new(TOPIC.to_string()));
+        orderbook
+            .gossipsub
+            .subscribe(Topic::new(BTC_DAI.to_string()));
 
         orderbook
     }

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -445,7 +445,7 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<OrderId, Response>> for O
 mod tests {
     use super::*;
     use crate::{
-        asset::{self, Erc20, Erc20Quantity},
+        asset::{self, Erc20Quantity},
         ledger,
         network::test::{await_events_or_timeout, new_connected_swarm_pair},
     };
@@ -457,13 +457,11 @@ mod tests {
             id: OrderId::random(),
             maker: MakerId::from(id),
             trade: Trade::Sell,
-            btc: asset::Bitcoin::from_sat(100),
+            bitcoin_amount: asset::Bitcoin::from_sat(100),
             bitcoin_ledger: ledger::Bitcoin::Regtest,
-            dai: Erc20 {
-                quantity: Erc20Quantity::max_value(),
-                // TODO: Use a more sane value?
-                token_contract: Default::default(),
-            },
+            // TODO: Use a more sane value?
+            ethereum_amount: Erc20Quantity::max_value(),
+            token_contract: Default::default(),
             ethereum_ledger: ledger::Ethereum::default(),
             absolute_expiry: 100,
         }
@@ -549,6 +547,7 @@ mod tests {
         }
     }
 
+    // TODO: Rename this - it should be maker_id_...
     #[test]
     fn peer_id_serializes_as_expected() {
         let given = "QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY".to_string();
@@ -561,6 +560,7 @@ mod tests {
         assert_that(&got).is_equal_to(want);
     }
 
+    // TODO: Rename this - it should be maker_id_...
     #[test]
     fn peer_id_serialization_roundtrip_test() {
         let s = "QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY".to_string();

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -428,11 +428,12 @@ mod tests {
             position: Position::Sell,
             bitcoin_amount: asset::Bitcoin::from_sat(100),
             bitcoin_ledger: ledger::Bitcoin::Regtest,
+            bitcoin_absolute_expiry: 100, // TODO: Use more meaningful value.
             // TODO: Use a more sane value?
             ethereum_amount: Erc20Quantity::max_value(),
             token_contract: Default::default(),
             ethereum_ledger: ledger::Ethereum::default(),
-            absolute_expiry: 100,
+            ethereum_absolute_expiry: 100, // TODO: Use more meaningful value.
         }
     }
 

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -425,7 +425,7 @@ mod tests {
         Order {
             id: OrderId::random(),
             maker: MakerId::from(id),
-            trade: Trade::Sell,
+            position: Position::Sell,
             bitcoin_amount: asset::Bitcoin::from_sat(100),
             bitcoin_ledger: ledger::Bitcoin::Regtest,
             // TODO: Use a more sane value?

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -523,9 +523,8 @@ mod tests {
         }
     }
 
-    // TODO: Rename this - it should be maker_id_...
     #[test]
-    fn peer_id_serializes_as_expected() {
+    fn maker_id_serializes_as_expected() {
         let given = "QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY".to_string();
         let peer_id = PeerId::from_str(&given).expect("failed to parse peer id");
         let maker_id = MakerId(peer_id);
@@ -536,9 +535,8 @@ mod tests {
         assert_that(&got).is_equal_to(want);
     }
 
-    // TODO: Rename this - it should be maker_id_...
     #[test]
-    fn peer_id_serialization_roundtrip_test() {
+    fn maker_id_serialization_roundtrip_test() {
         let s = "QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY".to_string();
         let peer_id = PeerId::from_str(&s).expect("failed to parse peer id");
         let maker_id = MakerId::from(peer_id);

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -336,10 +336,16 @@ impl NetworkBehaviourEventProcess<GossipsubEvent> for Orderbook {
 
             match decoded {
                 Message::CreateOrder(order) => {
-                    // TODO: Should we just blindly insert here?
+                    // This implies new orders remove old orders from
+                    // the orderbook. This means nodes can spoof the
+                    // network using previously seen order ids in
+                    // order to override orders.
                     self.orders.insert(order.id, order);
                 }
                 Message::DeleteOrder(order_id) => {
+                    // Same consideration here, nodes can cause orders
+                    // they did not create to be removed by spoofing
+                    // the network with a previously seen order id.
                     self.orders.remove(&order_id);
                 }
                 Message::TradingPair(tp) => {

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -15,6 +15,12 @@ impl OrderId {
     }
 }
 
+#[cfg(test)]
+fn meaningless_test_order_id() -> OrderId {
+    let uuid = Uuid::parse_str("936DA01F9ABD4d9d80C702AF85C822A8").unwrap();
+    OrderId(uuid)
+}
+
 impl Display for OrderId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
@@ -49,6 +55,27 @@ impl Order {
     pub fn tp(&self) -> TradingPair {
         TradingPair::BtcDai
     }
+}
+
+#[cfg(test)]
+pub fn meaningless_test_order(maker: MakerId) -> Order {
+    Order {
+        id: meaningless_test_order_id(),
+        maker,
+        position: Position::Sell,
+        bitcoin_amount: asset::Bitcoin::meaningless_test_value(),
+        bitcoin_ledger: ledger::Bitcoin::Regtest,
+        bitcoin_absolute_expiry: meaningless_expiry_value(),
+        ethereum_amount: asset::Erc20Quantity::meaningless_test_value(),
+        token_contract: Default::default(),
+        ethereum_ledger: ledger::Ethereum::default(),
+        ethereum_absolute_expiry: meaningless_expiry_value(),
+    }
+}
+
+#[cfg(test)]
+fn meaningless_expiry_value() -> u32 {
+    100
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -38,11 +38,11 @@ pub struct Order {
     #[serde(with = "asset::bitcoin::sats_as_string")]
     pub bitcoin_amount: asset::Bitcoin,
     pub bitcoin_ledger: ledger::Bitcoin,
+    pub bitcoin_absolute_expiry: u32,
     pub ethereum_amount: asset::Erc20Quantity,
     pub token_contract: identity::Ethereum,
     pub ethereum_ledger: ledger::Ethereum,
-    // TODO: Add both expiries
-    pub absolute_expiry: u32,
+    pub ethereum_absolute_expiry: u32,
 }
 
 impl Order {

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -88,26 +88,50 @@ pub enum Position {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use libp2p::PeerId;
     use spectral::prelude::*;
 
     #[test]
     fn order_id_serialization_roundtrip() {
-        // TODO: Implement order_id_serialization_roundtrip()
+        let order_id = meaningless_test_order_id();
+        let json = serde_json::to_string(&order_id).expect("failed to serialize order id");
+        let rinsed: OrderId = serde_json::from_str(&json).expect("failed to deserialize order id");
+        assert_that(&rinsed).is_equal_to(&order_id);
     }
 
     #[test]
     fn order_id_serialization_stability() {
-        // TODO: Implement order_id_serialization_stability()
-    }
+        let s = "936DA01F9ABD4d9d80C702AF85C822A8";
+        let uuid = Uuid::from_str(s).expect("failed to parse uuid string");
+        let order_id = OrderId(uuid);
 
-    #[test]
-    fn btc_dai_order_serialization_roundtrip() {
-        // TODO: Implement btc_dai_order_serialization_roundtrip()
+        let want = format!("\"{}\"", s);
+        let got = serde_json::to_string(&order_id).expect("failed to serialize order id");
+        assert_that(&got).is_equal_to(want);
     }
 
     #[test]
     fn btc_dai_order_serialization_stability() {
-        // TODO: Implement btc_dai_order_serialization_stability()
+        let given = "QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY".to_string();
+        let peer_id = PeerId::from_str(&given).expect("failed to parse peer id");
+        let maker_id = MakerId(peer_id);
+
+        let order = Order {
+            id: meaningless_test_order_id(),
+            maker: maker_id,
+            position: Position::Sell,
+            bitcoin_amount: asset::Bitcoin::meaningless_test_value(),
+            bitcoin_ledger: ledger::Bitcoin::Regtest,
+            bitcoin_absolute_expiry: meaningless_expiry_value(),
+            ethereum_amount: asset::Erc20Quantity::meaningless_test_value(),
+            token_contract: Default::default(),
+            ethereum_ledger: ledger::Ethereum::default(),
+            ethereum_absolute_expiry: meaningless_expiry_value(),
+        };
+
+        let got = serde_json::to_string(&order).expect("failed to serialize order");
+        let want = r#"{"id":"936da01f-9abd-4d9d-80c7-02af85c822a8","maker":"QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY","position":"sell","bitcoin_amount":"1000","bitcoin_ledger":"regtest","bitcoin_absolute_expiry":100,"ethereum_amount":"1000","token_contract":"0x0000000000000000000000000000000000000000","ethereum_ledger":{"chain_id":1337},"ethereum_absolute_expiry":100}"#.to_string();
+        assert_that(&got).is_equal_to(want);
     }
 
     #[test]

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -1,8 +1,5 @@
-use crate::{
-    asset, ledger,
-    network::protocols::orderbook::{MakerId, SwapType, TradingPair},
-};
-use libp2p::{gossipsub::Topic, PeerId};
+use crate::{asset, ledger, network::protocols::orderbook::MakerId};
+use libp2p::gossipsub::Topic;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, str::FromStr};
 use uuid::Uuid;
@@ -45,12 +42,8 @@ pub struct Order {
 
 impl Order {
     pub fn topic(&self) -> Topic {
-        let peer_id = PeerId::from(self.maker.clone());
-        TradingPair {
-            buy: SwapType::Hbit,
-            sell: SwapType::Herc20,
-        }
-        .to_topic(&peer_id)
+        // TODO: Do we need this?
+        unimplemented!();
     }
 }
 

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -34,7 +34,7 @@ impl FromStr for OrderId {
 pub struct Order {
     pub id: OrderId,
     pub maker: MakerId,
-    pub trade: Trade,
+    pub position: Position,
     #[serde(with = "asset::bitcoin::sats_as_string")]
     pub bitcoin_amount: asset::Bitcoin,
     pub bitcoin_ledger: ledger::Bitcoin,
@@ -52,8 +52,8 @@ impl Order {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum Trade {
+#[serde(rename_all = "lowercase")]
+pub enum Position {
     Buy,
     Sell,
 }
@@ -85,23 +85,23 @@ mod tests {
 
     #[test]
     fn trade_serialization_roundtrip() {
-        let trade = Trade::Buy;
+        let trade = Position::Buy;
         let json = serde_json::to_string(&trade).expect("failed to serialize trade");
-        let rinsed: Trade = serde_json::from_str(&json).expect("failed to deserialize trade");
+        let rinsed: Position = serde_json::from_str(&json).expect("failed to deserialize trade");
 
         assert_that(&rinsed).is_equal_to(&trade);
     }
 
     #[test]
     fn trade_buy_serialization_stability() {
-        let trade = Trade::Buy;
+        let trade = Position::Buy;
         let s = serde_json::to_string(&trade).expect("failed to serialize trade");
         assert_that(&s).is_equal_to(r#""buy""#.to_string());
     }
 
     #[test]
     fn trade_sell_serialization_stability() {
-        let trade = Trade::Sell;
+        let trade = Position::Sell;
         let s = serde_json::to_string(&trade).expect("failed to serialize trade");
         assert_that(&s).is_equal_to(r#""sell""#.to_string());
     }

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -1,6 +1,6 @@
 use crate::{
     asset, identity, ledger,
-    network::protocols::orderbook::{MakerId, TradingPair, BTC_DAI},
+    network::protocols::orderbook::{MakerId, TradingPair},
 };
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, str::FromStr};
@@ -48,10 +48,6 @@ pub struct Order {
 impl Order {
     pub fn tp(&self) -> TradingPair {
         TradingPair::BtcDai
-    }
-
-    pub fn topic(&self) -> String {
-        BTC_DAI.to_string()
     }
 }
 

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -105,7 +105,7 @@ mod tests {
         let uuid = Uuid::from_str(s).expect("failed to parse uuid string");
         let order_id = OrderId(uuid);
 
-        let want = format!("\"{}\"", s);
+        let want = "\"936da01f-9abd-4d9d-80c7-02af85c822a8\"".to_string();
         let got = serde_json::to_string(&order_id).expect("failed to serialize order id");
         assert_that(&got).is_equal_to(want);
     }

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -1,5 +1,7 @@
-use crate::{asset, ledger, network::protocols::orderbook::MakerId};
-use libp2p::gossipsub::Topic;
+use crate::{
+    asset, ledger,
+    network::protocols::orderbook::{MakerId, TradingPair, BTC_DAI},
+};
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, str::FromStr};
 use uuid::Uuid;
@@ -32,19 +34,31 @@ impl FromStr for OrderId {
 pub struct Order {
     pub id: OrderId,
     pub maker: MakerId,
+    pub trade: Trade,
     #[serde(with = "asset::bitcoin::sats_as_string")]
-    pub buy: asset::Bitcoin,
+    pub btc: asset::Bitcoin,
     pub bitcoin_ledger: ledger::Bitcoin,
-    pub sell: asset::Erc20,
+    pub dai: asset::Erc20,
     pub ethereum_ledger: ledger::Ethereum,
+    // TODO: Add both expiries
     pub absolute_expiry: u32,
 }
 
 impl Order {
-    pub fn topic(&self) -> Topic {
-        // TODO: Do we need this?
-        unimplemented!();
+    pub fn tp(&self) -> TradingPair {
+        TradingPair::BtcDai
     }
+
+    pub fn topic(&self) -> String {
+        BTC_DAI.to_string()
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum Trade {
+    Buy,
+    Sell,
 }
 
 #[cfg(test)]
@@ -61,12 +75,12 @@ mod tests {
     }
 
     #[test]
-    fn order_serialization_roundtrip() {
-        // TODO: Implement order_serialization_roundtrip()
+    fn btc_dai_order_serialization_roundtrip() {
+        // TODO: Implement btc_dai_order_serialization_roundtrip()
     }
 
     #[test]
-    fn order_serialization_stability() {
-        // TODO: Implement order_serialization_stability()
+    fn btc_dai_order_serialization_stability() {
+        // TODO: Implement btc_dai_order_serialization_stability()
     }
 }


### PR DESCRIPTION
A bunch of clean up work and additional features for the orderbook.  This work conflicts with https://github.com/comit-network/comit-rs/pull/2959 mainly due to different names, happy to find some common ground in order to get one of these in.

Does:

- Removes subscription handling
- Use domain term `Position` enabling trades in both directions
- Adds both expiries
- Removes a non-actionalble todos
- Removes unwraps (and associated todos)
- Adds ser/deser unit tests


Turns e2e test into a skeleton.