### PR TITLE
Add a dream API call for creating orders

### DIFF
--- a/comit/src/asset.rs
+++ b/comit/src/asset.rs
@@ -3,5 +3,5 @@ pub mod ethereum;
 
 pub use self::{
     bitcoin::Bitcoin,
-    ethereum::{Erc20, Erc20Quantity, Ether},
+    ethereum::{Dai, Erc20, Erc20Quantity, Ether},
 };

--- a/comit/src/asset/ethereum.rs
+++ b/comit/src/asset/ethereum.rs
@@ -4,7 +4,7 @@ mod erc20;
 mod ether;
 
 pub use self::{
-    erc20::{Erc20, Erc20Quantity},
+    erc20::{Dai, Erc20, Erc20Quantity},
     ether::Ether,
 };
 

--- a/comit/src/asset/ethereum/erc20.rs
+++ b/comit/src/asset/ethereum/erc20.rs
@@ -9,6 +9,8 @@ use std::{fmt, str::FromStr};
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Erc20Quantity(BigUint);
 
+pub type Dai = Erc20Quantity;
+
 impl Erc20Quantity {
     pub fn zero() -> Self {
         Self(BigUint::zero())


### PR DESCRIPTION
This is purely fictional but this is how I'd like to call to cnd to create a limit order. I assume I will later call cnd again supplying identities to use when I confirm the take order request that would come in if another node tried to take my order.


(Initial patch is for [closed PR](https://github.com/coblox/pitches/blob/cnd-trading-api/cnd_trading_api.adoc#24-whitelisting-erc20-tokens) adding DAI type alias, see the PR for explanation of why this is incomplete :)