### PR TITLE
Simplify announce error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,9 +1661,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1a4cc57489fa519b98c068277b9032f04d382e8da8c0ca040d5aa872d3bfd7"
+checksum = "6f48682b48a96545a323edd150c1d64fc1e250240bba02866e9f902e3dc032a9"
 dependencies = [
  "async-trait",
  "futures",


### PR DESCRIPTION
With the release of libp2p-request-response 0.1.1, we no longer
need to work around closing the substream explicitely. Instead,
we can simply drop the response channel.

Note: Given that `take-order` was more or less copied from `announce`, we could make those changes there as well.

cc @rishflab @tcharding 