### PR TITLE
Improve expiries

### DIFF
--- a/comit/src/expiries.rs
+++ b/comit/src/expiries.rs
@@ -278,14 +278,6 @@ where
         let now = self.beta_connector.current_time();
         now > expiry.0
     }
-
-    /// Generate a report from the expiries.
-    pub fn report(&self) -> String {
-        format!(
-            "config: {}\n    alpha_offset: {}\n    beta_offset: {}",
-            self.config, self.alpha_offset, self.beta_offset
-        )
-    }
 }
 
 /// Duration for a complete happy path swap for Alice.
@@ -343,6 +335,16 @@ fn scale_by_factor(d: Duration, factor: u32) -> Duration {
     let reduced = (scaled as f64 / 100.0).floor();
 
     Duration::seconds(reduced as i64)
+}
+
+impl<A, B> fmt::Display for Expiries<A, B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "config: {}\n    alpha_offset: {}\n    beta_offset: {}",
+            self.config, self.alpha_offset, self.beta_offset
+        )
+    }
 }
 
 // Its super easy to mix these up, add types so the compiler saves us.
@@ -757,9 +759,9 @@ mod tests {
         );
 
         let exp = Expiries::new(Protocol::Herc20Hbit, alpha, beta, scale);
-        println!("\n herc20-hbit swap:\n {}", exp.report());
+        println!("\n herc20-hbit swap:\n {}", exp);
 
         let exp = Expiries::new(Protocol::HbitHerc20, alpha, beta, scale);
-        println!("\n hbit-herc20 swap:\n {}", exp.report());
+        println!("\n hbit-herc20 swap:\n {}", exp);
     }
 }

--- a/comit/src/expiries.rs
+++ b/comit/src/expiries.rs
@@ -690,14 +690,27 @@ mod tests {
 
     #[test]
     fn can_calculate_useful_expiries_for_all_supported_protocols() {
-        let no_scale = 100;
+        let scale = 100;
+        let future = Timestamp::now().plus(10);
+        let (alpha, beta) = mock_connectors();
+
+        let exp = Expiries::new(Protocol::Herc20Hbit, alpha, beta, scale);
+        assert!(exp.is_useful(future));
+
+        let exp = Expiries::new(Protocol::HbitHerc20, alpha, beta, scale);
+        assert!(exp.is_useful(future));
+    }
+
+    #[test]
+    fn can_calculate_useful_expiries_for_all_supported_protocols_with_scale() {
+        let scale = 120;
         let now = Timestamp::now();
         let (alpha, beta) = mock_connectors();
 
-        let exp = Expiries::new(Protocol::Herc20Hbit, alpha, beta, no_scale);
+        let exp = Expiries::new(Protocol::Herc20Hbit, alpha, beta, scale);
         assert!(exp.is_useful(now));
 
-        let exp = Expiries::new(Protocol::HbitHerc20, alpha, beta, no_scale);
+        let exp = Expiries::new(Protocol::HbitHerc20, alpha, beta, scale);
         assert!(exp.is_useful(now));
     }
 

--- a/comit/src/expiries.rs
+++ b/comit/src/expiries.rs
@@ -2,7 +2,7 @@
 //!
 //! The COMIT protocols rely on two expiry times in order for the swap to be
 //! atomic. One expiry for the alpha ledger and one for the beta ledger. The
-//! beta ledger expiry time must not elapse  the alpha ledger expiry time.
+//! beta ledger expiry time must not elapse the alpha ledger expiry time.
 
 mod config;
 

--- a/comit/src/expiries.rs
+++ b/comit/src/expiries.rs
@@ -237,9 +237,7 @@ where
 
 /// Duration for a complete happy path swap for Alice.
 fn happy_path_swap_period_for_alice(config: &Config) -> Duration {
-    let p = period_for_alice_to_complete(&config, AliceState::None);
-    println!("period for alice to complete: {}", p.whole_seconds());
-    p
+    period_for_alice_to_complete(&config, AliceState::None)
 }
 
 /// Duration for a complete happy path swap for Bob.
@@ -259,8 +257,6 @@ fn period_for_alice_to_complete(config: &Config, current_state: AliceState) -> D
         let (_action, next_state) = state.next();
         let transition_period = state.transition_period(config);
 
-        let d = acc + transition_period;
-        println!("acc {}", d.whole_seconds());
         period_to_complete(config, next_state, acc + transition_period)
     }
 

