### PR TITLE
Don't delete head branches if a PR is still open

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -35,7 +35,7 @@ pull_request_rules:
       - head~=^(?!release.*).*$
     actions:
       delete_head_branch:
-        force: true
+        force: false
   - name: Block regular PRs from merging into master
     conditions:
       - base=master


### PR DESCRIPTION
Unfortunately, GH PR retargeting doesn't work if a bot deletes the
head branch. At the same time, if we force delete it the PR gets
closed and closed PRs can't be changed at all, forcing you to open
a new one.

FYI @comit-network/comit-devs.