### PR TITLE
Always initialize a wallet for each ledger within the Actor

### DIFF
--- a/api_tests/src/actors/defaults.ts
+++ b/api_tests/src/actors/defaults.ts
@@ -1,5 +1,4 @@
 import { Ledger, LedgerKind } from "../ledgers/ledger";
-import { Actor } from "./actor";
 
 /**
  * WIP as the cnd REST API routes for lightning are not yet defined.
@@ -26,46 +25,6 @@ export function defaultLedgerDescriptionForLedger(ledger: LedgerKind): Ledger {
             };
         }
     }
-}
-
-export async function getIdentities(
-    self: Actor
-): Promise<{ ethereum: string; lightning: string; bitcoin: string }> {
-    let ethereum = "0x00a329c0648769a73afac7f9381e08fb43dbea72";
-    let lightning =
-        "02ed138aaed50d2d597f6fe8d30759fd3949fe73fdf961322713f1c19e10036a06";
-    let bitcoin =
-        "02c2a8efce029526d364c2cf39d89e3cdda05e5df7b2cbfc098b4e3d02b70b5275";
-
-    try {
-        ethereum = self.wallets.ethereum.account();
-    } catch (e) {
-        self.logger.warn(
-            "Ethereum wallet not available, using static value for identity"
-        );
-    }
-
-    try {
-        lightning = await self.wallets.lightning.inner.getPubkey();
-    } catch (e) {
-        self.logger.warn(
-            "Lightning wallet not available, using static value for identity"
-        );
-    }
-
-    try {
-        bitcoin = await self.wallets.bitcoin.address();
-    } catch (e) {
-        self.logger.warn(
-            "Bitcoin wallet not available, using static value for identity"
-        );
-    }
-
-    return {
-        ethereum,
-        lightning,
-        bitcoin,
-    };
 }
 
 export function defaultExpiries() {

--- a/api_tests/src/create_actors.ts
+++ b/api_tests/src/create_actors.ts
@@ -22,7 +22,9 @@ export async function createActors(
                 global.cargoTargetDir,
                 cndLogFile,
                 actorLogger,
-                global.cndConfigOverrides
+                global.cndConfigOverrides,
+                global.gethLockDir,
+                global.lndWallets
             )
         );
     }

--- a/api_tests/src/test_environment.ts
+++ b/api_tests/src/test_environment.ts
@@ -3,8 +3,8 @@ import { execAsync, existsAsync, HarnessGlobal } from "./utils";
 import { promises as asyncFs } from "fs";
 import NodeEnvironment from "jest-environment-node";
 import path from "path";
-import { LightningWallet } from "./wallets/lightning";
-import { BitcoinWallet } from "./wallets/bitcoin";
+import { LndWallet } from "./wallets/lightning";
+import { BitcoindWallet } from "./wallets/bitcoin";
 import { AssetKind } from "./asset";
 import { LedgerKind } from "./ledgers/ledger";
 import { BitcoindInstance } from "./ledgers/bitcoind_instance";
@@ -12,7 +12,7 @@ import { configure, Logger, shutdown as loggerShutdown } from "log4js";
 import { EnvironmentContext } from "@jest/environment";
 import ledgerLock from "./ledgers/ledger_lock";
 import BitcoinMinerInstance from "./ledgers/bitcoin_miner_instance";
-import { EthereumWallet } from "./wallets/ethereum";
+import { Web3EthereumWallet } from "./wallets/ethereum";
 import { LedgerInstance, LightningNodeConfig } from "./ledgers";
 import { GethInstance } from "./ledgers/geth_instance";
 import { LndInstance } from "./ledgers/lnd_instance";
@@ -219,7 +219,7 @@ export default class TestEnvironment extends NodeEnvironment {
         const config = await this.startLedger(lockDir, geth, async (geth) => {
             const rpcUrl = geth.rpcUrl;
             const devAccountKey = geth.devAccountKey();
-            const erc20Wallet = await EthereumWallet.new_instance(
+            const erc20Wallet = await Web3EthereumWallet.new_instance(
                 devAccountKey,
                 rpcUrl,
                 this.logger,
@@ -315,8 +315,8 @@ export default class TestEnvironment extends NodeEnvironment {
     }
 
     private async initLightningWallet(config: LightningNodeConfig) {
-        return LightningWallet.newInstance(
-            await BitcoinWallet.newInstance(
+        return LndWallet.newInstance(
+            await BitcoindWallet.newInstance(
                 this.global.ledgerConfigs.bitcoin,
                 this.logger
             ),

--- a/api_tests/src/utils.ts
+++ b/api_tests/src/utils.ts
@@ -1,5 +1,5 @@
-import { promises as asyncFs } from "fs";
 import * as fs from "fs";
+import { promises as asyncFs } from "fs";
 import { promisify } from "util";
 import { Global } from "@jest/types";
 import rimraf from "rimraf";

--- a/api_tests/src/wallets/ethereum.ts
+++ b/api_tests/src/wallets/ethereum.ts
@@ -8,7 +8,15 @@ import { lock } from "proper-lockfile";
 import { Asset } from "../asset";
 import path from "path";
 
-export class EthereumWallet implements Wallet {
+export interface EthereumWallet extends Wallet {
+    inner: EthereumWalletSdk;
+
+    account(): string;
+    deployErc20TokenContract(): Promise<string>;
+    getTransactionStatus(txid: string): Promise<number>;
+}
+
+export class Web3EthereumWallet implements EthereumWallet {
     public MaximumFee = 0;
 
     private constructor(
@@ -34,7 +42,7 @@ export class EthereumWallet implements Wallet {
             ""
         );
         const inner = new EthereumWalletSdk(rpcUrl);
-        return new EthereumWallet(
+        return new Web3EthereumWallet(
             ethereumDevAccount,
             logger,
             ethereumLockDir,

--- a/api_tests/tests/halbit_herc20.ts
+++ b/api_tests/tests/halbit_herc20.ts
@@ -11,14 +11,7 @@ describe("halbit-herc20", () => {
     it(
         "halbit-herc20-alice-redeems-bob-redeems",
         twoActorTest(async ({ alice, bob }) => {
-            const bodies = (
-                await SwapFactory.newSwap(alice, bob, {
-                    ledgers: {
-                        alpha: "lightning",
-                        beta: "ethereum",
-                    },
-                })
-            ).halbitHerc20;
+            const bodies = (await SwapFactory.newSwap(alice, bob)).halbitHerc20;
 
             await alice.createHalbitHerc20Swap(bodies.alice);
             await bob.createHalbitHerc20Swap(bodies.bob);
@@ -46,10 +39,6 @@ describe("halbit-herc20", () => {
         twoActorTest(async ({ alice, bob }) => {
             const bodies = (
                 await SwapFactory.newSwap(alice, bob, {
-                    ledgers: {
-                        alpha: "lightning",
-                        beta: "ethereum",
-                    },
                     instantRefund: true,
                 })
             ).halbitHerc20;

--- a/api_tests/tests/hbit_herc20.ts
+++ b/api_tests/tests/hbit_herc20.ts
@@ -11,14 +11,7 @@ describe("hbit-herc20", () => {
     it(
         "hbit-herc20-alice-redeems-bob-redeems",
         twoActorTest(async ({ alice, bob }) => {
-            const bodies = (
-                await SwapFactory.newSwap(alice, bob, {
-                    ledgers: {
-                        alpha: "bitcoin",
-                        beta: "ethereum",
-                    },
-                })
-            ).hbitHerc20;
+            const bodies = (await SwapFactory.newSwap(alice, bob)).hbitHerc20;
 
             await alice.createHbitHerc20Swap(bodies.alice);
             await bob.createHbitHerc20Swap(bodies.bob);
@@ -44,10 +37,6 @@ describe("hbit-herc20", () => {
         twoActorTest(async ({ alice, bob }) => {
             const bodies = (
                 await SwapFactory.newSwap(alice, bob, {
-                    ledgers: {
-                        alpha: "bitcoin",
-                        beta: "ethereum",
-                    },
                     instantRefund: true,
                 })
             ).hbitHerc20;

--- a/api_tests/tests/herc20_halbit.ts
+++ b/api_tests/tests/herc20_halbit.ts
@@ -11,14 +11,7 @@ describe("herc20-halbit", () => {
     it(
         "herc20-halbit-alice-redeems-bob-redeems",
         twoActorTest(async ({ alice, bob }) => {
-            const bodies = (
-                await SwapFactory.newSwap(alice, bob, {
-                    ledgers: {
-                        alpha: "ethereum",
-                        beta: "lightning",
-                    },
-                })
-            ).herc20Halbit;
+            const bodies = (await SwapFactory.newSwap(alice, bob)).herc20Halbit;
 
             await alice.createHerc20HalbitSwap(bodies.alice);
             await bob.createHerc20HalbitSwap(bodies.bob);
@@ -46,10 +39,6 @@ describe("herc20-halbit", () => {
         twoActorTest(async ({ alice, bob }) => {
             const bodies = (
                 await SwapFactory.newSwap(alice, bob, {
-                    ledgers: {
-                        alpha: "ethereum",
-                        beta: "lightning",
-                    },
                     instantRefund: true,
                 })
             ).herc20Halbit;

--- a/api_tests/tests/herc20_halbit_respawn.ts
+++ b/api_tests/tests/herc20_halbit_respawn.ts
@@ -11,14 +11,7 @@ describe("herc20-halbit-respawn", () => {
     it(
         "herc20-halbit-alice-misses-bob-fund",
         twoActorTest(async ({ alice, bob }) => {
-            const bodies = (
-                await SwapFactory.newSwap(alice, bob, {
-                    ledgers: {
-                        alpha: "ethereum",
-                        beta: "lightning",
-                    },
-                })
-            ).herc20Halbit;
+            const bodies = (await SwapFactory.newSwap(alice, bob)).herc20Halbit;
 
             await alice.createHerc20HalbitSwap(bodies.alice);
             await bob.createHerc20HalbitSwap(bodies.bob);
@@ -49,14 +42,7 @@ describe("herc20-halbit-respawn", () => {
     it(
         "herc20-halbit-bob-misses-alice-redeem",
         twoActorTest(async ({ alice, bob }) => {
-            const bodies = (
-                await SwapFactory.newSwap(alice, bob, {
-                    ledgers: {
-                        alpha: "ethereum",
-                        beta: "lightning",
-                    },
-                })
-            ).herc20Halbit;
+            const bodies = (await SwapFactory.newSwap(alice, bob)).herc20Halbit;
 
             await alice.createHerc20HalbitSwap(bodies.alice);
             await bob.createHerc20HalbitSwap(bodies.bob);
@@ -88,14 +74,7 @@ describe("herc20-halbit-respawn", () => {
     it(
         "halbit-herc20-alice-misses-bob-deploy-and-fund",
         twoActorTest(async ({ alice, bob }) => {
-            const bodies = (
-                await SwapFactory.newSwap(alice, bob, {
-                    ledgers: {
-                        alpha: "lightning",
-                        beta: "ethereum",
-                    },
-                })
-            ).halbitHerc20;
+            const bodies = (await SwapFactory.newSwap(alice, bob)).halbitHerc20;
 
             await alice.createHalbitHerc20Swap(bodies.alice);
             await bob.createHalbitHerc20Swap(bodies.bob);
@@ -127,14 +106,7 @@ describe("herc20-halbit-respawn", () => {
     it(
         "halbit-herc20-bob-down-misses-alice-redeem",
         twoActorTest(async ({ alice, bob }) => {
-            const bodies = (
-                await SwapFactory.newSwap(alice, bob, {
-                    ledgers: {
-                        alpha: "lightning",
-                        beta: "ethereum",
-                    },
-                })
-            ).halbitHerc20;
+            const bodies = (await SwapFactory.newSwap(alice, bob)).halbitHerc20;
 
             await alice.createHalbitHerc20Swap(bodies.alice);
             await bob.createHalbitHerc20Swap(bodies.bob);

--- a/api_tests/tests/herc20_hbit.ts
+++ b/api_tests/tests/herc20_hbit.ts
@@ -11,14 +11,7 @@ describe("herc20-hbit", () => {
     it(
         "herc20-hbit-alice-redeems-bob-redeems",
         twoActorTest(async ({ alice, bob }) => {
-            const bodies = (
-                await SwapFactory.newSwap(alice, bob, {
-                    ledgers: {
-                        alpha: "ethereum",
-                        beta: "bitcoin",
-                    },
-                })
-            ).herc20Hbit;
+            const bodies = (await SwapFactory.newSwap(alice, bob)).herc20Hbit;
 
             await alice.createHerc20HbitSwap(bodies.alice);
             await bob.createHerc20HbitSwap(bodies.bob);
@@ -44,10 +37,6 @@ describe("herc20-hbit", () => {
         twoActorTest(async ({ alice, bob }) => {
             const bodies = (
                 await SwapFactory.newSwap(alice, bob, {
-                    ledgers: {
-                        alpha: "ethereum",
-                        beta: "bitcoin",
-                    },
                     instantRefund: true,
                 })
             ).herc20Hbit;

--- a/api_tests/tests/herc20_hbit_respawn.ts
+++ b/api_tests/tests/herc20_hbit_respawn.ts
@@ -11,14 +11,7 @@ describe("herc20-hbit-respawn", () => {
     it(
         "herc20-hbit-alice-misses-bob-funds",
         twoActorTest(async ({ alice, bob }) => {
-            const bodies = (
-                await SwapFactory.newSwap(alice, bob, {
-                    ledgers: {
-                        alpha: "ethereum",
-                        beta: "bitcoin",
-                    },
-                })
-            ).herc20Hbit;
+            const bodies = (await SwapFactory.newSwap(alice, bob)).herc20Hbit;
 
             await alice.createHerc20HbitSwap(bodies.alice);
             await bob.createHerc20HbitSwap(bodies.bob);
@@ -48,14 +41,7 @@ describe("herc20-hbit-respawn", () => {
     it(
         "herc20-hbit-bob-misses-alice-redeems",
         twoActorTest(async ({ alice, bob }) => {
-            const bodies = (
-                await SwapFactory.newSwap(alice, bob, {
-                    ledgers: {
-                        alpha: "ethereum",
-                        beta: "bitcoin",
-                    },
-                })
-            ).herc20Hbit;
+            const bodies = (await SwapFactory.newSwap(alice, bob)).herc20Hbit;
 
             await alice.createHerc20HbitSwap(bodies.alice);
             await bob.createHerc20HbitSwap(bodies.bob);
@@ -86,14 +72,7 @@ describe("herc20-hbit-respawn", () => {
     it(
         "hbit-herc20-alice-misses-bob-deploys-and-funds",
         twoActorTest(async ({ alice, bob }) => {
-            const bodies = (
-                await SwapFactory.newSwap(alice, bob, {
-                    ledgers: {
-                        alpha: "bitcoin",
-                        beta: "ethereum",
-                    },
-                })
-            ).hbitHerc20;
+            const bodies = (await SwapFactory.newSwap(alice, bob)).hbitHerc20;
 
             await alice.createHbitHerc20Swap(bodies.alice);
             await bob.createHbitHerc20Swap(bodies.bob);
@@ -123,14 +102,7 @@ describe("herc20-hbit-respawn", () => {
     it(
         "hbit-herc20-bob-down-misses-alice-redeems",
         twoActorTest(async ({ alice, bob }) => {
-            const bodies = (
-                await SwapFactory.newSwap(alice, bob, {
-                    ledgers: {
-                        alpha: "bitcoin",
-                        beta: "ethereum",
-                    },
-                })
-            ).hbitHerc20;
+            const bodies = (await SwapFactory.newSwap(alice, bob)).hbitHerc20;
 
             await alice.createHbitHerc20Swap(bodies.alice);
             await bob.createHbitHerc20Swap(bodies.bob);

--- a/api_tests/tests/siren_schema.ts
+++ b/api_tests/tests/siren_schema.ts
@@ -49,14 +49,7 @@ describe("Siren Schema", () => {
     it(
         "get-single-swap-is-valid-siren",
         twoActorTest(async ({ alice, bob }) => {
-            const bodies = (
-                await SwapFactory.newSwap(alice, bob, {
-                    ledgers: {
-                        alpha: "bitcoin",
-                        beta: "ethereum",
-                    },
-                })
-            ).hbitHerc20;
+            const bodies = (await SwapFactory.newSwap(alice, bob)).hbitHerc20;
 
             await alice.createHbitHerc20Swap(bodies.alice);
             await bob.createHbitHerc20Swap(bodies.bob);


### PR DESCRIPTION
This allows us to write DRY tests that for example only require an
address. It is also cleaner in the way that `Actor` is now less
mutable because everything gets initialized from the start.