### PR TITLE
Handle deploy for ERC20

### DIFF
--- a/comit/src/expiries.rs
+++ b/comit/src/expiries.rs
@@ -490,25 +490,25 @@ impl AliceState {
     /// fund transaction has been broadcast since any time after attempting to
     /// refund is the correct cancellation action.
     fn has_broadcast_fund_transaction(&self) -> bool {
+        use AliceState::*;
+
         match self {
-            AliceState::None | AliceState::Started => false,
-            AliceState::FundAlphaTransactionBroadcast
-            | AliceState::AlphaFunded
-            | AliceState::BetaFunded
-            | AliceState::RedeemBetaTransactionBroadcast
-            | AliceState::Done => true,
+            None | Started => false,
+            FundAlphaTransactionBroadcast
+            | AlphaFunded
+            | BetaFunded
+            | RedeemBetaTransactionBroadcast
+            | Done => true,
         }
     }
 
     /// True if Alice has broadcast her redeem transaction.
     fn has_broadcast_redeem_transaction(&self) -> bool {
+        use AliceState::*;
+
         match self {
-            AliceState::None
-            | AliceState::Started
-            | AliceState::FundAlphaTransactionBroadcast
-            | AliceState::AlphaFunded
-            | AliceState::BetaFunded => false,
-            AliceState::RedeemBetaTransactionBroadcast | AliceState::Done => true,
+            None | Started | FundAlphaTransactionBroadcast | AlphaFunded | BetaFunded => false,
+            RedeemBetaTransactionBroadcast | Done => true,
         }
     }
 }
@@ -621,25 +621,29 @@ impl BobState {
     /// fund transaction has been broadcast since any time after attempting to
     /// refund is the correct cancellation action.
     fn has_broadcast_fund_transaction(&self) -> bool {
+        use BobState::*;
+
         match self {
-            BobState::Started | BobState::AlphaFunded => false,
-            BobState::FundBetaTransactionBroadcast
-            | BobState::BetaFunded
-            | BobState::RedeemBetaTransactionSeen
-            | BobState::RedeemAlphaTransactionBroadcast
-            | BobState::Done => true,
+            Started | AlphaFunded => false,
+            FundBetaTransactionBroadcast
+            | BetaFunded
+            | RedeemBetaTransactionSeen
+            | RedeemAlphaTransactionBroadcast
+            | Done => true,
         }
     }
 
     /// True if Bob has broadcast his redeem transaction.
     fn has_broadcast_redeem_transaction(&self) -> bool {
+        use BobState::*;
+
         match self {
-            BobState::Started
-            | BobState::AlphaFunded
-            | BobState::FundBetaTransactionBroadcast
-            | BobState::BetaFunded
-            | BobState::RedeemBetaTransactionSeen => false,
-            BobState::RedeemAlphaTransactionBroadcast | BobState::Done => true,
+            Started
+            | AlphaFunded
+            | FundBetaTransactionBroadcast
+            | BetaFunded
+            | RedeemBetaTransactionSeen => false,
+            RedeemAlphaTransactionBroadcast | Done => true,
         }
     }
 }

