### PR TITLE
Notes on itegration of the SECT module

### DIFF
--- a/cnd/src/http_api/swaps.rs
+++ b/cnd/src/http_api/swaps.rs
@@ -198,6 +198,14 @@ where
     //   here. What to do with the other new states? Especially those that do not
     //   require an action e.g. wait_for_foo ???
 
+    // Over in Nectar it seems that we can plug directly into the
+    // `hbit_herc20_happy_alice` function by:
+    //
+    // - Add an `Expiries` parameter.
+    // - Before each call to execute_foo() we could pass the state (since we have
+    //   full knowledge of it at that stage) to `expiries ` and confirm that the
+    //   next action is still the happy path action.
+
     if swap.init_action().is_ok() {
         return Ok(Some(ActionName::Init));
     }

--- a/cnd/src/http_api/swaps.rs
+++ b/cnd/src/http_api/swaps.rs
@@ -186,6 +186,18 @@ where
         + AlphaAbsoluteExpiry
         + BetaAbsoluteExpiry,
 {
+    // In order to be able to integrate the new expiries next action logic:
+    //
+    // - Will need to be able to access the Expires. One solution; we could add it
+    //   to the swap struct.
+    // - Ask the facade what state the swap is in and get back an
+    //   expiries::AliceState or BobState. This is the swap state from our
+    //   perspective, we know our role.
+    // - Call swap.expiries.next_action_for_<actor>()
+    // - If the action maps to init/deploy/fund/refund/redeem we can handle as we do
+    //   here. What to do with the other new states? Especially those that do not
+    //   require an action e.g. wait_for_foo ???
+
     if swap.init_action().is_ok() {
         return Ok(Some(ActionName::Init));
     }


### PR DESCRIPTION
This PR is not a merge candidate.

Integration of the new `expiries` module into cnd and Nectar is non-trivial. This PR adds some comments about how we might go about it. Opening as draft for comments and/or historical value until we decide how/when to do the integration. 