### PR TITLE
log connection limit error

### DIFF
--- a/cnd/src/facade.rs
+++ b/cnd/src/facade.rs
@@ -95,8 +95,8 @@ impl Facade {
         self.swarm.get_orders().await
     }
 
-    pub async fn dial_addr(&mut self, addr: Multiaddr) {
-        let _ = self.swarm.dial_addr(addr).await;
+    pub async fn dial_addr(&mut self, addr: Multiaddr) -> anyhow::Result<()> {
+        self.swarm.dial_addr(addr).await
     }
 }
 

--- a/cnd/src/http_api/dial_addr.rs
+++ b/cnd/src/http_api/dial_addr.rs
@@ -18,7 +18,10 @@ pub async fn post_dial_addr(
         .map_err(warp::reject::custom)?;
 
     for addr in body.addresses {
-        facade.dial_addr(addr).await;
+        match facade.dial_addr(addr.clone()).await {
+            Ok(()) => {}
+            Err(_) => tracing::warn!("connection limit hit when dialing address: {}", addr),
+        }
     }
     Ok(warp::reply::reply())
 }


### PR DESCRIPTION
We get an error back from `dial_addr`, no need to silently drop it. This error can only ever be returned if we hit the connection limit, this is useful information so log it.