### PR TITLE
Extend orderbook test to include swap execution

### DIFF
--- a/api_tests/src/actors/actor.ts
+++ b/api_tests/src/actors/actor.ts
@@ -256,6 +256,38 @@ export class Actor {
         );
     }
 
+    public async initOrderbookTest(swapUrl: string, create: Herc20HbitPayload) {
+        this.alphaLedger = {
+            name: LedgerKind.Ethereum,
+            chain_id: create.alpha.chain_id,
+        };
+        this.betaLedger = {
+            name: LedgerKind.Bitcoin,
+            network: create.beta.network,
+        };
+        this.alphaAsset = {
+            name: AssetKind.Erc20,
+            quantity: create.alpha.amount,
+            ledger: LedgerKind.Ethereum,
+            tokenContract: create.alpha.token_contract,
+        };
+        this.betaAsset = {
+            name: AssetKind.Bitcoin,
+            quantity: create.beta.amount,
+            ledger: LedgerKind.Bitcoin,
+        };
+        await this.setStartingBalances();
+
+        this.swap = new Swap(
+            this.cnd,
+            swapUrl,
+            new SdkWallets({
+                ethereum: this.wallets.ethereum.inner,
+                bitcoin: this.wallets.bitcoin.inner,
+            })
+        );
+    }
+
     /**
      * Makes a BtcDai sell order (herc20-hbit Swap)
      */

--- a/api_tests/src/actors/order_factory.ts
+++ b/api_tests/src/actors/order_factory.ts
@@ -1,11 +1,14 @@
+import { Herc20HbitPayload } from "../payload";
+
 export interface Herc20HbitOrder {
-    trade: string;
+    position: string;
     bitcoin_amount: string;
     bitcoin_ledger: string;
     ethereum_amount: string;
     token_contract: string;
     ethereum_ledger: Ethereum;
-    absolute_expiry: number;
+    bitcoin_absolute_expiry: number;
+    ethereum_absolute_expiry: number;
     refund_identity: string;
     redeem_identity: string;
 }
