### PR TITLE
Filter out market orders with "unsafe" expiries

### DIFF
--- a/cnd/src/http_api/markets/get_btc_dai.rs
+++ b/cnd/src/http_api/markets/get_btc_dai.rs
@@ -24,7 +24,7 @@ async fn handler(swarm: Swarm) -> Result<impl Reply> {
     let mut orders = siren::Entity::default();
     let local_peer_id = swarm.local_peer_id();
 
-    for (maker, order) in swarm.btc_dai_market().await {
+    for (maker, order) in swarm.btc_dai_market_safe_expiries().await {
         let market_item = siren::Entity::default()
             .with_properties(MarketItem {
                 id: order.id,

--- a/cnd/src/http_api/markets/get_btc_dai.rs
+++ b/cnd/src/http_api/markets/get_btc_dai.rs
@@ -24,7 +24,7 @@ async fn handler(swarm: Swarm) -> Result<impl Reply> {
     let mut orders = siren::Entity::default();
     let local_peer_id = swarm.local_peer_id();
 
-    for (maker, order) in swarm.btc_dai_market_safe_expiries().await {
+    for (maker, order) in swarm.btc_dai_market().await {
         let market_item = siren::Entity::default()
             .with_properties(MarketItem {
                 id: order.id,

--- a/cnd/src/http_api/markets/get_btc_dai.rs
+++ b/cnd/src/http_api/markets/get_btc_dai.rs
@@ -3,7 +3,7 @@ use crate::{
     network::Swarm,
 };
 use anyhow::{Context, Result};
-use comit::{OrderId, Position};
+use comit::{expiries, order::SwapProtocol, BtcDaiOrder, OrderId, Position};
 use futures::TryFutureExt;
 use libp2p::PeerId;
 use serde::Serialize;
@@ -20,11 +20,20 @@ pub fn route(swarm: Swarm) -> impl Filter<Extract = impl Reply, Error = Rejectio
         })
 }
 
+/// Retrieves "executable" orders: orders that have expiries that match the safe
+/// expiries determined by the expiries module.
 async fn handler(swarm: Swarm) -> Result<impl Reply> {
     let mut orders = siren::Entity::default();
     let local_peer_id = swarm.local_peer_id();
 
-    for (maker, order) in swarm.btc_dai_market().await {
+    let executable_orders = facade
+        .swarm
+        .btc_dai_market()
+        .await
+        .into_iter()
+        .filter(|(_, order)| has_executable_expiries(order));
+
+    for (maker, order) in executable_orders {
         let market_item = siren::Entity::default()
             .with_properties(MarketItem {
                 id: order.id,
@@ -42,6 +51,19 @@ async fn handler(swarm: Swarm) -> Result<impl Reply> {
     Ok(reply::json(&orders))
 }
 
+pub fn has_executable_expiries(order: &BtcDaiOrder) -> bool {
+    match order.swap_protocol {
+        SwapProtocol::HbitHerc20 {
+            hbit_expiry_offset,
+            herc20_expiry_offset,
+        } => (hbit_expiry_offset, herc20_expiry_offset) == expiries::expiry_offsets_hbit_herc20(),
+        SwapProtocol::Herc20Hbit {
+            herc20_expiry_offset,
+            hbit_expiry_offset,
+        } => (herc20_expiry_offset, hbit_expiry_offset) == expiries::expiry_offsets_herc20_hbit(),
+    }
+}
+
 #[derive(Clone, Debug, Serialize)]
 struct MarketItem {
     id: OrderId,
@@ -51,4 +73,65 @@ struct MarketItem {
     position: Position,
     quantity: Amount,
     price: Amount,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::http_api::markets::get_btc_dai::has_executable_expiries;
+    use comit::{asset, order::SwapProtocol, BtcDaiOrder, Position, Price, Quantity, Role};
+    use spectral::{assert_that, prelude::MappingIterAssertions};
+    use time::Duration;
+
+    #[test]
+    fn filter_out_orders_with_unexectubale_expiries() {
+        let order_with_executable_expiries = order_with_executable_expiries();
+        let unfiltered_orders = vec![
+            order_with_executable_expiries.clone(),
+            order_with_unexecutable_expiries(),
+        ];
+
+        let filtered_orders = unfiltered_orders
+            .into_iter()
+            .filter(|order| has_executable_expiries(order))
+            .collect::<Vec<BtcDaiOrder>>();
+
+        assert_eq!(filtered_orders.len(), 1);
+        assert_that(&filtered_orders)
+            .matching_contains(|order| order_with_executable_expiries.id == order.id);
+    }
+
+    fn order_with_executable_expiries() -> BtcDaiOrder {
+        BtcDaiOrder::sell(
+            Quantity::new(asset::Bitcoin::ZERO),
+            Price::from_wei_per_sat(asset::Erc20Quantity::zero()),
+            SwapProtocol::new(Role::Alice, Position::Sell),
+        )
+    }
+
+    fn order_with_unexecutable_expiries() -> BtcDaiOrder {
+        let unsafe_hbit_expiry_offset = Duration::zero();
+        let unsafe_herc20_expiry_offset = Duration::zero();
+
+        assert_ne!(
+            order_with_executable_expiries()
+                .swap_protocol
+                .hbit_expiry_offset(),
+            unsafe_hbit_expiry_offset
+        );
+        assert_ne!(
+            order_with_executable_expiries()
+                .swap_protocol
+                .herc20_expiry_offset(),
+            unsafe_herc20_expiry_offset
+        );
+
+        BtcDaiOrder::sell(
+            Quantity::new(asset::Bitcoin::ZERO),
+            Price::from_wei_per_sat(asset::Erc20Quantity::zero()),
+            SwapProtocol::HbitHerc20 {
+                hbit_expiry_offset: unsafe_hbit_expiry_offset.into(),
+                herc20_expiry_offset: unsafe_herc20_expiry_offset.into(),
+            },
+        )
+    }
 }

--- a/cnd/src/network/swarm.rs
+++ b/cnd/src/network/swarm.rs
@@ -131,13 +131,13 @@ impl Swarm {
         self.inner.lock().await.orderbook.publish(order);
     }
 
-    pub async fn btc_dai_market_safe_expiries(&self) -> Vec<(PeerId, BtcDaiOrder)> {
+    pub async fn btc_dai_market(&self) -> Vec<(PeerId, BtcDaiOrder)> {
         self.inner
             .lock()
             .await
             .orderbook
             .orderpool()
-            .safe_expiries()
+            .executable_orders()
             .map(|(maker, order)| (maker.clone(), order.clone()))
             .collect()
     }

--- a/cnd/src/network/swarm.rs
+++ b/cnd/src/network/swarm.rs
@@ -137,7 +137,7 @@ impl Swarm {
             .await
             .orderbook
             .orderpool()
-            .executable_orders()
+            .all()
             .map(|(maker, order)| (maker.clone(), order.clone()))
             .collect()
     }

--- a/cnd/src/network/swarm.rs
+++ b/cnd/src/network/swarm.rs
@@ -131,13 +131,13 @@ impl Swarm {
         self.inner.lock().await.orderbook.publish(order);
     }
 
-    pub async fn btc_dai_market(&self) -> Vec<(PeerId, BtcDaiOrder)> {
+    pub async fn btc_dai_market_safe_expiries(&self) -> Vec<(PeerId, BtcDaiOrder)> {
         self.inner
             .lock()
             .await
             .orderbook
             .orderpool()
-            .all()
+            .safe_expiries()
             .map(|(maker, order)| (maker.clone(), order.clone()))
             .collect()
     }


### PR DESCRIPTION
The GET markets/BTC-DAI endpoint in Cnd used to return all order including those that do not match the expiries determined by the expiry module. A filter has been added to remove orders that do not match these safe expiries.