### PR TITLE
Subscribe after we have a valid connection

### DIFF
--- a/api_tests/src/actors/order_factory.ts
+++ b/api_tests/src/actors/order_factory.ts
@@ -29,15 +29,16 @@ interface Ethereum {
 
 export default class OrderbookFactory {
     public static async connect(alice: Actor, bob: Actor) {
-        // Get alice's listen address
-        const aliceAddr = await alice.cnd.getPeerListenAddresses();
-
-        // Bob dials alices
+        // Alice dials Bob, must be this way around in order to ensure
+        // Alice subscribes to the BTC/DAI topic _after_ she has a connection.
+        const addr = await bob.cnd.getPeerListenAddresses();
         // @ts-ignore
-        await bob.cnd.client.post("dial", { addresses: aliceAddr });
+        await alice.cnd.client.post("dial", { addresses: addr });
 
         /// Wait for alice to accept an incoming connection from Bob
         await sleep(1000);
+
+        // TODO: This could be wait until a peer id is returned on the /peers endpoint.
     }
 
     public static async initWalletsForBtcDaiOrder(alice: Actor, bob: Actor) {

--- a/cnd/src/facade.rs
+++ b/cnd/src/facade.rs
@@ -98,6 +98,11 @@ impl Facade {
     pub async fn dial_addr(&mut self, addr: Multiaddr) {
         let _ = self.swarm.dial_addr(addr).await;
     }
+
+    /// Subscribe to the orderbook gossipsub network BTC/DAI topic.
+    pub async fn subscribe(&mut self) -> bool {
+        self.swarm.subscribe().await
+    }
 }
 
 #[async_trait::async_trait]

--- a/cnd/src/http_api/dial_addr.rs
+++ b/cnd/src/http_api/dial_addr.rs
@@ -20,5 +20,12 @@ pub async fn post_dial_addr(
     for addr in body.addresses {
         facade.dial_addr(addr).await;
     }
+
+    // Best effort, assume we got a connection.
+    let sub = facade.subscribe().await;
+    if !sub {
+        tracing::warn!("failed to subscribe to orderbook gossipsub for BTC/DAI");
+    }
+
     Ok(warp::reply::reply())
 }

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -154,6 +154,11 @@ impl Swarm {
         let _ = libp2p::Swarm::dial_addr(&mut *guard, addr)?;
         Ok(())
     }
+
+    pub async fn subscribe(&mut self) -> bool {
+        let mut guard = self.inner.lock().await;
+        guard.subscribe()
+    }
 }
 
 struct TokioExecutor {
@@ -400,6 +405,11 @@ impl ComitNode {
 
     pub fn get_orders(&self) -> Vec<Order> {
         self.orderbook.get_orders()
+    }
+
+    /// Subscribe to the orderbook gossipsub network for the BTC/DAI topic.
+    pub fn subscribe(&mut self) -> bool {
+        self.orderbook.subscribe()
     }
 }
 

--- a/comit/src/network/protocols/orderbook.rs
+++ b/comit/src/network/protocols/orderbook.rs
@@ -72,7 +72,7 @@ impl Orderbook {
             config,
         );
 
-        let mut orderbook = Orderbook {
+        let orderbook = Orderbook {
             peer_id,
             gossipsub,
             take_order: behaviour,
@@ -80,12 +80,19 @@ impl Orderbook {
             events: VecDeque::new(),
         };
 
-        // Since we only support a single trading pair topic just subscribe to it now.
         orderbook
-            .gossipsub
-            .subscribe(Topic::new(BTC_DAI.to_string()));
+    }
 
-        orderbook
+    /// Subscribe to the BTC/DAI gossipsub topic. Caller is responsible for
+    /// ensuring that there is an open connection to another node in the network
+    /// before calling.
+    // Currently we call subscribe after dialing, this implies that in order to
+    // receive orders on the gossipsub network one must dial to another node. For a
+    // node acting as a maker only it probably does not matter if we do not receive
+    // gossipsub messages.
+    // ref: https://github.com/libp2p/rust-libp2p/issues/1671#issuecomment-662709729
+    pub fn subscribe(&mut self) -> bool {
+        self.gossipsub.subscribe(Topic::new(BTC_DAI.to_string()))
     }
 
     /// Create and publish a new 'make' order. Called by Bob i.e. the maker.


### PR DESCRIPTION
Making draft while debugging other stuff.

If this issue on github is correct

https://github.com/libp2p/rust-libp2p/issues/1671#issuecomment-662709729

then we should have an open connection to another node on the network
before subscribing.

Add a method to the orderbook and all the layes above it to facilitate
subscribing. Call it after a succesfull dial is made.