### PR TITLE
Utilize diesel's `deserialize_as` feature of Queryable

### DIFF
--- a/cnd/src/http_api.rs
+++ b/cnd/src/http_api.rs
@@ -88,10 +88,10 @@ impl From<(tables::Order, tables::BtcDaiOrder)> for OrderProperties {
         let (order, btc_dai_order) = tuple;
 
         Self {
-            id: order.order_id.0,
-            position: order.position.0,
-            price: Amount::from(Price::from_wei_per_sat(btc_dai_order.price.0.into())),
-            quantity: Amount::from(Quantity::new(btc_dai_order.quantity.0.into())),
+            id: order.order_id,
+            position: order.position,
+            price: Amount::from(btc_dai_order.price),
+            quantity: Amount::from(btc_dai_order.quantity),
             state: State::new(
                 order.open,
                 order.closed,

--- a/cnd/src/network/comit_node.rs
+++ b/cnd/src/network/comit_node.rs
@@ -325,7 +325,7 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<setup_swap::BehaviourOutEvent<S
                                 let order_hbit_params = OrderHbitParams::by_order(conn, &order)?;
                                 insertable_hbit(
                                     swap_pk,
-                                    order_hbit_params.our_final_address.0.into(),
+                                    order_hbit_params.our_final_address.into(),
                                 )
                                 .insert(conn)?;
 

--- a/cnd/src/network/swarm.rs
+++ b/cnd/src/network/swarm.rs
@@ -306,20 +306,20 @@ async fn handle_new_match(
     #[allow(clippy::cast_possible_truncation)]
     let common_params = CommonParams {
         erc20: asset::Erc20 {
-            token_contract: order_herc20.token_contract.0,
+            token_contract: order_herc20.token_contract,
             quantity: erc20_quantity,
         },
         bitcoin: hbit_quantity.to_inner(),
         ethereum_absolute_expiry: ethereum_absolute_expiry.timestamp() as u32,
         bitcoin_absolute_expiry: bitcoin_absolute_expiry.timestamp() as u32,
         ethereum_chain_id: u32::from(order_herc20.chain_id).into(),
-        bitcoin_network: order_hbit.network.0,
+        bitcoin_network: order_hbit.network,
     };
     let role_params = match our_role {
         Role::Alice => {
             let swap_seed = seed.derive_swap_seed(swap_id);
             RoleDependentParams::Alice(AliceParams {
-                ethereum_identity: order_herc20.our_htlc_address.0,
+                ethereum_identity: order_herc20.our_htlc_address,
                 bitcoin_identity: storage.derive_transient_identity(
                     swap_id,
                     our_role,
@@ -329,7 +329,7 @@ async fn handle_new_match(
             })
         }
         Role::Bob => RoleDependentParams::Bob(BobParams {
-            ethereum_identity: order_herc20.our_htlc_address.0,
+            ethereum_identity: order_herc20.our_htlc_address,
             bitcoin_identity: storage.derive_transient_identity(
                 swap_id,
                 our_role,

--- a/cnd/src/storage.rs
+++ b/cnd/src/storage.rs
@@ -114,7 +114,7 @@ where
 {
     async fn load(&self, id: LocalSwapId) -> anyhow::Result<spawn::Swap<TParamsA, TParamsB>> {
         let tab = self.load_tables(id).await?;
-        let role = tab.swap.role.0;
+        let role = tab.swap.role;
         let secret_hash = derive_or_unwrap_secret_hash(id, self.seed, role, tab.secret_hash)?;
 
         let alpha = TParamsA::into_params(tab.alpha, id, self.seed, role, secret_hash)?;

--- a/cnd/src/storage/db.rs
+++ b/cnd/src/storage/db.rs
@@ -6,7 +6,7 @@ pub mod tables;
 mod wrapper_types;
 embed_migrations!("./migrations");
 
-pub use self::{errors::*, tables::*, wrapper_types::custom_sql_types::Text};
+pub use self::{errors::*, tables::*, wrapper_types::Text};
 pub use crate::storage::{ForSwap, Save};
 
 use crate::{LocalSwapId, Role};

--- a/cnd/src/storage/db/wrapper_types/text.rs
+++ b/cnd/src/storage/db/wrapper_types/text.rs
@@ -1,0 +1,74 @@
+use crate::{ethereum, ledger, LocalSwapId};
+use comit::{OrderId, Position, Role, Side};
+use diesel::{
+    backend::Backend,
+    deserialize::{self, FromSql},
+    serialize::{self, Output, ToSql},
+    sql_types,
+};
+use libp2p::PeerId;
+use std::{fmt, ops::Deref, str::FromStr};
+
+/// Custom diesel new-type that works as long as T implements `Display` and
+/// `FromStr`.
+#[derive(Debug, Clone, Copy, PartialEq, FromSqlRow, AsExpression)]
+#[sql_type = "sql_types::Text"]
+pub struct Text<T>(pub T);
+
+impl<T> Deref for Text<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<DB, T> ToSql<sql_types::Text, DB> for Text<T>
+where
+    DB: Backend,
+    String: ToSql<sql_types::Text, DB>,
+    T: fmt::Display + fmt::Debug,
+{
+    fn to_sql<W>(&self, out: &mut Output<'_, W, DB>) -> serialize::Result
+    where
+        W: std::io::Write,
+    {
+        let s = self.0.to_string();
+        s.to_sql(out)
+    }
+}
+
+impl<DB, T> FromSql<sql_types::Text, DB> for Text<T>
+where
+    DB: Backend,
+    String: FromSql<sql_types::Text, DB>,
+    T: FromStr,
+    <T as FromStr>::Err: std::error::Error + Send + Sync + 'static,
+{
+    fn from_sql(bytes: Option<&DB::RawValue>) -> deserialize::Result<Self> {
+        let s = String::from_sql(bytes)?;
+        let parsed = T::from_str(s.as_ref())?;
+
+        Ok(Text(parsed))
+    }
+}
+
+macro_rules! impl_from_text {
+    ($t:ty) => {
+        impl From<Text<$t>> for $t {
+            fn from(t: Text<$t>) -> Self {
+                t.0
+            }
+        }
+    };
+}
+
+impl_from_text!(LocalSwapId);
+impl_from_text!(Role);
+impl_from_text!(PeerId);
+impl_from_text!(ledger::Bitcoin);
+impl_from_text!(Side);
+impl_from_text!(ethereum::Address);
+impl_from_text!(::bitcoin::Address);
+impl_from_text!(OrderId);
+impl_from_text!(Position);


### PR DESCRIPTION
This allows us directly use our desired type within all structs
that derive `Queryable` and are used to load data from the DB.
As a result, we get less usage of `.0` once the data is loaded
and for the `BtcDaiOrder` in particular, we can directly go into
a `Price` and `Quantity`!