### PR TITLE
Small polish on our btsieve logs

### DIFF
--- a/comit/src/btsieve/bitcoin/bitcoind_connector.rs
+++ b/comit/src/btsieve/bitcoin/bitcoind_connector.rs
@@ -47,7 +47,7 @@ impl BitcoindConnector {
             .await
             .context("failed to deserialize JSON response as chaininfo")?;
 
-        tracing::debug!("Fetched chain info: {:?} from bitcoind", chain_info);
+        tracing::trace!("Fetched chain info: {:?} from bitcoind", chain_info);
 
         Ok(chain_info)
     }
@@ -82,7 +82,7 @@ impl BlockByHash for BitcoindConnector {
             .map_ok(decode_response)
             .await??;
 
-        tracing::debug!(
+        tracing::trace!(
             "Fetched block {} with {} transactions from bitcoind",
             block_hash,
             block.txdata.len()

--- a/comit/src/btsieve/ethereum/web3_connector.rs
+++ b/comit/src/btsieve/ethereum/web3_connector.rs
@@ -22,7 +22,7 @@ impl Web3Connector {
             .send::<Vec<()>, String>(jsonrpc::Request::new("net_version", vec![]))
             .await?;
 
-        tracing::debug!("Fetched net_version from web3: {:?}", version);
+        tracing::trace!("Fetched net_version from web3: {:?}", version);
 
         Ok(ChainId::from(version.parse::<u32>()?))
     }

--- a/comit/src/hbit.rs
+++ b/comit/src/hbit.rs
@@ -153,7 +153,7 @@ where
 
     let (transaction, location) =
         watch_for_created_outpoint(connector, start_of_swap, params.compute_address())
-            .instrument(tracing::info_span!("watch_fund"))
+            .instrument(tracing::info_span!("", action = "fund"))
             .await?;
 
     let asset = asset::Bitcoin::from_sat(transaction.output[location.vout as usize].value);
@@ -185,7 +185,7 @@ where
 {
     let (transaction, _) =
         watch_for_spent_outpoint(connector, start_of_swap, location, params.redeem_identity)
-            .instrument(tracing::info_span!("watch_redeem"))
+            .instrument(tracing::info_span!("", action = "redeem"))
             .await?;
 
     let secret = extract_secret(&transaction, &params.secret_hash)
@@ -208,7 +208,7 @@ where
 {
     let (transaction, _) =
         watch_for_spent_outpoint(connector, start_of_swap, location, params.refund_identity)
-            .instrument(tracing::info_span!("watch_refund"))
+            .instrument(tracing::info_span!("", action = "refund"))
             .await?;
 
     Ok(Refunded { transaction })

--- a/comit/src/herc20.rs
+++ b/comit/src/herc20.rs
@@ -162,10 +162,7 @@ where
 
     let (transaction, location) =
         watch_for_contract_creation(connector, start_of_swap, &expected_bytecode)
-            .instrument(tracing::trace_span!(
-                "watch_deploy",
-                expected_bytecode = %hex::encode(&expected_bytecode)
-            ))
+            .instrument(tracing::info_span!("", action = "deploy"))
             .await?;
 
     Ok(Deployed {
@@ -195,7 +192,7 @@ where
     };
 
     let (transaction, log) = watch_for_event(connector, start_of_swap, event)
-        .instrument(tracing::trace_span!("watch_fund"))
+        .instrument(tracing::info_span!("", action = "fund"))
         .await?;
 
     let expected_asset = &params.asset;
@@ -227,7 +224,7 @@ where
     };
 
     let (transaction, log) = watch_for_event(connector, start_of_swap, event)
-        .instrument(tracing::info_span!("watch_redeem"))
+        .instrument(tracing::info_span!("", action = "redeem"))
         .await?;
 
     let secret =
@@ -255,7 +252,7 @@ where
     };
 
     let (transaction, _) = watch_for_event(connector, start_of_swap, event)
-        .instrument(tracing::info_span!("watch_refund"))
+        .instrument(tracing::info_span!("", action = "refund"))
         .await?;
 
     Ok(Refunded { transaction })


### PR DESCRIPTION
1. Log btsieve functions on a consistent level (debug)
2. Reduce debug spam by moving some of the connectors logs to trace.