### PR TITLE
Implement new swap response format 

### DIFF
--- a/api_tests/src/actors/actor.ts
+++ b/api_tests/src/actors/actor.ts
@@ -1,21 +1,15 @@
+import { Cnd, Swap, Wallets as SdkWallets } from "comit-sdk";
 import {
-    Cnd,
-    LedgerParameters,
-    Step,
-    Swap,
-    Wallets as SdkWallets,
-} from "comit-sdk";
-import {
-    EscrowStatus,
+    ActionKind,
     HalbitHerc20Payload,
     HbitHerc20Payload,
     Herc20HalbitPayload,
     Herc20HbitPayload,
-    LedgerState,
     OpenOrdersEntity,
     OrderEntity,
     Position,
-    SwapResponse,
+    SwapEntity,
+    SwapEventKind,
 } from "../payload";
 import { Logger } from "log4js";
 import { CndConfigFile, E2ETestActorConfig } from "../config";
@@ -463,7 +457,7 @@ export class Actor {
         return `http://${socket}`;
     }
 
-    public async pollCndUntil<T = SwapResponse>(
+    public async pollCndUntil<T>(
         location: string,
         predicate: (body: T) => boolean
     ): Promise<T> {
@@ -480,7 +474,7 @@ export class Actor {
         }
     }
 
-    public async assertAndExecuteNextAction(expectedActionName: string) {
+    public async assertAndExecuteNextAction(expectedActionName: ActionKind) {
         if (!this.swap) {
             throw new Error("Cannot do anything on non-existent swap");
         }
@@ -510,198 +504,46 @@ export class Actor {
             this.swap.self,
             transaction
         );
-        switch (action.name) {
-            case "deploy":
-                await this.assertDeployed();
-                break;
-            case "fund":
-                await this.assertFunded();
-                break;
-            case "redeem":
-                await this.assertRedeemed();
-                break;
-            case "refund":
-                await this.assertRefunded();
+
+        const swapProperties = await this.getSwapResponse().then(
+            (e) => e.properties
+        );
+        const event = nextExpectedEvent(
+            swapProperties.role,
+            expectedActionName,
+            swapProperties.alpha.protocol,
+            swapProperties.beta.protocol
+        );
+
+        if (event === null) {
+            return;
         }
-    }
 
-    public async getSwapResponse(): Promise<SwapResponse> {
-        return this.cnd
-            .fetch<SwapResponse>(this.swap.self)
-            .then((response) => response.data);
-    }
+        await pTimeout(
+            (async () => {
+                while (true) {
+                    const swapEntity = await this.getSwapResponse();
 
-    public async cryptoRole(): Promise<"Alice" | "Bob"> {
-        return this.getSwapResponse().then(
-            (swapResponse) => swapResponse.properties.role
+                    if (
+                        swapEntity.properties.events
+                            .map((e) => e.name)
+                            .includes(event)
+                    ) {
+                        return;
+                    }
+
+                    await sleep(500);
+                }
+            })(),
+            30_000,
+            `event '${event}' expected but never found`
         );
     }
 
-    /**
-     * Assertions against cnd API Only
-     */
-
-    public async assertAlphaDeployed() {
-        await this.assertLedgerStatus("alpha", EscrowStatus.Deployed);
-        await this.assertLedgerEventPresence("alpha", Step.Deploy);
-    }
-
-    public async assertBetaDeployed() {
-        await this.assertLedgerStatus("beta", EscrowStatus.Deployed);
-        await this.assertLedgerEventPresence("beta", Step.Deploy);
-    }
-
-    public async assertAlphaFunded(): Promise<void> {
-        await this.assertLedgerStatus("alpha", EscrowStatus.Funded);
-        await this.assertLedgerEventPresence("alpha", Step.Fund);
-    }
-
-    public async assertBetaFunded() {
-        await this.assertLedgerStatus("beta", EscrowStatus.Funded);
-        await this.assertLedgerEventPresence("beta", Step.Fund);
-    }
-
-    public async assertAlphaRedeemed() {
-        await this.assertLedgerStatus("alpha", EscrowStatus.Redeemed);
-        await this.assertLedgerEventPresence("alpha", Step.Redeem);
-    }
-
-    public async assertBetaRedeemed() {
-        await this.assertLedgerStatus("beta", EscrowStatus.Redeemed);
-        await this.assertLedgerEventPresence("beta", Step.Redeem);
-    }
-
-    public async assertAlphaRefunded() {
-        await this.assertLedgerStatus("alpha", EscrowStatus.Refunded);
-        await this.assertLedgerEventPresence("alpha", Step.Refund);
-    }
-
-    public async assertBetaRefunded() {
-        await this.assertLedgerStatus("beta", EscrowStatus.Refunded);
-        await this.assertLedgerEventPresence("beta", Step.Refund);
-    }
-
-    private async assertDeployed() {
-        const role = await this.cryptoRole();
-        switch (role) {
-            case "Alice":
-                await this.actors.alice.assertAlphaDeployed();
-                if (this.actors.bob.cndInstance.isRunning()) {
-                    await this.actors.bob.assertAlphaDeployed();
-                }
-                break;
-            case "Bob":
-                if (this.actors.alice.cndInstance.isRunning()) {
-                    await this.actors.alice.assertBetaDeployed();
-                }
-                await this.actors.bob.assertBetaDeployed();
-                break;
-        }
-    }
-
-    private async assertFunded() {
-        const role = await this.cryptoRole();
-        switch (role) {
-            case "Alice":
-                await this.actors.alice.assertAlphaFunded();
-                if (this.actors.bob.cndInstance.isRunning()) {
-                    await this.actors.bob.assertAlphaFunded();
-                }
-                break;
-            case "Bob":
-                if (this.actors.alice.cndInstance.isRunning()) {
-                    await this.actors.alice.assertBetaFunded();
-                }
-                await this.actors.bob.assertBetaFunded();
-                break;
-        }
-    }
-
-    private async assertRedeemed() {
-        const role = await this.cryptoRole();
-        switch (role) {
-            case "Alice":
-                await this.actors.alice.assertBetaRedeemed();
-                if (this.actors.bob.cndInstance.isRunning()) {
-                    await this.actors.bob.assertBetaRedeemed();
-                }
-                break;
-            case "Bob":
-                if (this.actors.alice.cndInstance.isRunning()) {
-                    await this.actors.alice.assertAlphaRedeemed();
-                }
-                await this.actors.bob.assertAlphaRedeemed();
-                break;
-        }
-    }
-
-    private async assertRefunded() {
-        const role = await this.cryptoRole();
-        switch (role) {
-            case "Alice":
-                await this.actors.alice.assertAlphaRefunded();
-                if (this.actors.bob.cndInstance.isRunning()) {
-                    await this.actors.bob.assertAlphaRefunded();
-                }
-                break;
-            case "Bob":
-                if (this.actors.alice.cndInstance.isRunning()) {
-                    await this.actors.alice.assertBetaRefunded();
-                }
-                await this.actors.bob.assertBetaRefunded();
-                break;
-        }
-    }
-
-    private async assertLedgerStatus(
-        ledgerRel: "alpha" | "beta",
-        status: EscrowStatus
-    ): Promise<void> {
-        await this.pollCndUntil(this.swap.self, (swapResponse) => {
-            for (const entity of swapResponse.entities) {
-                const ledgerState = entity as LedgerState;
-                if (
-                    ledgerState.class.includes("state") &&
-                    ledgerState.rel.includes(ledgerRel)
-                ) {
-                    return ledgerState.properties.status === status;
-                }
-            }
-        });
-    }
-
-    private async assertLedgerEventPresence(
-        ledgerRel: "alpha" | "beta",
-        step: Step
-    ): Promise<void> {
-        await this.pollCndUntil(this.swap.self, (swapResponse) => {
-            let protocol;
-            for (const entity of swapResponse.entities) {
-                const ledgerParameters = entity as LedgerParameters;
-                if (
-                    ledgerParameters.class.includes("parameters") &&
-                    ledgerParameters.rel.includes(ledgerRel)
-                ) {
-                    protocol = ledgerParameters.properties.protocol;
-                    break;
-                }
-            }
-
-            // No events are set for halbit
-            if (protocol === "halbit") {
-                return true;
-            }
-
-            for (const entity of swapResponse.entities) {
-                const ledgerState = entity as LedgerState;
-                if (
-                    ledgerState.class.includes("state") &&
-                    ledgerState.rel.includes(ledgerRel)
-                ) {
-                    return !!ledgerState.properties.events[step];
-                }
-            }
-        });
+    public async getSwapResponse(): Promise<SwapEntity> {
+        return this.cnd
+            .fetch<SwapEntity>(this.swap.self)
+            .then((response) => response.data);
     }
 
     public async assertBalancesAfterSwap() {
@@ -787,10 +629,6 @@ export class Actor {
         if (this.swap) {
             const swapResponse = await this.getSwapResponse();
 
-            this.logger.debug(
-                "swap status: %s",
-                swapResponse.properties.status
-            );
             this.logger.debug("swap details: ", JSON.stringify(swapResponse));
 
             this.logger.debug(
@@ -967,6 +805,62 @@ function newLightningWallet(
             throw new Error(
                 `Cannot initialize Lightning wallet for actor: '${actor}'`
             );
+        }
+    }
+}
+
+/**
+ * Computes the event that we are expecting to see.
+ */
+function nextExpectedEvent(
+    role: "Alice" | "Bob",
+    action: ActionKind,
+    alphaProtocol: "hbit" | "halbit" | "herc20",
+    betaProtocol: "hbit" | "halbit" | "herc20"
+): SwapEventKind {
+    switch (action) {
+        case "init": {
+            return null;
+        }
+        // "deploy" can only mean we are waiting for "herc20_deployed"
+        case "deploy": {
+            return "herc20_deployed";
+        }
+
+        // Alice is always funding and refunding on the alpha ledger, likewise Bob on the beta ledger
+        case "fund":
+        case "refund": {
+            switch (role) {
+                case "Alice": {
+                    // @ts-ignore: Sad that TypeScript can't infer that.
+                    return `${alphaProtocol}_${action}ed`;
+                }
+                case "Bob": {
+                    // @ts-ignore: Sad that TypeScript can't infer that.
+                    return `${betaProtocol}_${action}ed`;
+                }
+                default:
+                    throw new Error(
+                        `Who is ${role}? We expected either Alice or Bob!`
+                    );
+            }
+        }
+        // Alice is always redeeming on the beta ledger, likewise Bob on the alpha ledger
+        case "redeem": {
+            switch (role) {
+                case "Alice": {
+                    // @ts-ignore: Sad that TypeScript can't infer that.
+                    return `${betaProtocol}_${action}ed`;
+                }
+                case "Bob": {
+                    // @ts-ignore: Sad that TypeScript can't infer that.
+                    return `${alphaProtocol}_${action}ed`;
+                }
+                default:
+                    throw new Error(
+                        `Who is ${role}? We expected either Alice or Bob!`
+                    );
+            }
         }
     }
 }

--- a/api_tests/src/payload.ts
+++ b/api_tests/src/payload.ts
@@ -51,9 +51,8 @@ export type HbitPayload = {
  * The payload returned when fetching one swap on the `/swaps/:id` endpoint
  */
 
-export interface SwapResponse extends Entity {
-    properties: Properties;
-    entities: (LedgerState | LedgerParameters)[];
+export interface SwapEntity extends Entity {
+    properties: SwapProperties;
     actions: SwapAction[];
     /**
      * links for this swap, contains a self reference
@@ -64,136 +63,95 @@ export interface SwapResponse extends Entity {
 /**
  * The properties of a swap
  */
-export interface Properties {
-    /**
-     * The status this swap is currently in.
-     */
-    status: SwapStatus;
+export interface SwapProperties {
     /**
      * The role in which you are participating in this swap.
      */
     role: "Alice" | "Bob";
+    /**
+     * The linear sequence of events related to this swap as observed by cnd.
+     */
+    events: SwapEvent[];
+    alpha: LockProtocol;
+    beta: LockProtocol;
 }
 
-/**
- * The overall status of a swap
- */
-export enum SwapStatus {
-    Created = "CREATED",
-    InProgress = "IN_PROGRESS",
-    Swapped = "SWAPPED",
-    NotSwapped = "NOT_SWAPPED",
-}
+export type LockProtocol = HbitProtocol | Herc20Protocol | HalbitProtocol;
 
-/**
- * The parameters of a given ledger
- */
-export interface LedgerParameters extends EmbeddedRepresentationSubEntity {
-    /**
-     * The relation of these ledger parameters to the parent object (*SwapProperties).
-     */
-    rel: ["alpha" | "beta"];
-    /**
-     * Human readable title.
-     */
-    title: "Parameters of the Alpha Ledger" | "Parameters of the Beta Ledger";
-    /**
-     * Class of this sub-entity to facilitate parsing.
-     */
-    class: ["parameters"];
-    properties: Hbit | Herc20 | Halbit;
-}
-
-export interface Hbit {
+export interface HbitProtocol {
     protocol: "hbit";
-    quantity: string; // In Satoshi.
+    asset: Amount;
 }
 
-export interface Herc20 {
+export interface Herc20Protocol {
     protocol: "herc20";
-    quantity: string; // In Wei.
-    contract_address: string;
+    asset: Amount;
 }
 
-export interface Halbit {
+export interface HalbitProtocol {
     protocol: "halbit";
-    quantity: string; // In Satoshi.
-}
-//
-/**
- * The detailed description of the ledger state.
- */
-export interface LedgerState extends EmbeddedRepresentationSubEntity {
-    /**
-     * The relation of this ledger state to the parent object (*SwapProperties).
-     */
-    rel: ["alpha" | "beta"];
-    /**
-     * Human readable title.
-     */
-    title: "State of the Alpha Ledger" | "State of the Beta Ledger";
-    /**
-     * Class of this sub-entity to facilitate parsing.
-     */
-    class: ["state"];
-    properties: {
-        events: LedgerEvent;
-        status: EscrowStatus;
-    };
+    asset: Amount;
 }
 
-/**
- * The ledger events related to a given step.
- */
-export type LedgerEvent = {
-    [k in Step]: string;
-};
+export type SwapEvent =
+    | HbitFundedEvent
+    | HbitRedeemedEvent
+    | HbitRefundedEvent
+    | Herc20DeployedEvent
+    | Herc20FundedEvent
+    | Herc20RedeemedEvent
+    | Herc20RefundedEvent
+    | HalbitFundedEvent
+    | HalbitRedeemedEvent
+    | HalbitRefundedEvent;
 
-/**
- * The status of the escrow (htlc, lightning invoice, etc) on the ledger.
- */
-export enum EscrowStatus {
-    /**
-     * The escrow does not exist yet.
-     */
-    None = "NONE",
-    /**
-     * The escrow has been initialized.
-     *
-     * Initialization is a step that does not endure any cost to the user.
-     */
-    Initialized = "INITIALIZED",
-    /**
-     * The escrow has been deployed.
-     *
-     * Deployment is a step that endures some, relatively small, cost to the user due to computation needed on the blockchain.
-     */
-    Deployed = "DEPLOYED",
-    /**
-     * The escrow has been funded.
-     *
-     * Funding is a step where all the assets to be sold are sent and locked in the escrow.
-     */
-    Funded = "FUNDED",
-    /**
-     * The assets have been redeemed from the escrow.
-     *
-     * Redemption is a step where all the assets to be acquired are received from the escrow.
-     */
-    Redeemed = "REDEEMED",
-    /**
-     * The assets have been refunded from the escrow.
-     *
-     * Refunding is a step where all the assets to be sold are received back from the escrow, meaning the swap has been aborted.
-     */
-    Refunded = "REFUNDED",
-    /**
-     * An incorrect amount of assets have been sent to the escrow.
-     *
-     * To protect the user, if an incorrect amount of asset have been sent to the escrow, cnd will not propose redemption
-     * as an option and only the refund actions will be available down the line.
-     */
-    IncorrectlyFunded = "INCORRECTLY_FUNDED",
+export type SwapEventKind = SwapEvent["name"]; // Oh yeah, type system magic baby!
+
+export interface HbitFundedEvent {
+    name: "hbit_funded";
+    tx: string;
+}
+
+export interface HbitRedeemedEvent {
+    name: "hbit_redeemed";
+    tx: string;
+}
+
+export interface HbitRefundedEvent {
+    name: "hbit_refunded";
+    tx: string;
+}
+
+export interface Herc20DeployedEvent {
+    name: "herc20_deployed";
+    tx: string;
+}
+
+export interface Herc20FundedEvent {
+    name: "herc20_funded";
+    tx: string;
+}
+
+export interface Herc20RedeemedEvent {
+    name: "herc20_redeemed";
+    tx: string;
+}
+
+export interface Herc20RefundedEvent {
+    name: "herc20_refunded";
+    tx: string;
+}
+
+export interface HalbitFundedEvent {
+    name: "halbit_funded";
+}
+
+export interface HalbitRedeemedEvent {
+    name: "halbit_redeemed";
+}
+
+export interface HalbitRefundedEvent {
+    name: "halbit_refunded";
 }
 
 /**
@@ -202,19 +160,13 @@ export enum EscrowStatus {
  * Not all steps are needed for all protocols and ledgers.
  * E.g. for Han Bitcoin the steps are: fund, redeem (or refund)
  */
-export enum Step {
-    Init = "init",
-    Deploy = "deploy",
-    Fund = "fund",
-    Redeem = "redeem",
-    Refund = "refund",
-}
+export type ActionKind = "init" | "fund" | "deploy" | "redeem" | "refund";
 
 /**
  * An action that is available for the given swap.
  */
 export interface SwapAction extends Action {
-    name: Step;
+    name: ActionKind;
 }
 
 export enum Position {

--- a/api_tests/src/payload.ts
+++ b/api_tests/src/payload.ts
@@ -62,19 +62,6 @@ export interface SwapResponse extends Entity {
 }
 
 /**
- * Element of the array in the payload returned when fetching all swaps on the `/swaps/` endpoint
- */
-export interface SwapElementResponse extends EmbeddedRepresentationSubEntity {
-    properties: Properties;
-    entities: (LedgerState | LedgerParameters)[];
-    actions: SwapAction[];
-    /**
-     * links for this swap, contains a self reference
-     */
-    links: Link[];
-}
-
-/**
  * The properties of a swap
  */
 export interface Properties {

--- a/api_tests/tests/siren_schema.ts
+++ b/api_tests/tests/siren_schema.ts
@@ -11,7 +11,7 @@ import * as sirenJsonSchema from "../siren.schema.json";
 import * as rootJsonSchema from "../root.schema.json";
 import { siren } from "comit-sdk";
 import axios from "axios";
-import { SwapResponse } from "../src/payload";
+import { SwapEntity } from "../src/payload";
 
 describe("Siren Schema", () => {
     it(
@@ -59,15 +59,13 @@ describe("Siren Schema", () => {
 
             // For now we just assert that the document returned by "/swaps/:id" is a valid siren object.
 
-            const responseAlice = await alice.cnd.fetch<SwapResponse>(
+            const responseAlice = await alice.cnd.fetch<SwapEntity>(
                 alice.swap.self
             );
             expect(responseAlice.status).toEqual(200);
             expect(responseAlice.data).toMatchSchema(sirenJsonSchema);
 
-            const responseBob = await bob.cnd.fetch<SwapResponse>(
-                bob.swap.self
-            );
+            const responseBob = await bob.cnd.fetch<SwapEntity>(bob.swap.self);
             expect(responseBob.status).toEqual(200);
             expect(responseBob.data).toMatchSchema(sirenJsonSchema);
         })

--- a/cnd/src/http_api/halbit_herc20/alice.rs
+++ b/cnd/src/http_api/halbit_herc20/alice.rs
@@ -4,21 +4,19 @@ use crate::{
     http_api::{
         halbit, herc20,
         protocol::{
-            AlphaAbsoluteExpiry, AlphaEvents, AlphaLedger, AlphaParams, BetaAbsoluteExpiry,
-            BetaEvents, BetaLedger, BetaParams, Halbit, Herc20, Ledger, LedgerEvents,
+            AlphaAbsoluteExpiry, AlphaLedger, AlphaProtocol, BetaAbsoluteExpiry, BetaLedger,
+            BetaProtocol, Events, Ledger, Protocol, SwapEvent,
         },
         ActionNotFound, AliceSwap,
     },
     DeployAction, FundAction, InitAction, Never, RedeemAction, RefundAction, SecretHash, Timestamp,
 };
 
-impl From<AliceSwap<asset::Bitcoin, asset::Erc20, halbit::Finalized, herc20::Finalized>>
-    for Herc20
+impl BetaProtocol
+    for AliceSwap<asset::Bitcoin, asset::Erc20, halbit::Finalized, herc20::Finalized>
 {
-    fn from(
-        from: AliceSwap<asset::Bitcoin, asset::Erc20, halbit::Finalized, herc20::Finalized>,
-    ) -> Self {
-        match from {
+    fn beta_protocol(&self) -> Protocol {
+        match self {
             AliceSwap::Created {
                 beta_created: herc20_asset,
                 ..
@@ -30,22 +28,16 @@ impl From<AliceSwap<asset::Bitcoin, asset::Erc20, halbit::Finalized, herc20::Fin
                         ..
                     },
                 ..
-            } => Self {
-                protocol: "herc20".to_owned(),
-                quantity: herc20_asset.quantity.to_wei_dec(),
-                token_contract: herc20_asset.token_contract.to_string(),
-            },
+            } => Protocol::herc20_dai(herc20_asset.quantity.clone()),
         }
     }
 }
 
-impl From<AliceSwap<asset::Bitcoin, asset::Erc20, halbit::Finalized, herc20::Finalized>>
-    for Halbit
+impl AlphaProtocol
+    for AliceSwap<asset::Bitcoin, asset::Erc20, halbit::Finalized, herc20::Finalized>
 {
-    fn from(
-        from: AliceSwap<asset::Bitcoin, asset::Erc20, halbit::Finalized, herc20::Finalized>,
-    ) -> Self {
-        match from {
+    fn alpha_protocol(&self) -> Protocol {
+        match self {
             AliceSwap::Created {
                 alpha_created: halbit_asset,
                 ..
@@ -57,56 +49,34 @@ impl From<AliceSwap<asset::Bitcoin, asset::Erc20, halbit::Finalized, herc20::Fin
                         ..
                     },
                 ..
-            } => Self {
-                protocol: "halbit".to_owned(),
-                quantity: halbit_asset.as_sat().to_string(),
-            },
+            } => Protocol::halbit(*halbit_asset),
         }
     }
 }
 
-impl BetaParams for AliceSwap<asset::Bitcoin, asset::Erc20, halbit::Finalized, herc20::Finalized> {
-    type Output = Herc20;
-    fn beta_params(&self) -> Self::Output {
-        self.clone().into()
-    }
-}
-
-impl BetaEvents for AliceSwap<asset::Bitcoin, asset::Erc20, halbit::Finalized, herc20::Finalized> {
-    fn beta_events(&self) -> Option<LedgerEvents> {
+impl Events for AliceSwap<asset::Bitcoin, asset::Erc20, halbit::Finalized, herc20::Finalized> {
+    fn events(&self) -> Vec<SwapEvent> {
         match self {
-            AliceSwap::Created { .. } => None,
-            AliceSwap::Finalized {
-                beta_finalized:
-                    herc20::Finalized {
-                        state: herc20_state,
-                        ..
-                    },
-                ..
-            } => Some(herc20_state.clone().into()),
-        }
-    }
-}
-
-impl AlphaParams for AliceSwap<asset::Bitcoin, asset::Erc20, halbit::Finalized, herc20::Finalized> {
-    type Output = Halbit;
-    fn alpha_params(&self) -> Self::Output {
-        self.clone().into()
-    }
-}
-
-impl AlphaEvents for AliceSwap<asset::Bitcoin, asset::Erc20, halbit::Finalized, herc20::Finalized> {
-    fn alpha_events(&self) -> Option<LedgerEvents> {
-        match self {
-            AliceSwap::Created { .. } => None,
+            AliceSwap::Created { .. } => Vec::new(),
             AliceSwap::Finalized {
                 alpha_finalized:
                     halbit::Finalized {
                         state: halbit_state,
                         ..
                     },
+                beta_finalized:
+                    herc20::Finalized {
+                        state: herc20_state,
+                        ..
+                    },
                 ..
-            } => Some((*halbit_state).into()),
+            } => {
+                let mut events = Vec::new();
+                events.extend(Vec::from(halbit_state));
+                events.extend(Vec::from(herc20_state));
+
+                events
+            }
         }
     }
 }


### PR DESCRIPTION
This format favours a flat design in which events are appended
to a list as they are observed by cnd. Or that is at least what
we should do. With the current implementation in cnd, this is not
possible because we compute this state every time the user asks for
it.

In the long run however, we can enrich this format with timestamps
and other information and actually save those events to the database
so that we just need to read them.

This also radically simplifies the assertions in our test.