### PR TITLE
Standardized COMIT Expiry Times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
+name = "base-x"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
+
+[[package]]
 name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,7 +446,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.43",
 ]
 
 [[package]]
@@ -575,6 +581,7 @@ dependencies = [
  "strum_macros",
  "testcontainers",
  "thiserror",
+ "time 0.2.16",
  "tokio",
  "tracing",
  "tracing-core",
@@ -828,6 +835,12 @@ dependencies = [
  "redox_users",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dtoa"
@@ -1203,7 +1216,7 @@ dependencies = [
  "http",
  "mime 0.3.16",
  "sha-1",
- "time",
+ "time 0.1.43",
 ]
 
 [[package]]
@@ -1336,7 +1349,7 @@ dependencies = [
  "log 0.3.9",
  "mime 0.2.6",
  "num_cpus",
- "time",
+ "time 0.1.43",
  "traitobject",
  "typeable",
  "unicase 1.4.2",
@@ -1360,7 +1373,7 @@ dependencies = [
  "itoa",
  "pin-project",
  "socket2",
- "time",
+ "time 0.1.43",
  "tokio",
  "tower-service",
  "tracing",
@@ -3060,6 +3073,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+
+[[package]]
 name = "sha2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3170,10 +3189,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "standback"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0437cfb83762844799a60e1e3b489d5ceb6a650fbacb86437badc1b6d87b246"
+dependencies = [
+ "version_check 0.9.2",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "serde",
+ "serde_derive",
+ "syn 1.0.37",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn 1.0.37",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "stream-cipher"
@@ -3365,6 +3442,44 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a51cadc5b1eec673a685ff7c33192ff7b7603d0b75446fb354939ee615acb15"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros",
+ "version_check 0.9.2",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9b6e9f095bc105e183e3cd493d72579be3181ad4004fceb01adbe9eecab2d"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "standback",
+ "syn 1.0.37",
 ]
 
 [[package]]

--- a/comit/Cargo.toml
+++ b/comit/Cargo.toml
@@ -36,6 +36,7 @@ sha2 = "0.9"
 strum = "0.19.2"
 strum_macros = "0.19.2"
 thiserror = "1"
+time = "0.2"
 tokio = { version = "0.2.22", features = ["sync"] }
 tracing = "0.1.19"
 tracing-futures = { version = "0.2", features = ["std-future", "futures-03"] }

--- a/comit/src/expiries.rs
+++ b/comit/src/expiries.rs
@@ -1,0 +1,641 @@
+//! Standardized COMIT Expiry Times
+//!
+//! The COMIT protocols rely on two expiry times in order for the swap to be
+//! atomic. One expiry for the alpha ledger and one for the beta ledger. The
+//! beta ledger expiry time must elapse before the alpha ledger expiry time.
+
+use crate::timestamp::{self, Timestamp};
+use time::{prelude::*, Duration};
+
+// TODO: Currently we ignore deploy for Erc20.
+
+// Note on expiry types: Any `Duration` expiry is a relative expiry, any
+// `Timestamp` expiry is an absolute expiry. We can use relative expiries to
+// create absolute expiries when, for example, swap execution starts.
+
+/// Current time as a UNIX timestamp from the perspective of the implementer.
+///
+/// Intended for getting the current time from the underlying blockchain.
+/// The definition `current time` varies depending on the blockchain, this
+/// always refers to the time used by the op codes used in the COMIT contracts.
+pub trait CurrentTime {
+    fn current_time(&self) -> Timestamp; // TODO: This will need to be async.
+}
+
+/// Data that defines and manipulates expiry times.
+///
+/// Language note: We use the term 'expiries' (plural of expiry) to make it
+/// explicit that there are two expiry times however we refer it as singular
+/// since it is the struct, or pair of expiries, that we are referring to.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Expiries<A, B> {
+    /// Configuration values for calculating transition periods.
+    config: Config,
+    /// Alpha blockchain connector for getting the current time.
+    alpha_connector: A,
+    /// Beta blockchain connector for getting the current time.
+    beta_connector: B,
+    /// The alpha ledger relative expiry time.
+    alpha_expiry: Duration,
+    /// The beta ledger relative expiry time.
+    beta_expiry: Duration,
+}
+
+impl<A, B> Expiries<A, B>
+where
+    A: CurrentTime,
+    B: CurrentTime,
+{
+    /// Construct a pair of relative expiries values.
+    pub fn new(protocol: Protocol, alpha: A, beta: B) -> Expiries<A, B> {
+        let config = protocol.config();
+
+        let alice_needs = happy_path_swap_period_for_alice(&config);
+        let bob_needs = happy_path_swap_period_for_bob(&config);
+
+        Expiries {
+            config,
+            alpha_connector: alpha,
+            beta_connector: beta,
+            // Bob redeems on alpha ledger so needs time to act before the alpha expiry.
+            alpha_expiry: bob_needs,
+            // Alice redeems on beta ledger so needs time to act before the beta expiry.
+            beta_expiry: alice_needs,
+        }
+    }
+
+    /// Returns true if both:
+    /// 1. Alice has time to transition from initial state to `Done`.
+    /// 2. Bob has time to transition from initial state to `Done`.
+    pub fn is_useful(&self) -> bool {
+        let alice_needs = happy_path_swap_period_for_alice(&self.config);
+        let bob_needs = happy_path_swap_period_for_bob(&self.config);
+
+        let alice_has_enough_time = self.beta_expiry >= alice_needs;
+        let bob_has_enough_time = self.alpha_expiry >= bob_needs;
+
+        alice_has_enough_time && bob_has_enough_time
+    }
+
+    /// Convert relative expiries to absolute expiries.
+    pub fn to_absolute(&self) -> (Timestamp, Timestamp) {
+        let alpha_now = self.alpha_connector.current_time();
+        let alpha_expiry = alpha_now.add_duration(self.alpha_expiry);
+
+        let beta_now = self.beta_connector.current_time();
+        let beta_expiry = beta_now.add_duration(self.beta_expiry);
+
+        (alpha_expiry, beta_expiry)
+    }
+
+    /// True if Alice has time to complete a swap (i.e. transition to done)
+    /// before the expiry time elapses.
+    fn alice_can_complete_from(&self, current_state: AliceState, beta_expiry: Timestamp) -> bool {
+        let period = period_for_alice_to_complete(&self.config, current_state);
+        let now = self.beta_connector.current_time();
+
+        // Alice redeems on beta ledger so is concerned about the beta expiry.
+        let end_time = now.add_duration(period);
+        end_time < beta_expiry
+    }
+
+    /// True if Bob has time to complete a swap (i.e transition to done)
+    /// before the expiry time elapses.
+    fn bob_can_complete_from(&self, current_state: BobState, alpha_expiry: Timestamp) -> bool {
+        let period = period_for_bob_to_complete(&self.config, current_state);
+        let now = self.alpha_connector.current_time();
+
+        // Bob redeems on alpha ledger so is concerned about the alpha expiry.
+        let end_time = now.add_duration(period);
+        end_time < alpha_expiry
+    }
+
+    /// If Alice's next action is not taken within X minutes the expiries will
+    /// become un-useful. Returns X.
+    pub fn alice_should_act_within(
+        &self,
+        current_state: AliceState,
+        beta_expiry: Timestamp,
+    ) -> Duration {
+        let period = period_for_alice_to_complete(&self.config, current_state);
+        let start_time = beta_expiry.sub_duration(period);
+        let now = self.beta_connector.current_time();
+
+        timestamp::duration_between(now, start_time)
+    }
+
+    /// If Bob's next action is not taken within X minutes the expiries will
+    /// become un-useful. Returns X.
+    pub fn bob_should_act_within(
+        &self,
+        current_state: BobState,
+        alpha_expiry: Timestamp,
+    ) -> Duration {
+        let period = period_for_bob_to_complete(&self.config, current_state);
+        let start_time = alpha_expiry.sub_duration(period);
+        let now = self.alpha_connector.current_time();
+
+        timestamp::duration_between(now, start_time)
+    }
+
+    /// Returns the recommended next action that Alice should take.
+    pub fn next_action_for_alice(
+        &self,
+        current_state: AliceState,
+        alpha_expiry: Timestamp,
+        beta_expiry: Timestamp,
+    ) -> AliceAction {
+        if current_state == AliceState::Done {
+            return AliceAction::NoFurtherAction;
+        }
+
+        let funded = current_state.has_sent_fund_transaction();
+
+        if self.alpha_expiry_has_elapsed(alpha_expiry) {
+            if funded {
+                return AliceAction::Refund;
+            }
+            return AliceAction::Abort;
+        }
+
+        let both_parties_can_complete = self.alice_can_complete_from(current_state, beta_expiry)
+            && self.bob_can_complete_from(current_state.into(), alpha_expiry);
+
+        if !both_parties_can_complete {
+            if funded {
+                return AliceAction::WaitForRefund;
+            }
+            return AliceAction::Abort;
+        }
+
+        let (next_action, _state) = current_state.next();
+        next_action
+    }
+
+    /// Returns the recommended next action that Bob should take.
+    pub fn next_action_for_bob(
+        &self,
+        current_state: BobState,
+        alpha_expiry: Timestamp,
+        beta_expiry: Timestamp,
+    ) -> BobAction {
+        if current_state == BobState::Done {
+            return BobAction::NoFurtherAction;
+        }
+
+        // If Alice has redeemed Bob's only action is to redeem irrespective of expiry
+        // time.
+        if current_state == BobState::RedeemBetaTransactionSeen {
+            return BobAction::RedeemAlpha;
+        }
+
+        let funded = current_state.has_sent_fund_transaction();
+
+        if self.beta_expiry_has_elapsed(alpha_expiry) {
+            if funded {
+                return BobAction::Refund;
+            }
+            return BobAction::Abort;
+        };
+
+        let both_parties_can_complete = self
+            .alice_can_complete_from(current_state.into(), beta_expiry)
+            && self.bob_can_complete_from(current_state, alpha_expiry);
+
+        if !both_parties_can_complete {
+            if funded {
+                return BobAction::WaitForRefund;
+            }
+            return BobAction::Abort;
+        }
+
+        let (next_action, _state) = current_state.next();
+        next_action
+    }
+
+    fn alpha_expiry_has_elapsed(&self, expiry: Timestamp) -> bool {
+        let now = self.alpha_connector.current_time();
+        now > expiry
+    }
+
+    fn beta_expiry_has_elapsed(&self, expiry: Timestamp) -> bool {
+        let now = self.beta_connector.current_time();
+        now > expiry
+    }
+}
+
+/// Duration for a complete happy path swap for Alice.
+fn happy_path_swap_period_for_alice(config: &Config) -> Duration {
+    period_for_alice_to_complete(&config, AliceState::None)
+}
+
+/// Duration for a complete happy path swap for Bob.
+fn happy_path_swap_period_for_bob(config: &Config) -> Duration {
+    period_for_bob_to_complete(&config, BobState::Created)
+}
+
+/// The minimum time we should allow for Alice to transition from
+/// `current_state` to done.
+fn period_for_alice_to_complete(config: &Config, current_state: AliceState) -> Duration {
+    // Tail call recursion with an accumulator.
+    fn period_to_complete(config: &Config, state: AliceState, acc: Duration) -> Duration {
+        if state == AliceState::Done {
+            return acc;
+        }
+
+        let (_action, next_state) = state.next();
+        let transition_period = state.transition_period(config);
+
+        period_to_complete(config, next_state, acc + transition_period)
+    }
+
+    period_to_complete(config, current_state, Duration::zero())
+}
+
+/// The minimum time we should allow for Bob to transition from
+/// `current_state` to done.
+fn period_for_bob_to_complete(config: &Config, current_state: BobState) -> Duration {
+    // Tail call recursion with an accumulator.
+    fn period_to_complete(config: &Config, state: BobState, acc: Duration) -> Duration {
+        if state == BobState::Done {
+            return acc;
+        }
+
+        let (_action, next_state) = state.next();
+        let transition_period = state.transition_period(config);
+
+        period_to_complete(config, next_state, acc + transition_period)
+    }
+
+    period_to_complete(config, current_state, Duration::zero())
+}
+
+/// Happy path states for Alice.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AliceState {
+    /// Initial state, swap not yet created.
+    None,
+    /// Swap has been created.
+    Created,
+    /// The fund alpha transaction has been sent to the network.
+    FundAlphaTransactionSent,
+    /// Implies fund alpha transaction has reached finality.
+    AlphaFunded,
+    /// Implies fund beta transaction has reached finality.
+    BetaFunded,
+    /// The redeem beta transaction has been sent to the network.
+    RedeemBetaTransactionSent,
+    /// Implies beta redeem transaction has reached finality.
+    Done,
+}
+
+/// Possible next action for Alice.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AliceAction {
+    // Happy path actions for Alice.
+    Create,
+    FundAlpha,
+    WaitForFundTransactionFinality,
+    WaitForBetaFunded,
+    RedeemBeta,
+    WaitForRedeemBetaTransactionFinality,
+    NoFurtherAction, // Implies swap is done from Alice's perspective.
+    // Cancel path.
+    Abort,         // Implies HTLC not funded, abort but take no further action.
+    WaitForRefund, // Implies alpha ledger HTLC funded but expiry not yet elapsed.
+    Refund,        // Implies HTLC funded and expiry time elapsed.
+}
+
+impl AliceState {
+    /// Gets the next action required to transition to the next state.
+    fn next(&self) -> (AliceAction, AliceState) {
+        use self::{AliceAction::*, AliceState::*};
+
+        match self {
+            None => (Create, Created),
+            Created => (FundAlpha, FundAlphaTransactionSent),
+            FundAlphaTransactionSent => (WaitForFundTransactionFinality, AlphaFunded),
+            AlphaFunded => (WaitForBetaFunded, BetaFunded),
+            BetaFunded => (RedeemBeta, RedeemBetaTransactionSent),
+            RedeemBetaTransactionSent => (WaitForRedeemBetaTransactionFinality, Done),
+            Done => (NoFurtherAction, Done),
+        }
+    }
+
+    /// The minimum time we need to allow to transition to the next state.
+    fn transition_period(&self, c: &Config) -> Duration {
+        use self::AliceAction::*;
+
+        let (next_action, _next_state) = self.next();
+
+        match next_action {
+            Create => {
+                // Transition from None to Created
+                c.alice_to_act()
+            }
+            FundAlpha => {
+                // Transition from Created to FundAlphaTransactionSent
+                c.alice_to_act()
+            }
+            WaitForFundTransactionFinality => {
+                // Transition from FundAlphaTransactionSent to AlphaFunded
+                c.mine_alpha_fund_transaction() + c.finality_alpha()
+            }
+            WaitForBetaFunded => {
+                // Transition from AlphaFunded to BetaFunded
+                c.bob_to_act() + c.mine_beta_fund_transaction() + c.finality_beta()
+            }
+            RedeemBeta => {
+                // Transition from BetaFunded to RedeemBetaTransactionSent
+                c.alice_to_act()
+            }
+            WaitForRedeemBetaTransactionFinality => {
+                // Transition from RedeemBetaTransactionSent to Done
+                c.mine_beta_redeem_transaction() + c.finality_beta()
+            }
+            // Transitioning to any of the cancel actions takes, be definition, zero time.
+            NoFurtherAction | Abort | WaitForRefund | Refund => Duration::zero(),
+        }
+    }
+
+    /// True if Alice has funded the alpha HTLC. We return true as soon as the
+    /// fund transaction has been sent since any time after attempting to refund
+    /// is the correct cancellation action.
+    fn has_sent_fund_transaction(&self) -> bool {
+        match self {
+            AliceState::None | AliceState::Created => false,
+            AliceState::FundAlphaTransactionSent
+            | AliceState::AlphaFunded
+            | AliceState::BetaFunded
+            | AliceState::RedeemBetaTransactionSent
+            | AliceState::Done => true,
+        }
+    }
+}
+
+/// Happy path states for Bob.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BobState {
+    // Bob does not have a None state because swap creation time is implicit in Bob's first time
+    // to act after Alice funds.
+    /// Initial state, swap has been created.
+    Created,
+    /// Implies fund alpha transaction has reached finality.
+    AlphaFunded,
+    /// The fund beta transaction has been sent to the network.
+    FundBetaTransactionSent,
+    /// Implies fund beta transaction has reached finality.
+    BetaFunded,
+    /// The redeem beta transaction has been seen (e.g. an unconfirmed
+    /// transaction in the mempool).
+    RedeemBetaTransactionSeen,
+    /// The redeem alpha transaction has been sent to the network.
+    RedeemAlphaTransactionSent,
+    /// Implies alpha redeem transaction has reached finality.
+    Done,
+}
+
+/// Possible next action for Alice.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BobAction {
+    // Happy path actions for Bob.
+    WaitForAlphaFunded,
+    FundBeta,
+    WaitForBetaFundTransactionFinality,
+    WaitForBetaRedeemTransactionToBeSeen,
+    RedeemAlpha,
+    WaitForAlphaRedeemTransactionFinality,
+    NoFurtherAction, // Implies swap is done from Bob's perspective.
+    // Cancel path.
+    Abort,         // Implies HTLC not funded, abort but take no further action.
+    WaitForRefund, // Implies alpha ledger HTLC funded but expiry not yet elapsed.
+    Refund,        // Implies HTLC funded and expiry time elapsed.
+}
+
+impl BobState {
+    /// Gets the next action required to transition to the next state.
+    fn next(&self) -> (BobAction, BobState) {
+        use self::{BobAction::*, BobState::*};
+
+        match self {
+            Created => (WaitForAlphaFunded, AlphaFunded),
+            AlphaFunded => (FundBeta, FundBetaTransactionSent),
+            FundBetaTransactionSent => (WaitForBetaFundTransactionFinality, BetaFunded),
+            BetaFunded => (
+                WaitForBetaRedeemTransactionToBeSeen,
+                RedeemBetaTransactionSeen,
+            ),
+            RedeemBetaTransactionSeen => (RedeemAlpha, RedeemAlphaTransactionSent),
+            RedeemAlphaTransactionSent => (WaitForAlphaRedeemTransactionFinality, Done),
+            Done => (NoFurtherAction, Done),
+        }
+    }
+
+    /// The minimum time we need to allow to transition to the next state.
+    fn transition_period(&self, c: &Config) -> Duration {
+        use self::BobAction::*;
+
+        let (next_action, _next_state) = self.next();
+
+        match next_action {
+            WaitForAlphaFunded => {
+                // Transition from Created to AlphaFunded
+                c.alice_to_act() + c.mine_alpha_fund_transaction() + c.finality_alpha()
+            }
+            FundBeta => {
+                // Transition from AlphaFunded to FundBetaTransactionSent
+                c.bob_to_act()
+            }
+            WaitForBetaFundTransactionFinality => {
+                // Transition from FundBetaTransactionSent to BetaFunded
+                c.mine_beta_fund_transaction() + c.finality_beta()
+            }
+            WaitForBetaRedeemTransactionToBeSeen => {
+                // Transition from BetaFunded to RedeemBetaTransactionSeen
+                c.alice_to_act() + c.mine_beta_redeem_transaction()
+            }
+            RedeemAlpha => {
+                // Transition from RedeemBetaTransactionSeen to
+                // RedeemAlphaTransactionSent
+                c.bob_to_act()
+            }
+            WaitForAlphaRedeemTransactionFinality => {
+                // Transition from RedeemAlphaTransactionSent to Done
+                c.mine_alpha_redeem_transaction() + c.finality_alpha()
+            }
+            // Transitioning to any of the cancel actions takes, be definition, zero time.
+            NoFurtherAction | Abort | WaitForRefund | Refund => Duration::zero(),
+        }
+    }
+
+    /// True if Bob has funded the beta HTLC. We return true as soon as the
+    /// fund transaction has been sent since any time after attempting to refund
+    /// is the correct cancellation action.
+    fn has_sent_fund_transaction(&self) -> bool {
+        match self {
+            BobState::Created | BobState::AlphaFunded => false,
+            BobState::FundBetaTransactionSent
+            | BobState::BetaFunded
+            | BobState::RedeemBetaTransactionSeen
+            | BobState::RedeemAlphaTransactionSent
+            | BobState::Done => true,
+        }
+    }
+}
+
+/// From<'role'State> converts a state object into a best guess at the
+/// counterparties state. We cannot know for sure what state the counterparty is
+/// in because there are state transitions which rely on local knowledge. We
+/// make a conservative guess at the counterparties state using only public
+/// knowledge.
+
+impl From<AliceState> for BobState {
+    fn from(state: AliceState) -> Self {
+        use AliceState::*;
+
+        match state {
+            None => Self::Created,
+            Created => Self::Created,
+            FundAlphaTransactionSent => Self::Created,
+            AlphaFunded => Self::AlphaFunded,
+            // We don't look for the redeem alpha transaction so `BetaFunded` is the last of Bob's
+            // states we can verify.
+            BetaFunded | RedeemBetaTransactionSent | Done => Self::BetaFunded,
+        }
+    }
+}
+
+impl From<BobState> for AliceState {
+    fn from(state: BobState) -> Self {
+        use BobState::*;
+
+        match state {
+            Created => Self::None,
+            AlphaFunded => Self::AlphaFunded,
+            FundBetaTransactionSent => Self::AlphaFunded,
+            BetaFunded => Self::BetaFunded,
+            // We don't wait for the redeem beta transaction to reach finality so
+            // `RedeemBetaTransactionSent` is the last of Alice's states we can verify.
+            RedeemBetaTransactionSeen | RedeemAlphaTransactionSent | Done => {
+                Self::RedeemBetaTransactionSent
+            }
+        }
+    }
+}
+
+// TODO: Add support for lightning.
+#[derive(Clone, Copy, Debug)]
+pub enum Protocol {
+    Herc20Hbit,
+    HbitHerc20,
+}
+
+impl Protocol {
+    fn config(&self) -> Config {
+        match self {
+            Protocol::Herc20Hbit => Config {
+                alpha_required_confirmations: ethereum_required_confirmations(),
+                beta_required_confirmations: bitcoin_required_confirmations(),
+            },
+            Protocol::HbitHerc20 => Config {
+                alpha_required_confirmations: bitcoin_required_confirmations(),
+                beta_required_confirmations: ethereum_required_confirmations(),
+            },
+        }
+    }
+}
+
+/// Configuration values used during transition period calculations.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Config {
+    alpha_required_confirmations: usize,
+    beta_required_confirmations: usize,
+}
+
+// TODO: Calculate _real_ values instead of just returning 1 hour.
+impl Config {
+    /// The duration of time it takes for Alice to act.
+    pub fn alice_to_act(&self) -> Duration {
+        1.hours()
+    }
+
+    /// The duration of time it takes for Bob to act.
+    pub fn bob_to_act(&self) -> Duration {
+        1.hours()
+    }
+
+    /// The duration of time it takes for the alpha fund transaction to be
+    /// mined into the blockchain.
+    pub fn mine_alpha_fund_transaction(&self) -> Duration {
+        1.hours()
+    }
+
+    /// The duration of time it takes for the beta fund transaction to be
+    /// mined into the blockchain.
+    pub fn mine_beta_fund_transaction(&self) -> Duration {
+        1.hours()
+    }
+
+    /// The duration of time it takes for the alpha redeem transaction to be
+    /// mined into the blockchain.
+    pub fn mine_alpha_redeem_transaction(&self) -> Duration {
+        1.hours()
+    }
+
+    /// The duration of time it takes for the beta redeem transaction to be
+    /// mined into the blockchain.
+    pub fn mine_beta_redeem_transaction(&self) -> Duration {
+        1.hours()
+    }
+
+    /// The duration of time it takes for a transaction to reach finality on the
+    /// alpha ledger.
+    pub fn finality_alpha(&self) -> Duration {
+        1.hours()
+    }
+
+    /// The duration of time it takes for a transaction to reach finality on the
+    /// beta ledger.
+    pub fn finality_beta(&self) -> Duration {
+        1.hours()
+    }
+}
+
+fn bitcoin_required_confirmations() -> usize {
+    // TODO: Add documentation on _why_ we picked this value.
+    6
+}
+
+fn ethereum_required_confirmations() -> usize {
+    // TODO: Add documentation on _why_ we picked this value.
+    12
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Copy, Debug)]
+    struct MockConnector;
+
+    impl CurrentTime for MockConnector {
+        fn current_time(&self) -> Timestamp {
+            Timestamp::now()
+        }
+    }
+
+    fn mock_connectors() -> (MockConnector, MockConnector) {
+        (MockConnector, MockConnector)
+    }
+
+    #[test]
+    fn can_calculate_useful_expiries_for_all_supported_protocols() {
+        let (alpha, beta) = mock_connectors();
+
+        let exp = Expiries::new(Protocol::Herc20Hbit, alpha, beta);
+        assert!(exp.is_useful());
+
+        let exp = Expiries::new(Protocol::HbitHerc20, alpha, beta);
+        assert!(exp.is_useful());
+    }
+}

--- a/comit/src/lib.rs
+++ b/comit/src/lib.rs
@@ -18,6 +18,7 @@ pub mod asset;
 pub mod bitcoin;
 pub mod btsieve;
 pub mod ethereum;
+pub mod expiries;
 pub mod halbit;
 pub mod hbit;
 pub mod herc20;


### PR DESCRIPTION
Add `expiries` module.

Ready for merge but not fully functional, reasoning is that this is a library module and the library module _is_ the project deliverable. I will of course attempt to use it after merge and before the project ends. I'd like to clearly separate the two phases described below, merge is how I propose to do that.

This PR completes the first phase, of primary concern are the two `transition_period` methods. The individual transition functions (TTI, TTL) are intended to be opaque (currently `todo!()`).  

The second phase is implementing all the period functions (represented in the spike by TTL, TTI, TTF etc.).

## Notes: 

We would like to be able to manipulate timestamps and durations together. We use `time::Duration` because it is more suited to durations of the timeframes we expect i.e., hour long durations (`std::time` is better suited, according to the docs, to system times i.e., smaller timeframes). We modify our `Timestamp` module to handle `Duration`s.