### PR TITLE
e2e: Use the orderbook for hbit/herc20 respawn tests

### DIFF
--- a/api_tests/tests/herc20_hbit_respawn.ts
+++ b/api_tests/tests/herc20_hbit_respawn.ts
@@ -3,18 +3,20 @@
  * @ledger bitcoin
  */
 
-import SwapFactory from "../src/actors/swap_factory";
-import { sleep } from "../src/utils";
 import { twoActorTest } from "../src/actor_test";
+import { sleep } from "../src/utils";
+import { Position } from "../src/payload";
 
 describe("herc20-hbit-respawn", () => {
     it(
         "herc20-hbit-alice-misses-bob-funds",
         twoActorTest(async ({ alice, bob }) => {
-            const bodies = (await SwapFactory.newSwap(alice, bob)).herc20Hbit;
+            await alice.connect(bob);
 
-            await alice.createHerc20HbitSwap(bodies.alice);
-            await bob.createHerc20HbitSwap(bodies.bob);
+            await alice.makeBtcDaiOrder(Position.Buy, 0.2, 9000);
+            await bob.makeBtcDaiOrder(Position.Sell, 0.2, 9000);
+
+            await Promise.all([alice.waitForSwap(), bob.waitForSwap()]);
 
             await alice.assertAndExecuteNextAction("deploy");
             await alice.assertAndExecuteNextAction("fund");
@@ -41,10 +43,12 @@ describe("herc20-hbit-respawn", () => {
     it(
         "herc20-hbit-bob-misses-alice-redeems",
         twoActorTest(async ({ alice, bob }) => {
-            const bodies = (await SwapFactory.newSwap(alice, bob)).herc20Hbit;
+            await alice.connect(bob);
 
-            await alice.createHerc20HbitSwap(bodies.alice);
-            await bob.createHerc20HbitSwap(bodies.bob);
+            await alice.makeBtcDaiOrder(Position.Buy, 0.2, 9000);
+            await bob.makeBtcDaiOrder(Position.Sell, 0.2, 9000);
+
+            await Promise.all([alice.waitForSwap(), bob.waitForSwap()]);
 
             await alice.assertAndExecuteNextAction("deploy");
             await alice.assertAndExecuteNextAction("fund");
@@ -72,10 +76,12 @@ describe("herc20-hbit-respawn", () => {
     it(
         "hbit-herc20-alice-misses-bob-deploys-and-funds",
         twoActorTest(async ({ alice, bob }) => {
-            const bodies = (await SwapFactory.newSwap(alice, bob)).hbitHerc20;
+            await alice.connect(bob);
 
-            await alice.createHbitHerc20Swap(bodies.alice);
-            await bob.createHbitHerc20Swap(bodies.bob);
+            await alice.makeBtcDaiOrder(Position.Sell, 0.2, 9000);
+            await bob.makeBtcDaiOrder(Position.Buy, 0.2, 9000);
+
+            await Promise.all([alice.waitForSwap(), bob.waitForSwap()]);
 
             await alice.assertAndExecuteNextAction("fund");
 
@@ -102,10 +108,12 @@ describe("herc20-hbit-respawn", () => {
     it(
         "hbit-herc20-bob-down-misses-alice-redeems",
         twoActorTest(async ({ alice, bob }) => {
-            const bodies = (await SwapFactory.newSwap(alice, bob)).hbitHerc20;
+            await alice.connect(bob);
 
-            await alice.createHbitHerc20Swap(bodies.alice);
-            await bob.createHbitHerc20Swap(bodies.bob);
+            await alice.makeBtcDaiOrder(Position.Sell, 0.2, 9000);
+            await bob.makeBtcDaiOrder(Position.Buy, 0.2, 9000);
+
+            await Promise.all([alice.waitForSwap(), bob.waitForSwap()]);
 
             await alice.assertAndExecuteNextAction("fund");
 

--- a/api_tests/tests/orderbook.ts
+++ b/api_tests/tests/orderbook.ts
@@ -9,7 +9,7 @@ import { Position } from "../src/payload";
 
 describe("orderbook", () => {
     it(
-        "btc_dai_buy_order",
+        "herc20-hbit",
         twoActorTest(async ({ alice, bob }) => {
             await alice.connect(bob);
 
@@ -35,7 +35,7 @@ describe("orderbook", () => {
     );
 
     it(
-        "btc_dai_sell_order",
+        "hbit-herc20",
         twoActorTest(async ({ alice, bob }) => {
             await alice.connect(bob);
 


### PR DESCRIPTION
Currently the hbit/herc20 respawn tests use the old create swap POST endpoints. Now that we have an orderbook for swap negotiation we can use it to test respawn functionality.