### PR TITLE
bidirectional e2e test for orderbook 

### DIFF
--- a/api_tests/src/actors/actor.ts
+++ b/api_tests/src/actors/actor.ts
@@ -353,7 +353,6 @@ export class Actor {
             const aliceTakeOrderResponse = await this.cnd.executeSirenAction(
                 aliceOrderTakeAction,
                 async (field) => {
-                    // this could be wrong
                     if (field.name === "bitcoin_identity") {
                         // @ts-ignore
                         return Promise.resolve(bitcoinIdentity);

--- a/api_tests/src/actors/actor.ts
+++ b/api_tests/src/actors/actor.ts
@@ -255,27 +255,7 @@ export class Actor {
     }
 
     public async initLedgerAndBalancesForOrder(order: BtcDaiOrder) {
-        if (order.position === "sell") {
-            this.alphaLedger = {
-                name: LedgerKind.Ethereum,
-                chain_id: order.ethereum_ledger.chain_id,
-            };
-            this.betaLedger = {
-                name: LedgerKind.Bitcoin,
-                network: order.bitcoin_ledger,
-            };
-            this.alphaAsset = {
-                name: AssetKind.Erc20,
-                quantity: order.ethereum_amount,
-                ledger: LedgerKind.Ethereum,
-                tokenContract: order.token_contract,
-            };
-            this.betaAsset = {
-                name: AssetKind.Bitcoin,
-                quantity: order.bitcoin_amount,
-                ledger: LedgerKind.Bitcoin,
-            };
-        } else if (order.position === "buy") {
+        if (order.position === "buy") {
             this.alphaLedger = {
                 name: LedgerKind.Bitcoin,
                 network: order.bitcoin_ledger,
@@ -294,6 +274,26 @@ export class Actor {
                 quantity: order.ethereum_amount,
                 ledger: LedgerKind.Ethereum,
                 tokenContract: order.token_contract,
+            };
+        } else if (order.position === "sell") {
+            this.alphaLedger = {
+                name: LedgerKind.Ethereum,
+                chain_id: order.ethereum_ledger.chain_id,
+            };
+            this.betaLedger = {
+                name: LedgerKind.Bitcoin,
+                network: order.bitcoin_ledger,
+            };
+            this.alphaAsset = {
+                name: AssetKind.Erc20,
+                quantity: order.ethereum_amount,
+                ledger: LedgerKind.Ethereum,
+                tokenContract: order.token_contract,
+            };
+            this.betaAsset = {
+                name: AssetKind.Bitcoin,
+                quantity: order.bitcoin_amount,
+                ledger: LedgerKind.Bitcoin,
             };
         } else {
             throw new Error(
@@ -329,8 +329,8 @@ export class Actor {
      * Takes a BtcDai sell order (herc20-hbit Swap)
      */
     public async takeOrderAndAssertSwapCreated(
-        refundIdentity: string,
-        redeemIdentity: string
+        bitcoinIdentity: string,
+        ethereumIdentity: string
     ) {
         if (this.name === "alice") {
             // Poll until Alice receives an order. The order must be the one that Bob created above.
@@ -354,14 +354,13 @@ export class Actor {
                 aliceOrderTakeAction,
                 async (field) => {
                     // this could be wrong
-                    if (field.name === "refund_identity") {
+                    if (field.name === "bitcoin_identity") {
                         // @ts-ignore
-                        return Promise.resolve(refundIdentity);
+                        return Promise.resolve(bitcoinIdentity);
                     }
-
-                    if (field.name === "redeem_identity") {
+                    if (field.name === "ethereum_identity") {
                         // @ts-ignore
-                        return Promise.resolve(redeemIdentity);
+                        return Promise.resolve(ethereumIdentity);
                     }
                 }
             );

--- a/api_tests/src/actors/defaults.ts
+++ b/api_tests/src/actors/defaults.ts
@@ -1,4 +1,5 @@
 import { Ledger, LedgerKind } from "../ledgers/ledger";
+import { Actor } from "./actor";
 
 /**
  * WIP as the cnd REST API routes for lightning are not yet defined.
@@ -25,4 +26,72 @@ export function defaultLedgerDescriptionForLedger(ledger: LedgerKind): Ledger {
             };
         }
     }
+}
+
+export async function getIdentities(
+    self: Actor
+): Promise<{ ethereum: string; lightning: string; bitcoin: string }> {
+    let ethereum = "0x00a329c0648769a73afac7f9381e08fb43dbea72";
+    let lightning =
+        "02ed138aaed50d2d597f6fe8d30759fd3949fe73fdf961322713f1c19e10036a06";
+    let bitcoin =
+        "02c2a8efce029526d364c2cf39d89e3cdda05e5df7b2cbfc098b4e3d02b70b5275";
+
+    try {
+        ethereum = self.wallets.ethereum.account();
+    } catch (e) {
+        self.logger.warn(
+            "Ethereum wallet not available, using static value for identity"
+        );
+    }
+
+    try {
+        lightning = await self.wallets.lightning.inner.getPubkey();
+    } catch (e) {
+        self.logger.warn(
+            "Lightning wallet not available, using static value for identity"
+        );
+    }
+
+    try {
+        bitcoin = await self.wallets.bitcoin.address();
+    } catch (e) {
+        self.logger.warn(
+            "Bitcoin wallet not available, using static value for identity"
+        );
+    }
+
+    return {
+        ethereum,
+        lightning,
+        bitcoin,
+    };
+}
+
+export function defaultExpiries() {
+    const {
+        alphaAbsoluteExpiry,
+        betaAbsoluteExpiry,
+        alphaCltvExpiry,
+        betaCltvExpiry,
+    } = nowExpiries();
+
+    return {
+        alphaAbsoluteExpiry: alphaAbsoluteExpiry + 240,
+        betaAbsoluteExpiry: betaAbsoluteExpiry + 120,
+        alphaCltvExpiry,
+        betaCltvExpiry,
+    };
+}
+
+export function nowExpiries() {
+    const alphaAbsoluteExpiry = Math.round(Date.now() / 1000);
+    const betaAbsoluteExpiry = Math.round(Date.now() / 1000);
+
+    return {
+        alphaAbsoluteExpiry,
+        betaAbsoluteExpiry,
+        alphaCltvExpiry: 350,
+        betaCltvExpiry: 350,
+    };
 }

--- a/api_tests/src/actors/order_factory.ts
+++ b/api_tests/src/actors/order_factory.ts
@@ -1,6 +1,7 @@
 import { Actor } from "./actor";
 import { sleep } from "../utils";
 import { HarnessGlobal } from "../utils";
+import { defaultExpiries, getIdentities } from "./defaults";
 
 declare var global: HarnessGlobal;
 
@@ -26,7 +27,7 @@ interface Ethereum {
     chain_id: number;
 }
 
-export default class OrderbookUtils {
+export default class OrderbookFactory {
     public static async initialiseWalletsForBtcDaiOrder(
         alice: Actor,
         bob: Actor
@@ -44,12 +45,6 @@ export default class OrderbookUtils {
 
         await bob.wallets.initializeForLedger("bitcoin", bob.logger, "bob");
         await bob.wallets.initializeForLedger("ethereum", bob.logger, "bob");
-    }
-
-    public static async getIdentities(
-        alice: Actor
-    ): Promise<{ ethereum: string; lightning: string; bitcoin: string }> {
-        return getIdentities(alice);
     }
 
     public static async connect(alice: Actor, bob: Actor) {
@@ -109,81 +104,4 @@ export default class OrderbookUtils {
             ethereum_identity: bobIdentities.ethereum,
         };
     }
-}
-
-async function getIdentities(
-    self: Actor
-): Promise<{ ethereum: string; lightning: string; bitcoin: string }> {
-    let ethereum = "0x00a329c0648769a73afac7f9381e08fb43dbea72";
-    let lightning =
-        "02ed138aaed50d2d597f6fe8d30759fd3949fe73fdf961322713f1c19e10036a06";
-    let bitcoin =
-        "02c2a8efce029526d364c2cf39d89e3cdda05e5df7b2cbfc098b4e3d02b70b5275";
-
-    try {
-        ethereum = self.wallets.ethereum.account();
-    } catch (e) {
-        self.logger.warn(
-            "Ethereum wallet not available, using static value for identity"
-        );
-    }
-
-    try {
-        lightning = await self.wallets.lightning.inner.getPubkey();
-    } catch (e) {
-        self.logger.warn(
-            "Lightning wallet not available, using static value for identity"
-        );
-    }
-
-    try {
-        bitcoin = await self.wallets.bitcoin.address();
-    } catch (e) {
-        self.logger.warn(
-            "Bitcoin wallet not available, using static value for identity"
-        );
-    }
-
-    return {
-        ethereum,
-        lightning,
-        bitcoin,
-    };
-}
-
-// async function makePeer(actor: Actor): Promise<Peer> {
-//     return {
-//         peer_id: await actor.cnd.getPeerId(),
-//         address_hint: await actor.cnd
-//             .getPeerListenAddresses()
-//             .then((addresses) => addresses[0]),
-//     };
-// }
-
-function defaultExpiries() {
-    const {
-        alphaAbsoluteExpiry,
-        betaAbsoluteExpiry,
-        alphaCltvExpiry,
-        betaCltvExpiry,
-    } = nowExpiries();
-
-    return {
-        alphaAbsoluteExpiry: alphaAbsoluteExpiry + 240,
-        betaAbsoluteExpiry: betaAbsoluteExpiry + 120,
-        alphaCltvExpiry,
-        betaCltvExpiry,
-    };
-}
-
-function nowExpiries() {
-    const alphaAbsoluteExpiry = Math.round(Date.now() / 1000);
-    const betaAbsoluteExpiry = Math.round(Date.now() / 1000);
-
-    return {
-        alphaAbsoluteExpiry,
-        betaAbsoluteExpiry,
-        alphaCltvExpiry: 350,
-        betaCltvExpiry: 350,
-    };
 }

--- a/api_tests/src/actors/order_factory.ts
+++ b/api_tests/src/actors/order_factory.ts
@@ -28,10 +28,19 @@ interface Ethereum {
 }
 
 export default class OrderbookFactory {
-    public static async initialiseWalletsForBtcDaiOrder(
-        alice: Actor,
-        bob: Actor
-    ) {
+    public static async connect(alice: Actor, bob: Actor) {
+        // Get alice's listen address
+        const aliceAddr = await alice.cnd.getPeerListenAddresses();
+
+        // Bob dials alices
+        // @ts-ignore
+        await bob.cnd.client.post("dial", { addresses: aliceAddr });
+
+        /// Wait for alice to accept an incoming connection from Bob
+        await sleep(1000);
+    }
+
+    public static async initWalletsForBtcDaiOrder(alice: Actor, bob: Actor) {
         await alice.wallets.initializeForLedger(
             "bitcoin",
             alice.logger,
@@ -45,18 +54,6 @@ export default class OrderbookFactory {
 
         await bob.wallets.initializeForLedger("bitcoin", bob.logger, "bob");
         await bob.wallets.initializeForLedger("ethereum", bob.logger, "bob");
-    }
-
-    public static async connect(alice: Actor, bob: Actor) {
-        // Get alice's listen address
-        const aliceAddr = await alice.cnd.getPeerListenAddresses();
-
-        // Bob dials alices
-        // @ts-ignore
-        await bob.cnd.client.post("dial", { addresses: aliceAddr });
-
-        /// Wait for alice to accept an incoming connection from Bob
-        await sleep(1000);
     }
 
     public static async newBtcDaiOrder(

--- a/api_tests/src/actors/order_factory.ts
+++ b/api_tests/src/actors/order_factory.ts
@@ -1,6 +1,15 @@
-import { Herc20HbitPayload } from "../payload";
+import { Actor } from "./actor";
+import { sleep } from "../utils";
+import { HarnessGlobal } from "../utils";
 
-export interface Herc20HbitOrder {
+declare var global: HarnessGlobal;
+
+export interface Identities {
+    refund_identity: string;
+    redeem_identity: string;
+}
+
+export interface BtcDaiOrder {
     position: string;
     bitcoin_amount: string;
     bitcoin_ledger: string;
@@ -17,23 +26,142 @@ interface Ethereum {
     chain_id: number;
 }
 
-export default class OrderFactory {
-    public static newHerc20HbitSellOrder(
-        swap: Herc20HbitPayload
-    ): Herc20HbitOrder {
+export default class OrderbookUtils {
+    public static async initialiseWalletsForBtcDaiOrder(
+        alice: Actor,
+        bob: Actor
+    ) {
+        await alice.wallets.initializeForLedger(
+            "bitcoin",
+            alice.logger,
+            "alice"
+        );
+        await alice.wallets.initializeForLedger(
+            "ethereum",
+            alice.logger,
+            "alice"
+        );
+
+        await bob.wallets.initializeForLedger("bitcoin", bob.logger, "bob");
+        await bob.wallets.initializeForLedger("ethereum", bob.logger, "bob");
+    }
+
+    public static async getIdentities(
+        alice: Actor
+    ): Promise<{ ethereum: string; lightning: string; bitcoin: string }> {
+        return getIdentities(alice);
+    }
+
+    public static async connect(alice: Actor, bob: Actor) {
+        // Get alice's listen address
+        const aliceAddr = await alice.cnd.getPeerListenAddresses();
+
+        // Bob dials alices
+        // @ts-ignore
+        await bob.cnd.client.post("dial", { addresses: aliceAddr });
+
+        /// Wait for alice to accept an incoming connection from Bob
+        await sleep(1000);
+    }
+
+    public static async newBtcDaiSellOrder(bob: Actor): Promise<BtcDaiOrder> {
+        const bobIdentities = await getIdentities(bob);
+
+        // todo: do make this the actual DAI contract? It doesnt actually matter
+        const daiTokenContract = global.tokenContract
+            ? global.tokenContract
+            : "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280";
+
         return {
             position: "sell",
-            bitcoin_amount: swap.beta.amount,
-            bitcoin_ledger: swap.beta.network,
-            token_contract: swap.alpha.token_contract,
-            ethereum_amount: swap.alpha.amount,
+            bitcoin_amount: "1000000",
+            bitcoin_ledger: "regtest",
+            token_contract: daiTokenContract,
+            ethereum_amount: "9000000000000000000",
             ethereum_ledger: {
-                chain_id: swap.alpha.chain_id,
+                chain_id: 1337,
             },
-            ethereum_absolute_expiry: swap.alpha.absolute_expiry,
-            bitcoin_absolute_expiry: swap.beta.absolute_expiry,
-            refund_identity: swap.beta.final_identity,
-            redeem_identity: swap.alpha.identity,
+            ethereum_absolute_expiry: defaultExpiries().alphaAbsoluteExpiry,
+            bitcoin_absolute_expiry: defaultExpiries().betaAbsoluteExpiry,
+            refund_identity: bobIdentities.bitcoin,
+            redeem_identity: bobIdentities.ethereum,
         };
     }
+}
+
+async function getIdentities(
+    self: Actor
+): Promise<{ ethereum: string; lightning: string; bitcoin: string }> {
+    let ethereum = "0x00a329c0648769a73afac7f9381e08fb43dbea72";
+    let lightning =
+        "02ed138aaed50d2d597f6fe8d30759fd3949fe73fdf961322713f1c19e10036a06";
+    let bitcoin =
+        "02c2a8efce029526d364c2cf39d89e3cdda05e5df7b2cbfc098b4e3d02b70b5275";
+
+    try {
+        ethereum = self.wallets.ethereum.account();
+    } catch (e) {
+        self.logger.warn(
+            "Ethereum wallet not available, using static value for identity"
+        );
+    }
+
+    try {
+        lightning = await self.wallets.lightning.inner.getPubkey();
+    } catch (e) {
+        self.logger.warn(
+            "Lightning wallet not available, using static value for identity"
+        );
+    }
+
+    try {
+        bitcoin = await self.wallets.bitcoin.address();
+    } catch (e) {
+        self.logger.warn(
+            "Bitcoin wallet not available, using static value for identity"
+        );
+    }
+
+    return {
+        ethereum,
+        lightning,
+        bitcoin,
+    };
+}
+
+// async function makePeer(actor: Actor): Promise<Peer> {
+//     return {
+//         peer_id: await actor.cnd.getPeerId(),
+//         address_hint: await actor.cnd
+//             .getPeerListenAddresses()
+//             .then((addresses) => addresses[0]),
+//     };
+// }
+
+function defaultExpiries() {
+    const {
+        alphaAbsoluteExpiry,
+        betaAbsoluteExpiry,
+        alphaCltvExpiry,
+        betaCltvExpiry,
+    } = nowExpiries();
+
+    return {
+        alphaAbsoluteExpiry: alphaAbsoluteExpiry + 240,
+        betaAbsoluteExpiry: betaAbsoluteExpiry + 120,
+        alphaCltvExpiry,
+        betaCltvExpiry,
+    };
+}
+
+function nowExpiries() {
+    const alphaAbsoluteExpiry = Math.round(Date.now() / 1000);
+    const betaAbsoluteExpiry = Math.round(Date.now() / 1000);
+
+    return {
+        alphaAbsoluteExpiry,
+        betaAbsoluteExpiry,
+        alphaCltvExpiry: 350,
+        betaCltvExpiry: 350,
+    };
 }

--- a/api_tests/src/actors/order_factory.ts
+++ b/api_tests/src/actors/order_factory.ts
@@ -18,8 +18,8 @@ export interface BtcDaiOrder {
     ethereum_ledger: Ethereum;
     bitcoin_absolute_expiry: number;
     ethereum_absolute_expiry: number;
-    refund_identity: string;
-    redeem_identity: string;
+    bitcoin_identity: string;
+    ethereum_identity: string;
 }
 
 interface Ethereum {
@@ -64,7 +64,10 @@ export default class OrderbookUtils {
         await sleep(1000);
     }
 
-    public static async newBtcDaiSellOrder(bob: Actor): Promise<BtcDaiOrder> {
+    public static async newBtcDaiOrder(
+        bob: Actor,
+        position: string
+    ): Promise<BtcDaiOrder> {
         const bobIdentities = await getIdentities(bob);
 
         // todo: do make this the actual DAI contract? It doesnt actually matter
@@ -72,8 +75,27 @@ export default class OrderbookUtils {
             ? global.tokenContract
             : "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280";
 
+        // todo: add a enum for buy/sell
+        const expiries = function () {
+            if (position === "buy") {
+                return {
+                    ethereum_absolute_expiry: defaultExpiries()
+                        .betaAbsoluteExpiry,
+                    bitcoin_absolute_expiry: defaultExpiries()
+                        .alphaAbsoluteExpiry,
+                };
+            } else {
+                return {
+                    ethereum_absolute_expiry: defaultExpiries()
+                        .alphaAbsoluteExpiry,
+                    bitcoin_absolute_expiry: defaultExpiries()
+                        .betaAbsoluteExpiry,
+                };
+            }
+        };
+
         return {
-            position: "sell",
+            position,
             bitcoin_amount: "1000000",
             bitcoin_ledger: "regtest",
             token_contract: daiTokenContract,
@@ -81,10 +103,10 @@ export default class OrderbookUtils {
             ethereum_ledger: {
                 chain_id: 1337,
             },
-            ethereum_absolute_expiry: defaultExpiries().alphaAbsoluteExpiry,
-            bitcoin_absolute_expiry: defaultExpiries().betaAbsoluteExpiry,
-            refund_identity: bobIdentities.bitcoin,
-            redeem_identity: bobIdentities.ethereum,
+            ethereum_absolute_expiry: expiries().ethereum_absolute_expiry,
+            bitcoin_absolute_expiry: expiries().bitcoin_absolute_expiry,
+            bitcoin_identity: bobIdentities.bitcoin,
+            ethereum_identity: bobIdentities.ethereum,
         };
     }
 }

--- a/api_tests/src/actors/swap_factory.ts
+++ b/api_tests/src/actors/swap_factory.ts
@@ -19,6 +19,7 @@ import {
     HbitPayload,
 } from "../payload";
 import { HarnessGlobal } from "../utils";
+import { defaultExpiries, getIdentities, nowExpiries } from "./defaults";
 
 declare var global: HarnessGlobal;
 
@@ -203,46 +204,6 @@ export default class SwapFactory {
     }
 }
 
-async function getIdentities(
-    self: Actor
-): Promise<{ ethereum: string; lightning: string; bitcoin: string }> {
-    let ethereum = "0x00a329c0648769a73afac7f9381e08fb43dbea72";
-    let lightning =
-        "02ed138aaed50d2d597f6fe8d30759fd3949fe73fdf961322713f1c19e10036a06";
-    let bitcoin =
-        "02c2a8efce029526d364c2cf39d89e3cdda05e5df7b2cbfc098b4e3d02b70b5275";
-
-    try {
-        ethereum = self.wallets.ethereum.account();
-    } catch (e) {
-        self.logger.warn(
-            "Ethereum wallet not available, using static value for identity"
-        );
-    }
-
-    try {
-        lightning = await self.wallets.lightning.inner.getPubkey();
-    } catch (e) {
-        self.logger.warn(
-            "Lightning wallet not available, using static value for identity"
-        );
-    }
-
-    try {
-        bitcoin = await self.wallets.bitcoin.address();
-    } catch (e) {
-        self.logger.warn(
-            "Bitcoin wallet not available, using static value for identity"
-        );
-    }
-
-    return {
-        ethereum,
-        lightning,
-        bitcoin,
-    };
-}
-
 async function makePeer(actor: Actor): Promise<Peer> {
     return {
         peer_id: await actor.cnd.getPeerId(),
@@ -287,33 +248,5 @@ function defaultHerc20Payload(
         chain_id: 1337,
         identity,
         absolute_expiry: absoluteExpiry,
-    };
-}
-
-function defaultExpiries() {
-    const {
-        alphaAbsoluteExpiry,
-        betaAbsoluteExpiry,
-        alphaCltvExpiry,
-        betaCltvExpiry,
-    } = nowExpiries();
-
-    return {
-        alphaAbsoluteExpiry: alphaAbsoluteExpiry + 240,
-        betaAbsoluteExpiry: betaAbsoluteExpiry + 120,
-        alphaCltvExpiry,
-        betaCltvExpiry,
-    };
-}
-
-function nowExpiries() {
-    const alphaAbsoluteExpiry = Math.round(Date.now() / 1000);
-    const betaAbsoluteExpiry = Math.round(Date.now() / 1000);
-
-    return {
-        alphaAbsoluteExpiry,
-        betaAbsoluteExpiry,
-        alphaCltvExpiry: 350,
-        betaCltvExpiry: 350,
     };
 }

--- a/api_tests/tests/orderbook.ts
+++ b/api_tests/tests/orderbook.ts
@@ -7,14 +7,15 @@ import { twoActorTest } from "../src/actor_test";
 import OrderbookUtils from "../src/actors/order_factory";
 import { sleep } from "../src/utils";
 
+// todo: move test initialisation into single mega function to reduce noise
 describe("orderbook", () => {
     it(
-        "btc_dai_sell_order",
+        "btc_dai_buy_order",
         twoActorTest(async ({ alice, bob }) => {
             await OrderbookUtils.connect(alice, bob);
             await OrderbookUtils.initialiseWalletsForBtcDaiOrder(alice, bob);
 
-            const order = await OrderbookUtils.newBtcDaiSellOrder(bob);
+            const order = await OrderbookUtils.newBtcDaiOrder(bob, "buy");
             await alice.initLedgerAndBalancesForOrder(order);
             await bob.initLedgerAndBalancesForOrder(order);
 
@@ -23,8 +24,44 @@ describe("orderbook", () => {
             const orderUrl = await bob.makeOrder(order);
 
             await alice.takeOrderAndAssertSwapCreated(
-                aliceIdentities.ethereum,
-                aliceIdentities.bitcoin
+                aliceIdentities.bitcoin,
+                aliceIdentities.ethereum
+            );
+
+            await bob.checkSwapCreatedFromOrder(orderUrl);
+
+            await alice.assertAndExecuteNextAction("fund");
+
+            await bob.assertAndExecuteNextAction("deploy");
+            await bob.assertAndExecuteNextAction("fund");
+
+            await alice.assertAndExecuteNextAction("redeem");
+            await bob.assertAndExecuteNextAction("redeem");
+
+            // Wait until the wallet sees the new balance.
+            await sleep(2000);
+
+            await alice.assertBalancesAfterSwap();
+            await bob.assertBalancesAfterSwap();
+        })
+    );
+    it(
+        "btc_dai_sell_order",
+        twoActorTest(async ({ alice, bob }) => {
+            await OrderbookUtils.connect(alice, bob);
+            await OrderbookUtils.initialiseWalletsForBtcDaiOrder(alice, bob);
+
+            const order = await OrderbookUtils.newBtcDaiOrder(bob, "sell");
+            await alice.initLedgerAndBalancesForOrder(order);
+            await bob.initLedgerAndBalancesForOrder(order);
+
+            const aliceIdentities = await OrderbookUtils.getIdentities(alice);
+
+            const orderUrl = await bob.makeOrder(order);
+
+            await alice.takeOrderAndAssertSwapCreated(
+                aliceIdentities.bitcoin,
+                aliceIdentities.ethereum
             );
 
             await bob.checkSwapCreatedFromOrder(orderUrl);

--- a/api_tests/tests/orderbook.ts
+++ b/api_tests/tests/orderbook.ts
@@ -33,9 +33,6 @@ describe("orderbook", () => {
             const orderUrl = await bob.makeOrder(bodies.bob);
             await alice.takeOrderAndAssertSwapCreated(bodies.alice);
 
-            // Wait for bob to acknowledge that Alice has taken the order he created
-            await sleep(1000);
-
             await bob.assertSwapCreatedFromOrder(orderUrl, bodies.bob);
 
             await alice.assertAndExecuteNextAction("deploy");

--- a/api_tests/tests/orderbook.ts
+++ b/api_tests/tests/orderbook.ts
@@ -14,7 +14,7 @@ describe("orderbook", () => {
         "btc_dai_buy_order",
         twoActorTest(async ({ alice, bob }) => {
             await OrderFactory.connect(alice, bob);
-            await OrderFactory.initialiseWalletsForBtcDaiOrder(alice, bob);
+            await OrderFactory.initWalletsForBtcDaiOrder(alice, bob);
 
             const order = await OrderFactory.newBtcDaiOrder(bob, "buy");
             await alice.initLedgerAndBalancesForOrder(order);
@@ -50,7 +50,7 @@ describe("orderbook", () => {
         "btc_dai_sell_order",
         twoActorTest(async ({ alice, bob }) => {
             await OrderFactory.connect(alice, bob);
-            await OrderFactory.initialiseWalletsForBtcDaiOrder(alice, bob);
+            await OrderFactory.initWalletsForBtcDaiOrder(alice, bob);
 
             const order = await OrderFactory.newBtcDaiOrder(bob, "sell");
             await alice.initLedgerAndBalancesForOrder(order);

--- a/api_tests/tests/orderbook.ts
+++ b/api_tests/tests/orderbook.ts
@@ -3,15 +3,13 @@
  * @ledger bitcoin
  */
 
-import OrderFactory from "../src/actors/order_factory";
 import { twoActorTest } from "../src/actor_test";
-import { Entity, Link } from "comit-sdk/dist/src/cnd/siren";
 import { sleep } from "../src/utils";
 import SwapFactory from "../src/actors/swap_factory";
 
 describe("orderbook", () => {
     it(
-        "btc_dai_sell_order_2",
+        "btc_dai_sell_order",
         twoActorTest(async ({ alice, bob }) => {
             // Get alice's listen address
             const aliceAddr = await alice.cnd.getPeerListenAddresses();
@@ -23,33 +21,6 @@ describe("orderbook", () => {
             /// Wait for alice to accept an incoming connection from Bob
             await sleep(1000);
 
-            const orderUrl = await bob.makeOrder();
-            await alice.takeOrderAndAssertSwapCreated();
-
-            // Wait for bob to acknowledge that Alice has taken the order he created
-            await sleep(1000);
-
-            await bob.assertSwapCreatedFromOrder(orderUrl);
-
-            await alice.assertAndExecuteNextAction("deploy");
-            await alice.assertAndExecuteNextAction("fund");
-
-            await bob.assertAndExecuteNextAction("fund");
-
-            await alice.assertAndExecuteNextAction("redeem");
-            await bob.assertAndExecuteNextAction("redeem");
-
-            // Wait until the wallet sees the new balance.
-            await sleep(2000);
-
-            await alice.assertBalancesAfterSwap();
-            await bob.assertBalancesAfterSwap();
-        })
-    );
-    it(
-        "btc_dai_sell_order",
-        twoActorTest(async ({ alice, bob }) => {
-            // Bob and Alice both have a swap created from the order that Bob made and alice took.
             const bodies = (
                 await SwapFactory.newSwap(alice, bob, {
                     ledgers: {
@@ -59,101 +30,13 @@ describe("orderbook", () => {
                 })
             ).herc20Hbit;
 
-            // Get alice's listen address
-            const aliceAddr = await alice.cnd.getPeerListenAddresses();
-
-            // is this required still?
-            // Bob dials alices
-            // @ts-ignore
-            await bob.cnd.client.post("dial", { addresses: aliceAddr });
-
-            /// Wait for alice to accept an incoming connection from Bob
-            await sleep(1000);
-
-            // assuming the nodes are connected from now on
-
-            // this payload could be wrong
-            const bobMakeOrderBody = OrderFactory.newHerc20HbitSellOrder(
-                bodies.bob
-            );
-            // @ts-ignore
-            // make response contain url in the header to the created order
-            // poll this order to see when when it has been converted to a swap
-            // "POST /orders"
-            const bobMakeOrderResponse = await bob.cnd.client.post(
-                "orders",
-                bobMakeOrderBody
-            );
-
-            // Poll until Alice receives an order. The order must be the one that Bob created above.
-            // @ts-ignore
-            const aliceOrdersResponse = await alice.pollCndUntil<Entity>(
-                "orders",
-                (entity) => entity.entities.length > 0
-            );
-            const aliceOrderResponse: Entity = aliceOrdersResponse.entities[0];
-
-            // Alice extracts the siren action to take the order
-            const aliceOrderTakeAction = aliceOrderResponse.actions.find(
-                (action: any) => action.name === "take"
-            );
-            // Alice executes the siren take action extracted in the previous line
-            // The resolver function fills the refund and redeem address fields required
-            // "POST /orders/63c0f8bd-beb2-4a9c-8591-a46f65913b0a/take"
-            // Alice receives a url to the swap that was created as a result of taking the order
-            // @ts-ignore
-            const aliceTakeOrderResponse = await alice.cnd.executeSirenAction(
-                aliceOrderTakeAction,
-                async (field) => {
-                    // this could be wrong
-                    if (field.name === "refund_identity") {
-                        // @ts-ignore
-                        return Promise.resolve(bodies.alice.alpha.identity);
-                    }
-
-                    if (field.name === "redeem_identity") {
-                        // @ts-ignore
-                        return Promise.resolve(
-                            bodies.alice.beta.final_identity
-                        );
-                    }
-                }
-            );
+            const orderUrl = await bob.makeOrder(bodies.bob);
+            await alice.takeOrderAndAssertSwapCreated(bodies.alice);
 
             // Wait for bob to acknowledge that Alice has taken the order he created
             await sleep(1000);
 
-            // @ts-ignore
-            const aliceSwapResponse = await alice.cnd.client.get(
-                aliceTakeOrderResponse.headers.location
-            );
-            expect(aliceSwapResponse.status).toEqual(200);
-
-            await alice.initOrderbookTest(
-                aliceTakeOrderResponse.headers.location,
-                bodies.alice
-            );
-
-            // Since Alice has taken the swap, the order created by Bob should have an associated swap in the navigational link
-            const bobGetOrderResponse = await bob.cnd.fetch<Entity>(
-                bobMakeOrderResponse.headers.location
-            );
-
-            expect(bobGetOrderResponse.status).toEqual(200);
-            const linkToBobSwap = bobGetOrderResponse.data.links.find(
-                (link: Link) => link.rel.includes("swap")
-            );
-            expect(linkToBobSwap).toBeDefined();
-
-            // The link the Bobs swap should return 200
-            // "GET /swaps/934dd090-f8eb-4244-9aba-78e23d3f79eb HTTP/1.1"
-            const bobSwapResponse = await bob.cnd.fetch<Entity>(
-                linkToBobSwap.href
-            );
-
-            expect(bobSwapResponse.status).toEqual(200);
-
-            await bob.initOrderbookTest(linkToBobSwap.href, bodies.bob);
+            await bob.assertSwapCreatedFromOrder(orderUrl, bodies.bob);
 
             await alice.assertAndExecuteNextAction("deploy");
             await alice.assertAndExecuteNextAction("fund");

--- a/api_tests/tests/orderbook.ts
+++ b/api_tests/tests/orderbook.ts
@@ -4,22 +4,23 @@
  */
 
 import { twoActorTest } from "../src/actor_test";
-import OrderbookUtils from "../src/actors/order_factory";
+import OrderFactory from "../src/actors/order_factory";
 import { sleep } from "../src/utils";
+import { getIdentities } from "../src/actors/defaults";
 
 // todo: move test initialisation into single mega function to reduce noise
 describe("orderbook", () => {
     it(
         "btc_dai_buy_order",
         twoActorTest(async ({ alice, bob }) => {
-            await OrderbookUtils.connect(alice, bob);
-            await OrderbookUtils.initialiseWalletsForBtcDaiOrder(alice, bob);
+            await OrderFactory.connect(alice, bob);
+            await OrderFactory.initialiseWalletsForBtcDaiOrder(alice, bob);
 
-            const order = await OrderbookUtils.newBtcDaiOrder(bob, "buy");
+            const order = await OrderFactory.newBtcDaiOrder(bob, "buy");
             await alice.initLedgerAndBalancesForOrder(order);
             await bob.initLedgerAndBalancesForOrder(order);
 
-            const aliceIdentities = await OrderbookUtils.getIdentities(alice);
+            const aliceIdentities = await getIdentities(alice);
 
             const orderUrl = await bob.makeOrder(order);
 
@@ -48,14 +49,14 @@ describe("orderbook", () => {
     it(
         "btc_dai_sell_order",
         twoActorTest(async ({ alice, bob }) => {
-            await OrderbookUtils.connect(alice, bob);
-            await OrderbookUtils.initialiseWalletsForBtcDaiOrder(alice, bob);
+            await OrderFactory.connect(alice, bob);
+            await OrderFactory.initialiseWalletsForBtcDaiOrder(alice, bob);
 
-            const order = await OrderbookUtils.newBtcDaiOrder(bob, "sell");
+            const order = await OrderFactory.newBtcDaiOrder(bob, "sell");
             await alice.initLedgerAndBalancesForOrder(order);
             await bob.initLedgerAndBalancesForOrder(order);
 
-            const aliceIdentities = await OrderbookUtils.getIdentities(alice);
+            const aliceIdentities = await getIdentities(alice);
 
             const orderUrl = await bob.makeOrder(order);
 

--- a/cnd/src/facade.rs
+++ b/cnd/src/facade.rs
@@ -63,15 +63,15 @@ impl Facade {
         &mut self,
         order_id: OrderId,
         swap_id: LocalSwapId,
-        redeem_identity: crate::bitcoin::Address,
-        refund_identity: identity::Ethereum,
+        bitcoin_identity: crate::bitcoin::Address,
+        ethereum_identity: identity::Ethereum,
     ) -> anyhow::Result<()> {
         self.storage
             .associate_swap_with_order(order_id, swap_id)
             .await;
 
         self.swarm
-            .take_order(order_id, swap_id, redeem_identity, refund_identity)
+            .take_order(order_id, swap_id, bitcoin_identity, ethereum_identity)
             .await
     }
 
@@ -79,11 +79,11 @@ impl Facade {
         &self,
         order: NewOrder,
         swap_id: LocalSwapId,
-        redeem_identity: identity::Ethereum,
-        refund_identity: crate::bitcoin::Address,
+        ethereum_identity: identity::Ethereum,
+        bitcoin_identity: crate::bitcoin::Address,
     ) -> anyhow::Result<OrderId> {
         self.swarm
-            .make_order(order, swap_id, redeem_identity, refund_identity)
+            .make_order(order, swap_id, ethereum_identity, bitcoin_identity)
             .await
     }
 

--- a/cnd/src/http_api/orderbook.rs
+++ b/cnd/src/http_api/orderbook.rs
@@ -307,8 +307,8 @@ mod tests {
             "token_contract": "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280",
             "ethereum_ledger": {"chain_id":2},
             "ethereum_absolute_expiry": 600,
-            "refund_identity": "1F1tAaz5x1HUXrCNLbtMDqcw6o5GNn4xqX",
-            "redeem_identity": "0x00a329c0648769a73afac7f9381e08fb43dbea72"
+            "bitcoin_identity": "1F1tAaz5x1HUXrCNLbtMDqcw6o5GNn4xqX",
+            "ethereum_identity": "0x00a329c0648769a73afac7f9381e08fb43dbea72"
         }"#;
 
         let _body: MakeOrderBody = serde_json::from_str(json).expect("failed to deserialize order");

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -158,6 +158,7 @@ impl Orderbook {
     }
 
     /// Get the order matching `id` if known to this node.
+    /// todo: check error handling in usages of this function
     pub fn get_order(&self, id: &OrderId) -> Option<Order> {
         self.orders.get(id).cloned()
     }


### PR DESCRIPTION
Added bidirectional test path in the orderbook e2e test. Refactored the test to improve code reuse and make the test less noisy and easier to understand.

In order to get bidirectional trades working happen the orderbook API was changed. Refund and redeem identity has been replaced bitcoin and ethereum identity. Derivation of transient identities has also changed to take into consideration the direction of the trade.
