### PR TITLE
Clean up ts-ignore statements

### DIFF
--- a/api_tests/src/actors/actor.ts
+++ b/api_tests/src/actors/actor.ts
@@ -334,7 +334,6 @@ export class Actor {
     ) {
         if (this.name === "alice") {
             // Poll until Alice receives an order. The order must be the one that Bob created above.
-            // @ts-ignore
             const aliceOrdersResponse = await this.pollCndUntil<Entity>(
                 "orders",
                 (entity) => entity.entities.length > 0
@@ -349,16 +348,13 @@ export class Actor {
             // The resolver function fills the refund and redeem address fields required
             // "POST /orders/63c0f8bd-beb2-4a9c-8591-a46f65913b0a/take"
             // Alice receives a url to the swap that was created as a result of taking the order
-            // @ts-ignore
             const aliceTakeOrderResponse = await this.cnd.executeSirenAction(
                 aliceOrderTakeAction,
                 async (field) => {
                     if (field.name === "bitcoin_identity") {
-                        // @ts-ignore
                         return Promise.resolve(bitcoinIdentity);
                     }
                     if (field.name === "ethereum_identity") {
-                        // @ts-ignore
                         return Promise.resolve(ethereumIdentity);
                     }
                 }

--- a/api_tests/src/actors/actor.ts
+++ b/api_tests/src/actors/actor.ts
@@ -312,7 +312,7 @@ export class Actor {
             // make response contain url in the header to the created order
             // poll this order to see when when it has been converted to a swap
             // "POST /orders"
-            // @ts-ignore
+            // @ts-ignore: client is private.
             const bobMakeOrderResponse = await this.cnd.client.post(
                 "orders",
                 order
@@ -367,7 +367,7 @@ export class Actor {
             // Wait for bob to acknowledge that Alice has taken the order he created
             await sleep(1000);
 
-            // @ts-ignore
+            // @ts-ignore: client is private.
             const aliceSwapResponse = await this.cnd.client.get(
                 aliceTakeOrderResponse.headers.location
             );
@@ -845,7 +845,7 @@ export class Actor {
     public async createHerc20Halbit(
         body: Herc20HalbitPayload
     ): Promise<string> {
-        // @ts-ignore
+        // @ts-ignore: client is private.
         const response = await this.cnd.client.post(
             "swaps/herc20/halbit",
             body
@@ -857,7 +857,7 @@ export class Actor {
     public async createHalbitHerc20(
         body: HalbitHerc20Payload
     ): Promise<string> {
-        // @ts-ignore
+        // @ts-ignore: client is private.
         const response = await this.cnd.client.post(
             "swaps/halbit/herc20",
             body
@@ -867,14 +867,14 @@ export class Actor {
     }
 
     public async createHerc20Hbit(body: Herc20HbitPayload): Promise<string> {
-        // @ts-ignore
+        // @ts-ignore: client is private.
         const response = await this.cnd.client.post("swaps/herc20/hbit", body);
 
         return response.headers.location;
     }
 
     public async createHbitHerc20(body: HbitHerc20Payload): Promise<string> {
-        // @ts-ignore
+        // @ts-ignore: client is private.
         const response = await this.cnd.client.post("swaps/hbit/herc20", body);
 
         return response.headers.location;


### PR DESCRIPTION
`ts-ignore` statements should be justified so that the next dev knows why they are there.

- Patch 1: Justify usage of `ts-ignore` due to access of private `client` field.
- Patch 2: Remove unnecessary `ts-ignore` statements.
