### PR TITLE
Remove custom thread stack size

### DIFF
--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -135,7 +135,6 @@ fn main() -> anyhow::Result<()> {
     let mut runtime = runtime::Builder::new()
         .enable_all()
         .threaded_scheduler()
-        .thread_stack_size(1024 * 1024 * 8) // the default is 2MB but that causes a segfault for some reason
         .build()?;
 
     let bitcoin_connector = {


### PR DESCRIPTION
I believe the stack was due to our heavy use of traits which is now
gone. Let's see what the CI says.