### PR TITLE
Use forex trading terminology

### DIFF
--- a/cnd/src/storage/db/wrapper_types.rs
+++ b/cnd/src/storage/db/wrapper_types.rs
@@ -57,7 +57,7 @@ impl FromStr for Ether {
     type Err = crate::asset::ethereum::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        asset::Ether::from_wei_dec_str(s).map(Ether)
+        asset::Ether::try_from_wei_dec_str(s).map(Ether)
     }
 }
 
@@ -86,7 +86,7 @@ impl FromStr for Erc20Amount {
     type Err = crate::asset::ethereum::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        asset::Erc20Quantity::from_wei_dec_str(s).map(Erc20Amount)
+        asset::Erc20Quantity::try_from_wei_dec_str(s).map(Erc20Amount)
     }
 }
 

--- a/comit/src/asset.rs
+++ b/comit/src/asset.rs
@@ -2,6 +2,6 @@ pub mod bitcoin;
 pub mod ethereum;
 
 pub use self::{
-    bitcoin::Bitcoin,
+    bitcoin::{Bitcoin, Btc},
     ethereum::{Dai, Erc20, Erc20Quantity, Ether},
 };

--- a/comit/src/asset.rs
+++ b/comit/src/asset.rs
@@ -3,5 +3,5 @@ pub mod ethereum;
 
 pub use self::{
     bitcoin::Bitcoin,
-    ethereum::{Erc20, Erc20Quantity, Ether},
+    ethereum::{Dai, Erc20, Erc20Quantity, Ether},
 };

--- a/comit/src/asset/bitcoin.rs
+++ b/comit/src/asset/bitcoin.rs
@@ -1,6 +1,9 @@
 use bitcoin::{util::amount::Denomination, Amount};
 use std::fmt;
 
+/// Convenience alias to allow uniform usage with DAI.
+pub type Btc = Bitcoin;
+
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Bitcoin(Amount);
 

--- a/comit/src/asset/ethereum.rs
+++ b/comit/src/asset/ethereum.rs
@@ -4,7 +4,7 @@ mod erc20;
 mod ether;
 
 pub use self::{
-    erc20::{Erc20, Erc20Quantity},
+    erc20::{Dai, Erc20, Erc20Quantity},
     ether::Ether,
 };
 

--- a/comit/src/asset/ethereum.rs
+++ b/comit/src/asset/ethereum.rs
@@ -16,13 +16,13 @@ pub trait TryFromWei<W>
 where
     Self: std::marker::Sized,
 {
-    fn try_from_wei(wei: W) -> Result<Self, Error>;
+    fn try_from_wei(wei: W) -> anyhow::Result<Self>;
 }
 
+#[derive(Clone, Copy, Debug, thiserror::Error, PartialEq)]
+#[error("value provided overflows")]
+pub struct ValueOverflow;
+
 #[derive(Clone, Debug, thiserror::Error, PartialEq)]
