### PR TITLE
Some more cleanup to the orderbook

### DIFF
--- a/cnd/src/facade.rs
+++ b/cnd/src/facade.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use comit::{
     bitcoin, identity,
-    network::{Order, OrderId, TradingPair},
+    network::{Order, OrderId},
 };
 use libp2p::{Multiaddr, PeerId};
 
@@ -99,10 +99,6 @@ impl Facade {
 
     pub async fn dial_addr(&mut self, addr: Multiaddr) {
         let _ = self.swarm.dial_addr(addr).await;
-    }
-
-    pub async fn announce_trading_pair(&mut self, tp: TradingPair) -> anyhow::Result<()> {
-        self.swarm.announce_trading_pair(tp).await
     }
 }
 

--- a/cnd/src/http_api/orderbook.rs
+++ b/cnd/src/http_api/orderbook.rs
@@ -281,38 +281,6 @@ pub async fn post_dial_peer(
     Ok(warp::reply::reply())
 }
 
-// TODO: Add ser stability and roundtrip tests.
-#[derive(Deserialize, Debug, Copy, Clone)]
-pub enum TradingPair {
-    BtcDai,
-}
-
-impl From<TradingPair> for comit::network::orderbook::TradingPair {
-    fn from(tp: TradingPair) -> Self {
-        match tp {
-            TradingPair::BtcDai => comit::network::orderbook::TradingPair::BtcDai,
-        }
-    }
-}
-
-pub async fn post_announce_trading_pair(
-    body: serde_json::Value,
-    mut facade: Facade,
-) -> Result<impl Reply, Rejection> {
-    let tp = TradingPair::deserialize(&body)
-        .map_err(anyhow::Error::new)
-        .map_err(problem::from_anyhow)
-        .map_err(warp::reject::custom)?;
-
-    facade
-        .announce_trading_pair(tp.into())
-        .await
-        .map_err(problem::from_anyhow)
-        .map_err(warp::reject::custom)?;
-
-    Ok(warp::reply::reply())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cnd/src/http_api/route_factory.rs
+++ b/cnd/src/http_api/route_factory.rs
@@ -155,15 +155,8 @@ pub fn create(facade: Facade, allowed_origins: &AllowedOrigins) -> BoxedFilter<(
         .and(warp::path!("dial"))
         .and(warp::path::end())
         .and(warp::body::json())
-        .and(facade.clone())
-        .and_then(orderbook::post_dial_peer);
-
-    let post_announce_trading_pair = warp::post()
-        .and(warp::path!("announce"))
-        .and(warp::path::end())
-        .and(warp::body::json())
         .and(facade)
-        .and_then(orderbook::post_announce_trading_pair);
+        .and_then(orderbook::post_dial_peer);
 
     preflight_cors_route
         .or(get_peers)
@@ -184,7 +177,6 @@ pub fn create(facade: Facade, allowed_origins: &AllowedOrigins) -> BoxedFilter<(
         .or(get_orders)
         .or(get_order)
         .or(post_dial_addr)
-        .or(post_announce_trading_pair)
         //.or(get_makers)
         //.or(subscribe)
         .recover(http_api::unpack_problem)

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -154,11 +154,6 @@ impl Swarm {
         let _ = libp2p::Swarm::dial_addr(&mut *guard, addr)?;
         Ok(())
     }
-
-    pub async fn announce_trading_pair(&mut self, tp: TradingPair) -> anyhow::Result<()> {
-        let mut guard = self.inner.lock().await;
-        guard.announce_trading_pair(tp)
-    }
 }
 
 struct TokioExecutor {
@@ -390,10 +385,6 @@ impl ComitNode {
 
     pub fn get_orders(&self) -> Vec<Order> {
         self.orderbook.get_orders()
-    }
-
-    pub fn announce_trading_pair(&mut self, tp: TradingPair) -> anyhow::Result<()> {
-        self.orderbook.announce_trading_pair(tp)
     }
 }
 

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -29,6 +29,9 @@ use std::{
 
 pub use self::order::*;
 
+// TODO: Audit function scope
+// TODO: Rethink topic logic
+
 /// String representing the BTC/DAI trading pair.
 const BTC_DAI: &str = "BTC/DAI";
 

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -97,9 +97,9 @@ impl Orderbook {
     pub fn make(&mut self, order: Order) -> anyhow::Result<OrderId> {
         let ser = bincode::serialize(&Message::CreateOrder(order.clone()))?;
         let topic = order.tp().topic();
-        let id = order.id;
-
         self.gossipsub.publish(&topic, ser);
+
+        let id = order.id;
         self.orders.insert(id, order);
 
         Ok(id)

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -183,17 +183,6 @@ impl Orderbook {
 #[error("order not found in orderbook: {0:?}")]
 pub struct OrderNotFound(OrderId);
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub enum TradingPair {
-    BtcDai,
-}
-
-impl TradingPair {
-    pub fn topic(&self) -> Topic {
-        Topic::new(BTC_DAI.to_string())
-    }
-}
-
 /// MakerId is a PeerId wrapper so we control serialization/deserialization.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MakerId(PeerId);

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -96,7 +96,7 @@ impl Orderbook {
     /// Create and publish a new 'make' order. Called by Bob i.e. the maker.
     pub fn make(&mut self, order: Order) -> anyhow::Result<OrderId> {
         let ser = bincode::serialize(&Message::CreateOrder(order.clone()))?;
-        let topic = order.tp().topic();
+        let topic = order.tp().to_topic();
         self.gossipsub.publish(&topic, ser);
 
         let id = order.id;

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -110,7 +110,7 @@ impl Orderbook {
     pub fn take(&mut self, order_id: OrderId) -> anyhow::Result<()> {
         let maker_id = self
             .maker_id(order_id)
-            .ok_or_else(|| OrderbookError::OrderNotFound(order_id))?;
+            .ok_or_else(|| OrderNotFound(order_id))?;
 
         self.take_order.send_request(&maker_id.into(), order_id);
 
@@ -179,19 +179,9 @@ impl Orderbook {
     }
 }
 
-#[derive(thiserror::Error, Debug, Clone, Copy)]
-pub enum OrderbookError {
-    #[error("could not make order")]
-    Make,
-    #[error("could not take order because identities not found")]
-    IdentitiesForOrderNotFound(OrderId),
-    #[error("could not take order because not found")]
-    OrderNotFound(OrderId),
-    #[error("could not subscribe to all peers for topic")]
-    Subscribe,
-    #[error("could not unsubscribe to all peers for topic")]
-    UnSubscribe,
-}
+#[derive(PartialEq, Clone, Copy, Debug, thiserror::Error)]
+#[error("order not found in orderbook: {0:?}")]
+pub struct OrderNotFound(OrderId);
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum TradingPair {

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -100,8 +100,6 @@ impl Orderbook {
         let id = order.id;
 
         self.gossipsub.publish(&topic, ser);
-        tracing::info!("published order: {}", id);
-
         self.orders.insert(id, order);
 
         Ok(id)

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -180,7 +180,7 @@ impl Orderbook {
 }
 
 #[derive(PartialEq, Clone, Copy, Debug, thiserror::Error)]
-#[error("order not found in orderbook: {0:?}")]
+#[error("order {0} not found in orderbook")]
 pub struct OrderNotFound(OrderId);
 
 /// MakerId is a PeerId wrapper so we control serialization/deserialization.

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -98,11 +98,11 @@ fn meaningless_expiry_value() -> u32 {
     100
 }
 
-/// The position the maker takes in this order. A BTC/DAI buy order,
+/// The position of the maker for this order. A BTC/DAI buy order,
 /// also described as an order that buys the trading pair BTC/DAI,
-/// means that the order maker buys the base currency (in this case
-/// BTC) in return for DAI. A sell order means that the maker sells
-/// BTC and receives DAI.
+/// means that the maker buys the base currency (in this case BTC) in
+/// return for DAI. A sell order means that the maker sells BTC and
+/// receives DAI.
 ///
 /// Please note: we do not set the base currency to 1 and use rate
 /// (i.e., quote currency) and amount as is commonly done in Forex

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -72,7 +72,7 @@ pub enum TradingPair {
 }
 
 impl TradingPair {
-    pub fn topic(&self) -> Topic {
+    pub fn to_topic(&self) -> Topic {
         Topic::new(BTC_DAI.to_string())
     }
 }

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -36,6 +36,8 @@ impl FromStr for OrderId {
     }
 }
 
+/// An order, created by a maker (Bob) and shared with the network via
+/// gossipsub.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Order {
     pub id: OrderId,
@@ -51,6 +53,7 @@ pub struct Order {
     pub ethereum_absolute_expiry: u32,
 }
 
+// We explicitly only support BTC/DAI.
 impl Order {
     pub fn tp(&self) -> TradingPair {
         TradingPair::BtcDai
@@ -78,6 +81,16 @@ fn meaningless_expiry_value() -> u32 {
     100
 }
 
+/// The position the maker takes in this order. A BTC/DAI buy order,
+/// also described as an order that buys the trading pair BTC/DAI,
+/// means that the order maker buys the base currency (in this case
+/// BTC) in return for DAI. A sell order means that the maker sells
+/// BTC and receives DAI.
+///
+/// Please note: we do not set the base currency to 1 and use rate
+/// (i.e., quote currency) and amount as is commonly done in Forex
+/// trading. We use the amounts of each currency to determine the
+/// rate.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Position {

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -1,7 +1,8 @@
 use crate::{
     asset, identity, ledger,
-    network::protocols::orderbook::{MakerId, TradingPair},
+    network::protocols::orderbook::{MakerId, BTC_DAI},
 };
+use libp2p::gossipsub::Topic;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, str::FromStr};
 use uuid::Uuid;
@@ -57,6 +58,22 @@ pub struct Order {
 impl Order {
     pub fn tp(&self) -> TradingPair {
         TradingPair::BtcDai
+    }
+}
+
+// Since we only support a single trading pair this struct is actually
+// not needed, the information is implicit in the Order struct. Keep
+// this and the calls to order.tp().topic() to make it explicit that
+// there is only a single trading pair and the trading pair is
+// defined by the order struct.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum TradingPair {
+    BtcDai,
+}
+
+impl TradingPair {
+    pub fn topic(&self) -> Topic {
+        Topic::new(BTC_DAI.to_string())
     }
 }
 

--- a/comit/src/network/protocols/orderbook/take_order.rs
+++ b/comit/src/network/protocols/orderbook/take_order.rs
@@ -39,7 +39,7 @@ impl RequestResponseCodec for TakeOrderCodec {
     type Request = OrderId;
     type Response = Response;
 
-    // handling take order req
+    /// Reads a take order request from the given I/O stream.
     async fn read_request<T>(&mut self, _: &Self::Protocol, io: &mut T) -> io::Result<Self::Request>
     where
         T: AsyncRead + Unpin + Send,
@@ -54,7 +54,7 @@ impl RequestResponseCodec for TakeOrderCodec {
         Ok(order_id)
     }
 
-    // handling take order resp
+    /// Reads a response (to a take order request) from the given I/O stream.
     async fn read_response<T>(
         &mut self,
         _: &Self::Protocol,
@@ -72,7 +72,7 @@ impl RequestResponseCodec for TakeOrderCodec {
         Ok(res)
     }
 
-    // sending take order req
+    /// Writes a take order request to the given I/O stream.
     async fn write_request<T>(
         &mut self,
         _: &Self::Protocol,
@@ -89,7 +89,7 @@ impl RequestResponseCodec for TakeOrderCodec {
         Ok(())
     }
 
-    // sending take order resp
+    /// Writes a response (to a take order request) to the given I/O stream.
     async fn write_response<T>(
         &mut self,
         _: &Self::Protocol,

--- a/comit/src/network/protocols/orderbook/take_order.rs
+++ b/comit/src/network/protocols/orderbook/take_order.rs
@@ -106,9 +106,9 @@ impl RequestResponseCodec for TakeOrderCodec {
             }
             Response::Error => {
                 debug!("closing write response channel");
-                // for now, errors just close the substream.
-                // we can send actual error responses at a later point
-                // denied take order request is an error
+                // For now, errors just close the substream. We can
+                // send actual error responses at a later point. A
+                // denied take order request is defined as an error.
                 let _ = io.close().await;
             }
         }


### PR DESCRIPTION
This PR does:

- Add todos from previous PR review
- Improve documentation of the order and orderbook
- Removes the announce trading pair logic from cnd and the orderbook

Reason for announce trading pair removal: We only support a single trading pair, all the announce logic is not needed, it adds unnecessary complexity, code to maintain and reason about.