### PR TITLE
Save address hint in the peer tracker

### DIFF
--- a/api_tests/src/actors/order_factory.ts
+++ b/api_tests/src/actors/order_factory.ts
@@ -29,12 +29,9 @@ interface Ethereum {
 
 export default class OrderbookFactory {
     public static async connect(alice: Actor, bob: Actor) {
-        // Get alice's listen address
-        const aliceAddr = await alice.cnd.getPeerListenAddresses();
-
-        // Bob dials alices
+        const addr = await bob.cnd.getPeerListenAddresses();
         // @ts-ignore
-        await bob.cnd.client.post("dial", { addresses: aliceAddr });
+        await alice.cnd.client.post("dial", { addresses: addr });
 
         /// Wait for alice to accept an incoming connection from Bob
         await sleep(1000);

--- a/cnd/src/network.rs
+++ b/cnd/src/network.rs
@@ -21,7 +21,6 @@ use async_trait::async_trait;
 use chrono::Utc;
 use futures::{stream::StreamExt, Future, TryFutureExt};
 use libp2p::{
-    core::connection::ConnectionLimit,
     identity::{ed25519, Keypair},
     swarm::SwarmBuilder,
     Multiaddr, NetworkBehaviour, PeerId,
@@ -109,13 +108,7 @@ impl Swarm {
 
             if !existing_connection_to_peer {
                 tracing::debug!("dialing ...");
-                match libp2p::Swarm::dial_addr(&mut guard, address_hint) {
-                    Ok(()) => {}
-                    // How did we hit the connection limit if we are not connected?
-                    // Match on the error directly so our assumption of only hitting the connection
-                    // limit here is not violated by future API changes.
-                    Err(ConnectionLimit { .. }) => {}
-                }
+                let _ = libp2p::Swarm::dial(&mut guard, &peer)?;
             }
         }
 

--- a/cnd/src/network/peer_tracker.rs
+++ b/cnd/src/network/peer_tracker.rs
@@ -39,16 +39,19 @@ impl NetworkBehaviour for PeerTracker {
     }
 
     fn addresses_of_peer(&mut self, peer: &PeerId) -> Vec<Multiaddr> {
+        let mut addresses: Vec<Multiaddr> = vec![];
+
         if let Some(addr) = self.address_hints.get(peer) {
-            return vec![addr.clone()];
+            addresses.push(addr.clone());
         }
 
-        // FIXME: Why do we return addresses of connected peers? Isn't this function
-        // called when another component wants to find out what addr to try to dial to?
-        self.connected_peers
-            .get(peer)
-            .cloned()
-            .unwrap_or_else(Vec::new)
+        if let Some(connected) = self.connected_peers.get(peer) {
+            for addr in connected.iter() {
+                addresses.push(addr.clone())
+            }
+        }
+
+        addresses
     }
 
     fn inject_connected(&mut self, _: &PeerId) {}

--- a/cnd/src/network/peer_tracker.rs
+++ b/cnd/src/network/peer_tracker.rs
@@ -17,11 +17,16 @@ use std::{
 #[derive(Default, Debug)]
 pub struct PeerTracker {
     connected_peers: HashMap<PeerId, Vec<Multiaddr>>,
+    address_hints: HashMap<PeerId, Multiaddr>,
 }
 
 impl PeerTracker {
     pub fn connected_peers(&self) -> impl Iterator<Item = (PeerId, Vec<Multiaddr>)> {
         self.connected_peers.clone().into_iter()
+    }
+
+    pub fn add_address_hint(&mut self, id: PeerId, addr: Multiaddr) -> Option<Multiaddr> {
+        self.address_hints.insert(id, addr)
     }
 }
 
@@ -34,6 +39,12 @@ impl NetworkBehaviour for PeerTracker {
     }
 
     fn addresses_of_peer(&mut self, peer: &PeerId) -> Vec<Multiaddr> {
+        if let Some(addr) = self.address_hints.get(peer) {
+            return vec![addr.clone()];
+        }
+
+        // FIXME: Why do we return addresses of connected peers? Isn't this function
+        // called when another component wants to find out what addr to try to dial to?
         self.connected_peers
             .get(peer)
             .cloned()


### PR DESCRIPTION
The peer tracker is our component that takes care of peer and address discovery.

Currently when the `addresses_of_peers()` method is called we return a list of the addresses of peers we are connected to, this is not that useful if we are trying to find out an address to dial to make the connection in the first place.

Add a map of peer ids to address hints and return this hint if one exists when the `addresses_of_peer()` method is called (with other known addresses appended).

Fix other dial bug by dialing Bob from Alice in the orderbook e2e tests - just because.