### PR TITLE
Remove makers topic

### DIFF
--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -29,8 +29,6 @@ use std::{
 
 pub use self::order::*;
 
-// TODO: Rethink topic logic
-
 /// String representing the BTC/DAI trading pair.
 const BTC_DAI: &str = "BTC/DAI";
 
@@ -81,8 +79,6 @@ impl Orderbook {
             orders: HashMap::new(),
             events: VecDeque::new(),
         };
-
-        orderbook.gossipsub.subscribe(Makers::topic());
 
         // Since we only support a single trading pair topic just subscribe to it now.
         orderbook
@@ -229,16 +225,6 @@ impl<'de> Deserialize<'de> for MakerId {
         let peer_id = PeerId::from_str(&string).map_err(D::Error::custom)?;
 
         Ok(MakerId(peer_id))
-    }
-}
-
-/// Used to publish/subscribe available makers.
-#[derive(Debug, Clone, Copy)]
-pub struct Makers;
-
-impl Makers {
-    pub fn topic() -> Topic {
-        Topic::new("makers".to_string())
     }
 }
 
@@ -396,7 +382,7 @@ mod tests {
 
         // act
 
-        // Trigger subscription.
+        // Trigger subscription to BCT/DAI topic.
         poll_no_event(&mut alice.swarm).await;
         poll_no_event(&mut bob.swarm).await;
 

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -29,7 +29,6 @@ use std::{
 
 pub use self::order::*;
 
-// TODO: Audit function scope
 // TODO: Rethink topic logic
 
 /// String representing the BTC/DAI trading pair.

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -242,12 +242,6 @@ impl Makers {
     }
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Hash, Eq)]
-pub enum SwapType {
-    Herc20,
-    Hbit,
-}
-
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub enum Message {
     CreateOrder(Order),


### PR DESCRIPTION
This is all conceptually clean up but changes logic.

Patch 1 - Whitespace, removes a non-actionable TODO
Patch 2 - Remove unused type `SwapType`
Patch 3 - Remove the "makers" topic.

The makers topic is currently not used apart from subscribing to it. Remove it.