### PR TITLE
Include all CI runs in mergify conditions

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,6 +4,8 @@ pull_request_rules:
       - "author=dependabot[bot]"
       - "status-success=static_analysis"
       - "status-success=build (ubuntu-latest)"
+      - "status-success=build (windows-latest)"
+      - "status-success=build (macos-latest)"
       - "status-success=license/cla"
       - label!=no-mergify
     actions:
@@ -15,6 +17,8 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - "status-success=static_analysis"
       - "status-success=build (ubuntu-latest)"
+      - "status-success=build (windows-latest)"
+      - "status-success=build (macos-latest)"
       - "status-success=license/cla"
       - -conflict
       - label!=work-in-progress


### PR DESCRIPTION
Now that bors is waiting for all 4 to succeed, we should also
include them here to avoid preemtive handover to bors in case
a build other than the ubuntu one fails.