### PR TITLE
Orderbook cnd

### DIFF
--- a/cnd/src/facade.rs
+++ b/cnd/src/facade.rs
@@ -59,7 +59,7 @@ impl Facade {
         Ok(timestamp)
     }
 
-    pub async fn take_herc20_hbit_order(
+    pub async fn take_order(
         &mut self,
         order_id: OrderId,
         swap_id: LocalSwapId,
@@ -73,11 +73,11 @@ impl Facade {
             .await;
 
         self.swarm
-            .take_herc20_hbit_order(order_id, swap_id, redeem_identity, refund_identity)
+            .take_order(order_id, swap_id, redeem_identity, refund_identity)
             .await
     }
 
-    pub async fn make_herc20_hbit_order(
+    pub async fn make_order(
         &self,
         order: NewOrder,
         swap_id: LocalSwapId,
@@ -85,7 +85,7 @@ impl Facade {
         refund_identity: crate::bitcoin::Address,
     ) -> anyhow::Result<OrderId> {
         self.swarm
-            .make_herc20_hbit_order(order, swap_id, redeem_identity, refund_identity)
+            .make_order(order, swap_id, redeem_identity, refund_identity)
             .await
     }
 

--- a/cnd/src/http_api.rs
+++ b/cnd/src/http_api.rs
@@ -11,6 +11,7 @@ mod route_factory;
 #[macro_use]
 mod impl_serialize_http;
 mod action;
+mod dial_addr;
 mod peers;
 mod problem;
 mod protocol;

--- a/cnd/src/http_api/dial_addr.rs
+++ b/cnd/src/http_api/dial_addr.rs
@@ -1,0 +1,26 @@
+use crate::{facade::Facade, http_api::problem};
+use libp2p::Multiaddr;
+use serde::Deserialize;
+use warp::{Rejection, Reply};
+
+// TODO: Do we even want this module?
+
+#[derive(Deserialize, Debug)]
+pub struct DialPeerBody {
+    addresses: Vec<Multiaddr>,
+}
+
+pub async fn post_dial_addr(
+    body: serde_json::Value,
+    mut facade: Facade,
+) -> Result<impl Reply, Rejection> {
+    let body = DialPeerBody::deserialize(&body)
+        .map_err(anyhow::Error::new)
+        .map_err(problem::from_anyhow)
+        .map_err(warp::reject::custom)?;
+    // TODO: find out if the dial was successful?
+    for addr in body.addresses {
+        facade.dial_addr(addr).await;
+    }
+    Ok(warp::reply::reply())
+}

--- a/cnd/src/http_api/orderbook.rs
+++ b/cnd/src/http_api/orderbook.rs
@@ -107,7 +107,6 @@ pub async fn post_make_herc20_hbit_order(
         .map_err(problem::from_anyhow)
         .map_err(warp::reject::custom)?;
 
-    // TODO: We need to save the bitcoin address here else it is lost.
     let swap_id = LocalSwapId::default();
 
     facade

--- a/cnd/src/http_api/orderbook.rs
+++ b/cnd/src/http_api/orderbook.rs
@@ -31,6 +31,10 @@ pub async fn post_take_order(
     let refund_identity = body.refund_identity;
     let redeem_identity = body.redeem_identity;
 
+    // TODO: We can just pass the identities down to the network layer
+    // in the `take_order` method. Then swap creation and save would
+    // be done down there as it is for make order.
+
     let swap_id = LocalSwapId::default();
 
     let order_id = order_id;
@@ -129,8 +133,12 @@ pub async fn post_make_order(
 pub async fn get_order(order_id: OrderId, facade: Facade) -> Result<impl Reply, Rejection> {
     let swap_id = facade
         .storage
+        // TODO: Rename this, its a simple mapping - why the unusually long name?
         .get_swap_associated_with_order(&order_id)
         .await;
+
+    // TODO: This only returns the order data if a swap has not been created. Surely
+    // that's not what we want?
 
     // let entity = siren::Entity::default().with_class_member("order");
     let entity = match swap_id {
@@ -145,6 +153,8 @@ pub async fn get_order(order_id: OrderId, facade: Facade) -> Result<impl Reply, 
     Ok(warp::reply::json(&entity))
 }
 
+// TODO: This code smells, these identities are specific to the
+// role but this function can be called by a user in either role.
 pub async fn get_orders(facade: Facade) -> Result<impl Reply, Rejection> {
     let orders = facade.get_orders().await;
 

--- a/cnd/src/http_api/route_factory.rs
+++ b/cnd/src/http_api/route_factory.rs
@@ -135,21 +135,21 @@ pub fn create(facade: Facade, allowed_origins: &AllowedOrigins) -> BoxedFilter<(
         .and(facade.clone())
         .and_then(orderbook::get_orders);
 
-    let take_herc20_hbit_order = warp::post()
+    let take_order = warp::post()
         .and(warp::path("orders"))
         .and(warp::path::param::<OrderId>())
         .and(warp::path("take"))
         .and(warp::path::end())
         .and(warp::body::json())
         .and(facade.clone())
-        .and_then(orderbook::post_take_herc20_hbit_order);
+        .and_then(orderbook::post_take_order);
 
-    let make_herc20_hbit_order = warp::post()
+    let make_order = warp::post()
         .and(warp::path!("orders"))
         .and(warp::path::end())
         .and(warp::body::json())
         .and(facade.clone())
-        .and_then(orderbook::post_make_herc20_hbit_order);
+        .and_then(orderbook::post_make_order);
 
     let post_dial_addr = warp::post()
         .and(warp::path!("dial"))
@@ -172,8 +172,8 @@ pub fn create(facade: Facade, allowed_origins: &AllowedOrigins) -> BoxedFilter<(
         .or(action_refund)
         .or(hbit_herc20)
         .or(herc20_hbit)
-        .or(take_herc20_hbit_order)
-        .or(make_herc20_hbit_order)
+        .or(take_order)
+        .or(make_order)
         .or(get_orders)
         .or(get_order)
         .or(post_dial_addr)

--- a/cnd/src/http_api/route_factory.rs
+++ b/cnd/src/http_api/route_factory.rs
@@ -2,7 +2,8 @@ use crate::{
     config::AllowedOrigins,
     http_api,
     http_api::{
-        halbit_herc20, hbit_herc20, herc20_halbit, herc20_hbit, info, orderbook, peers, swaps,
+        dial_addr, halbit_herc20, hbit_herc20, herc20_halbit, herc20_hbit, info, orderbook, peers,
+        swaps,
     },
     network::OrderId,
     Facade, LocalSwapId,
@@ -156,7 +157,7 @@ pub fn create(facade: Facade, allowed_origins: &AllowedOrigins) -> BoxedFilter<(
         .and(warp::path::end())
         .and(warp::body::json())
         .and(facade)
-        .and_then(orderbook::post_dial_peer);
+        .and_then(dial_addr::post_dial_addr);
 
     preflight_cors_route
         .or(get_peers)

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -116,7 +116,7 @@ impl Swarm {
     }
 
     /// The taker plays the role of Alice.
-    pub async fn take_herc20_hbit_order(
+    pub async fn take_order(
         &self,
         order_id: OrderId,
         swap_id: LocalSwapId,
@@ -124,11 +124,11 @@ impl Swarm {
         refund_identity: identity::Ethereum,
     ) -> anyhow::Result<()> {
         let mut guard = self.inner.lock().await;
-        guard.take_herc20_hbit_order(order_id, swap_id, redeem_identity, refund_identity)
+        guard.take_order(order_id, swap_id, redeem_identity, refund_identity)
     }
 
     /// The maker plays the role of Bob.
-    pub async fn make_herc20_hbit_order(
+    pub async fn make_order(
         &self,
         order: NewOrder,
         swap_id: LocalSwapId,
@@ -136,7 +136,7 @@ impl Swarm {
         refund_identity: crate::bitcoin::Address,
     ) -> anyhow::Result<OrderId> {
         let mut guard = self.inner.lock().await;
-        guard.make_herc20_hbit_order(order, swap_id, redeem_identity, refund_identity)
+        guard.make_order(order, swap_id, redeem_identity, refund_identity)
     }
 
     pub async fn get_orders(&self) -> Vec<Order> {
@@ -307,7 +307,7 @@ impl ComitNode {
     }
 
     /// The taker plays the role of Alice.
-    pub fn take_herc20_hbit_order(
+    pub fn take_order(
         &mut self,
         order_id: OrderId,
         swap_id: LocalSwapId,
@@ -337,7 +337,7 @@ impl ComitNode {
     }
 
     /// The maker plays the role of Bob.
-    pub fn make_herc20_hbit_order(
+    pub fn make_order(
         &mut self,
         new_order: NewOrder,
         swap_id: LocalSwapId,

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -450,7 +450,7 @@ mod tests {
             (
                 BehaviourOutEvent::TakeOrderConfirmation {
                     peer_id: alice_got_peer_id,
-                    order_id: _,
+                    order_id: alice_got_order_id,
                     shared_swap_id: alice_got_swap_id,
                 },
                 BehaviourOutEvent::TakeOrderConfirmation {
@@ -461,7 +461,10 @@ mod tests {
             ) => {
                 assert_eq!(alice_got_peer_id, bob.peer_id);
                 assert_eq!(bob_got_peer_id, alice.peer_id);
-                assert_eq!(bob_got_order_id, alice_order.id);
+
+                assert_eq!(alice_got_order_id, alice_order.id);
+                assert_eq!(bob_got_order_id, alice_got_order_id);
+
                 assert_eq!(alice_got_swap_id, bob_got_swap_id);
             }
             _ => panic!("failed to get take order confirmation"),


### PR DESCRIPTION
A few cleanup to cnd orderbook code:

- Remove stale comment
- Simplify identifiers
- Move the dial peer/addr endpoint to its own module
- Add some todos for further cleanup work
- Add more assertions to the orderbook unit test