### PR TITLE
Make bors listen on all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,21 +28,21 @@ jobs:
         with:
           path: ~/.cargo/registry
           # The registry cache is useful as long as we need the same dependencies as another job, regardless of the Rust version and operating system.
-          key: cargo-registry-${{ hashFiles('Cargo.lock') }}-v1
+          key: cargo-registry-${{ hashFiles('Cargo.lock') }}-v2
 
       - name: Cache cargo binaries
         uses: actions/cache@v2
         with:
           path: ~/.cargo/bin
           # The cargo binary cache is useful as long as we use the same Rust version but regardless of our dependencies.
-          key: ubuntu-latest-cargo-binaries-${{ steps.toolchain.outputs.rustc_hash }}-v1
+          key: ubuntu-latest-cargo-binaries-${{ steps.toolchain.outputs.rustc_hash }}-v2
 
       - name: Cache target directory
         uses: actions/cache@v2
         with:
           path: target
           # The target directory is only useful with the same Rust version, dependencies and operating system.
-          key: ubuntu-latest-target-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('Cargo.lock') }}-clippy-v1
+          key: ubuntu-latest-target-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('Cargo.lock') }}-clippy-v2
 
       - name: Check formatting
         run: make check_format
@@ -76,14 +76,14 @@ jobs:
         with:
           path: ~/.cargo/registry
           # The registry cache is useful as long as we need the same dependencies as another job, regardless of the Rust version and operating system.
-          key: cargo-registry-${{ hashFiles('Cargo.lock') }}-v1
+          key: cargo-registry-${{ hashFiles('Cargo.lock') }}-v2
 
       - name: Cache cargo binaries
         uses: actions/cache@v2
         with:
           path: ~/.cargo/bin
           # The cargo binary cache is useful as long as we use the same Rust version and operating system, but regardless of our dependencies.
-          key: ${{ matrix.os }}-cargo-binaries-${{ steps.toolchain.outputs.rustc_hash }}-v1
+          key: ${{ matrix.os }}-cargo-binaries-${{ steps.toolchain.outputs.rustc_hash }}-v2
 
       - name: Cache target directory
         uses: actions/cache@v2
@@ -91,7 +91,7 @@ jobs:
         with:
           path: target
           # The target directory is only useful with the same Rust version, dependencies and operating system.
-          key: ${{ matrix.os }}-target-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('Cargo.lock') }}-build-v1
+          key: ${{ matrix.os }}-target-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('Cargo.lock') }}-build-v2
 
       - name: Build ${{ matrix.os }} binary
         run: make build
@@ -123,7 +123,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: api_tests/node_modules
-          key: ${{ matrix.os }}-node-modules-directory-${{ hashFiles('api_tests/package.json') }}-v1
+          key: ${{ matrix.os }}-node-modules-directory-${{ hashFiles('api_tests/package.json') }}-v2
 
       - name: Run e2e tests
         if: matrix.e2e

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,8 @@
 status = [
     "static_analysis",
     "build (ubuntu-latest)",
+    "build (macos-latest)",
+    "build (windows-latest)",
 ]
 pr_status = ["license/cla"]
 block_labels = ["no-mergify"]

--- a/comit/Cargo.toml
+++ b/comit/Cargo.toml
@@ -27,7 +27,7 @@ num = "0.3"
 primitive-types = { version = "0.7.2", features = ["serde"] }
 rand = "0.7"
 reqwest = { version = "0.10.7", default-features = false, features = ["json", "native-tls"] }
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 serde-hex = "0.1.0"
 serde_json = "1"
 serdebug = "1"


### PR DESCRIPTION
This prevents weird timeout errors in bors in case the macos job fails and therefore cancels the ubuntu build.

It does mean that we are now requiring all of those to pass before we can merge but I reckon that is ok. If we don't actually care about these jobs, we should remove them altogether.