### PR TITLE
Remove PATCH semvar number from all libraries

### DIFF
--- a/comit/Cargo.toml
+++ b/comit/Cargo.toml
@@ -8,49 +8,49 @@ description = "Core components of the COMIT protocol"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-base64 = "0.12.3"
-bitcoin = { version = "0.23.0", features = ["rand", "use-serde"] }
-blockchain_contracts = "0.3.2"
+base64 = "0.12"
+bitcoin = { version = "0.23", features = ["rand", "use-serde"] }
+blockchain_contracts = "0.3"
 byteorder = "1.3"
 chrono = { version = "0.4", features = ["serde"] }
-conquer-once = "0.2.1"
+conquer-once = "0.2"
 derivative = "2"
 digest = { path = "../digest" }
-ethbloom = "0.9.1"
+ethbloom = "0.9"
 futures = { version = "0.3", default-features = false }
 genawaiter = { version = "0.99", default-features = false, features = ["futures03"] }
 hex = { version = "0.4", features = ["serde"] }
 levenshtein = "1"
 libp2p = { version = "0.24", default-features = false, features = ["gossipsub", "request-response"] }
-lru = "0.6.0"
+lru = "0.6"
 num = "0.3"
-primitive-types = { version = "0.7.2", features = ["serde"] }
+primitive-types = { version = "0.7", features = ["serde"] }
 rand = "0.7"
-reqwest = { version = "0.10.8", default-features = false, features = ["json", "native-tls"] }
+reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde-hex = "0.1.0"
 serde_derive = "1.0"
 serde_json = "1"
 serdebug = "1"
 sha2 = "0.9"
-strum = "0.19.2"
-strum_macros = "0.19.2"
+strum = "0.19"
+strum_macros = "0.19"
 thiserror = "1"
-time = { version = "0.2.17", features = ["serde"] }
-tokio = { version = "0.2.22", features = ["sync"] }
+time = { version = "0.2", features = ["serde"] }
+tokio = { version = "0.2", features = ["sync"] }
 tracing = "0.1.19"
 tracing-futures = { version = "0.2", features = ["std-future", "futures-03"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies]
 atty = "0.2"
-bitcoincore-rpc = "0.11.0"
+bitcoincore-rpc = "0.11"
 libp2p = { version = "0.24", default-features = false, features = ["secio", "yamux"] }
 log = { version = "0.4", features = ["serde"] }
-proptest = "0.10.1"
+proptest = "0.10"
 spectral = { version = "0.6", default-features = false }
 testcontainers = "0.9"
-tokio = { version = "0.2.22", features = ["macros"] }
+tokio = { version = "0.2", features = ["macros"] }
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-core = "0.1"
 tracing-futures = { version = "0.2", features = ["std-future", "futures-03"] }


### PR DESCRIPTION
In semvar changing the PATCH version by definition should not break
the usage of the library.

In Nectar we depend on comit, if we use explicit patch versions for a
dependency that we have in common with cnd then the patch versions
have to match. This adds unnecessary maintenance burden on the two
repositories.

Remove the patch version number from all dependencies.