### PR TITLE
Upgrade to latest comit-sdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           path: ~/.cargo/registry
           # The registry cache is useful as long as we need the same dependencies as another job, regardless of the Rust version and operating system.
-          key: cargo-registry-${{ hashFiles('Cargo.lock') }}-v2
+          key: cargo-registry-${{ hashFiles('Cargo.lock') }}-v3
 
       - name: Cache cargo binaries
         uses: actions/cache@v2
@@ -91,7 +91,7 @@ jobs:
         with:
           path: target
           # The target directory is only useful with the same Rust version, dependencies and operating system.
-          key: ${{ matrix.os }}-target-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('Cargo.lock') }}-build-v2
+          key: ${{ matrix.os }}-target-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('Cargo.lock') }}-build-v3
 
       - name: Build ${{ matrix.os }} binary
         run: make build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde-hex",
+ "serde_derive",
  "serde_json",
  "serde_urlencoded",
  "serdebug",
@@ -565,6 +566,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde-hex",
+ "serde_derive",
  "serde_json",
  "serdebug",
  "sha2 0.9.1",
@@ -761,6 +763,7 @@ dependencies = [
  "hex 0.4.2",
  "multihash",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/api_tests/package.json
+++ b/api_tests/package.json
@@ -32,7 +32,7 @@
         "bitcoin-core": "^3.0.0",
         "bitcoinjs-lib": "^5.1.10",
         "chmod": "^0.2.1",
-        "comit-sdk": "^0.17.0",
+        "comit-sdk": "^0.17.1",
         "download": "^8.0.0",
         "ethers": "^5.0.7",
         "find-cache-dir": "^3.3.1",

--- a/api_tests/yarn.lock
+++ b/api_tests/yarn.lock
@@ -1935,10 +1935,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-comit-sdk@^0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/comit-sdk/-/comit-sdk-0.17.0.tgz#1e770bece91d9bcacaf7ed6b997765f45e143e33"
-  integrity sha512-vxzMjLOYSqmOYeBdykzFoYc8VTKL84Lu/EWHcbL1BGAlUmMiLzq0PkhBc/NvciQwCtkBX+ph/E4XL9jGiNsYuQ==
+comit-sdk@^0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/comit-sdk/-/comit-sdk-0.17.1.tgz#72192e0d770d7d929e56f811eff6b9b307d109f9"
+  integrity sha512-7ZTNmIykhkOxmRtdC01EQ6VdBDWl+S8TkFqYhDuXE/0a4sQJ0exRTA1fbN5uCw6jRfixZij4kppP+M82ALxJYA==
   dependencies:
     "@radar/lnrpc" "^0.9.1-beta"
     axios "^0.19.2"

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -39,6 +39,7 @@ rand = "0.7"
 reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde-hex = "0.1.0"
+serde_derive = "1.0"
 serde_json = "1"
 serdebug = "1"
 sha2 = "0.9"

--- a/comit/Cargo.toml
+++ b/comit/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1"
 async-trait = "0.1"
 base64 = "0.12.3"
 bincode = "1.2.1"
-bitcoin = { version = "0.23.0", features = ["rand"] }
+bitcoin = { version = "0.23.0", features = ["rand", "use-serde"] }
 blockchain_contracts = "0.3.2"
 chrono = { version = "0.4", features = ["serde"] }
 derivative = "2"

--- a/comit/Cargo.toml
+++ b/comit/Cargo.toml
@@ -29,6 +29,7 @@ rand = "0.7"
 reqwest = { version = "0.10.7", default-features = false, features = ["json", "native-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde-hex = "0.1.0"
+serde_derive = "1.0"
 serde_json = "1"
 serdebug = "1"
 sha2 = "0.9"

--- a/digest/Cargo.toml
+++ b/digest/Cargo.toml
@@ -11,3 +11,4 @@ hex = "0.4"
 [dev-dependencies]
 multihash = "0.11"
 serde = { version = "1.0", features = ["derive"] }
+serde_derive = "1.0"


### PR DESCRIPTION
To hopefully fix the lightning CI error `OpenStatusUpdate is malformed`.

Also fixed the `cannot find serde_derive crate` issue.

See https://github.com/comit-network/comit-js-sdk/pull/255