### PR TITLE
Embrace JS bigint literals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
           profile: minimal
           override: true
 
+      - name: Install NodeJS 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+
       - name: Cache cargo registry
         uses: actions/cache@v2
         with:
@@ -112,18 +117,18 @@ jobs:
           path: target/debug/cnd
 
       ## Run e2e tests
-      - name: Install NodeJS 12.x
+      - name: Install NodeJS 14.x
         if: matrix.e2e
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
 
       - name: Cache node_modules directory
         if: matrix.e2e
         uses: actions/cache@v2
         with:
           path: api_tests/node_modules
-          key: ${{ matrix.os }}-node-modules-directory-${{ hashFiles('api_tests/package.json') }}-v2
+          key: ${{ matrix.os }}-node-14-node-modules-directory-${{ hashFiles('api_tests/package.json') }}
 
       - name: Run e2e tests
         if: matrix.e2e

--- a/api_tests/package.json
+++ b/api_tests/package.json
@@ -11,7 +11,7 @@
         "fix": "tslint --project . --fix && prettier --write '**/*.{ts,js,json,yml}'"
     },
     "engines": {
-        "node": "^12"
+        "node": "^14"
     },
     "author": "CoBloX Team",
     "license": "ISC",

--- a/api_tests/src/actors/balance_asserter.ts
+++ b/api_tests/src/actors/balance_asserter.ts
@@ -84,7 +84,7 @@ export class Erc20BalanceAsserter implements BalanceAsserter {
 export class OnChainBitcoinBalanceAsserter implements BalanceAsserter {
     public static async newInstance(wallet: BitcoinWallet, swapAmount: bigint) {
         // need to mint more than what we want to swap to pay for miner fees
-        await wallet.mint(swapAmount * BigInt(2));
+        await wallet.mint(swapAmount * 2n);
 
         const startingBalance = await wallet.getBalance();
 

--- a/api_tests/src/actors/cnd_actor.ts
+++ b/api_tests/src/actors/cnd_actor.ts
@@ -85,24 +85,24 @@ export class CndActor {
             case "Alice": {
                 this.alphaBalance = await Erc20BalanceAsserter.newInstance(
                     this.wallets.ethereum,
-                    BigInt(create.alpha.amount),
+                    create.alpha.amount,
                     create.alpha.token_contract
                 );
                 this.betaBalance = await LNBitcoinBalanceAsserter.newInstance(
                     this.wallets.lightning,
-                    BigInt(create.beta.amount)
+                    create.beta.amount
                 );
                 break;
             }
             case "Bob": {
                 this.alphaBalance = await Erc20BalanceAsserter.newInstance(
                     this.wallets.ethereum,
-                    BigInt(create.alpha.amount),
+                    create.alpha.amount,
                     create.alpha.token_contract
                 );
                 this.betaBalance = await LNBitcoinBalanceAsserter.newInstance(
                     this.wallets.lightning,
-                    BigInt(create.beta.amount)
+                    create.beta.amount
                 );
                 break;
             }
@@ -125,11 +125,11 @@ export class CndActor {
             case "Alice": {
                 this.alphaBalance = await LNBitcoinBalanceAsserter.newInstance(
                     this.wallets.lightning,
-                    BigInt(create.alpha.amount)
+                    create.alpha.amount
                 );
                 this.betaBalance = await Erc20BalanceAsserter.newInstance(
                     this.wallets.ethereum,
-                    BigInt(create.beta.amount),
+                    create.beta.amount,
                     create.beta.token_contract
                 );
                 break;
@@ -137,11 +137,11 @@ export class CndActor {
             case "Bob": {
                 this.alphaBalance = await LNBitcoinBalanceAsserter.newInstance(
                     this.wallets.lightning,
-                    BigInt(create.alpha.amount)
+                    create.alpha.amount
                 );
                 this.betaBalance = await Erc20BalanceAsserter.newInstance(
                     this.wallets.ethereum,
-                    BigInt(create.beta.amount),
+                    create.beta.amount,
                     create.beta.token_contract
                 );
                 break;
@@ -165,24 +165,24 @@ export class CndActor {
             case "Alice": {
                 this.alphaBalance = await Erc20BalanceAsserter.newInstance(
                     this.wallets.ethereum,
-                    BigInt(create.alpha.amount),
+                    create.alpha.amount,
                     create.alpha.token_contract
                 );
                 this.betaBalance = await OnChainBitcoinBalanceAsserter.newInstance(
                     this.wallets.bitcoin,
-                    BigInt(create.beta.amount)
+                    create.beta.amount
                 );
                 break;
             }
             case "Bob": {
                 this.alphaBalance = await Erc20BalanceAsserter.newInstance(
                     this.wallets.ethereum,
-                    BigInt(create.alpha.amount),
+                    create.alpha.amount,
                     create.alpha.token_contract
                 );
                 this.betaBalance = await OnChainBitcoinBalanceAsserter.newInstance(
                     this.wallets.bitcoin,
-                    BigInt(create.beta.amount)
+                    create.beta.amount
                 );
                 break;
             }
@@ -205,11 +205,11 @@ export class CndActor {
             case "Alice": {
                 this.alphaBalance = await OnChainBitcoinBalanceAsserter.newInstance(
                     this.wallets.bitcoin,
-                    BigInt(create.alpha.amount)
+                    create.alpha.amount
                 );
                 this.betaBalance = await Erc20BalanceAsserter.newInstance(
                     this.wallets.ethereum,
-                    BigInt(create.beta.amount),
+                    create.beta.amount,
                     create.beta.token_contract
                 );
                 break;
@@ -217,11 +217,11 @@ export class CndActor {
             case "Bob": {
                 this.alphaBalance = await OnChainBitcoinBalanceAsserter.newInstance(
                     this.wallets.bitcoin,
-                    BigInt(create.alpha.amount)
+                    create.alpha.amount
                 );
                 this.betaBalance = await Erc20BalanceAsserter.newInstance(
                     this.wallets.ethereum,
-                    BigInt(create.beta.amount),
+                    create.beta.amount,
                     create.beta.token_contract
                 );
                 break;
@@ -248,13 +248,13 @@ export class CndActor {
         quantity: number,
         price: number
     ): Promise<string> {
-        const sats = (Number(quantity) * 100_000_000).toString(10);
-
+        const sats = BigInt(quantity * 100_000_000);
         const daiPerBtc = BigInt(price);
-        const weiPerDai = BigInt("1000000000000000000");
-        const satsPerBtc = BigInt("100000000");
+
+        const weiPerDai = 1000000000000000000n;
+        const satsPerBtc = 100000000n;
         const weiPerSat = (daiPerBtc * weiPerDai) / satsPerBtc;
-        const dai = BigInt(sats) * weiPerSat;
+        const dai = sats * weiPerSat;
 
         switch (position) {
             case Position.Buy: {
@@ -267,14 +267,14 @@ export class CndActor {
                         );
                         this.betaBalance = await OnChainBitcoinBalanceAsserter.newInstance(
                             this.wallets.bitcoin,
-                            BigInt(sats)
+                            sats
                         );
                         break;
                     }
                     case "Bob": {
                         this.alphaBalance = await OnChainBitcoinBalanceAsserter.newInstance(
                             this.wallets.bitcoin,
-                            BigInt(sats)
+                            sats
                         );
                         this.betaBalance = await Erc20BalanceAsserter.newInstance(
                             this.wallets.ethereum,
@@ -291,7 +291,7 @@ export class CndActor {
                     case "Alice": {
                         this.alphaBalance = await OnChainBitcoinBalanceAsserter.newInstance(
                             this.wallets.bitcoin,
-                            BigInt(sats)
+                            sats
                         );
                         this.betaBalance = await Erc20BalanceAsserter.newInstance(
                             this.wallets.ethereum,
@@ -308,7 +308,7 @@ export class CndActor {
                         );
                         this.betaBalance = await OnChainBitcoinBalanceAsserter.newInstance(
                             this.wallets.bitcoin,
-                            BigInt(sats)
+                            sats
                         );
                         break;
                     }
@@ -320,7 +320,7 @@ export class CndActor {
         return this.cnd.createBtcDaiOrder({
             position,
             quantity: sats,
-            price: weiPerSat.toString(10),
+            price: weiPerSat,
             swap: {
                 role: this.role,
                 bitcoin_address: await this.wallets.bitcoin.getAddress(),

--- a/api_tests/src/cnd_client/index.ts
+++ b/api_tests/src/cnd_client/index.ts
@@ -19,6 +19,9 @@ export default class CndClient {
     public constructor(cndUrl: string) {
         this.client = axios.create({
             baseURL: cndUrl,
+            headers: {
+                "Content-Type": "application/json",
+            },
         });
         this.client.interceptors.response.use(
             (response) => response,
@@ -90,13 +93,19 @@ export default class CndClient {
     }
 
     public async createHerc20Hbit(body: Herc20HbitPayload): Promise<string> {
-        const response = await this.client.post("swaps/herc20/hbit", body);
+        const response = await this.client.post(
+            "swaps/herc20/hbit",
+            JSON.stringify(body, bigIntSerializer)
+        );
 
         return response.headers.location;
     }
 
     public async createHbitHerc20(body: HbitHerc20Payload): Promise<string> {
-        const response = await this.client.post("swaps/hbit/herc20", body);
+        const response = await this.client.post(
+            "swaps/hbit/herc20",
+            JSON.stringify(body, bigIntSerializer)
+        );
 
         return response.headers.location;
     }
@@ -104,7 +113,10 @@ export default class CndClient {
     public async createHalbitHerc20(
         body: HalbitHerc20Payload
     ): Promise<string> {
-        const response = await this.client.post("swaps/halbit/herc20", body);
+        const response = await this.client.post(
+            "swaps/halbit/herc20",
+            JSON.stringify(body, bigIntSerializer)
+        );
 
         return response.headers.location;
     }
@@ -112,13 +124,19 @@ export default class CndClient {
     public async createHerc20Halbit(
         body: Herc20HalbitPayload
     ): Promise<string> {
-        const response = await this.client.post("swaps/herc20/halbit", body);
+        const response = await this.client.post(
+            "swaps/herc20/halbit",
+            JSON.stringify(body, bigIntSerializer)
+        );
 
         return response.headers.location;
     }
 
     public async createBtcDaiOrder(order: CreateBtcDaiOrderPayload) {
-        const response = await this.client.post("/orders/BTC-DAI", order);
+        const response = await this.client.post(
+            "/orders/BTC-DAI",
+            JSON.stringify(order, bigIntSerializer)
+        );
 
         return response.headers.location;
     }
@@ -128,4 +146,12 @@ export default class CndClient {
 
         return response.data;
     }
+}
+
+function bigIntSerializer(_key: string, value: any): any {
+    if (typeof value === "bigint") {
+        return value.toString(10);
+    }
+
+    return value;
 }

--- a/api_tests/src/cnd_client/payload.ts
+++ b/api_tests/src/cnd_client/payload.ts
@@ -25,14 +25,14 @@ export type HbitHerc20Payload = Payload<HbitPayload, Herc20Payload>;
 export type Herc20HbitPayload = Payload<Herc20Payload, HbitPayload>;
 
 export type HalbitPayload = {
-    amount: string;
+    amount: bigint;
     identity: string;
     network: string;
     cltv_expiry: number;
 };
 
 export type Herc20Payload = {
-    amount: string;
+    amount: bigint;
     identity: string;
     token_contract: string;
     absolute_expiry: number;
@@ -40,7 +40,7 @@ export type Herc20Payload = {
 };
 
 export type HbitPayload = {
-    amount: string;
+    amount: bigint;
     final_identity: string;
     network: string;
     absolute_expiry: number;
@@ -228,8 +228,8 @@ export interface OpenOrdersEntity extends Entity {
 
 export interface CreateBtcDaiOrderPayload {
     position: Position;
-    quantity: string;
-    price: string;
+    quantity: bigint;
+    price: bigint;
     swap: {
         role: string;
         bitcoin_address: string;

--- a/api_tests/src/environment/test_environment.ts
+++ b/api_tests/src/environment/test_environment.ts
@@ -287,7 +287,7 @@ export default class TestEnvironment extends NodeEnvironment {
         this.global.ledgerConfigs.aliceLnd = config;
 
         await this.bitcoinFaucet.mint(
-            BigInt(1_000_000_000), // 10 BTC should be enough money in the LND instance for a few swaps :)
+            1_000_000_000n, // 10 BTC should be enough money in the LND instance for a few swaps :)
             await alice.newFundingAddress(),
             async () => alice.confirmedWalletBalance()
         );
@@ -307,7 +307,7 @@ export default class TestEnvironment extends NodeEnvironment {
         this.global.ledgerConfigs.bobLnd = config;
 
         await this.bitcoinFaucet.mint(
-            BigInt(1_000_000_000), // 10 BTC should be enough money in the LND instance for a few swaps :)
+            1_000_000_000n, // 10 BTC should be enough money in the LND instance for a few swaps :)
             await bob.newFundingAddress(),
             async () => bob.confirmedWalletBalance()
         );

--- a/api_tests/src/swap_factory.ts
+++ b/api_tests/src/swap_factory.ts
@@ -204,7 +204,7 @@ function defaultHbitPayload(
     finalIdentity: string
 ): HbitPayload {
     return {
-        amount: "1000000",
+        amount: 1000000n,
         final_identity: finalIdentity,
         network: "regtest",
         absolute_expiry: absoluteExpiry,
@@ -216,7 +216,7 @@ function defaultHalbitPayload(
     lndPubkey: string
 ): HalbitPayload {
     return {
-        amount: "100000",
+        amount: 100000n,
         network: "regtest",
         identity: lndPubkey,
         cltv_expiry: cltvExpiry,
@@ -229,7 +229,7 @@ function defaultHerc20Payload(
     tokenContract: string
 ): Herc20Payload {
     return {
-        amount: "9000000000000000000",
+        amount: 9000000000000000000n,
         token_contract: tokenContract,
         chain_id: 1337,
         identity,

--- a/api_tests/src/wallets/bitcoin.ts
+++ b/api_tests/src/wallets/bitcoin.ts
@@ -114,7 +114,7 @@ export class BitcoindWallet implements BitcoinWallet {
         return new BitcoindWallet(faucet, walletClient);
     }
 
-    public MaximumFee = BigInt(100000);
+    public MaximumFee = 100000n;
 
     constructor(
         private readonly faucet: BitcoinFaucet,

--- a/api_tests/src/wallets/index.ts
+++ b/api_tests/src/wallets/index.ts
@@ -42,10 +42,10 @@ export class Wallets {
 
 export function newBitcoinStubWallet(): BitcoinWallet {
     return newStubWallet({
-        MaximumFee: BigInt(0),
+        MaximumFee: 0n,
         getAddress: () =>
             Promise.resolve("bcrt1qq7pflkfujg6dq25n73n66yjkvppq6h9caklrhz"),
-        getBalance: () => Promise.resolve(BigInt(0)),
+        getBalance: () => Promise.resolve(0n),
         mint: (_satoshis: bigint) => Promise.resolve(),
     });
 }
@@ -56,7 +56,7 @@ export function newEthereumStubWallet(): EthereumWallet {
         getErc20Balance: (
             _contractAddress: string,
             _decimals?: number
-        ): Promise<bigint> => Promise.resolve(BigInt(0)),
+        ): Promise<bigint> => Promise.resolve(0n),
         mintErc20: (_quantity: bigint, _tokenContract: string) =>
             Promise.resolve(),
     });
@@ -64,7 +64,7 @@ export function newEthereumStubWallet(): EthereumWallet {
 
 export function newLightningStubChannel(): LightningChannel {
     return newStubWallet({
-        getBalance: () => Promise.resolve(BigInt(0)),
+        getBalance: () => Promise.resolve(0n),
     });
 }
 

--- a/api_tests/src/wallets/lightning.ts
+++ b/api_tests/src/wallets/lightning.ts
@@ -225,8 +225,9 @@ export class LndClient {
     public async confirmedWalletBalance(): Promise<bigint> {
         return this.lnrpc
             .walletBalance()
-            .then((r) => (r.confirmedBalance ? r.confirmedBalance : ""))
-            .then(BigInt);
+            .then((r) =>
+                r.confirmedBalance ? BigInt(r.confirmedBalance) : 0n
+            );
     }
 
     private async isSyncedToChain(): Promise<boolean> {
@@ -258,7 +259,7 @@ export class LndClient {
 
         // as the counterparty, localBalance is undefined ...
         if (!channel.localBalance) {
-            return BigInt(0);
+            return 0n;
         }
 
         return BigInt(channel.localBalance);

--- a/api_tests/tests/halbit_herc20.ts
+++ b/api_tests/tests/halbit_herc20.ts
@@ -12,10 +12,7 @@ describe("halbit-herc20", () => {
         "halbit-herc20-alice-redeems-bob-redeems",
         startAliceAndBob(async ([alice, bob]) => {
             const bodies = (await SwapFactory.newSwap(alice, bob)).halbitHerc20;
-            await alice.openLnChannel(
-                bob,
-                BigInt(bodies.alice.alpha.amount) * BigInt(2)
-            );
+            await alice.openLnChannel(bob, bodies.alice.alpha.amount * 2n);
 
             await alice.createHalbitHerc20Swap(bodies.alice);
             await bob.createHalbitHerc20Swap(bodies.bob);
@@ -46,10 +43,7 @@ describe("halbit-herc20", () => {
                     instantRefund: true,
                 })
             ).halbitHerc20;
-            await alice.openLnChannel(
-                bob,
-                BigInt(bodies.alice.alpha.amount) * BigInt(2)
-            );
+            await alice.openLnChannel(bob, bodies.alice.alpha.amount * 2n);
 
             await alice.createHalbitHerc20Swap(bodies.alice);
             await bob.createHalbitHerc20Swap(bodies.bob);

--- a/api_tests/tests/herc20_halbit.ts
+++ b/api_tests/tests/herc20_halbit.ts
@@ -12,10 +12,7 @@ describe("herc20-halbit", () => {
         "herc20-halbit-alice-redeems-bob-redeems",
         startAliceAndBob(async ([alice, bob]) => {
             const bodies = (await SwapFactory.newSwap(alice, bob)).herc20Halbit;
-            await bob.openLnChannel(
-                alice,
-                BigInt(bodies.bob.beta.amount) * BigInt(2)
-            );
+            await bob.openLnChannel(alice, bodies.bob.beta.amount * 2n);
 
             await alice.createHerc20HalbitSwap(bodies.alice);
             await bob.createHerc20HalbitSwap(bodies.bob);
@@ -46,10 +43,7 @@ describe("herc20-halbit", () => {
                     instantRefund: true,
                 })
             ).herc20Halbit;
-            await bob.openLnChannel(
-                alice,
-                BigInt(bodies.bob.beta.amount) * BigInt(2)
-            );
+            await bob.openLnChannel(alice, bodies.bob.beta.amount * 2n);
 
             await alice.createHerc20HalbitSwap(bodies.alice);
             await bob.createHerc20HalbitSwap(bodies.bob);

--- a/api_tests/tests/herc20_halbit_respawn.ts
+++ b/api_tests/tests/herc20_halbit_respawn.ts
@@ -12,10 +12,7 @@ describe("herc20-halbit-respawn", () => {
         "herc20-halbit-alice-misses-bob-fund",
         startAliceAndBob(async ([alice, bob]) => {
             const bodies = (await SwapFactory.newSwap(alice, bob)).herc20Halbit;
-            await bob.openLnChannel(
-                alice,
-                BigInt(bodies.bob.beta.amount) * BigInt(2)
-            );
+            await bob.openLnChannel(alice, bodies.bob.beta.amount * 2n);
 
             await alice.createHerc20HalbitSwap(bodies.alice);
             await bob.createHerc20HalbitSwap(bodies.bob);
@@ -47,10 +44,7 @@ describe("herc20-halbit-respawn", () => {
         "herc20-halbit-bob-misses-alice-redeem",
         startAliceAndBob(async ([alice, bob]) => {
             const bodies = (await SwapFactory.newSwap(alice, bob)).herc20Halbit;
-            await bob.openLnChannel(
-                alice,
-                BigInt(bodies.bob.beta.amount) * BigInt(2)
-            );
+            await bob.openLnChannel(alice, bodies.bob.beta.amount * 2n);
 
             await alice.createHerc20HalbitSwap(bodies.alice);
             await bob.createHerc20HalbitSwap(bodies.bob);
@@ -83,10 +77,7 @@ describe("herc20-halbit-respawn", () => {
         "halbit-herc20-alice-misses-bob-deploy-and-fund",
         startAliceAndBob(async ([alice, bob]) => {
             const bodies = (await SwapFactory.newSwap(alice, bob)).halbitHerc20;
-            await alice.openLnChannel(
-                bob,
-                BigInt(bodies.alice.alpha.amount) * BigInt(2)
-            );
+            await alice.openLnChannel(bob, bodies.alice.alpha.amount * 2n);
 
             await alice.createHalbitHerc20Swap(bodies.alice);
             await bob.createHalbitHerc20Swap(bodies.bob);
@@ -119,10 +110,7 @@ describe("herc20-halbit-respawn", () => {
         "halbit-herc20-bob-down-misses-alice-redeem",
         startAliceAndBob(async ([alice, bob]) => {
             const bodies = (await SwapFactory.newSwap(alice, bob)).halbitHerc20;
-            await alice.openLnChannel(
-                bob,
-                BigInt(bodies.alice.alpha.amount) * BigInt(2)
-            );
+            await alice.openLnChannel(bob, bodies.alice.alpha.amount * 2n);
 
             await alice.createHalbitHerc20Swap(bodies.alice);
             await bob.createHalbitHerc20Swap(bodies.bob);

--- a/api_tests/tsconfig.json
+++ b/api_tests/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es6",
+        "target": "es2020",
         "module": "commonjs",
         "allowSyntheticDefaultImports": true,
         "noImplicitAny": true,


### PR DESCRIPTION
By targeting ES2020 we can use bigint literals. One can create those
by appending the letter `n` to a number.
To target ES2020, we bump the node version used for our tests to 14.x.

Unfortunately, bigints to serialize automatically to JSON, hence we
utility the `replacer` function of JSON.stringify to serialize all
bigints to strings.

FYI to all @comit-network/comit-devs: You will need to bump your local node version to 14.x after this PR lands.