--- a/comit/src/expiries.rs
+++ b/comit/src/expiries.rs
@@ -871,7 +871,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn alice_can_complete_a_swap() {
+    async fn alice_can_complete_a_hbit_herc20_swap() {
         let start_at = Timestamp::now();
         let (ac, bc) = mock_connectors();
 
@@ -892,7 +892,49 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bob_can_complete_a_swap() {
+    async fn alice_can_complete_a_herc20_hbit_swap() {
+        let start_at = Timestamp::now();
+        let (ac, bc) = mock_connectors();
+
+        let exp = Expiries::new_herc20_hbit(start_at, ac.clone(), bc.clone());
+        let mut cur = AliceState::initial();
+
+        let inc = 1.minutes();
+
+        while cur != AliceState::Done {
+            inc_connectors(inc, ac.clone(), bc.clone()).await;
+            let (want_action, state) = cur.next_herc20_hbit();
+            let got_action = exp.next_action_for_alice(cur).await;
+
+            assert_that!(got_action).is_equal_to(want_action);
+
+            cur = state;
+        }
+    }
+
+    #[tokio::test]
+    async fn bob_can_complete_a_herc20_hbit_swap() {
+        let start_at = Timestamp::now();
+        let (ac, bc) = mock_connectors();
+
+        let exp = Expiries::new_herc20_hbit(start_at, ac.clone(), bc.clone());
+        let mut cur = BobState::initial();
+
+        let inc = 1.minutes();
+
+        while cur != BobState::Done {
+            inc_connectors(inc, ac.clone(), bc.clone()).await;
+            let (want_action, state) = cur.next_herc20_hbit();
+            let got_action = exp.next_action_for_bob(cur).await;
+
+            assert_that!(got_action).is_equal_to(want_action);
+
+            cur = state;
+        }
+    }
+
+    #[tokio::test]
+    async fn bob_can_complete_a_hbit_herc20_swap() {
         let start_at = Timestamp::now();
         let (ac, bc) = mock_connectors();
 

--- a/comit/src/expiries.rs
+++ b/comit/src/expiries.rs
@@ -516,8 +516,9 @@ impl AliceState {
         match self {
             None => (Start, Started),
             Started => (FundAlpha, FundAlphaTransactionBroadcast),
-            DeployAlphaTransactionBroadcast => unreachable!("hbit-herc20 no deploy for Alice"),
-            AlphaDeployed => unreachable!("hbit-herc20 no deploy for Alice"),
+            DeployAlphaTransactionBroadcast | AlphaDeployed => {
+                unreachable!("hbit-herc20 no deploy for Alice")
+            }
             FundAlphaTransactionBroadcast => (WaitForAlphaFundTransactionFinality, AlphaFunded),
             AlphaFunded => (WaitForBetaFundTransactionFinality, BetaFunded),
             BetaFunded => (RedeemBeta, RedeemBetaTransactionBroadcast),
@@ -666,8 +667,9 @@ impl BobState {
         match self {
             Started => (WaitForAlphaFundTransactionFinality, AlphaFunded),
             AlphaFunded => (FundBeta, FundBetaTransactionBroadcast),
-            DeployBetaTransactionBroadcast => unreachable!("herc20-hbit no deploy for Bob"),
-            BetaDeployed => unreachable!("herc20-hbit no deploy for Bob"),
+            DeployBetaTransactionBroadcast | BetaDeployed => {
+                unreachable!("herc20-hbit no deploy for Bob")
+            }
             FundBetaTransactionBroadcast => (WaitForBetaFundTransactionFinality, BetaFunded),
             BetaFunded => (
                 WaitForBetaRedeemTransactionBroadcast,

--- a/comit/src/expiries.rs
+++ b/comit/src/expiries.rs
@@ -13,12 +13,6 @@ use num::integer;
 use std::{cmp, fmt};
 use time::Duration;
 
-#[cfg(not(test))]
-use tracing::debug;
-
-#[cfg(test)]
-use std::println as debug;
-
 // TODO: Research how times are calculated on each chain and if we can compare
 // time across chains? This knowledge is needed because we calculate the alpha
 // expiry offset based on the beta expiry offset, if one cannot compare times on
@@ -157,11 +151,6 @@ where
         };
         let bob_can_complete = self.bob_can_complete(current_state.into()).await;
 
-        debug!(
-            "{:?}: {} {}",
-            current_state, alice_can_complete, bob_can_complete
-        );
-
         if !(alice_can_complete && bob_can_complete) {
             if funded {
                 return AliceAction::WaitToRefund;
@@ -253,10 +242,6 @@ where
 
         // Alice redeems on beta ledger so is concerned about the beta expiry.
         let end_time = now.add_duration(period);
-        // debug!(
-        //     "alice_can_complete {:?} \n end_time: {:?} beta_expiry: {:?}",
-        //     current_state, end_time, self.beta_expiry.0
-        // );
         end_time < self.beta_expiry.0
     }
 
@@ -266,14 +251,8 @@ where
         let period = period_for_bob_to_complete(&self.config, current_state);
         let now = self.alpha_connector.current_time().await;
 
-        debug!("Bob now: {:?} period: {:?}", now, period.whole_seconds());
-
         // Bob redeems on alpha ledger so is concerned about the alpha expiry.
         let end_time = now.add_duration(period);
-        debug!(
-            "bob_can_complete {:?} \n end_time: {:?} alpha_expiry: {:?}",
-            current_state, end_time, self.alpha_expiry.0
-        );
         end_time < self.alpha_expiry.0
     }
 

--- a/comit/src/expiries/config.rs
+++ b/comit/src/expiries/config.rs
@@ -4,11 +4,10 @@
 use std::fmt;
 use time::Duration;
 
-// TODO: From somewhere within the system we need to return to the
-// user a transaction fee to use for each of the transactions (deploy,
-// fund, refund, redeem). In this module we assume the fee is set to
-// the suggested amount. We rely on this assumption for the
-// confirmation time calculations in this module to be correct.
+// TODO: From somewhere within the system we need to return to the user a
+// transaction fee to use for each of the transactions (deploy, fund, refund,
+// redeem). In this module we assume the fee is set to the suggested amount. We
+// rely on this assumption for the confirmation time calculations to be correct.
 //
 // For Ethereum:
 //
@@ -36,7 +35,7 @@ use time::Duration;
 const BITCOIN_BLOCK_TIME_SECS: u16 = 600; // 10 minutes, average Bitcoin block time.
 const ETHEREUM_BLOCK_TIME_SECS: u16 = 20; // Conservative Ethereum block time.
 
-// TODO: Fee recommendation must use this value.
+// TODO: Fee recommendation must use this value of N.
 const BITCOIN_MINE_WITHIN_N_BLOCKS: u8 = 3; // Value arbitrarily chosen.
 const ETHEREUM_MINE_WITHIN_N_BLOCKS: u8 = 3; // Value arbitrarily chosen.
 
@@ -262,8 +261,9 @@ const fn time_to_mine_n_blocks(n: u8, average_block_time_secs: u16) -> Duration 
     // average block time an actor waits longer than time T, this will cause the
     // swap to abort. Therefore we double the time T.
     //
-    // TODO: Define an acceptable probability threshold and actually do the math to
-    // calculate this time window.
+    // In the future we could define an acceptable probability threshold and
+    // actually do the math to calculate this time window. This adds however a lot
+    // of complexity for minimal benefit.
 
     let acceptable = t as i64 * 2;
 


### PR DESCRIPTION
Add support for the deploy action.

Currently we do not take the deployment of the ERC20 contract into account. Do so by adding variants to the `AliceState` and `BobState` enums and conditional logic depending on the protocol in use when determining next action and next state.

Note: Re-introduces a `Protocol` type. Do we want this?

- Patch 1 is refactor: Add `use` statement to reduce noise.
- Patch 2 is the ERC20 support.
- Patch 3 is refactor: Use 'broadcast' uniformly throughout the module.
- Patch 4 is whitespace: audit TODOs and tidy up the TODO comments.
- Patch 5 adds units test for complete swaps in all directions.