### PR TITLE
Add swap execution to orderbook e2e test

### DIFF
--- a/api_tests/src/actors/actor.ts
+++ b/api_tests/src/actors/actor.ts
@@ -237,7 +237,7 @@ export class Actor {
         };
         this.betaAsset = {
             name: AssetKind.Erc20,
-            quantity: create.alpha.amount,
+            quantity: create.beta.amount,
             ledger: LedgerKind.Ethereum,
             tokenContract: create.beta.token_contract,
         };

--- a/api_tests/src/actors/actor.ts
+++ b/api_tests/src/actors/actor.ts
@@ -237,7 +237,7 @@ export class Actor {
         };
         this.betaAsset = {
             name: AssetKind.Erc20,
-            quantity: create.beta.amount,
+            quantity: create.alpha.amount,
             ledger: LedgerKind.Ethereum,
             tokenContract: create.beta.token_contract,
         };
@@ -252,6 +252,38 @@ export class Actor {
             new SdkWallets({
                 bitcoin: this.wallets.bitcoin.inner,
                 ethereum: this.wallets.ethereum.inner,
+            })
+        );
+    }
+
+    public async initOrderbookTest(swapUrl: string, create: Herc20HbitPayload) {
+        this.alphaLedger = {
+            name: LedgerKind.Ethereum,
+            chain_id: create.alpha.chain_id,
+        };
+        this.betaLedger = {
+            name: LedgerKind.Bitcoin,
+            network: create.beta.network,
+        };
+        this.alphaAsset = {
+            name: AssetKind.Erc20,
+            quantity: create.alpha.amount,
+            ledger: LedgerKind.Ethereum,
+            tokenContract: create.alpha.token_contract,
+        };
+        this.betaAsset = {
+            name: AssetKind.Bitcoin,
+            quantity: create.beta.amount,
+            ledger: LedgerKind.Bitcoin,
+        };
+        await this.setStartingBalances();
+
+        this.swap = new Swap(
+            this.cnd,
+            swapUrl,
+            new SdkWallets({
+                ethereum: this.wallets.ethereum.inner,
+                bitcoin: this.wallets.bitcoin.inner,
             })
         );
     }

--- a/api_tests/src/actors/order_factory.ts
+++ b/api_tests/src/actors/order_factory.ts
@@ -18,11 +18,10 @@ interface Ethereum {
 }
 
 export default class OrderFactory {
-    public static bobOrderfromSwap(
+    public static bobOrderFromSwap(
         makerAddr: string,
         swap: Herc20HbitPayload
     ): Herc20HbitOrder {
-        console.log(swap);
         return {
             btc_quantity: swap.alpha.amount,
             bitcoin_ledger: swap.beta.network,

--- a/api_tests/src/actors/order_factory.ts
+++ b/api_tests/src/actors/order_factory.ts
@@ -1,12 +1,15 @@
+import { Herc20HbitPayload } from "../payload";
+
 export interface Herc20HbitOrder {
-    buy_quantity: string;
+    btc_quantity: string;
     bitcoin_ledger: string;
-    sell_token_contract: string;
-    sell_quantity: string;
+    erc20_token_contract: string;
+    erc20_quantity: string;
     ethereum_ledger: Ethereum;
-    absolute_expiry: number;
-    refund_identity: string;
-    redeem_identity: string;
+    alpha_expiry: number;
+    beta_expiry: number;
+    bob_refund_identity: string;
+    bob_redeem_identity: string;
     maker_addr: string;
 }
 
@@ -15,18 +18,23 @@ interface Ethereum {
 }
 
 export default class OrderFactory {
-    public static newHerc20HbitOrder(makerAddr: string): Herc20HbitOrder {
+    public static bobOrderfromSwap(
+        makerAddr: string,
+        swap: Herc20HbitPayload
+    ): Herc20HbitOrder {
+        console.log(swap);
         return {
-            buy_quantity: "100",
-            bitcoin_ledger: "regtest",
-            sell_token_contract: "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280",
-            sell_quantity: "200",
+            btc_quantity: swap.alpha.amount,
+            bitcoin_ledger: swap.beta.network,
+            erc20_token_contract: swap.alpha.token_contract,
+            erc20_quantity: swap.alpha.amount,
             ethereum_ledger: {
-                chain_id: 1337,
+                chain_id: swap.alpha.chain_id,
             },
-            absolute_expiry: 600,
-            refund_identity: "1F1tAaz5x1HUXrCNLbtMDqcw6o5GNn4xqX",
-            redeem_identity: "0x00a329c0648769a73afac7f9381e08fb43dbea72",
+            alpha_expiry: swap.alpha.absolute_expiry,
+            beta_expiry: swap.beta.absolute_expiry,
+            bob_refund_identity: swap.beta.final_identity,
+            bob_redeem_identity: swap.alpha.identity,
             maker_addr: makerAddr,
         };
     }

--- a/api_tests/tests/orderbook.ts
+++ b/api_tests/tests/orderbook.ts
@@ -35,7 +35,7 @@ it(
         /// Wait for alice to accept an incoming connection from Bob
         await sleep(1000);
 
-        const bobMakeOrderBody = OrderFactory.bobOrderfromSwap(
+        const bobMakeOrderBody = OrderFactory.bobOrderFromSwap(
             bobAddr[0],
             bodies.bob
         );
@@ -73,14 +73,14 @@ it(
                 if (field.name === "refund_identity") {
                     // @ts-ignore
                     return Promise.resolve(
-                        "0x00a329c0648769a73afac7f9381e08fb43dbea72"
+                        bodies.alice.alpha.identity
                     );
                 }
 
                 if (field.name === "redeem_identity") {
                     // @ts-ignore
                     return Promise.resolve(
-                        "1F1tAaz5x1HUXrCNLbtMDqcw6o5GNn4xqX"
+                        bodies.alice.beta.final_identity
                     );
                 }
             }

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -476,14 +476,15 @@ mod tests {
         Order {
             id: OrderId::random(),
             maker: MakerId::from(id),
-            buy: asset::Bitcoin::from_sat(100),
+            btc_quantity: asset::Bitcoin::from_sat(100),
             bitcoin_ledger: ledger::Bitcoin::Regtest,
-            sell: Erc20 {
+            erc20_quantity: Erc20 {
                 token_contract: Default::default(),
                 quantity: Erc20Quantity::max_value(),
             },
             ethereum_ledger: ledger::Ethereum::default(),
-            absolute_expiry: 100,
+            alpha_expiry: 500,
+            beta_expiry: 300,
         }
     }
 

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -36,11 +36,12 @@ pub struct Order {
     pub id: OrderId,
     pub maker: MakerId,
     #[serde(with = "asset::bitcoin::sats_as_string")]
-    pub buy: asset::Bitcoin,
+    pub btc_quantity: asset::Bitcoin,
     pub bitcoin_ledger: ledger::Bitcoin,
-    pub sell: asset::Erc20,
+    pub erc20_quantity: asset::Erc20,
     pub ethereum_ledger: ledger::Ethereum,
-    pub absolute_expiry: u32,
+    pub alpha_expiry: u32,
+    pub beta_expiry: u32,
 }
 
 impl Order {


### PR DESCRIPTION
The orderbook e2e test executes the comit protocol to ensure
that swaps are correctly created from the order. Alpha and
beta ledger expiries have been added to the order to facilitate
this change.