@@ -15,19 +18,23 @@ interface Ethereum {
 }
 
 export default class OrderFactory {
-    public static newHerc20HbitOrder(): Herc20HbitOrder {
+    public static newHerc20HbitOrder(
+        swap: Herc20HbitPayload,
+        position: string
+    ): Herc20HbitOrder {
         return {
-            trade: "sell",
-            bitcoin_amount: "100000",
-            bitcoin_ledger: "regtest",
-            ethereum_amount: "200",
-            token_contract: "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280",
+            position,
+            bitcoin_amount: swap.alpha.amount,
+            bitcoin_ledger: swap.beta.network,
+            token_contract: swap.alpha.token_contract,
+            ethereum_amount: swap.alpha.amount,
             ethereum_ledger: {
-                chain_id: 1337,
+                chain_id: swap.alpha.chain_id,
             },
-            absolute_expiry: 600,
-            refund_identity: "1F1tAaz5x1HUXrCNLbtMDqcw6o5GNn4xqX",
-            redeem_identity: "0x00a329c0648769a73afac7f9381e08fb43dbea72",
+            ethereum_absolute_expiry: swap.alpha.absolute_expiry,
+            bitcoin_absolute_expiry: swap.beta.absolute_expiry,
+            refund_identity: swap.beta.final_identity,
+            redeem_identity: swap.alpha.identity,
         };
     }
 }

--- a/api_tests/src/actors/order_factory.ts
+++ b/api_tests/src/actors/order_factory.ts
@@ -18,12 +18,11 @@ interface Ethereum {
 }
 
 export default class OrderFactory {
-    public static newHerc20HbitOrder(
-        swap: Herc20HbitPayload,
-        position: string
+    public static newHerc20HbitSellOrder(
+        swap: Herc20HbitPayload
     ): Herc20HbitOrder {
         return {
-            position,
+            position: "sell",
             bitcoin_amount: swap.alpha.amount,
             bitcoin_ledger: swap.beta.network,
             token_contract: swap.alpha.token_contract,

--- a/api_tests/src/actors/order_factory.ts
+++ b/api_tests/src/actors/order_factory.ts
@@ -23,7 +23,7 @@ export default class OrderFactory {
     ): Herc20HbitOrder {
         return {
             position: "sell",
-            bitcoin_amount: swap.alpha.amount,
+            bitcoin_amount: swap.beta.amount,
             bitcoin_ledger: swap.beta.network,
             token_contract: swap.alpha.token_contract,
             ethereum_amount: swap.alpha.amount,

--- a/api_tests/tests/orderbook.ts
+++ b/api_tests/tests/orderbook.ts
@@ -33,9 +33,8 @@ describe("orderbook", () => {
             /// Wait for alice to accept an incoming connection from Bob
             await sleep(1000);
 
-            const bobMakeOrderBody = OrderFactory.newHerc20HbitOrder(
-                bodies.bob,
-                "sell"
+            const bobMakeOrderBody = OrderFactory.newHerc20HbitSellOrder(
+                bodies.bob
             );
             // @ts-ignore
             // make response contain url in the header to the created order

--- a/api_tests/tests/orderbook.ts
+++ b/api_tests/tests/orderbook.ts
@@ -69,8 +69,7 @@ describe("orderbook", () => {
             const aliceTakeOrderResponse = await alice.cnd.executeSirenAction(
                 aliceOrderTakeAction,
                 async (field) => {
-
-                        // this could be wrong
+                    // this could be wrong
                     if (field.name === "refund_identity") {
                         // @ts-ignore
                         return Promise.resolve(bodies.alice.alpha.identity);

--- a/api_tests/tests/orderbook.ts
+++ b/api_tests/tests/orderbook.ts
@@ -26,6 +26,7 @@ describe("orderbook", () => {
             // Get alice's listen address
             const aliceAddr = await alice.cnd.getPeerListenAddresses();
 
+            // is this required still?
             // Bob dials alices
             // @ts-ignore
             await bob.cnd.client.post("dial", { addresses: aliceAddr });
@@ -33,6 +34,9 @@ describe("orderbook", () => {
             /// Wait for alice to accept an incoming connection from Bob
             await sleep(1000);
 
+            // assuming the nodes are connected from now on
+
+            // this payload could be wrong
             const bobMakeOrderBody = OrderFactory.newHerc20HbitSellOrder(
                 bodies.bob
             );
@@ -65,8 +69,8 @@ describe("orderbook", () => {
             const aliceTakeOrderResponse = await alice.cnd.executeSirenAction(
                 aliceOrderTakeAction,
                 async (field) => {
-                    //                const classes = field.class;
 
+                        // this could be wrong
                     if (field.name === "refund_identity") {
                         // @ts-ignore
                         return Promise.resolve(bodies.alice.alpha.identity);
@@ -116,9 +120,9 @@ describe("orderbook", () => {
                 bodies.alice
             );
 
+            await alice.assertAndExecuteNextAction("deploy");
             await alice.assertAndExecuteNextAction("fund");
 
-            await bob.assertAndExecuteNextAction("deploy");
             await bob.assertAndExecuteNextAction("fund");
 
             await alice.assertAndExecuteNextAction("redeem");

--- a/cnd/src/http_api/orderbook.rs
+++ b/cnd/src/http_api/orderbook.rs
@@ -93,7 +93,7 @@ pub async fn post_make_herc20_hbit_order(
     body: serde_json::Value,
     facade: Facade,
 ) -> Result<impl Reply, Rejection> {
-    tracing::info!("entered take order controller");
+    tracing::info!("entered make order controller");
     let body = MakeHerc20HbitOrderBody::deserialize(&body)
         .map_err(anyhow::Error::new)
         .map_err(problem::from_anyhow)

--- a/cnd/src/http_api/orderbook.rs
+++ b/cnd/src/http_api/orderbook.rs
@@ -155,7 +155,7 @@ pub async fn get_orders(facade: Facade) -> Result<impl Reply, Rejection> {
     for order in orders.into_iter() {
         let redeem_field = siren::Field {
             name: "redeem_identity".to_string(),
-            class: vec!["ethereum".to_string(), "address".to_string()],
+            class: vec!["bitcoin".to_string(), "address".to_string()],
             _type: None,
             value: None,
             title: None,
@@ -163,7 +163,7 @@ pub async fn get_orders(facade: Facade) -> Result<impl Reply, Rejection> {
 
         let refund_field = siren::Field {
             name: "refund_identity".to_string(),
-            class: vec!["bitcoin".to_string(), "address".to_string()],
+            class: vec!["ethereum".to_string(), "address".to_string()],
             _type: None,
             value: None,
             title: None,

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -662,6 +662,8 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<orderbook::BehaviourOutEvent> f
                         return;
                     }
                 };
+                self.local_swap_ids
+                    .insert(shared_swap_id, local_swap_id.clone());
                 self.comit
                     .communicate(peer_id.clone(), shared_swap_id, data);
             }

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -662,12 +662,9 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<orderbook::BehaviourOutEvent> f
                         return;
                     }
                 };
-                self.local_swap_ids
-                    .insert(shared_swap_id, local_swap_id.clone());
-                self.comit
-                    .communicate(peer_id.clone(), shared_swap_id, data);
+                self.local_swap_ids.insert(shared_swap_id, *local_swap_id);
+                self.comit.communicate(peer_id, shared_swap_id, data);
             }
-
             orderbook::BehaviourOutEvent::Failed { peer_id, order_id } => tracing::warn!(
                 "take order request failed, peer: {}, order: {}",
                 peer_id,

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -635,9 +635,10 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<orderbook::BehaviourOutEvent> f
 
                 // No other validation, just take the order. This
                 // implies that an order can be taken multiple times.
-                self.orderbook.confirm(order_id, response_channel);
+                self.orderbook.confirm(order_id, response_channel, peer_id);
             }
             orderbook::BehaviourOutEvent::TakeOrderConfirmation {
+                peer_id,
                 order_id,
                 shared_swap_id,
             } => {
@@ -657,17 +658,6 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<orderbook::BehaviourOutEvent> f
                         tracing::warn!(
                             "inconsistent state, no local data found for swap id: {}",
                             shared_swap_id
-                        );
-                        return;
-                    }
-                };
-
-                let peer_id = match self.orderbook.get_order(&order_id) {
-                    Some(order) => PeerId::from(order.maker),
-                    None => {
-                        tracing::error!(
-                            "order {} specified in take order confirmation not found in local store",
-                            order_id
                         );
                         return;
                     }

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -122,7 +122,7 @@ impl Orderbook {
         self.orders.get(&order_id).map(|order| order.maker.clone())
     }
 
-    /// Confirm a take order request, called by Bob i.e., the maker
+    /// Confirm a take order request, called by Bob i.e., the maker.
     /// Does _not_ remove the order from the order book.
     pub fn confirm(
         &mut self,

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -122,9 +122,14 @@ impl Orderbook {
         self.orders.get(&order_id).map(|order| order.maker.clone())
     }
 
-    /// Confirm a take order request, called by Bob i.e., the maker.
+    /// Confirm a take order request, called by Bob i.e., the maker
     /// Does _not_ remove the order from the order book.
-    pub fn confirm(&mut self, order_id: OrderId, channel: ResponseChannel<Response>) {
+    pub fn confirm(
+        &mut self,
+        order_id: OrderId,
+        channel: ResponseChannel<Response>,
+        peer_id: PeerId,
+    ) {
         let shared_swap_id = SharedSwapId::default();
         tracing::debug!(
             "confirming take order request with swap id: {}",
@@ -139,6 +144,7 @@ impl Orderbook {
 
         self.events
             .push_back(BehaviourOutEvent::TakeOrderConfirmation {
+                peer_id,
                 order_id,
                 shared_swap_id,
             });
@@ -273,6 +279,8 @@ pub enum BehaviourOutEvent {
     /// Event emitted in both Alice and Bob's node when a take order is
     /// confirmed.
     TakeOrderConfirmation {
+        /// The peer from whom request originated.
+        peer_id: PeerId,
         /// The ID of the order taken.
         order_id: OrderId,
         /// Identifier for the swap, used by the COMIT communication protocols.
@@ -340,7 +348,7 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<OrderId, Response>> for O
                 None => tracing::info!("received take order request for non-existent order"),
             },
             RequestResponseEvent::Message {
-                peer: _,
+                peer: peer_id,
                 message:
                     RequestResponseMessage::Response {
                         request_id: _,
@@ -353,6 +361,7 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<OrderId, Response>> for O
             } => {
                 self.events
                     .push_back(BehaviourOutEvent::TakeOrderConfirmation {
+                        peer_id,
                         order_id,
                         shared_swap_id,
                     });
@@ -425,7 +434,7 @@ mod tests {
             .await
             .expect("failed to get TakeOrderRequest event");
 
-        let (_peer_id, channel, order_id) = match bob_event {
+        let (alice_peer_id, channel, order_id) = match bob_event {
             BehaviourOutEvent::TakeOrderRequest {
                 peer_id,
                 response_channel,
@@ -433,22 +442,25 @@ mod tests {
             } => (peer_id, response_channel, order_id),
             _ => panic!("unexepected bob event"),
         };
-        bob.swarm.confirm(order_id, channel);
+        bob.swarm.confirm(order_id, channel, alice_peer_id);
 
         let (alice_event, bob_event) =
             await_events_or_timeout(alice.swarm.next(), bob.swarm.next()).await;
         match (alice_event, bob_event) {
             (
                 BehaviourOutEvent::TakeOrderConfirmation {
+                    peer_id: alice_got_peer_id,
                     order_id: alice_got_order_id,
                     shared_swap_id: alice_got_swap_id,
                 },
                 BehaviourOutEvent::TakeOrderConfirmation {
+                    peer_id: bob_got_peer_id,
                     order_id: bob_got_order_id,
                     shared_swap_id: bob_got_swap_id,
                 },
             ) => {
-                assert_eq!(alice_got_order_id, bob_order.id);
+                assert_eq!(alice_got_peer_id, bob.peer_id);
+                assert_eq!(bob_got_peer_id, alice.peer_id);
                 assert_eq!(bob_got_order_id, alice_order.id);
                 assert_eq!(alice_got_swap_id, bob_got_swap_id);
             }

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -450,7 +450,7 @@ mod tests {
             (
                 BehaviourOutEvent::TakeOrderConfirmation {
                     peer_id: alice_got_peer_id,
-                    order_id: alice_got_order_id,
+                    order_id: _,
                     shared_swap_id: alice_got_swap_id,
                 },
                 BehaviourOutEvent::TakeOrderConfirmation {


### PR DESCRIPTION
Extended the orderbook test to execute the swap created from an order.

Various bug fixes in comit, cnd and the test code to get the extended test working.

There will be a follow up PR to cleanup the test code to make it more readable.