-pub enum Error {
-    #[error("value provided overflows")]
-    Overflow,
-    #[error("parsing error encountered")]
-    Parse(#[from] ParseBigIntError),
-}
+#[error("parsing error encountered")]
+pub struct ParseError(#[from] ParseBigIntError);

--- a/comit/src/asset/ethereum/erc20.rs
+++ b/comit/src/asset/ethereum/erc20.rs
@@ -22,7 +22,7 @@ impl Erc20Quantity {
         self.0.to_str_radix(10)
     }
 
-    pub fn from_wei_dec_str(str: &str) -> Result<Self, Error> {
+    pub fn try_from_wei_dec_str(str: &str) -> Result<Self, Error> {
         let int = BigUint::from_str_radix(str, 10)?;
         Ok(Self::try_from_wei(int)?)
     }
@@ -259,13 +259,13 @@ mod tests {
 
     #[test]
     fn given_str_of_wei_in_dec_format_instantiate_ether() {
-        let quantity = Erc20Quantity::from_wei_dec_str("12345").unwrap();
+        let quantity = Erc20Quantity::try_from_wei_dec_str("12345").unwrap();
         assert_eq!(quantity, Erc20Quantity::from_wei(12_345u32))
     }
 
     #[test]
     fn given_str_above_u256_max_in_dec_format_return_overflow() {
-        let res = Erc20Quantity::from_wei_dec_str(
+        let res = Erc20Quantity::try_from_wei_dec_str(
             "115792089237316195423570985008687907853269984665640564039457584007913129639936",
         ); // This is Erc20Quantity::max_value() + 1
         assert_eq!(res, Err(Error::Overflow))

--- a/comit/src/asset/ethereum/erc20.rs
+++ b/comit/src/asset/ethereum/erc20.rs
@@ -35,6 +35,10 @@ impl Erc20Quantity {
         Ok(Self::try_from_wei(int)?)
     }
 
+    pub fn to_wei(&self) -> BigUint {
+        self.0.clone()
+    }
+
     /// Create a erc20 quantity from a float string. E.g., this can be used to
     /// create a DAI quantity from the ergonomic string "1234.56".
     pub fn try_from_float(eth: &str) -> anyhow::Result<Self> {
@@ -54,6 +58,12 @@ impl Erc20Quantity {
     #[cfg(test)]
     pub fn meaningless_test_value() -> Self {
         Erc20Quantity::from_wei(1_000u32)
+    }
+}
+
+impl FromWei<BigUint> for Erc20Quantity {
+    fn from_wei(wei: BigUint) -> Self {
+        Self(wei)
     }
 }
 

--- a/comit/src/asset/ethereum/erc20.rs
+++ b/comit/src/asset/ethereum/erc20.rs
@@ -11,6 +11,7 @@ use std::{fmt, str::FromStr};
 // 1 Ether = 1,000,000,000,000,000,000 Wei (10 exp 18)
 const WEI_EXP: u16 = 18;
 
+/// Convenience alias for referring to DAI tokens.
 pub type Dai = Erc20Quantity;
 
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]

--- a/comit/src/asset/ethereum/erc20.rs
+++ b/comit/src/asset/ethereum/erc20.rs
@@ -11,6 +11,8 @@ use std::{fmt, str::FromStr};
 // 1 Ether = 1,000,000,000,000,000,000 Wei (10 exp 18)
 const WEI_EXP: u16 = 18;
 
+pub type Dai = Erc20Quantity;
+
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Erc20Quantity(BigUint);
 

--- a/comit/src/asset/ethereum/ether.rs
+++ b/comit/src/asset/ethereum/ether.rs
@@ -1,5 +1,5 @@
 use crate::{
-    asset::ethereum::{Error, FromWei, TryFromWei},
+    asset::ethereum::{FromWei, TryFromWei, ValueOverflow},
     ethereum::U256,
 };
 use lazy_static::lazy_static;
@@ -31,7 +31,7 @@ impl Ether {
         self.0.to_str_radix(10)
     }
 
-    pub fn try_from_wei_dec_str(str: &str) -> Result<Self, Error> {
+    pub fn try_from_wei_dec_str(str: &str) -> anyhow::Result<Self> {
         let int = BigUint::from_str_radix(str, 10)?;
         Ok(Self::try_from_wei(int)?)
     }
@@ -92,9 +92,9 @@ impl FromWei<U256> for Ether {
 }
 
 impl TryFromWei<BigUint> for Ether {
-    fn try_from_wei(wei: BigUint) -> Result<Self, Error> {
+    fn try_from_wei(wei: BigUint) -> anyhow::Result<Self> {
         if wei > Self::max_value().0 {
-            Err(Error::Overflow)
+            Err(anyhow::Error::new(ValueOverflow))
         } else {
             Ok(Self(wei))
         }
@@ -102,7 +102,7 @@ impl TryFromWei<BigUint> for Ether {
 }
 
 impl TryFromWei<&str> for Ether {
-    fn try_from_wei(string: &str) -> Result<Ether, Error> {
+    fn try_from_wei(string: &str) -> anyhow::Result<Ether> {
         let uint = BigUint::from_str(string)?;
         Ok(Self(uint))
     }
@@ -225,8 +225,10 @@ mod tests {
             std::u32::MAX,
             std::u32::MAX, // 9th u32, should make it over u256
         ]);
-        let quantity = Ether::try_from_wei(wei);
-        assert_eq!(quantity, Err(Error::Overflow))
+        match Ether::try_from_wei(wei) {
+            Ok(_) => panic!("should overflow"),
+            Err(e) => assert!(e.is::<ValueOverflow>()),
+        }
     }
 
     #[test]
@@ -254,6 +256,9 @@ mod tests {
         let res = Ether::try_from_wei_dec_str(
             "115792089237316195423570985008687907853269984665640564039457584007913129639936",
         ); // This is Ether::max_value() + 1
-        assert_eq!(res, Err(Error::Overflow))
+        match res {
+            Ok(_) => panic!("should overflow"),
+            Err(e) => assert!(e.is::<ValueOverflow>()),
+        }
     }
 }

--- a/comit/src/asset/ethereum/ether.rs
+++ b/comit/src/asset/ethereum/ether.rs
@@ -31,7 +31,7 @@ impl Ether {
         self.0.to_str_radix(10)
     }
 
-    pub fn from_wei_dec_str(str: &str) -> Result<Self, Error> {
+    pub fn try_from_wei_dec_str(str: &str) -> Result<Self, Error> {
         let int = BigUint::from_str_radix(str, 10)?;
         Ok(Self::try_from_wei(int)?)
     }
@@ -245,13 +245,13 @@ mod tests {
 
     #[test]
     fn given_str_of_wei_in_dec_format_instantiate_ether() {
-        let ether = Ether::from_wei_dec_str("12345").unwrap();
+        let ether = Ether::try_from_wei_dec_str("12345").unwrap();
         assert_eq!(ether, Ether::from_wei(12_345u32))
     }
 
     #[test]
     fn given_str_above_u256_max_in_dec_format_return_overflow() {
-        let res = Ether::from_wei_dec_str(
+        let res = Ether::try_from_wei_dec_str(
             "115792089237316195423570985008687907853269984665640564039457584007913129639936",
         ); // This is Ether::max_value() + 1
         assert_eq!(res, Err(Error::Overflow))

--- a/comit/src/float_math.rs
+++ b/comit/src/float_math.rs
@@ -1,0 +1,204 @@
+use bitcoin::hashes::core::cmp::Ordering;
+use num::{BigUint, Zero};
+use std::str::FromStr;
+
+/// Truncate the float's mantissa to length `precision`.
+pub fn truncate(float: f64, precision: u16) -> f64 {
+    let mut string = float.to_string();
+    let index = string.find('.');
+
+    match index {
+        None => float,
+        Some(index) => {
+            let trunc = index + 1 + precision as usize;
+            string.truncate(trunc);
+            f64::from_str(&string).expect("This should still be a number")
+        }
+    }
+}
+
+/// Multiply float by 10e`pow`, Returns as a BigUint. No data loss.
+/// Errors if the float is negative.
+/// Errors if the result is a fraction.
+pub fn multiply_pow_ten(float: f64, pow: u16) -> anyhow::Result<BigUint> {
+    if float.is_sign_negative() {
+        anyhow::bail!("Float is negative");
+    }
+
+    if !float.is_finite() {
+        anyhow::bail!("Float is not finite");
+    }
+
+    let mut float = float.to_string();
+    let decimal_index = float.find('.');
+
+    match decimal_index {
+        None => {
+            let zeroes = "0".repeat(pow as usize);
+            Ok(BigUint::from_str(&format!("{}{}", float, zeroes)).expect("an integer"))
+        }
+        Some(decimal_index) => {
+            let mantissa = float.split_off(decimal_index + 1);
+            // Removes the decimal point
+            float.truncate(float.len() - 1);
+            let integer = float;
+
+            let pow = pow as usize;
+            match mantissa.len().cmp(&pow) {
+                Ordering::Less => {
+                    let remain = pow as usize - mantissa.len();
+                    let zeroes = "0".repeat(remain);
+                    Ok(
+                        BigUint::from_str(&format!("{}{}{}", integer, mantissa, zeroes))
+                            .expect("an integer"),
+                    )
+                }
+                Ordering::Equal => {
+                    Ok(BigUint::from_str(&format!("{}{}", integer, mantissa)).expect("an integer"))
+                }
+                Ordering::Greater => anyhow::bail!("Result is not an integer"),
+            }
+        }
+    }
+}
+
+/// Divide BigUint by 10e`inv_pow`, Returns as a BigUint.
+/// Result is truncated
+pub fn divide_pow_ten_trunc(uint: BigUint, inv_pow: usize) -> BigUint {
+    let mut uint_str = uint.to_string();
+
+    match uint_str.len().cmp(&inv_pow) {
+        Ordering::Less => BigUint::zero(),
+        Ordering::Equal => BigUint::zero(),
+        Ordering::Greater => {
+            uint_str.truncate(uint_str.len() - inv_pow);
+            BigUint::from_str(&uint_str).expect("still an integer")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn it_truncates() {
+        let float = 1.123_456_789;
+
+        assert_eq!(&truncate(float, 5).to_string(), "1.12345");
+    }
+
+    proptest! {
+        #[test]
+        fn truncate_doesnt_panic(f in any::<f64>(), p in any::<u16>()) {
+            truncate(f, p);
+        }
+    }
+
+    #[test]
+    fn given_integer_then_it_multiplies() {
+        let float = 123_456_789.0f64;
+        let pow = 6;
+
+        assert_eq!(
+            multiply_pow_ten(float, pow).unwrap(),
+            BigUint::from(123_456_789_000_000u64)
+        )
+    }
+
+    #[test]
+    fn given_mantissa_of_pow_length_then_it_multiplies() {
+        let float = 123.123_456_789f64;
+        let pow = 9;
+
+        assert_eq!(
+            multiply_pow_ten(float, pow).unwrap(),
+            BigUint::from(123_123_456_789u64)
+        )
+    }
+
+    #[test]
+    fn given_mantissa_length_lesser_than_pow_then_it_multiplies() {
+        let float = 123.123_456_789f64;
+        let pow = 12;
+
+        assert_eq!(
+            multiply_pow_ten(float, pow).unwrap(),
+            BigUint::from(123_123_456_789_000u64)
+        )
+    }
+
+    #[test]
+    fn given_mantissa_length_greater_than_pow_then_it_errors() {
+        let float = 123.123_456_789f64;
+        let pow = 6;
+
+        assert!(multiply_pow_ten(float, pow).is_err(),)
+    }
+
+    #[test]
+    fn given_negative_float_then_it_errors() {
+        let float = -123_456_789.0f64;
+        let pow = 6;
+
+        assert!(multiply_pow_ten(float, pow).is_err(),)
+    }
+
+    proptest! {
+        #[test]
+        fn multiple_pow_ten_doesnt_panic(f in any::<f64>(), p in any::<u16>()) {
+            let _ = multiply_pow_ten(f, p);
+        }
+    }
+
+    #[test]
+    fn given_too_precise_uint_it_truncates() {
+        let uint = BigUint::from(1_000_000_001u64);
+        let pow = 6;
+        assert_eq!(divide_pow_ten_trunc(uint, pow), BigUint::from(1_000u64))
+    }
+
+    #[test]
+    fn given_not_that_precise_uint_it_doesnt_truncate() {
+        let uint = BigUint::from(1_234_000_000u64);
+        let pow = 6;
+        assert_eq!(divide_pow_ten_trunc(uint, pow), BigUint::from(1_234u64))
+    }
+
+    #[test]
+    fn given_pow_zero_it_doesnt_modifies() {
+        let uint = BigUint::from(1_234_567_890u64);
+        let pow = 0;
+        assert_eq!(divide_pow_ten_trunc(uint.clone(), pow), uint)
+    }
+
+    #[test]
+    fn given_pow_greater_than_uint_it_truncates_to_zero_1() {
+        let uint = BigUint::from(1_234_567_890u64);
+        let pow = 10;
+        assert_eq!(divide_pow_ten_trunc(uint, pow), BigUint::zero())
+    }
+
+    #[test]
+    fn given_pow_greater_than_uint_it_truncates_to_zero_2() {
+        let uint = BigUint::from(1_234_456_789u64);
+        let pow = 11;
+        assert_eq!(divide_pow_ten_trunc(uint, pow), BigUint::zero())
+    }
+
+    prop_compose! {
+        fn new_biguint()(s in "[0-9]+") -> anyhow::Result<BigUint> {
+            Ok(BigUint::from_str(&s)?)
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn divide_pow_ten_trunc_doesnt_panic(uint in new_biguint(), p in any::<usize>()) {
+            if let Ok(uint) = uint {
+                let _ = divide_pow_ten_trunc(uint, p);
+            }
+        }
+    }
+}

--- a/comit/src/float_math.rs
+++ b/comit/src/float_math.rs
@@ -4,11 +4,18 @@ use std::str::FromStr;
 
 /// Truncate the float's mantissa to length `precision`.
 pub fn truncate(float: f64, precision: u16) -> f64 {
+    let s = float.to_string();
+    truncate_str(&s, precision)
+}
+
+/// Truncate the float's mantissa to length `precision`.
+pub fn truncate_str(float: &str, precision: u16) -> f64 {
     let mut string = float.to_string();
+
     let index = string.find('.');
 
     match index {
-        None => float,
+        None => f64::from_str(float).expect("This has no decimal, should convert"),
         Some(index) => {
             let trunc = index + 1 + precision as usize;
             string.truncate(trunc);
@@ -29,6 +36,18 @@ pub fn multiply_pow_ten(float: f64, pow: u16) -> anyhow::Result<BigUint> {
         anyhow::bail!("Float is not finite");
     }
 
+    let s = float.to_string();
+    multiply_pow_ten_str(&s, pow)
+}
+
+/// Multiply float by 10e`pow`, Returns as a BigUint. No data loss.
+/// Input is expected to represent a positive float with decimal places no
+/// bigger than pow i.e., the following are invalid calls
+/// - multiply_pow_ten_str("0.12345, 3")
+/// - multiply_pow_ten_str("-1.23, 3")
+/// Call truncate(float) before using this function if you need to.
+// TODO: Enforce the above in code.
+pub fn multiply_pow_ten_str(float: &str, pow: u16) -> anyhow::Result<BigUint> {
     let mut float = float.to_string();
     let decimal_index = float.find('.');
 

--- a/comit/src/lib.rs
+++ b/comit/src/lib.rs
@@ -18,6 +18,7 @@ pub mod asset;
 pub mod bitcoin;
 pub mod btsieve;
 pub mod ethereum;
+pub mod float_math;
 pub mod halbit;
 pub mod hbit;
 pub mod herc20;

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -5,6 +5,7 @@ use crate::{
     network::protocols::orderbook::take_order::{Response, TakeOrderCodec, TakeOrderProtocol},
     SharedSwapId,
 };
+
 use libp2p::{
     core::either::EitherOutput,
     gossipsub,
@@ -91,7 +92,7 @@ impl Orderbook {
     /// Create and publish a new 'make' order. Called by Bob i.e. the maker.
     pub fn make(&mut self, order: Order) -> anyhow::Result<OrderId> {
         let ser = bincode::serialize(&Message::CreateOrder(order.clone()))?;
-        let topic = order.tp().to_topic();
+        let topic = order.to_topic();
         self.gossipsub.publish(&topic, ser);
 
         let id = order.id;

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -26,8 +26,8 @@ pub struct Order {
 
 // We explicitly only support BTC/DAI.
 impl Order {
-    pub fn tp(&self) -> TradingPair {
-        TradingPair::BtcDai
+    pub fn to_topic(&self) -> Topic {
+        Topic::new(BTC_DAI.to_string())
     }
 }
 
@@ -58,22 +58,6 @@ impl FromStr for OrderId {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let uuid = Uuid::from_str(s)?;
         Ok(OrderId(uuid))
-    }
-}
-
-// Since we only support a single trading pair this struct is actually
-// not needed, the information is implicit in the Order struct. Keep
-// this and the calls to order.tp().topic() to make it explicit that
-// there is only a single trading pair and the trading pair is
-// defined by the order struct.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub enum TradingPair {
-    BtcDai,
-}
-
-impl TradingPair {
-    pub fn to_topic(&self) -> Topic {
-        Topic::new(BTC_DAI.to_string())
     }
 }
 

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -16,21 +16,21 @@ pub struct BtcDaiOrder {
     pub position: Position, // Position of the order from the creators perspective.
     pub quote: Quote,       // Indirect quote i.e., one unit of BTC = quote units of DAI.
     #[serde(with = "asset::bitcoin::sats_as_string")]
-    pub amount: asset::Bitcoin, // Orders are quoted in the base currency.
+    pub amount: asset::Btc, // Orders are quoted in the base currency.
 }
 
 impl BtcDaiOrder {
     /// Create a new buy limit order.
-    pub fn new_buy(quote: Quote, amount: asset::Bitcoin) -> Self {
+    pub fn new_buy(quote: Quote, amount: asset::Btc) -> Self {
         BtcDaiOrder::new(quote, amount, Position::Buy)
     }
 
     /// Create a new sell limit order.
-    pub fn new_sell(quote: Quote, amount: asset::Bitcoin) -> Self {
+    pub fn new_sell(quote: Quote, amount: asset::Btc) -> Self {
         BtcDaiOrder::new(quote, amount, Position::Sell)
     }
 
-    fn new(quote: Quote, amount: asset::Bitcoin, position: Position) -> Self {
+    fn new(quote: Quote, amount: asset::Btc, position: Position) -> Self {
         BtcDaiOrder {
             id: OrderId::random(),
             position,
@@ -45,7 +45,7 @@ impl BtcDaiOrder {
     }
 
     /// Converts forex terminology (quote/amount) to COMIT terminology.
-    pub fn value(&self) -> (asset::Bitcoin, asset::Erc20Quantity) {
+    pub fn value(&self) -> (asset::Btc, asset::Erc20Quantity) {
         unimplemented!()
     }
 
@@ -55,7 +55,7 @@ impl BtcDaiOrder {
             id: OrderId::random(),
             position: Position::Sell,
             quote: Quote::from_float(9123.45).expect("failed to construct quote"),
-            amount: asset::Bitcoin::from_sat(1000),
+            amount: asset::Btc::from_sat(1000),
         }
     }
 }

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -7,6 +7,30 @@ use serde::{Deserialize, Serialize};
 use std::{fmt::Display, str::FromStr};
 use uuid::Uuid;
 
+/// An order, created by a maker (Bob) and shared with the network via
+/// gossipsub.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Order {
+    pub id: OrderId,
+    pub maker: MakerId,
+    pub position: Position,
+    #[serde(with = "asset::bitcoin::sats_as_string")]
+    pub bitcoin_amount: asset::Bitcoin,
+    pub bitcoin_ledger: ledger::Bitcoin,
+    pub bitcoin_absolute_expiry: u32,
+    pub ethereum_amount: asset::Erc20Quantity,
+    pub token_contract: identity::Ethereum,
+    pub ethereum_ledger: ledger::Ethereum,
+    pub ethereum_absolute_expiry: u32,
+}
+
+// We explicitly only support BTC/DAI.
+impl Order {
+    pub fn tp(&self) -> TradingPair {
+        TradingPair::BtcDai
+    }
+}
+
 #[derive(Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OrderId(Uuid);
 
@@ -34,30 +58,6 @@ impl FromStr for OrderId {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let uuid = Uuid::from_str(s)?;
         Ok(OrderId(uuid))
-    }
-}
-
-/// An order, created by a maker (Bob) and shared with the network via
-/// gossipsub.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct Order {
-    pub id: OrderId,
-    pub maker: MakerId,
-    pub position: Position,
-    #[serde(with = "asset::bitcoin::sats_as_string")]
-    pub bitcoin_amount: asset::Bitcoin,
-    pub bitcoin_ledger: ledger::Bitcoin,
-    pub bitcoin_absolute_expiry: u32,
-    pub ethereum_amount: asset::Erc20Quantity,
-    pub token_contract: identity::Ethereum,
-    pub ethereum_ledger: ledger::Ethereum,
-    pub ethereum_absolute_expiry: u32,
-}
-
-// We explicitly only support BTC/DAI.
-impl Order {
-    pub fn tp(&self) -> TradingPair {
-        TradingPair::BtcDai
     }
 }
 

--- a/comit/src/network/protocols/orderbook/order.rs
+++ b/comit/src/network/protocols/orderbook/order.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::{fmt::Display, str::FromStr};
 use uuid::Uuid;
 
-/// An limit order, created in order to supply liquidity to the network and
+/// An limit order, created to supply liquidity to the network and
 /// shared with the network via gossipsub.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct BtcDaiOrder {
@@ -20,10 +20,12 @@ pub struct BtcDaiOrder {
 }
 
 impl BtcDaiOrder {
+    /// Create a new buy limit order.
     pub fn new_buy(quote: Quote, amount: asset::Bitcoin) -> Self {
         BtcDaiOrder::new(quote, amount, Position::Buy)
     }
 
+    /// Create a new sell limit order.
     pub fn new_sell(quote: Quote, amount: asset::Bitcoin) -> Self {
         BtcDaiOrder::new(quote, amount, Position::Sell)
     }
@@ -37,11 +39,12 @@ impl BtcDaiOrder {
         }
     }
 
+    /// Convert this order to the Topic used to publish it.
     pub fn to_topic(&self) -> Topic {
         Topic::new(BTC_DAI.to_string())
     }
 
-    /// Converts forex terminology (rate/amount) to COMIT terminology.
+    /// Converts forex terminology (quote/amount) to COMIT terminology.
     pub fn value(&self) -> (asset::Bitcoin, asset::Erc20Quantity) {
         unimplemented!()
     }
@@ -57,10 +60,12 @@ impl BtcDaiOrder {
     }
 }
 
+/// The identifier used for orders.
 #[derive(Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OrderId(Uuid);
 
 impl OrderId {
+    /// Create a random identifier, this should be globally unique.
     pub fn random() -> OrderId {
         OrderId(Uuid::new_v4())
     }

--- a/comit/src/network/protocols/orderbook/orders.rs
+++ b/comit/src/network/protocols/orderbook/orders.rs
@@ -1,0 +1,99 @@
+//! Abstract Data Type for managing the orders contained in the orderbook.
+
+use crate::network::protocols::orderbook::{BtcDaiOrder, OrderId};
+use anyhow::bail;
+use libp2p::PeerId;
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct Orders {
+    inner: HashMap<OrderId, Order>,
+}
+
+impl Orders {
+    /// Insert a new live order. A BTC/DAI order is immutable, it is therefore
+    /// an error to insert the same order twice.
+    pub fn insert(&mut self, maker: PeerId, order: BtcDaiOrder) -> anyhow::Result<()> {
+        let id = order.id;
+
+        let r = Order {
+            order,
+            maker,
+            status: Status::Live,
+        };
+
+        if self.inner.get(&id).is_some() {
+            bail!("order already exists: {}", id);
+        }
+        let _ = self.inner.insert(id, r);
+
+        Ok(())
+    }
+
+    /// Returns the peer id of the node that created this order.
+    pub fn maker(&self, id: &OrderId) -> Option<PeerId> {
+        self.inner.get(id).map(|r| r.maker.clone())
+    }
+
+    pub fn contains(&self, id: &OrderId) -> bool {
+        self.inner.contains_key(id)
+    }
+
+    /// true if order exists and is live.
+    pub fn is_live(&self, id: &OrderId) -> bool {
+        match self.inner.get(id) {
+            None => false,
+            Some(r) => r.status == Status::Live,
+        }
+    }
+
+    pub fn get_orders(&self) -> Vec<BtcDaiOrder> {
+        self.inner.values().map(|r| r.order).collect()
+    }
+
+    pub fn get_order(&self, id: &OrderId) -> Option<BtcDaiOrder> {
+        self.inner.get(id).map(|r| r.order)
+    }
+
+    /// Kill an order. Return true if order was killed, false if order is
+    /// already dead, and an error if order does not exist.
+    pub fn kill_order(&mut self, maker: PeerId, id: &OrderId) -> anyhow::Result<bool> {
+        let update = match self.inner.get_mut(id) {
+            None => bail!("order not found"),
+            Some(mut r) => {
+                if r.maker != maker {
+                    bail!("cannot kill someone else's order");
+                }
+                let update = r.status == Status::Live;
+                r.status = Status::Dead;
+                update
+            }
+        };
+
+        Ok(update)
+    }
+}
+
+impl Default for Orders {
+    fn default() -> Self {
+        Orders {
+            inner: HashMap::new(),
+        }
+    }
+}
+
+/// Conceptually orders are 'owned' by the peer that creates them (the maker),
+/// only the maker can gossip create/delete for this order id so we associate
+/// the makers peer id with the order.
+#[derive(Debug, PartialEq)]
+struct Order {
+    order: BtcDaiOrder,
+    maker: PeerId,
+    status: Status,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Status {
+    Live,
+    Dead, // Cancelled or filled.
+}

--- a/comit/src/network/protocols/orderbook/orders.rs
+++ b/comit/src/network/protocols/orderbook/orders.rs
@@ -35,11 +35,13 @@ impl Orders {
         self.inner.get(id).map(|r| r.maker.clone())
     }
 
+    /// Returns true if an order with `id` is known.
     pub fn contains(&self, id: &OrderId) -> bool {
         self.inner.contains_key(id)
     }
 
-    /// true if order exists and is live.
+    /// Returns true if the order is live i.e., has been seen by the network and
+    /// a delete message has not been seen. See [Status] for more details.
     pub fn is_live(&self, id: &OrderId) -> bool {
         match self.inner.get(id) {
             None => false,
@@ -47,10 +49,12 @@ impl Orders {
         }
     }
 
+    /// Gets all orders, live and dead.
     pub fn get_orders(&self) -> Vec<BtcDaiOrder> {
         self.inner.values().map(|r| r.order).collect()
     }
 
+    /// Gets a specific order if it is known.
     pub fn get_order(&self, id: &OrderId) -> Option<BtcDaiOrder> {
         self.inner.get(id).map(|r| r.order)
     }
@@ -92,6 +96,10 @@ struct Order {
     status: Status,
 }
 
+/// We purposely do not use the terms filled/cancelled because the network
+/// has no way of guaranteeing these things, from the networks perspective
+/// an order is 'live' if it has been received and 'dead' if a the order was
+/// deleted by the node that created it.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Status {
     Live,

--- a/comit/src/network/protocols/orderbook/orders.rs
+++ b/comit/src/network/protocols/orderbook/orders.rs
@@ -51,12 +51,12 @@ impl Orders {
 
     /// Gets all orders, live and dead.
     pub fn get_orders(&self) -> Vec<BtcDaiOrder> {
-        self.inner.values().map(|r| r.order).collect()
+        self.inner.values().map(|r| r.order.clone()).collect()
     }
 
     /// Gets a specific order if it is known.
     pub fn get_order(&self, id: &OrderId) -> Option<BtcDaiOrder> {
-        self.inner.get(id).map(|r| r.order)
+        self.inner.get(id).map(|r| r.order.clone())
     }
 
     /// Kill an order. Return true if order was killed, false if order is

--- a/comit/src/network/protocols/orderbook/quote.rs
+++ b/comit/src/network/protocols/orderbook/quote.rs
@@ -1,0 +1,102 @@
+use anyhow::bail;
+use serde::{Deserialize, Serialize};
+
+const PRECISION: usize = 6;
+
+/// An indirect quote i.e., the amount of the quote currency required
+/// to buy one unit of the base currency. We use indirect quotes
+/// because we currently only support BTC/DAI and it is more useful to
+/// quote the amount of DAI required to buy a single Bitcoin.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct Quote {
+    /// The value stored as an integer `floor(initial * precision)`.
+    raw: usize,
+    /// Number of decimal places included.
+    precision: usize,
+}
+
+impl Quote {
+    pub fn new(precision: usize) -> Self {
+        Quote { raw: 0, precision }
+    }
+
+    pub fn from_float(f: f32) -> anyhow::Result<Quote> {
+        Quote::default().with_value(f)
+    }
+
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_wrap
+    )]
+    pub fn with_value(&mut self, f: f32) -> anyhow::Result<Quote> {
+        if f.is_sign_negative() {
+            bail!("quotes must be positive");
+        }
+
+        // Indirect quote, expect bitcoin to be above US$1000 and below US$10000000
+        debug_assert!(f > 1000.0); // debug only, ok to use float comparison.
+        debug_assert!(f < 1000000.0);
+
+        let x = 10.0_f32;
+        let multiplier = x.powi(self.precision as i32);
+
+        let r = f * multiplier as f32;
+        let r = r.floor();
+        let raw = r as usize;
+
+        if raw == 0 {
+            bail!(
+                "qoute is too small, should be within {} decimal places",
+                self.precision,
+            );
+        }
+
+        Ok(Quote {
+            raw,
+            precision: self.precision,
+        })
+    }
+
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_wrap
+    )]
+    pub fn to_float(&self) -> f32 {
+        let x = 10.0_f32;
+        let multiplier = x.powi(self.precision as i32);
+        self.raw as f32 / multiplier as f32
+    }
+}
+
+impl Default for Quote {
+    fn default() -> Self {
+        Quote {
+            raw: 0,
+            precision: PRECISION,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spectral::prelude::*;
+
+    #[test]
+    fn simple_valid_functionality() {
+        let f = 9_000.123;
+        let precision = 2;
+        let q = Quote::new(precision)
+            .with_value(f)
+            .expect("failed to construct quote");
+
+        let want = 9_000.12;
+        let got = q.to_float();
+
+        assert_that(&got).is_equal_to(&want);
+    }
+}


### PR DESCRIPTION
This PR explores a different design for the orderbook. Concretely it uses forex terms for the orderbook (further explained below). Currently the additional swap paramaters (e.g. expiries) are not handled. Also I plan on re-thinking the `take_order` logic.

All and any suggestions welcomed.

The forex industry uses specific terminology. We are writing a distributed orderbook for trading asset pairs - this is equivalent to forex trading but in crypto. We should fit in with the world :)

Use quote and amount to construct an order, depends on the trading pair (we have just BTC/DAI). Replaces the usage of two amounts as was previously done.

For a swap of 10 BTC to 100_000 DAI (COMIT terminology) forex terminology would be:

```
tp: BTC/DAI
quote: 10_000
amount: 10
```

Whether this is a buy or sell order will determine which COMIT protocol we use. Currently we assume order makers act in the role of Bob.

Pre-work now in a separate PR: https://github.com/comit-network/comit-rs/pull/2990
