### PR TITLE
Re-design orderbook to a pull-based approach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,13 +542,13 @@ dependencies = [
  "bitcoincore-rpc",
  "blockchain_contracts",
  "chrono",
+ "conquer-once",
  "derivative 2.1.1",
  "digest 0.1.0",
  "ethbloom",
  "futures",
  "genawaiter",
  "hex 0.4.2",
- "lazy_static",
  "levenshtein",
  "libp2p 0.23.0",
  "log 0.4.11",
@@ -589,6 +589,21 @@ dependencies = [
  "serde",
  "toml",
 ]
+
+[[package]]
+name = "conquer-once"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96eb12fb69466716fbae9009d389e6a30830ae8975e170eff2d2cff579f9efa3"
+dependencies = [
+ "conquer-util",
+]
+
+[[package]]
+name = "conquer-util"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654fb2472cc369d311c547103a1fa81d467bef370ae7a0680f65939895b1182a"
 
 [[package]]
 name = "const-random"

--- a/cnd/src/http_api.rs
+++ b/cnd/src/http_api.rs
@@ -8,6 +8,7 @@ mod herc20_hbit;
 mod info;
 mod orderbook;
 mod route_factory;
+mod serde_peer_id;
 #[macro_use]
 mod impl_serialize_http;
 mod action;
@@ -44,7 +45,7 @@ use std::{
 };
 
 /// Object representing the data of a POST request for creating a swap.
-#[derive(serde::Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Debug)]
 pub struct PostBody<A, B> {
     pub alpha: A,
     pub beta: B,

--- a/cnd/src/http_api/serde_peer_id.rs
+++ b/cnd/src/http_api/serde_peer_id.rs
@@ -1,0 +1,37 @@
+//! A serde module that defines how we want to serialize PeerIds on the
+//! HTTP-API.
+
+use libp2p::PeerId;
+use serde::Serializer;
+
+pub fn serialize<S>(peer_id: &PeerId, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let string = peer_id.to_string();
+    serializer.serialize_str(&string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Serialize;
+    use spectral::prelude::*;
+
+    #[derive(Serialize)]
+    struct SerializablePeerId(#[serde(with = "super")] PeerId);
+
+    #[test]
+    fn maker_id_serializes_as_expected() {
+        let peer_id = SerializablePeerId(
+            "QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY"
+                .parse()
+                .unwrap(),
+        );
+
+        let got = serde_json::to_string(&peer_id).expect("failed to serialize peer id");
+
+        assert_that(&got)
+            .is_equal_to(r#""QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY""#.to_string());
+    }
+}

--- a/cnd/src/trace.rs
+++ b/cnd/src/trace.rs
@@ -1,6 +1,6 @@
 use atty::{self, Stream};
 use log::LevelFilter;
-use tracing::{info, subscriber, Level};
+use tracing::{info, subscriber};
 use tracing_log::LogTracer;
 use tracing_subscriber::FmtSubscriber;
 
@@ -14,7 +14,7 @@ pub fn init_tracing(level: log::LevelFilter) -> anyhow::Result<()> {
 
     let is_terminal = atty::is(Stream::Stdout);
     let subscriber = FmtSubscriber::builder()
-        .with_max_level(level_from_level_filter(level))
+        .with_env_filter(format!("cnd={},comit={},http=info,warp=info", level, level))
         .with_ansi(is_terminal)
         .finish();
 
@@ -22,15 +22,4 @@ pub fn init_tracing(level: log::LevelFilter) -> anyhow::Result<()> {
     info!("Initialized tracing with level: {}", level);
 
     Ok(())
-}
-
-fn level_from_level_filter(level: LevelFilter) -> Level {
-    match level {
-        LevelFilter::Off => unreachable!(),
-        LevelFilter::Error => Level::ERROR,
-        LevelFilter::Warn => Level::WARN,
-        LevelFilter::Info => Level::INFO,
-        LevelFilter::Debug => Level::DEBUG,
-        LevelFilter::Trace => Level::TRACE,
-    }
 }

--- a/comit/Cargo.toml
+++ b/comit/Cargo.toml
@@ -13,13 +13,13 @@ bincode = "1.2.1"
 bitcoin = { version = "0.23.0", features = ["rand", "use-serde"] }
 blockchain_contracts = "0.3.2"
 chrono = { version = "0.4", features = ["serde"] }
+conquer-once = "0.2.1"
 derivative = "2"
 digest = { path = "../digest" }
 ethbloom = "0.9.1"
 futures = { version = "0.3", default-features = false }
 genawaiter = { version = "0.99", default-features = false, features = ["futures03"] }
 hex = "0.4"
-lazy_static = "1"
 levenshtein = "1"
 libp2p = { version = "0.23", default-features = false, features = ["gossipsub", "request-response"] }
 lru = "0.5.3"

--- a/comit/src/asset/ethereum/ether.rs
+++ b/comit/src/asset/ethereum/ether.rs
@@ -2,7 +2,7 @@ use crate::{
     asset::ethereum::{Error, FromWei, TryFromWei},
     ethereum::U256,
 };
-use lazy_static::lazy_static;
+use conquer_once::Lazy;
 use num::{pow::Pow, BigUint, Integer, Num, Zero};
 use serde::{
     de::{self, Deserialize, Deserializer},
@@ -10,10 +10,8 @@ use serde::{
 };
 use std::{fmt, str::FromStr};
 
-lazy_static! {
-    static ref WEI_IN_ETHER_U128: u128 = (10u128).pow(18);
-    static ref WEI_IN_ETHER_BIGUINT: BigUint = BigUint::from(*WEI_IN_ETHER_U128);
-}
+static WEI_IN_ETHER_U128: Lazy<u128> = Lazy::new(|| (10u128).pow(18));
+static WEI_IN_ETHER_BIGUINT: Lazy<BigUint> = Lazy::new(|| BigUint::from(*WEI_IN_ETHER_U128));
 
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Ether(BigUint);

--- a/comit/src/herc20.rs
+++ b/comit/src/herc20.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use blockchain_contracts::ethereum::rfc003::Erc20Htlc;
 use chrono::NaiveDateTime;
+use conquer_once::Lazy;
 use futures::{
     future::{self, Either},
     Stream,
@@ -22,11 +23,21 @@ use genawaiter::sync::{Co, Gen};
 use std::cmp::Ordering;
 use tracing_futures::Instrument;
 
-lazy_static::lazy_static! {
-    static ref REDEEM_LOG_MSG: Hash = blockchain_contracts::ethereum::rfc003::REDEEMED_LOG_MSG.parse().expect("to be valid hex");
-    static ref REFUND_LOG_MSG: Hash = blockchain_contracts::ethereum::rfc003::REFUNDED_LOG_MSG.parse().expect("to be valid hex");
-    static ref TRANSFER_LOG_MSG: Hash = blockchain_contracts::ethereum::rfc003::ERC20_TRANSFER.parse().expect("to be valid hex");
-}
+static REDEEM_LOG_MSG: Lazy<Hash> = Lazy::new(|| {
+    blockchain_contracts::ethereum::rfc003::REDEEMED_LOG_MSG
+        .parse()
+        .expect("to be valid hex")
+});
+static REFUND_LOG_MSG: Lazy<Hash> = Lazy::new(|| {
+    blockchain_contracts::ethereum::rfc003::REFUNDED_LOG_MSG
+        .parse()
+        .expect("to be valid hex")
+});
+static TRANSFER_LOG_MSG: Lazy<Hash> = Lazy::new(|| {
+    blockchain_contracts::ethereum::rfc003::ERC20_TRANSFER
+        .parse()
+        .expect("to be valid hex")
+});
 
 /// Represents the events in the herc20 protocol.
 #[derive(Debug, Clone, PartialEq, strum_macros::Display)]

--- a/comit/src/network/orderbook.rs
+++ b/comit/src/network/orderbook.rs
@@ -1,73 +1,52 @@
+mod makerbook;
 mod order;
-mod take_order;
+mod order_source;
+mod orders;
+pub mod take_order;
 
-use crate::{
-    network::orderbook::take_order::{Response, TakeOrderCodec, TakeOrderProtocol},
-    SharedSwapId,
-};
-
+use crate::SharedSwapId;
 use libp2p::{
-    core::either::EitherOutput,
-    gossipsub,
-    gossipsub::{Gossipsub, GossipsubEvent, GossipsubRpc, Topic},
     request_response::{
-        handler::RequestProtocol, ProtocolSupport, RequestResponse, RequestResponseConfig,
-        RequestResponseEvent, RequestResponseMessage, ResponseChannel,
+        ProtocolSupport, RequestResponse, RequestResponseConfig, RequestResponseEvent,
+        RequestResponseMessage, ResponseChannel,
     },
     swarm::{NetworkBehaviourAction, NetworkBehaviourEventProcess, PollParameters},
     NetworkBehaviour, PeerId,
 };
-use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use std::{
-    collections::{hash_map::DefaultHasher, HashMap, VecDeque},
-    fmt,
-    fmt::Display,
-    hash::{Hash, Hasher},
-    str::FromStr,
+    collections::VecDeque,
     task::{Context, Poll},
     time::Duration,
 };
 
+use makerbook::Makerbook;
 pub use order::*;
-pub use take_order::Response as TakeOrderResponse;
+use order_source::*;
+use take_order::{Confirmation, TakeOrderCodec, TakeOrderProtocol};
 
-lazy_static::lazy_static! {
-    /// The Topic used to publish BTC/DAI orders.
-    static ref BTC_DAI_TOPIC: Topic = Topic::new("BTC/DAI".to_string());
-}
+pub use self::{order::*, orders::*};
 
 /// The time we wait for a take order request to be confirmed or denied.
 const REQUEST_TIMEOUT_SECS: u64 = 10;
 
 /// The Orderbook libp2p network behaviour.
 #[derive(NetworkBehaviour)]
-#[behaviour(out_event = "BehaviourOutEvent", poll_method = "poll")]
+#[behaviour(out_event = "BehaviourOutEvent", poll_method = "my_poll")]
+#[allow(missing_debug_implementations)]
 pub struct Orderbook {
-    gossipsub: Gossipsub,
+    makerbook: Makerbook,
+    order_source: OrderSource,
     take_order: RequestResponse<TakeOrderCodec>,
+
     #[behaviour(ignore)]
     events: VecDeque<BehaviourOutEvent>,
     #[behaviour(ignore)]
-    orders: HashMap<OrderId, Order>,
-    #[behaviour(ignore)]
-    pub peer_id: PeerId,
+    orders: Orders,
 }
 
 impl Orderbook {
     /// Construct a new orderbook for this node using the node's peer ID.
-    pub fn new(peer_id: PeerId) -> Orderbook {
-        let message_id_fn = |message: &gossipsub::GossipsubMessage| {
-            let mut s = DefaultHasher::new();
-            message.data.hash(&mut s);
-            gossipsub::MessageId(s.finish().to_string())
-        };
-
-        let config = gossipsub::GossipsubConfigBuilder::new()
-            .heartbeat_interval(Duration::from_secs(1))
-            .message_id_fn(message_id_fn) // No two messages of the same content will be propagated.
-            .build();
-        let gossipsub = Gossipsub::new(peer_id.clone(), config);
-
+    pub fn new(me: PeerId) -> Orderbook {
         let mut config = RequestResponseConfig::default();
         config.set_request_timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS));
         let behaviour = RequestResponse::new(
@@ -76,54 +55,59 @@ impl Orderbook {
             config,
         );
 
-        let mut orderbook = Orderbook {
-            peer_id,
-            gossipsub,
+        Orderbook {
+            makerbook: Makerbook::new(me.clone()),
+            order_source: OrderSource::default(),
             take_order: behaviour,
-            orders: HashMap::new(),
             events: VecDeque::new(),
-        };
-
-        // Since we only support a single trading pair topic just subscribe to it now.
-        orderbook.gossipsub.subscribe(BTC_DAI_TOPIC.clone());
-
-        orderbook
+            orders: Orders::new(me),
+        }
     }
 
-    /// Create and publish a new 'make' order. Called by Bob i.e. the maker.
-    pub fn make(&mut self, order: Order) -> anyhow::Result<OrderId> {
-        let ser = bincode::serialize(&Message::CreateOrder(order.clone()))?;
-        self.gossipsub.publish(&BTC_DAI_TOPIC, ser);
+    /// Declare oneself to the network as a maker.
+    pub fn declare_as_maker(&mut self) {
+        self.makerbook.login();
+    }
 
-        let id = order.id;
-        self.orders.insert(id, order);
+    /// Announce retraction of oneself as a maker, undoes `declare_as_maker()`.
+    pub fn retract(&mut self) {
+        self.makerbook.logout();
+        self.orders.clear_own_orders();
+    }
 
-        Ok(id)
+    /// Make a new order.
+    ///
+    /// The resulting order will eventually be visible to other peers.
+    pub fn make(&mut self, new_order: NewOrder) -> OrderId {
+        self.orders.new_order(new_order)
+    }
+
+    /// Cancel an order we previously made.
+    pub fn cancel(&mut self, id: OrderId) {
+        self.orders.cancel(id);
     }
 
     /// Take an order, called by Alice i.e., the taker.
-    /// Does _not_ remove the order from the order book.
-    pub fn take(&mut self, order_id: OrderId) -> anyhow::Result<()> {
-        let maker_id = self
-            .maker_id(order_id)
+    pub fn take(&mut self, order_id: OrderId) -> anyhow::Result<Order> {
+        let order = self
+            .orders
+            .theirs()
+            .find(|order| order.id == order_id)
             .ok_or_else(|| OrderNotFound(order_id))?;
+        let maker = &order.maker;
 
-        self.take_order.send_request(&maker_id.into(), order_id);
+        tracing::info!("attempting to take order {} from maker {}", order_id, maker);
 
-        Ok(())
-    }
+        self.take_order.send_request(maker, order_id);
 
-    /// Get the ID of the node that published this order.
-    fn maker_id(&self, order_id: OrderId) -> Option<MakerId> {
-        self.orders.get(&order_id).map(|order| order.maker.clone())
+        Ok(order.clone())
     }
 
     /// Confirm a take order request, called by Bob i.e., the maker.
-    /// Does _not_ remove the order from the order book.
     pub fn confirm(
         &mut self,
         order_id: OrderId,
-        channel: ResponseChannel<Response>,
+        channel: ResponseChannel<Confirmation>,
         peer_id: PeerId,
     ) {
         let shared_swap_id = SharedSwapId::default();
@@ -132,11 +116,10 @@ impl Orderbook {
             shared_swap_id
         );
 
-        self.take_order
-            .send_response(channel, Response::Confirmation {
-                order_id,
-                shared_swap_id,
-            });
+        self.take_order.send_response(channel, Confirmation {
+            shared_swap_id,
+            order_id,
+        });
 
         self.events
             .push_back(BehaviourOutEvent::TakeOrderConfirmation {
@@ -147,33 +130,30 @@ impl Orderbook {
     }
 
     /// Deny a take order request, called by Bob i.e., the maker.
-    pub fn deny(&mut self, peer_id: PeerId, order_id: OrderId, channel: ResponseChannel<Response>) {
+    pub fn deny(
+        &mut self,
+        peer_id: PeerId,
+        order_id: OrderId,
+        channel: ResponseChannel<Confirmation>,
+    ) {
         self.events
             .push_back(BehaviourOutEvent::Failed { peer_id, order_id });
-        self.take_order.send_response(channel, Response::Error);
+        std::mem::drop(channel); // triggers an error on the other end
     }
 
-    /// Get a list of all orders known to this node.
-    pub fn get_orders(&self) -> Vec<Order> {
-        self.orders.values().cloned().collect()
+    pub fn orders(&self) -> &Orders {
+        &self.orders
     }
 
-    /// Get the order matching `id` if known to this node.
-    /// todo: check error handling in usages of this function
-    pub fn get_order(&self, id: &OrderId) -> Option<Order> {
-        self.orders.get(id).cloned()
+    pub fn orders_mut(&mut self) -> &mut Orders {
+        &mut self.orders
     }
 
-    fn poll(
+    fn my_poll<BIE>(
         &mut self,
         _: &mut Context<'_>,
         _: &mut impl PollParameters,
-    ) -> Poll<
-        NetworkBehaviourAction<
-            EitherOutput<GossipsubRpc, RequestProtocol<TakeOrderCodec>>,
-            BehaviourOutEvent,
-        >,
-    > {
+    ) -> Poll<NetworkBehaviourAction<BIE, BehaviourOutEvent>> {
         if let Some(event) = self.events.pop_front() {
             return Poll::Ready(NetworkBehaviourAction::GenerateEvent(event));
         }
@@ -186,65 +166,6 @@ impl Orderbook {
 #[error("order {0} not found in orderbook")]
 pub struct OrderNotFound(OrderId);
 
-/// MakerId is a PeerId wrapper so we control serialization/deserialization.
-#[derive(Debug, Clone, PartialEq)]
-pub struct MakerId(PeerId);
-
-impl From<PeerId> for MakerId {
-    fn from(id: PeerId) -> Self {
-        MakerId(id)
-    }
-}
-
-impl From<MakerId> for PeerId {
-    fn from(id: MakerId) -> Self {
-        id.0
-    }
-}
-
-impl Display for MakerId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0.to_string())
-    }
-}
-
-impl Serialize for MakerId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let string = self.0.to_string();
-        serializer.serialize_str(&string)
-    }
-}
-
-impl<'de> Deserialize<'de> for MakerId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let string = String::deserialize(deserializer)?;
-        let peer_id = PeerId::from_str(&string).map_err(D::Error::custom)?;
-
-        Ok(MakerId(peer_id))
-    }
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-pub enum Message {
-    CreateOrder(Order),
-    DeleteOrder(OrderId),
-}
-
-impl fmt::Debug for Orderbook {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("BasicOrderbook")
-            .field("peer_id", &self.peer_id)
-            .field("orders", &self.orders)
-            .finish()
-    }
-}
-
 /// Event emitted  by the `Orderbook` behaviour.
 #[derive(Debug)]
 pub enum BehaviourOutEvent {
@@ -253,7 +174,7 @@ pub enum BehaviourOutEvent {
         /// The peer from whom request originated.
         peer_id: PeerId,
         /// Channel to send a confirm/deny response on.
-        response_channel: ResponseChannel<Response>,
+        response_channel: ResponseChannel<Confirmation>,
         /// The ID of the order peer wants to take.
         order_id: OrderId,
     },
@@ -277,40 +198,38 @@ pub enum BehaviourOutEvent {
     },
 }
 
-impl NetworkBehaviourEventProcess<GossipsubEvent> for Orderbook {
-    fn inject_event(&mut self, event: GossipsubEvent) {
-        if let GossipsubEvent::Message(_peer_id, message_id, message) = event {
-            let decoded: Message = match bincode::deserialize(&message.data[..]) {
-                Ok(msg) => msg,
-                Err(e) => {
-                    tracing::warn!("deserialization of gossipsub message failed: {}", e);
-                    return;
-                }
-            };
-
-            match decoded {
-                Message::CreateOrder(order) => {
-                    tracing::debug!("received create order message: {}", message_id);
-                    // This implies new orders remove old orders from
-                    // the orderbook. This means nodes can spoof the
-                    // network using previously seen order ids in
-                    // order to override orders.
-                    self.orders.insert(order.id, order);
-                }
-                Message::DeleteOrder(order_id) => {
-                    tracing::debug!("received delete order message: {}", message_id);
-                    // Same consideration here, nodes can cause orders
-                    // they did not create to be removed by spoofing
-                    // the network with a previously seen order id.
-                    self.orders.remove(&order_id);
-                }
+impl NetworkBehaviourEventProcess<makerbook::BehaviourOutEvent> for Orderbook {
+    fn inject_event(&mut self, event: makerbook::BehaviourOutEvent) {
+        match event {
+            makerbook::BehaviourOutEvent::Logout { peer } => {
+                self.order_source.stop_getting_orders_from(&peer);
+                self.orders.remove_all_from(&peer)
             }
         }
     }
 }
 
-impl NetworkBehaviourEventProcess<RequestResponseEvent<OrderId, Response>> for Orderbook {
-    fn inject_event(&mut self, event: RequestResponseEvent<OrderId, Response>) {
+impl NetworkBehaviourEventProcess<order_source::BehaviourOutEvent> for Orderbook {
+    fn inject_event(&mut self, event: order_source::BehaviourOutEvent) {
+        match event {
+            order_source::BehaviourOutEvent::GetOrdersRequest { response_handle } => {
+                self.order_source
+                    .send_orders(response_handle, self.orders.ours().cloned().collect());
+            }
+            order_source::BehaviourOutEvent::RetrievedOrders { maker, orders } => {
+                if !orders.is_empty() {
+                    self.orders.replace(maker, orders);
+                }
+            }
+            order_source::BehaviourOutEvent::MakerIsGone { maker } => {
+                self.orders.remove_all_from(&maker);
+            }
+        }
+    }
+}
+
+impl NetworkBehaviourEventProcess<RequestResponseEvent<OrderId, Confirmation>> for Orderbook {
+    fn inject_event(&mut self, event: RequestResponseEvent<OrderId, Confirmation>) {
         match event {
             RequestResponseEvent::Message {
                 peer: peer_id,
@@ -319,26 +238,30 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<OrderId, Response>> for O
                         request: order_id,
                         channel: response_channel,
                     },
-            } => match self.get_order(&order_id) {
-                Some(_) => {
-                    tracing::info!("received take order request");
+            } => {
+                if self.orders.is_ours(order_id) {
+                    tracing::info!("received take order request for order {}", order_id);
                     self.events.push_back(BehaviourOutEvent::TakeOrderRequest {
                         peer_id,
                         response_channel,
                         order_id,
                     });
+                } else {
+                    tracing::info!(
+                        "received take order request for order {} we never published",
+                        order_id
+                    );
                 }
-                None => tracing::info!("received take order request for non-existent order"),
-            },
+            }
             RequestResponseEvent::Message {
                 peer: peer_id,
                 message:
                     RequestResponseMessage::Response {
                         request_id: _,
                         response:
-                            Response::Confirmation {
-                                order_id,
+                            Confirmation {
                                 shared_swap_id,
+                                order_id,
                             },
                     },
             } => {
@@ -349,17 +272,6 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<OrderId, Response>> for O
                         shared_swap_id,
                     });
             }
-            RequestResponseEvent::Message {
-                peer: peer_id,
-                message:
-                    RequestResponseMessage::Response {
-                        request_id: _,
-                        response: Response::Error,
-                    },
-            } => {
-                // This should be unreachable because we close the channel on error.
-                tracing::error!("received take order response error from peer: {}", peer_id);
-            }
             RequestResponseEvent::OutboundFailure { error, .. } => {
                 tracing::warn!("outbound failure: {:?}", error);
             }
@@ -367,123 +279,5 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<OrderId, Response>> for O
                 tracing::warn!("inbound failure: {:?}", error);
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::network::test::{await_events_or_timeout, new_connected_swarm_pair};
-    use libp2p::Swarm;
-    use spectral::prelude::*;
-
-    #[tokio::test]
-    async fn take_order_request_confirmation() {
-        // arrange
-
-        let (mut alice, mut bob) = new_connected_swarm_pair(Orderbook::new).await;
-        let bob_order = order::meaningless_test_order(MakerId::from(bob.peer_id.clone()));
-
-        // act
-
-        // Trigger subscription to BCT/DAI topic.
-        poll_no_event(&mut alice.swarm).await;
-        poll_no_event(&mut bob.swarm).await;
-
-        let _ = bob
-            .swarm
-            .make(bob_order.clone())
-            .expect("order id should exist");
-
-        // Trigger publish and receipt of order.
-        poll_no_event(&mut bob.swarm).await;
-        poll_no_event(&mut alice.swarm).await;
-
-        let alice_order = alice
-            .swarm
-            .get_orders()
-            .first()
-            .cloned()
-            .expect("Alice has no orders");
-
-        alice
-            .swarm
-            .take(alice_order.id)
-            .expect("failed to take order");
-
-        // Trigger request/response messages.
-        poll_no_event(&mut alice.swarm).await;
-        let bob_event = tokio::time::timeout(Duration::from_secs(2), bob.swarm.next())
-            .await
-            .expect("failed to get TakeOrderRequest event");
-
-        let (alice_peer_id, channel, order_id) = match bob_event {
-            BehaviourOutEvent::TakeOrderRequest {
-                peer_id,
-                response_channel,
-                order_id,
-            } => (peer_id, response_channel, order_id),
-            _ => panic!("unexepected bob event"),
-        };
-        bob.swarm.confirm(order_id, channel, alice_peer_id);
-
-        let (alice_event, bob_event) =
-            await_events_or_timeout(alice.swarm.next(), bob.swarm.next()).await;
-        match (alice_event, bob_event) {
-            (
-                BehaviourOutEvent::TakeOrderConfirmation {
-                    peer_id: alice_got_peer_id,
-                    order_id: alice_got_order_id,
-                    shared_swap_id: alice_got_swap_id,
-                },
-                BehaviourOutEvent::TakeOrderConfirmation {
-                    peer_id: bob_got_peer_id,
-                    order_id: bob_got_order_id,
-                    shared_swap_id: bob_got_swap_id,
-                },
-            ) => {
-                assert_eq!(alice_got_peer_id, bob.peer_id);
-                assert_eq!(bob_got_peer_id, alice.peer_id);
-
-                assert_eq!(alice_got_order_id, alice_order.id);
-                assert_eq!(bob_got_order_id, alice_got_order_id);
-
-                assert_eq!(alice_got_swap_id, bob_got_swap_id);
-            }
-            _ => panic!("failed to get take order confirmation"),
-        }
-    }
-
-    // Poll the swarm for some time, we don't expect any events though.
-    async fn poll_no_event(swarm: &mut Swarm<Orderbook>) {
-        let delay = Duration::from_secs(2);
-
-        while let Ok(event) = tokio::time::timeout(delay, swarm.next()).await {
-            panic!("unexpected event emitted: {:?}", event)
-        }
-    }
-
-    #[test]
-    fn maker_id_serializes_as_expected() {
-        let given = "QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY".to_string();
-        let peer_id = PeerId::from_str(&given).expect("failed to parse peer id");
-        let maker_id = MakerId(peer_id);
-
-        let want = format!("\"{}\"", given);
-        let got = serde_json::to_string(&maker_id).expect("failed to serialize peer id");
-
-        assert_that(&got).is_equal_to(want);
-    }
-
-    #[test]
-    fn maker_id_serialization_roundtrip_test() {
-        let s = "QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY".to_string();
-        let peer_id = PeerId::from_str(&s).expect("failed to parse peer id");
-        let maker_id = MakerId::from(peer_id);
-
-        let json = serde_json::to_string(&maker_id).expect("failed to serialize peer id");
-        let rinsed: MakerId = serde_json::from_str(&json).expect("failed to deserialize peer id");
-
-        assert_that(&maker_id).is_equal_to(rinsed);
     }
 }

--- a/comit/src/network/orderbook/makerbook.rs
+++ b/comit/src/network/orderbook/makerbook.rs
@@ -1,0 +1,169 @@
+use conquer_once::Lazy;
+use libp2p::{
+    gossipsub::{
+        Gossipsub, GossipsubConfigBuilder, GossipsubEvent, GossipsubMessage, GossipsubRpc,
+        MessageId, Topic,
+    },
+    swarm::{
+        DialPeerCondition, NetworkBehaviourAction, NetworkBehaviourEventProcess, PollParameters,
+    },
+    NetworkBehaviour, PeerId,
+};
+use std::{
+    collections::{hash_map::DefaultHasher, VecDeque},
+    hash::{Hash, Hasher},
+    task::{Context, Poll},
+    time::Duration,
+};
+
+static COMIT_MAKERS: Lazy<Topic> = Lazy::new(|| Topic::new("/comit/makers".to_string()));
+
+#[derive(Debug)]
+pub enum BehaviourOutEvent {
+    /// The given peer is no longer available for trading the given trading
+    /// pair.
+    ///
+    /// Connections to this peer can be closed as a result of this event.
+    Logout { peer: PeerId },
+}
+
+/// A [NetworkBehaviour] for discovering peers that are likely to trade with us.
+///
+/// The functional scope of this [NetworkBehaviour] is to establish connections
+/// to interesting peers. Once the connections are established, other modules
+/// can utilize these connection for executing trading protocols.
+#[derive(NetworkBehaviour)]
+#[behaviour(poll_method = "poll", out_event = "BehaviourOutEvent")]
+#[allow(missing_debug_implementations)]
+pub struct Makerbook {
+    gossipsub: Gossipsub,
+
+    #[behaviour(ignore)]
+    actions: VecDeque<NetworkBehaviourAction<GossipsubRpc, BehaviourOutEvent>>,
+}
+
+impl Makerbook {
+    pub fn new(me: PeerId) -> Self {
+        let mut gossipsub = Gossipsub::new(
+            me,
+            GossipsubConfigBuilder::new()
+                .heartbeat_interval(Duration::from_secs(1))
+                .message_id_fn(content_based_id)
+                .build(),
+        );
+
+        gossipsub.subscribe(COMIT_MAKERS.clone());
+
+        Self {
+            gossipsub,
+            actions: VecDeque::default(),
+        }
+    }
+
+    pub fn login(&mut self) {
+        let message = serde_json::to_vec(&wire::Message::Login {
+            trading_pair: wire::TradingPair::BtcDai,
+        })
+        .expect("serialization doesn't panic");
+        self.gossipsub.publish(&COMIT_MAKERS, message);
+    }
+
+    pub fn logout(&mut self) {
+        let message = serde_json::to_vec(&wire::Message::Logout {
+            trading_pair: wire::TradingPair::BtcDai,
+        })
+        .expect("serialization doesn't panic");
+        self.gossipsub.publish(&COMIT_MAKERS, message);
+    }
+
+    fn poll(
+        &mut self,
+        _: &mut Context<'_>,
+        _: &mut impl PollParameters,
+    ) -> Poll<NetworkBehaviourAction<GossipsubRpc, BehaviourOutEvent>> {
+        if let Some(action) = self.actions.pop_front() {
+            return Poll::Ready(action);
+        }
+
+        Poll::Pending
+    }
+}
+
+impl NetworkBehaviourEventProcess<GossipsubEvent> for Makerbook {
+    fn inject_event(&mut self, event: GossipsubEvent) {
+        if let GossipsubEvent::Message(relayed_from, _, message) = event {
+            let source = message.source;
+            let message = match serde_json::from_slice::<wire::Message>(&message.data) {
+                Ok(message) => message,
+                Err(e) => {
+                    tracing::debug!("receives malformed message from {}: {:?}", relayed_from, e);
+                    return;
+                }
+            };
+
+            match message {
+                wire::Message::Login { trading_pair } => {
+                    tracing::info!(
+                        "{} announced that they are trading {}, dialling ...",
+                        source,
+                        trading_pair
+                    );
+                    self.actions.push_back(NetworkBehaviourAction::DialPeer {
+                        peer_id: source,
+                        condition: DialPeerCondition::NotDialing, /* we only want to establish a
+                                                                   * connection in case we don't
+                                                                   * already have one */
+                    });
+                }
+                wire::Message::Logout { trading_pair } => {
+                    tracing::info!(
+                        "{} is no longer available for trading {}",
+                        source,
+                        trading_pair
+                    );
+                    self.actions
+                        .push_back(NetworkBehaviourAction::GenerateEvent(
+                            BehaviourOutEvent::Logout { peer: source },
+                        ))
+                }
+            }
+        }
+    }
+}
+
+fn content_based_id(message: &GossipsubMessage) -> MessageId {
+    let mut s = DefaultHasher::new();
+    message.data.hash(&mut s);
+    MessageId(s.finish().to_string())
+}
+
+mod wire {
+    use serde::{Deserialize, Serialize};
+    use std::fmt;
+
+    /// All messages sent to the `/comit/makers` topic.
+    #[derive(Debug, Serialize, Deserialize)]
+    pub enum Message {
+        /// Informs all subscribers that the source peer is online and ready to
+        /// trade the given trading pair.
+        Login { trading_pair: TradingPair },
+        /// Informs all subscribers that the source peers is going offline and
+        /// no longer available for trading the given trading pair.
+        Logout { trading_pair: TradingPair },
+    }
+
+    /// Defines the set of trading pairs that we support.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    pub enum TradingPair {
+        #[serde(rename = "BTC/DAI")]
+        BtcDai,
+    }
+
+    impl fmt::Display for TradingPair {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", match self {
+                TradingPair::BtcDai => "BTC/DAI",
+            })
+        }
+    }
+}

--- a/comit/src/network/orderbook/order.rs
+++ b/comit/src/network/orderbook/order.rs
@@ -1,24 +1,8 @@
-use crate::{asset, identity, ledger, network::orderbook::MakerId};
+use crate::{asset, identity, ledger};
+use libp2p::PeerId;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, str::FromStr};
 use uuid::Uuid;
-
-/// An order, created by a maker (Bob) and shared with the network via
-/// gossipsub.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct Order {
-    pub id: OrderId,
-    pub maker: MakerId,
-    pub position: Position,
-    #[serde(with = "asset::bitcoin::sats_as_string")]
-    pub bitcoin_amount: asset::Bitcoin,
-    pub bitcoin_ledger: ledger::Bitcoin,
-    pub bitcoin_absolute_expiry: u32,
-    pub ethereum_amount: asset::Erc20Quantity,
-    pub token_contract: identity::Ethereum,
-    pub ethereum_ledger: ledger::Ethereum,
-    pub ethereum_absolute_expiry: u32,
-}
 
 #[derive(Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OrderId(Uuid);
@@ -27,12 +11,6 @@ impl OrderId {
     pub fn random() -> OrderId {
         OrderId(Uuid::new_v4())
     }
-}
-
-#[cfg(test)]
-fn meaningless_test_order_id() -> OrderId {
-    let uuid = Uuid::parse_str("936DA01F9ABD4d9d80C702AF85C822A8").unwrap();
-    OrderId(uuid)
 }
 
 impl Display for OrderId {
@@ -50,25 +28,45 @@ impl FromStr for OrderId {
     }
 }
 
-#[cfg(test)]
-pub fn meaningless_test_order(maker: MakerId) -> Order {
-    Order {
-        id: meaningless_test_order_id(),
-        maker,
-        position: Position::Sell,
-        bitcoin_amount: asset::Bitcoin::meaningless_test_value(),
-        bitcoin_ledger: ledger::Bitcoin::Regtest,
-        bitcoin_absolute_expiry: meaningless_expiry_value(),
-        ethereum_amount: asset::Erc20Quantity::meaningless_test_value(),
-        token_contract: Default::default(),
-        ethereum_ledger: ledger::Ethereum::default(),
-        ethereum_absolute_expiry: meaningless_expiry_value(),
+/// Represents a "form" that contains all data for creating a new order.
+#[derive(Debug)]
+pub struct NewOrder {
+    pub position: Position,
+    pub bitcoin_amount: asset::Bitcoin,
+    pub bitcoin_ledger: ledger::Bitcoin,
+    pub bitcoin_absolute_expiry: u32,
+    pub ethereum_amount: asset::Erc20Quantity,
+    pub token_contract: identity::Ethereum,
+    pub ethereum_ledger: ledger::Ethereum,
+    pub ethereum_absolute_expiry: u32,
+}
+
+impl NewOrder {
+    // TODO: I think this should live in the controller an be asserted before we
+    // construct the type
+    pub fn assert_valid_ledger_pair(&self) -> anyhow::Result<()> {
+        let a = self.bitcoin_ledger;
+        let b = self.ethereum_ledger;
+
+        if ledger::is_valid_ledger_pair(a, b) {
+            return Ok(());
+        }
+        Err(anyhow::anyhow!("invalid ledger pair {}/{}", a, b))
     }
 }
 
-#[cfg(test)]
-fn meaningless_expiry_value() -> u32 {
-    100
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Order {
+    pub id: OrderId,
+    pub maker: PeerId,
+    pub position: Position,
+    pub bitcoin_amount: asset::Bitcoin,
+    pub bitcoin_ledger: ledger::Bitcoin,
+    pub bitcoin_absolute_expiry: u32,
+    pub ethereum_amount: asset::Erc20Quantity,
+    pub token_contract: identity::Ethereum,
+    pub ethereum_ledger: ledger::Ethereum,
+    pub ethereum_absolute_expiry: u32,
 }
 
 /// The position of the maker for this order. A BTC/DAI buy order,
@@ -81,82 +79,9 @@ fn meaningless_expiry_value() -> u32 {
 /// (i.e., quote currency) and amount as is commonly done in Forex
 /// trading. We use the amounts of each currency to determine the
 /// rate.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum Position {
     Buy,
     Sell,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use libp2p::PeerId;
-    use spectral::prelude::*;
-
-    #[test]
-    fn order_id_serialization_roundtrip() {
-        let order_id = meaningless_test_order_id();
-        let json = serde_json::to_string(&order_id).expect("failed to serialize order id");
-        let rinsed: OrderId = serde_json::from_str(&json).expect("failed to deserialize order id");
-        assert_that(&rinsed).is_equal_to(&order_id);
-    }
-
-    #[test]
-    fn order_id_serialization_stability() {
-        let s = "936DA01F9ABD4d9d80C702AF85C822A8";
-        let uuid = Uuid::from_str(s).expect("failed to parse uuid string");
-        let order_id = OrderId(uuid);
-
-        let want = "\"936da01f-9abd-4d9d-80c7-02af85c822a8\"".to_string();
-        let got = serde_json::to_string(&order_id).expect("failed to serialize order id");
-        assert_that(&got).is_equal_to(want);
-    }
-
-    #[test]
-    fn btc_dai_order_serialization_stability() {
-        let given = "QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY".to_string();
-        let peer_id = PeerId::from_str(&given).expect("failed to parse peer id");
-        let maker_id = MakerId(peer_id);
-
-        let order = Order {
-            id: meaningless_test_order_id(),
-            maker: maker_id,
-            position: Position::Sell,
-            bitcoin_amount: asset::Bitcoin::meaningless_test_value(),
-            bitcoin_ledger: ledger::Bitcoin::Regtest,
-            bitcoin_absolute_expiry: meaningless_expiry_value(),
-            ethereum_amount: asset::Erc20Quantity::meaningless_test_value(),
-            token_contract: Default::default(),
-            ethereum_ledger: ledger::Ethereum::default(),
-            ethereum_absolute_expiry: meaningless_expiry_value(),
-        };
-
-        let got = serde_json::to_string(&order).expect("failed to serialize order");
-        let want = r#"{"id":"936da01f-9abd-4d9d-80c7-02af85c822a8","maker":"QmfUfpC2frwFvcDzpspnfZitHt5wct6n4kpG5jzgRdsxkY","position":"sell","bitcoin_amount":"1000","bitcoin_ledger":"regtest","bitcoin_absolute_expiry":100,"ethereum_amount":"1000","token_contract":"0x0000000000000000000000000000000000000000","ethereum_ledger":{"chain_id":1337},"ethereum_absolute_expiry":100}"#.to_string();
-        assert_that(&got).is_equal_to(want);
-    }
-
-    #[test]
-    fn trade_serialization_roundtrip() {
-        let trade = Position::Buy;
-        let json = serde_json::to_string(&trade).expect("failed to serialize trade");
-        let rinsed: Position = serde_json::from_str(&json).expect("failed to deserialize trade");
-
-        assert_that(&rinsed).is_equal_to(&trade);
-    }
-
-    #[test]
-    fn trade_buy_serialization_stability() {
-        let trade = Position::Buy;
-        let s = serde_json::to_string(&trade).expect("failed to serialize trade");
-        assert_that(&s).is_equal_to(r#""buy""#.to_string());
-    }
-
-    #[test]
-    fn trade_sell_serialization_stability() {
-        let trade = Position::Sell;
-        let s = serde_json::to_string(&trade).expect("failed to serialize trade");
-        assert_that(&s).is_equal_to(r#""sell""#.to_string());
-    }
 }

--- a/comit/src/network/orderbook/order_source.rs
+++ b/comit/src/network/orderbook/order_source.rs
@@ -1,0 +1,456 @@
+use crate::network::orderbook::Order;
+use futures::{AsyncRead, AsyncWrite};
+use libp2p::{
+    core::{
+        connection::{ConnectionId, ListenerId},
+        upgrade, ConnectedPoint,
+    },
+    request_response::{
+        handler::{RequestProtocol, RequestResponseHandlerEvent},
+        ProtocolName, ProtocolSupport, RequestResponse, RequestResponseCodec,
+        RequestResponseConfig, RequestResponseEvent, RequestResponseMessage, ResponseChannel,
+    },
+    swarm::{NetworkBehaviour, NetworkBehaviourAction, PollParameters},
+    Multiaddr, PeerId,
+};
+use serde::Deserialize;
+use std::{
+    collections::{HashSet, VecDeque},
+    error::Error,
+    io,
+    task::{Context, Poll},
+    time::{Duration, Instant},
+};
+
+/// Wait at least this long before re-getting orders from a maker.
+const POLLING_INTERVAL: Duration = Duration::from_secs(5);
+
+/// A [NetworkBehaviour] that acts as a source for orders.
+///
+/// Orders are pulled regularly from a given set of makers. Every connection
+/// established will be tried as a potential order source.
+#[allow(missing_debug_implementations)]
+pub struct OrderSource {
+    get_orders: RequestResponse<GetBtcDaiOrdersCodec>,
+    /// Makers we will attempt to get updated orders from.
+    active_makers: HashSet<PeerId>,
+    last_polled_makers_at: Instant,
+    actions:
+        VecDeque<NetworkBehaviourAction<RequestProtocol<GetBtcDaiOrdersCodec>, BehaviourOutEvent>>,
+}
+
+impl OrderSource {
+    /// Start getting orders from this peer.
+    pub fn start_getting_orders_from(&mut self, maker: PeerId) {
+        self.active_makers.insert(maker);
+    }
+
+    pub fn stop_getting_orders_from(&mut self, maker: &PeerId) {
+        self.active_makers.remove(maker);
+    }
+
+    /// Respond to a get orders request.
+    pub fn send_orders(&mut self, handle: ResponseHandle, orders: Vec<Order>) {
+        self.get_orders.send_response(
+            handle.0,
+            orders.into_iter().map(wire::Order::from_model).collect(),
+        );
+    }
+
+    fn is_time_to_update_orders(&self) -> bool {
+        Instant::now().duration_since(self.last_polled_makers_at) > POLLING_INTERVAL
+    }
+}
+
+impl NetworkBehaviour for OrderSource {
+    type ProtocolsHandler =
+        <RequestResponse<GetBtcDaiOrdersCodec> as NetworkBehaviour>::ProtocolsHandler;
+    type OutEvent = BehaviourOutEvent;
+
+    fn new_handler(&mut self) -> Self::ProtocolsHandler {
+        self.get_orders.new_handler()
+    }
+
+    fn addresses_of_peer(&mut self, peer_id: &PeerId) -> Vec<Multiaddr> {
+        self.get_orders.addresses_of_peer(peer_id)
+    }
+
+    fn inject_connected(&mut self, peer_id: &PeerId) {
+        self.get_orders.inject_connected(peer_id);
+        self.active_makers.insert(peer_id.clone());
+
+        tracing::debug!("connected to {}, attempting to get orders", peer_id);
+
+        // try and get orders through this connection as soon as it is available
+        self.get_orders.send_request(peer_id, ());
+    }
+
+    fn inject_disconnected(&mut self, peer_id: &PeerId) {
+        self.get_orders.inject_disconnected(peer_id);
+        self.active_makers.remove(peer_id);
+        self.actions
+            .push_back(NetworkBehaviourAction::GenerateEvent(
+                BehaviourOutEvent::MakerIsGone {
+                    maker: peer_id.clone(),
+                },
+            ));
+    }
+
+    fn inject_connection_established(
+        &mut self,
+        peer: &PeerId,
+        connection_id: &ConnectionId,
+        connected_point: &ConnectedPoint,
+    ) {
+        self.get_orders
+            .inject_connection_established(peer, connection_id, connected_point)
+    }
+
+    fn inject_connection_closed(
+        &mut self,
+        peer: &PeerId,
+        connection_id: &ConnectionId,
+        connected_point: &ConnectedPoint,
+    ) {
+        self.get_orders
+            .inject_connection_closed(peer, connection_id, connected_point);
+    }
+
+    fn inject_address_change(
+        &mut self,
+        peer: &PeerId,
+        connection_id: &ConnectionId,
+        old: &ConnectedPoint,
+        new: &ConnectedPoint,
+    ) {
+        self.get_orders
+            .inject_address_change(peer, connection_id, old, new)
+    }
+
+    fn inject_event(
+        &mut self,
+        peer_id: PeerId,
+        connection: ConnectionId,
+        event: RequestResponseHandlerEvent<GetBtcDaiOrdersCodec>,
+    ) {
+        self.get_orders.inject_event(peer_id, connection, event)
+    }
+
+    fn inject_addr_reach_failure(
+        &mut self,
+        peer_id: Option<&PeerId>,
+        addr: &Multiaddr,
+        error: &dyn Error,
+    ) {
+        self.get_orders
+            .inject_addr_reach_failure(peer_id, addr, error)
+    }
+
+    fn inject_dial_failure(&mut self, peer_id: &PeerId) {
+        self.get_orders.inject_dial_failure(peer_id)
+    }
+
+    fn inject_new_listen_addr(&mut self, addr: &Multiaddr) {
+        self.get_orders.inject_new_listen_addr(addr)
+    }
+
+    fn inject_expired_listen_addr(&mut self, addr: &Multiaddr) {
+        self.get_orders.inject_expired_listen_addr(addr)
+    }
+
+    fn inject_new_external_addr(&mut self, addr: &Multiaddr) {
+        self.get_orders.inject_new_external_addr(addr)
+    }
+
+    fn inject_listener_error(&mut self, id: ListenerId, err: &(dyn Error + 'static)) {
+        self.get_orders.inject_listener_error(id, err)
+    }
+
+    fn inject_listener_closed(&mut self, id: ListenerId, reason: Result<(), &std::io::Error>) {
+        self.get_orders.inject_listener_closed(id, reason)
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context<'_>,
+        params: &mut impl PollParameters,
+    ) -> Poll<NetworkBehaviourAction<RequestProtocol<GetBtcDaiOrdersCodec>, Self::OutEvent>> {
+        match self.get_orders.poll(cx, params) {
+            Poll::Ready(NetworkBehaviourAction::GenerateEvent(event)) => match event {
+                RequestResponseEvent::Message {
+                    peer: _,
+                    message:
+                        RequestResponseMessage::Request {
+                            channel: response_channel,
+                            ..
+                        },
+                } => {
+                    return Poll::Ready(NetworkBehaviourAction::GenerateEvent(
+                        BehaviourOutEvent::GetOrdersRequest {
+                            response_handle: ResponseHandle(response_channel),
+                        },
+                    ))
+                }
+                RequestResponseEvent::Message {
+                    peer: peer_id,
+                    message:
+                        RequestResponseMessage::Response {
+                            response: orders, ..
+                        },
+                } => {
+                    tracing::debug!("fetched {} orders from {}", orders.len(), peer_id);
+
+                    return Poll::Ready(NetworkBehaviourAction::GenerateEvent(
+                        BehaviourOutEvent::RetrievedOrders {
+                            maker: peer_id.clone(),
+                            orders: orders
+                                .into_iter()
+                                .map(move |order| order.into_model(peer_id.clone()))
+                                .collect(),
+                        },
+                    ));
+                }
+                RequestResponseEvent::OutboundFailure { error, peer, .. } => {
+                    self.active_makers.remove(&peer);
+
+                    tracing::info!("removing {} as a potential order source because we failed to establish a connection to them: {:?}", peer, error);
+                }
+                RequestResponseEvent::InboundFailure { error, .. } => {
+                    // TODO: stop fetching orders from this peer?
+                    tracing::warn!("inbound failure: {:?}", error);
+                }
+            },
+            Poll::Ready(NetworkBehaviourAction::DialPeer { peer_id, condition }) => {
+                return Poll::Ready(NetworkBehaviourAction::DialPeer { peer_id, condition })
+            }
+            Poll::Ready(NetworkBehaviourAction::NotifyHandler {
+                peer_id,
+                event,
+                handler,
+            }) => {
+                return Poll::Ready(NetworkBehaviourAction::NotifyHandler {
+                    peer_id,
+                    event,
+                    handler,
+                })
+            }
+            Poll::Ready(NetworkBehaviourAction::DialAddress { address }) => {
+                return Poll::Ready(NetworkBehaviourAction::DialAddress { address })
+            }
+            Poll::Ready(NetworkBehaviourAction::ReportObservedAddr { address }) => {
+                return Poll::Ready(NetworkBehaviourAction::ReportObservedAddr { address })
+            }
+            Poll::Pending => {}
+        }
+
+        if self.is_time_to_update_orders() {
+            self.last_polled_makers_at = Instant::now();
+            for id in &self.active_makers {
+                self.get_orders.send_request(&id, ());
+            }
+        }
+
+        if let Some(action) = self.actions.pop_front() {
+            return Poll::Ready(action);
+        }
+
+        Poll::Pending
+    }
+}
+
+impl Default for OrderSource {
+    fn default() -> Self {
+        let config = RequestResponseConfig::default();
+        let behaviour = RequestResponse::new(
+            GetBtcDaiOrdersCodec::default(),
+            vec![(GetBtcDaiOrdersProtocol, ProtocolSupport::Full)],
+            config,
+        );
+
+        Self {
+            get_orders: behaviour,
+            active_makers: HashSet::default(),
+            last_polled_makers_at: Instant::now(),
+            actions: VecDeque::default(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum BehaviourOutEvent {
+    /// Our orders are being requested by another peer.
+    GetOrdersRequest { response_handle: ResponseHandle },
+    /// We retrieved orders from the given maker.
+    RetrievedOrders { maker: PeerId, orders: Vec<Order> },
+    /// The given maker disconnected.
+    ///
+    /// It is unlikely that they will respond to any of their orders published
+    /// in the past. We will also stop attempting to get new orders from
+    /// them after this event has been emitted.
+    MakerIsGone { maker: PeerId },
+}
+
+/// An opaque response handle required for sending back orders.
+///
+/// This type allows us to keep the `wire` module private to this module.
+#[derive(Debug)]
+pub struct ResponseHandle(ResponseChannel<Vec<wire::Order>>);
+
+#[derive(Debug, Clone, Copy)]
+pub struct GetBtcDaiOrdersProtocol;
+
+impl ProtocolName for GetBtcDaiOrdersProtocol {
+    fn protocol_name(&self) -> &[u8] {
+        b"/comit/get-orders/btc-dai/1.0.0"
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct GetBtcDaiOrdersCodec;
+
+#[async_trait::async_trait]
+impl RequestResponseCodec for GetBtcDaiOrdersCodec {
+    type Protocol = GetBtcDaiOrdersProtocol;
+    type Request = ();
+    // TODO: Allow a response of "I am not a maker" to stop asking them.
+    type Response = Vec<wire::Order>;
+
+    /// Reads a get orders request from the given I/O stream.
+    async fn read_request<T>(&mut self, _: &Self::Protocol, _: &mut T) -> io::Result<Self::Request>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        Ok(())
+    }
+
+    /// Reads a response (to a get orders request) from the given I/O stream.
+    async fn read_response<T>(
+        &mut self,
+        _: &Self::Protocol,
+        io: &mut T,
+    ) -> io::Result<Self::Response>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        let message = upgrade::read_one(io, 1024)
+            .await
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let mut de = serde_json::Deserializer::from_slice(&message);
+        let orders = Vec::<wire::Order>::deserialize(&mut de)?;
+
+        Ok(orders)
+    }
+
+    /// Writes a get orders request to the given I/O stream.
+    #[allow(clippy::unit_arg)]
+    async fn write_request<T>(
+        &mut self,
+        _: &Self::Protocol,
+        _: &mut T,
+        _: Self::Request,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        Ok(())
+    }
+
+    /// Writes a response (to a get orders request) to the given I/O stream.
+    async fn write_response<T>(
+        &mut self,
+        _: &Self::Protocol,
+        io: &mut T,
+        orders: Self::Response,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        let bytes = serde_json::to_vec(&orders)?;
+        upgrade::write_one(io, &bytes).await?;
+
+        Ok(())
+    }
+}
+
+/// A dedicated module for the types that represent our messages "on the wire".
+mod wire {
+    use crate::{
+        asset, identity, ledger,
+        network::{orderbook::Position, OrderId},
+    };
+    use serde::{Deserialize, Serialize};
+
+    /// An order, created by a maker (Bob) and shared with the network via
+    /// gossipsub.
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+    pub struct Order {
+        pub id: OrderId,
+        pub position: Position,
+        #[serde(with = "asset::bitcoin::sats_as_string")]
+        pub bitcoin_amount: asset::Bitcoin,
+        pub bitcoin_ledger: ledger::Bitcoin,
+        pub bitcoin_absolute_expiry: u32,
+        pub ethereum_amount: asset::Erc20Quantity,
+        pub token_contract: identity::Ethereum,
+        pub ethereum_ledger: ledger::Ethereum,
+        pub ethereum_absolute_expiry: u32,
+    }
+}
+
+impl wire::Order {
+    fn into_model(self, maker: PeerId) -> Order {
+        let wire::Order {
+            id,
+            position,
+            bitcoin_amount,
+            bitcoin_ledger,
+            bitcoin_absolute_expiry,
+            ethereum_amount,
+            token_contract,
+            ethereum_ledger,
+            ethereum_absolute_expiry,
+        } = self;
+        let position = position;
+
+        Order {
+            id,
+            maker,
+            position,
+            bitcoin_amount,
+            bitcoin_ledger,
+            bitcoin_absolute_expiry,
+            ethereum_amount,
+            token_contract,
+            ethereum_ledger,
+            ethereum_absolute_expiry,
+        }
+    }
+
+    fn from_model(order: Order) -> Self {
+        let Order {
+            id,
+            position,
+            bitcoin_amount,
+            bitcoin_ledger,
+            bitcoin_absolute_expiry,
+            ethereum_amount,
+            token_contract,
+            ethereum_ledger,
+            ethereum_absolute_expiry,
+            ..
+        } = order;
+        let position = position;
+
+        Self {
+            id,
+            position,
+            bitcoin_amount,
+            bitcoin_ledger,
+            bitcoin_absolute_expiry,
+            ethereum_amount,
+            token_contract,
+            ethereum_ledger,
+            ethereum_absolute_expiry,
+        }
+    }
+}

--- a/comit/src/network/orderbook/orders.rs
+++ b/comit/src/network/orderbook/orders.rs
@@ -1,0 +1,121 @@
+use crate::network::{
+    orderbook::{Order, OrderId},
+    NewOrder,
+};
+use libp2p::PeerId;
+use std::collections::HashMap;
+
+/// A collection of orders gathered from several makers.
+#[derive(Clone, Debug)]
+pub struct Orders {
+    inner: HashMap<PeerId, HashMap<OrderId, Order>>,
+    /// Our own id.
+    ///
+    /// Allows us to filter out our own orders.
+    me: PeerId,
+}
+
+impl Orders {
+    pub fn new(me: PeerId) -> Self {
+        Self {
+            inner: HashMap::default(),
+            me,
+        }
+    }
+
+    /// Get the peer id of the maker of this order.
+    pub fn maker_id(&self, id: OrderId) -> Option<PeerId> {
+        for (maker, orders) in self.inner.iter() {
+            if orders.get(&id).is_some() {
+                return Some(maker.clone());
+            }
+        }
+        None
+    }
+
+    pub fn new_order(&mut self, form: NewOrder) -> OrderId {
+        let id = OrderId::random();
+
+        let order = Order {
+            id,
+            maker: self.me.clone(),
+            position: form.position,
+            bitcoin_amount: form.bitcoin_amount,
+            bitcoin_ledger: form.bitcoin_ledger,
+            bitcoin_absolute_expiry: form.bitcoin_absolute_expiry,
+            ethereum_amount: form.ethereum_amount,
+            token_contract: form.token_contract,
+            ethereum_ledger: form.ethereum_ledger,
+            ethereum_absolute_expiry: form.ethereum_absolute_expiry,
+        };
+
+        self.inner
+            .entry(self.me.clone())
+            .or_default()
+            .insert(id, order);
+
+        tracing::info!("created new order with id {}", id);
+
+        id
+    }
+
+    /// Replaces the orders for this maker with the given list of orders.
+    pub fn replace(&mut self, maker: PeerId, orders: Vec<Order>) {
+        let mut map = HashMap::with_capacity(orders.len());
+        for order in orders.into_iter() {
+            map.insert(order.id, order);
+        }
+
+        self.inner.insert(maker, map);
+    }
+
+    pub fn remove_all_from(&mut self, maker: &PeerId) {
+        self.inner.remove(maker);
+    }
+
+    pub fn clear_own_orders(&mut self) {
+        self.inner.remove(&self.me);
+    }
+
+    pub fn cancel(&mut self, id: OrderId) {
+        self.remove_ours(id);
+    }
+
+    pub fn remove_ours(&mut self, id: OrderId) -> Option<Order> {
+        if let Some(map) = self.inner.get_mut(&self.me) {
+            return map.remove(&id);
+        }
+        None
+    }
+
+    pub fn all(&self) -> impl Iterator<Item = &Order> {
+        self.inner.values().flat_map(|orders| orders.values())
+    }
+
+    pub fn theirs(&self) -> impl Iterator<Item = &Order> {
+        let me = &self.me;
+
+        self.inner
+            .iter()
+            .filter_map(move |(maker, orders)| {
+                if maker != me {
+                    Some(orders.values())
+                } else {
+                    None
+                }
+            })
+            .flatten()
+    }
+
+    pub fn ours(&self) -> impl Iterator<Item = &Order> {
+        self.inner
+            .get(&self.me)
+            .map(|orders| orders.values())
+            .into_iter()
+            .flatten()
+    }
+
+    pub fn is_ours(&self, id: OrderId) -> bool {
+        self.ours().any(|o| o.id == id)
+    }
+}

--- a/comit/src/network/orderbook/take_order.rs
+++ b/comit/src/network/orderbook/take_order.rs
@@ -1,43 +1,38 @@
 use crate::{network::OrderId, SharedSwapId};
-use futures::{prelude::*, AsyncWriteExt};
+use futures::prelude::*;
 use libp2p::{
     core::upgrade,
     request_response::{ProtocolName, RequestResponseCodec},
 };
 use serde::{Deserialize, Serialize};
 use std::io;
-use tracing::debug;
 
 #[derive(Debug, Clone, Copy)]
 pub struct TakeOrderProtocol;
 
 impl ProtocolName for TakeOrderProtocol {
     fn protocol_name(&self) -> &[u8] {
-        b"/comit/orderbook/take/1.0.0"
+        b"/comit/take-order/1.0.0"
     }
 }
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct TakeOrderCodec;
 
-/// The different responses we can send back as part of an announcement.
-///
-/// For now, this only includes a generic error variant in addition to the
-/// confirmation because we simply close the connection in case of an error.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-pub enum Response {
-    Confirmation {
-        order_id: OrderId,
-        shared_swap_id: SharedSwapId,
-    },
-    Error,
+#[derive(Clone, Debug, Serialize, Deserialize, Copy)]
+pub struct Confirmation {
+    pub shared_swap_id: SharedSwapId,
+    // TODO: We should store this locally, the context of the substream should be good enough to
+    // know which order was confirmed, no need to send this across the wire again. See "context" in
+    // announce protocol.
+    pub order_id: OrderId,
 }
 
 #[async_trait::async_trait]
 impl RequestResponseCodec for TakeOrderCodec {
     type Protocol = TakeOrderProtocol;
     type Request = OrderId;
-    type Response = Response;
+    type Response = Confirmation;
 
     /// Reads a take order request from the given I/O stream.
     async fn read_request<T>(&mut self, _: &Self::Protocol, io: &mut T) -> io::Result<Self::Request>
@@ -49,7 +44,6 @@ impl RequestResponseCodec for TakeOrderCodec {
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         let mut de = serde_json::Deserializer::from_slice(&message);
         let order_id = OrderId::deserialize(&mut de)?;
-        debug!("read request order id: {}", order_id);
 
         Ok(order_id)
     }
@@ -67,7 +61,7 @@ impl RequestResponseCodec for TakeOrderCodec {
             .await
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         let mut de = serde_json::Deserializer::from_slice(&message);
-        let res = Response::deserialize(&mut de)?;
+        let res = Confirmation::deserialize(&mut de)?;
 
         Ok(res)
     }
@@ -82,7 +76,6 @@ impl RequestResponseCodec for TakeOrderCodec {
     where
         T: AsyncWrite + Unpin + Send,
     {
-        debug!("writing request order id: {}", req);
         let bytes = serde_json::to_vec(&req)?;
         upgrade::write_one(io, &bytes).await?;
 
@@ -99,19 +92,8 @@ impl RequestResponseCodec for TakeOrderCodec {
     where
         T: AsyncWrite + Unpin + Send,
     {
-        match res {
-            Response::Confirmation { .. } => {
-                let bytes = serde_json::to_vec(&res)?;
-                upgrade::write_one(io, &bytes).await?;
-            }
-            Response::Error => {
-                debug!("closing write response channel");
-                // For now, errors just close the substream. We can
-                // send actual error responses at a later point. A
-                // denied take order request is defined as an error.
-                let _ = io.close().await;
-            }
-        }
+        let bytes = serde_json::to_vec(&res)?;
+        upgrade::write_one(io, &bytes).await?;
 
         Ok(())
     }

--- a/digest-macro-derive/src/lib.rs
+++ b/digest-macro-derive/src/lib.rs
@@ -84,19 +84,13 @@ fn impl_digest_macro(ast: &syn::DeriveInput) -> TokenStream {
             let tuple_variant_idents = data
                 .variants
                 .iter()
-                .filter(|variant| match variant.fields {
-                    Fields::Unnamed(_) => true,
-                    _ => false,
-                })
+                .filter(|variant| matches!(variant.fields, Fields::Unnamed(_)))
                 .map(|variant| &variant.ident);
 
             let tuple_variant_bytes = data
                 .variants
                 .iter()
-                .filter(|variant| match variant.fields {
-                    Fields::Unnamed(_) => true,
-                    _ => false,
-                })
+                .filter(|variant| matches!(variant.fields, Fields::Unnamed(_)))
                 .map(|variant| extract_bytes(&variant.attrs));
 
             let gen = quote! {


### PR DESCRIPTION
This allows us to fetch orders from nodes at whichever rate we want
and we are not restricted to the broadcast through the gossipsub
network.

We still use a pubsub-based approach for learning about other makers
but it is now independent from the actual exchange of orders.