### PR TITLE
Add debug statements for receipt of gossipsub messages

### DIFF
--- a/api_tests/src/actors/order_factory.ts
+++ b/api_tests/src/actors/order_factory.ts
@@ -1,5 +1,4 @@
 import { Actor } from "./actor";
-import { sleep } from "../utils";
 import { HarnessGlobal } from "../utils";
 import { defaultExpiries, getIdentities } from "./defaults";
 
@@ -28,15 +27,6 @@ interface Ethereum {
 }
 
 export default class OrderbookFactory {
-    public static async connect(alice: Actor, bob: Actor) {
-        const addr = await bob.cnd.getPeerListenAddresses();
-        // @ts-ignore
-        await alice.cnd.client.post("dial", { addresses: addr });
-
-        /// Wait for alice to accept an incoming connection from Bob
-        await sleep(1000);
-    }
-
     public static async initWalletsForBtcDaiOrder(alice: Actor, bob: Actor) {
         await alice.wallets.initializeForLedger(
             "bitcoin",

--- a/api_tests/tests/orderbook.ts
+++ b/api_tests/tests/orderbook.ts
@@ -13,7 +13,8 @@ describe("orderbook", () => {
     it(
         "btc_dai_buy_order",
         twoActorTest(async ({ alice, bob }) => {
-            await OrderFactory.connect(alice, bob);
+            await alice.connect(bob);
+
             await OrderFactory.initWalletsForBtcDaiOrder(alice, bob);
 
             const order = await OrderFactory.newBtcDaiOrder(bob, "buy");
@@ -49,7 +50,7 @@ describe("orderbook", () => {
     it(
         "btc_dai_sell_order",
         twoActorTest(async ({ alice, bob }) => {
-            await OrderFactory.connect(alice, bob);
+            await alice.connect(bob);
             await OrderFactory.initWalletsForBtcDaiOrder(alice, bob);
 
             const order = await OrderFactory.newBtcDaiOrder(bob, "sell");

--- a/comit/src/network/orderbook.rs
+++ b/comit/src/network/orderbook.rs
@@ -278,7 +278,7 @@ pub enum BehaviourOutEvent {
 
 impl NetworkBehaviourEventProcess<GossipsubEvent> for Orderbook {
     fn inject_event(&mut self, event: GossipsubEvent) {
-        if let GossipsubEvent::Message(_peer_id, _message_id, message) = event {
+        if let GossipsubEvent::Message(_peer_id, message_id, message) = event {
             let decoded: Message = match bincode::deserialize(&message.data[..]) {
                 Ok(msg) => msg,
                 Err(e) => {
@@ -289,6 +289,7 @@ impl NetworkBehaviourEventProcess<GossipsubEvent> for Orderbook {
 
             match decoded {
                 Message::CreateOrder(order) => {
+                    tracing::debug!("received create order message: {}", message_id);
                     // This implies new orders remove old orders from
                     // the orderbook. This means nodes can spoof the
                     // network using previously seen order ids in
@@ -296,6 +297,7 @@ impl NetworkBehaviourEventProcess<GossipsubEvent> for Orderbook {
                     self.orders.insert(order.id, order);
                 }
                 Message::DeleteOrder(order_id) => {
+                    tracing::debug!("received delete order message: {}", message_id);
                     // Same consideration here, nodes can cause orders
                     // they did not create to be removed by spoofing
                     // the network with a previously seen order id.


### PR DESCRIPTION
In order to debug gossipsub its useful to know when a message arrives at a node from the network.

This PR adds two log statements, merging without review.