### PR TITLE
Add a DAI type alias

### DIFF
--- a/comit/src/asset.rs
+++ b/comit/src/asset.rs
@@ -3,5 +3,5 @@ pub mod ethereum;
 
 pub use self::{
     bitcoin::Bitcoin,
-    ethereum::{Erc20, Erc20Quantity, Ether},
+    ethereum::{Dai, Erc20, Erc20Quantity, Ether},
 };

--- a/comit/src/asset/ethereum.rs
+++ b/comit/src/asset/ethereum.rs
@@ -4,7 +4,7 @@ mod erc20;
 mod ether;
 
 pub use self::{
-    erc20::{Erc20, Erc20Quantity},
+    erc20::{Dai, Erc20, Erc20Quantity},
     ether::Ether,
 };
 

--- a/comit/src/asset/ethereum/erc20.rs
+++ b/comit/src/asset/ethereum/erc20.rs
@@ -9,6 +9,8 @@ use std::{fmt, str::FromStr};
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Erc20Quantity(BigUint);
 
+pub type Dai = Erc20Quantity;
+
 impl Erc20Quantity {
     pub fn zero() -> Self {
         Self(BigUint::zero())


### PR DESCRIPTION
We are heavily invested in code that manipulates DAI tokens, saying `Erc20Quantity` is cumbersome.

Add a DAI type alias to enable writing `asset::Dai`.

This PR adds code that is not used. I've written this code 10 times in the last two weeks and its still not in, just add it already.