--- a/comit/src/expiries/config.rs
+++ b/comit/src/expiries/config.rs
@@ -1,0 +1,210 @@
+//! This module provides functionality for calculating the duration of actions
+//! required to determine the transition period from one swap state to the next.
+
+use time::{prelude::*, Duration};
+
+// TODO: From somewhere within the system we need to return to the
+// user a transaction fee to use for each of the transactions (deploy,
+// fund, refund, redeem). In this module we assume the fee is set to
+// the suggested amount. We rely on this assumption for the
+// confirmation time calculations in this module to be correct.
+//
+// For Ethereum:
+//
+// gas limit: blockchain-contracts already implements gas limit functionality
+//            for each Ethereum transaction type.
+// gas price: current gas price can be learned from the Ethereum blockchain,
+//            for example from geth or infura.
+// modifier:  We could use a pre-configured modifier, as is widely done in the
+//            Ethereum ecosystem for slow, medium, fast.
+//
+// For Bitcoin:
+//
+// With a configured 'include within N blocks' we can use bitcoind via
+// bitcoin-cli, by calling:
+//
+//  `bitcoin-cli estimatesmartfee N_BLOCKS`
+//
+// CAVEAT: The fee estimator relies on an active mempool with good uptime to
+// watch fee activity on the network, that in turn implies that our calculations
+// herein are only as good as the fee estimator of the Bitcoin connector.
+
+// We use specific integer types to limit the upper bound, this reduces the need
+// to turn off lints.
+
+const BITCOIN_BLOCK_TIME_SECS: u16 = 600; // 10 minutes, average Bitcoin block time.
+const ETHEREUM_BLOCK_TIME_SECS: u16 = 20; // Conservative Ethereum block time.
+
+const BITCOIN_MINE_WITHIN_N_BLOCKS: u8 = 3; // Value arbitrarily chosen.
+const ETHEREUM_MINE_WITHIN_N_BLOCKS: u8 = 3; // Value arbitrarily chosen.
+
+const BITCOIN_CONFIRMATIONS: u8 = 6; // Standard in the Bitcoin ecosystem.
+const ETHEREUM_CONFIRMATIONS: u8 = 30; // Value used by Kraken.
+
+// TODO: Add support for lightning.
+#[derive(Clone, Copy, Debug)]
+pub enum Protocol {
+    Herc20Hbit,
+    HbitHerc20,
+}
+
+impl Protocol {
+    pub fn config(&self) -> Config {
+        // Since we are targeting Nectar and the App we can set these.
+        let alice = ActorType::Human;
+        let bob = ActorType::Bot;
+
+        match self {
+            Protocol::Herc20Hbit => Config {
+                alice,
+                bob,
+                alpha_required_confirmations: ethereum_required_confirmations(),
+                beta_required_confirmations: bitcoin_required_confirmations(),
+                alpha_block_time: ETHEREUM_BLOCK_TIME_SECS,
+                beta_block_time: BITCOIN_BLOCK_TIME_SECS,
+                alpha_mine_fund_within_n_blocks: ETHEREUM_MINE_WITHIN_N_BLOCKS,
+                beta_mine_fund_within_n_blocks: BITCOIN_MINE_WITHIN_N_BLOCKS,
+                alpha_mine_redeem_within_n_blocks: ETHEREUM_MINE_WITHIN_N_BLOCKS,
+                beta_mine_redeem_within_n_blocks: BITCOIN_MINE_WITHIN_N_BLOCKS,
+            },
+            Protocol::HbitHerc20 => Config {
+                alice,
+                bob,
+                alpha_required_confirmations: bitcoin_required_confirmations(),
+                beta_required_confirmations: ethereum_required_confirmations(),
+                alpha_block_time: BITCOIN_BLOCK_TIME_SECS,
+                beta_block_time: ETHEREUM_BLOCK_TIME_SECS,
+                alpha_mine_fund_within_n_blocks: BITCOIN_MINE_WITHIN_N_BLOCKS,
+                beta_mine_fund_within_n_blocks: ETHEREUM_MINE_WITHIN_N_BLOCKS,
+                alpha_mine_redeem_within_n_blocks: BITCOIN_MINE_WITHIN_N_BLOCKS,
+                beta_mine_redeem_within_n_blocks: ETHEREUM_MINE_WITHIN_N_BLOCKS,
+            },
+        }
+    }
+}
+
+/// Configuration values used during transition period calculations.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Config {
+    alice: ActorType,
+    bob: ActorType,
+    alpha_required_confirmations: u8,
+    beta_required_confirmations: u8,
+    alpha_block_time: u16,
+    beta_block_time: u16,
+    alpha_mine_fund_within_n_blocks: u8,
+    beta_mine_fund_within_n_blocks: u8,
+    alpha_mine_redeem_within_n_blocks: u8,
+    beta_mine_redeem_within_n_blocks: u8,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ActorType {
+    Bot,
+    Human,
+}
+
+impl ActorType {
+    fn period_to_act(&self) -> Duration {
+        match self {
+            ActorType::Bot => 15.minutes(),
+            ActorType::Human => 60.minutes(),
+        }
+    }
+}
+
+impl Config {
+    /// The duration of time it takes for Alice to act.
+    pub fn alice_to_act(&self) -> Duration {
+        self.alice.period_to_act()
+    }
+
+    /// The duration of time it takes for Bob to act.
+    pub fn bob_to_act(&self) -> Duration {
+        self.bob.period_to_act()
+    }
+
+    /// The duration of time it takes for the alpha fund transaction to be
+    /// mined into the blockchain.
+    pub fn mine_alpha_fund_transaction(&self) -> Duration {
+        let n = self.alpha_mine_fund_within_n_blocks;
+        let block_time = self.alpha_block_time;
+
+        time_to_mine_n_blocks(n, block_time)
+    }
+
+    /// The duration of time it takes for the beta fund transaction to be
+    /// mined into the blockchain.
+    pub fn mine_beta_fund_transaction(&self) -> Duration {
+        let n = self.beta_mine_fund_within_n_blocks;
+        let block_time = self.beta_block_time;
+
+        time_to_mine_n_blocks(n, block_time)
+    }
+
+    /// The duration of time it takes for the alpha redeem transaction to be
+    /// mined into the blockchain.
+    pub fn mine_alpha_redeem_transaction(&self) -> Duration {
+        let n = self.alpha_mine_redeem_within_n_blocks;
+        let block_time = self.alpha_block_time;
+
+        time_to_mine_n_blocks(n, block_time)
+    }
+
+    /// The duration of time it takes for the beta redeem transaction to be
+    /// mined into the blockchain.
+    pub fn mine_beta_redeem_transaction(&self) -> Duration {
+        let n = self.beta_mine_redeem_within_n_blocks;
+        let block_time = self.beta_block_time;
+
+        time_to_mine_n_blocks(n, block_time)
+    }
+
+    /// The duration of time it takes for a transaction to reach finality on the
+    /// alpha ledger.
+    pub fn finality_alpha(&self) -> Duration {
+        let n = self.alpha_required_confirmations;
+        let block_time = self.alpha_block_time;
+
+        time_to_mine_n_blocks(n, block_time)
+    }
+
+    /// The duration of time it takes for a transaction to reach finality on the
+    /// beta ledger.
+    pub fn finality_beta(&self) -> Duration {
+        let n = self.beta_required_confirmations;
+        let block_time = self.beta_block_time;
+
+        time_to_mine_n_blocks(n, block_time)
+    }
+}
+
+fn bitcoin_required_confirmations() -> u8 {
+    BITCOIN_CONFIRMATIONS
+}
+
+fn ethereum_required_confirmations() -> u8 {
+    ETHEREUM_CONFIRMATIONS
+}
+
+fn time_to_mine_n_blocks(n: u8, average_block_time_secs: u16) -> Duration {
+    let t = n as u16 * average_block_time_secs;
+    Duration::seconds(t as i64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spectral::prelude::*;
+
+    #[test]
+    fn time_to_mine_n_blocks_bitcoin() {
+        let n = bitcoin_required_confirmations();
+        let block_time = BITCOIN_BLOCK_TIME_SECS;
+
+        let max = 5.hours(); // Arbitrarily chosen ceiling.
+        let time = time_to_mine_n_blocks(n, block_time);
+
+        assert_that!(time).is_less_than(max)
+    }
+}

--- a/comit/src/expiries/config.rs
+++ b/comit/src/expiries/config.rs
@@ -187,6 +187,11 @@ fn ethereum_required_confirmations() -> u8 {
     ETHEREUM_CONFIRMATIONS
 }
 
+// Time to mine n blocks is governed by a Poisson distribution. As an
+// improvement we could calculate that instead of using this naive
+// implementation. For more details see:
+// - https://en.wikipedia.org/wiki/Poisson_distribution
+// - https://www.reddit.com/r/btc/comments/6v5ee7/block_times_and_probabilities/
 fn time_to_mine_n_blocks(n: u8, average_block_time_secs: u16) -> Duration {
     let t = n as u16 * average_block_time_secs;
     Duration::seconds(t as i64)

--- a/comit/src/expiries/config.rs
+++ b/comit/src/expiries/config.rs
@@ -1,6 +1,7 @@
 //! This module provides functionality for calculating the duration of actions
 //! required to determine the transition period from one swap state to the next.
 
+use std::fmt;
 use time::{prelude::*, Duration};
 
 // TODO: From somewhere within the system we need to return to the
@@ -200,6 +201,33 @@ fn ethereum_required_confirmations() -> u8 {
 fn time_to_mine_n_blocks(n: u8, average_block_time_secs: u16) -> Duration {
     let t = n as u16 * average_block_time_secs;
     Duration::seconds(t as i64)
+}
+
+impl fmt::Display for Config {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let pretty = format!(
+            r#"
+    alpha_required_confirmations: {}
+    beta_required_confirmations: {}
+    alpha_block_time: {}
+    beta_block_time: {}
+    alpha_mine_fund_within_n_blocks {}
+    beta_mine_fund_within_n_blocks {}
+    alpha_mine_redeem_within_n_blocks {}
+    beta_mine_redeem_within_n_blocks {}
+"#,
+            self.alpha_required_confirmations,
+            self.beta_required_confirmations,
+            self.alpha_block_time,
+            self.beta_block_time,
+            self.alpha_mine_fund_within_n_blocks,
+            self.beta_mine_fund_within_n_blocks,
+            self.alpha_mine_redeem_within_n_blocks,
+            self.beta_mine_redeem_within_n_blocks,
+        );
+
+        write!(f, "{}", pretty)
+    }
 }
 
 #[cfg(test)]

--- a/comit/src/expiries/config.rs
+++ b/comit/src/expiries/config.rs
@@ -2,7 +2,7 @@
 //! required to determine the transition period from one swap state to the next.
 
 use std::fmt;
-use time::{prelude::*, Duration};
+use time::Duration;
 
 // TODO: From somewhere within the system we need to return to the
 // user a transaction fee to use for each of the transactions (deploy,
@@ -94,33 +94,33 @@ pub struct Config {
 
 impl Config {
     /// The duration of time it takes for Alice to start.
-    pub fn start(&self) -> Duration {
+    pub const fn start(&self) -> Duration {
         period_to_act_with_user_interaction()
     }
 
     /// The duration of time it takes to create the alpha fund transaction.
-    pub fn create_alpha_fund_transaction(&self) -> Duration {
+    pub const fn create_alpha_fund_transaction(&self) -> Duration {
         period_to_act_with_user_interaction()
     }
 
     /// The duration of time it takes to create the beta fund transaction.
-    pub fn create_beta_fund_transaction(&self) -> Duration {
+    pub const fn create_beta_fund_transaction(&self) -> Duration {
         period_to_act_in_software()
     }
 
     /// The duration of time it takes to create the alpha redeem transaction.
-    pub fn create_alpha_redeem_transaction(&self) -> Duration {
+    pub const fn create_alpha_redeem_transaction(&self) -> Duration {
         period_to_act_in_software()
     }
 
     /// The duration of time it takes to create the beta redeem transaction.
-    pub fn create_beta_redeem_transaction(&self) -> Duration {
+    pub const fn create_beta_redeem_transaction(&self) -> Duration {
         period_to_act_with_user_interaction()
     }
 
     /// The duration of time it takes for the alpha fund transaction to be
     /// mined into the blockchain.
-    pub fn mine_alpha_fund_transaction(&self) -> Duration {
+    pub const fn mine_alpha_fund_transaction(&self) -> Duration {
         let n = self.alpha_mine_fund_within_n_blocks;
         let block_time = self.alpha_block_time;
 
@@ -129,7 +129,7 @@ impl Config {
 
     /// The duration of time it takes for the beta fund transaction to be
     /// mined into the blockchain.
-    pub fn mine_beta_fund_transaction(&self) -> Duration {
+    pub const fn mine_beta_fund_transaction(&self) -> Duration {
         let n = self.beta_mine_fund_within_n_blocks;
         let block_time = self.beta_block_time;
 
@@ -138,7 +138,7 @@ impl Config {
 
     /// The duration of time it takes for the alpha redeem transaction to be
     /// mined into the blockchain.
-    pub fn mine_alpha_redeem_transaction(&self) -> Duration {
+    pub const fn mine_alpha_redeem_transaction(&self) -> Duration {
         let n = self.alpha_mine_redeem_within_n_blocks;
         let block_time = self.alpha_block_time;
 
@@ -147,7 +147,7 @@ impl Config {
 
     /// The duration of time it takes for the beta redeem transaction to be
     /// mined into the blockchain.
-    pub fn mine_beta_redeem_transaction(&self) -> Duration {
+    pub const fn mine_beta_redeem_transaction(&self) -> Duration {
         let n = self.beta_mine_redeem_within_n_blocks;
         let block_time = self.beta_block_time;
 
@@ -156,7 +156,7 @@ impl Config {
 
     /// The duration of time it takes for a transaction to reach finality on the
     /// alpha ledger.
-    pub fn finality_alpha(&self) -> Duration {
+    pub const fn finality_alpha(&self) -> Duration {
         let n = self.alpha_required_confirmations;
         let block_time = self.alpha_block_time;
 
@@ -165,7 +165,7 @@ impl Config {
 
     /// The duration of time it takes for a transaction to reach finality on the
     /// beta ledger.
-    pub fn finality_beta(&self) -> Duration {
+    pub const fn finality_beta(&self) -> Duration {
         let n = self.beta_required_confirmations;
         let block_time = self.beta_block_time;
 
@@ -175,21 +175,21 @@ impl Config {
 
 /// If some action requires only software give the counterparty this long to
 /// act. 15 minutes to allow for network congestion etc.
-pub fn period_to_act_in_software() -> Duration {
-    ACT_IN_SOFTWARE_MINS.minutes()
+pub const fn period_to_act_in_software() -> Duration {
+    Duration::minutes(ACT_IN_SOFTWARE_MINS as i64)
 }
 
 /// If some action requires user input give the counterparty this long to
 /// act.
-pub fn period_to_act_with_user_interaction() -> Duration {
-    ACT_WITH_USER_INTERVENTION_MINS.minutes()
+pub const fn period_to_act_with_user_interaction() -> Duration {
+    Duration::minutes(ACT_WITH_USER_INTERVENTION_MINS as i64)
 }
 
-fn bitcoin_required_confirmations() -> u8 {
+const fn bitcoin_required_confirmations() -> u8 {
     BITCOIN_CONFIRMATIONS
 }
 
-fn ethereum_required_confirmations() -> u8 {
+const fn ethereum_required_confirmations() -> u8 {
     ETHEREUM_CONFIRMATIONS
 }
 
@@ -198,7 +198,7 @@ fn ethereum_required_confirmations() -> u8 {
 // implementation. For more details see:
 // - https://en.wikipedia.org/wiki/Poisson_distribution
 // - https://www.reddit.com/r/btc/comments/6v5ee7/block_times_and_probabilities/
-fn time_to_mine_n_blocks(n: u8, average_block_time_secs: u16) -> Duration {
+const fn time_to_mine_n_blocks(n: u8, average_block_time_secs: u16) -> Duration {
     let t = n as u16 * average_block_time_secs;
     Duration::seconds(t as i64)
 }
@@ -240,7 +240,7 @@ mod tests {
         let n = bitcoin_required_confirmations();
         let block_time = BITCOIN_BLOCK_TIME_SECS;
 
-        let max = 5.hours(); // Arbitrarily chosen ceiling.
+        let max = Duration::hours(5); // Arbitrarily chosen ceiling.
         let time = time_to_mine_n_blocks(n, block_time);
 
         assert_that!(time).is_less_than(max)


### PR DESCRIPTION
Improve expiries based on review discussion. This is at a stage now where I'm happy with the research and output. I intend on spending some time now thinking further about how this new module may be used. It would be great to jump on a call with @thomaseizinger and/or @D4nte and walk through the code to see if there are any edge cases I've missed. 

- Use `Started` instead of `Created` (thanks Franck).
- Define periods based on user interaction or software only instead of human vs bot.
- Add checks that invariant beta_expiry <= alpha_expiry always holds.
- Add TODO comment about chain time disparity.
- Use term 'offset' for duration expiries
- Add Alpha/Beta Expiry and Offset types
- Use `cmd::min`
- Improve API, add `start_time`
- Adds a reporting method to show output of created expiries
- Adds a time to start when determining usefulness
- Adds scaling
- Adds/fixes unit tests to use the two points directly above this one
