### PR TITLE
Only fund an LndInstance once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -1144,7 +1144,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
  "synstructure",
@@ -2568,7 +2568,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f09b9841adb6b5e1f89ef7087ea636e0fd94b2851f887c1e3eb5d5f8228fab3"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -4076,7 +4076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
  "heck",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]

--- a/api_tests/src/environment/test_environment.ts
+++ b/api_tests/src/environment/test_environment.ts
@@ -281,16 +281,11 @@ export default class TestEnvironment extends NodeEnvironment {
      */
     private async startAliceLightning() {
         const config = await this.initLightningLedger("lnd-alice");
-        const alice = await LndClient.newInstance(config, this.logger);
-
-        this.global.lndClients.alice = alice;
-        this.global.ledgerConfigs.aliceLnd = config;
-
-        await this.bitcoinFaucet.mint(
-            1_000_000_000n, // 10 BTC should be enough money in the LND instance for a few swaps :)
-            await alice.newFundingAddress(),
-            async () => alice.confirmedWalletBalance()
+        this.global.lndClients.alice = await LndClient.newInstance(
+            config,
+            this.logger
         );
+        this.global.ledgerConfigs.aliceLnd = config;
     }
 
     /**
@@ -301,16 +296,11 @@ export default class TestEnvironment extends NodeEnvironment {
      */
     private async startBobLightning() {
         const config = await this.initLightningLedger("lnd-bob");
-        const bob = await LndClient.newInstance(config, this.logger);
-
-        this.global.lndClients.bob = bob;
-        this.global.ledgerConfigs.bobLnd = config;
-
-        await this.bitcoinFaucet.mint(
-            1_000_000_000n, // 10 BTC should be enough money in the LND instance for a few swaps :)
-            await bob.newFundingAddress(),
-            async () => bob.confirmedWalletBalance()
+        this.global.lndClients.bob = await LndClient.newInstance(
+            config,
+            this.logger
         );
+        this.global.ledgerConfigs.bobLnd = config;
     }
 
     private async initLightningLedger(
@@ -326,6 +316,7 @@ export default class TestEnvironment extends NodeEnvironment {
         const lnd = await LndInstance.new(
             await this.global.getDataDir(role),
             this.logger,
+            this.bitcoinFaucet,
             await this.global.getDataDir("bitcoind"),
             path.join(lockDir, "lnd.pid")
         );

--- a/api_tests/src/wallets/lightning.ts
+++ b/api_tests/src/wallets/lightning.ts
@@ -1,6 +1,5 @@
 import { sleep } from "../utils";
 import createLnRpc, {
-    AddressType,
     ChannelPoint,
     createInvoicesRpc,
     InvoicesRpc,
@@ -222,14 +221,6 @@ export class LndClient {
         return this.lnrpc.getInfo().then((r) => r.identityPubkey);
     }
 
-    public async confirmedWalletBalance(): Promise<bigint> {
-        return this.lnrpc
-            .walletBalance()
-            .then((r) =>
-                r.confirmedBalance ? BigInt(r.confirmedBalance) : 0n
-            );
-    }
-
     private async isSyncedToChain(): Promise<boolean> {
         return this.lnrpc.getInfo().then((r) => r.syncedToChain);
     }
@@ -242,12 +233,6 @@ export class LndClient {
         } catch (e) {
             this.logger.warn("Error while connecting to peer", host);
         }
-    }
-
-    public async newFundingAddress(): Promise<string> {
-        return this.lnrpc
-            .newAddress({ type: AddressType.NESTED_PUBKEY_HASH })
-            .then((r) => r.address);
     }
 
     public async getChannelBalance(id: string): Promise<bigint> {


### PR DESCRIPTION
This caused race conditions in CI. Conceptually, funding Lnd's wallet
during startup is also similar to how we treat the other ledgers.
They start with a single account that has a lot of money and can
distribute it to other accounts. Similarily, we start lnd with a lot
of money and distribute it to individual channels later for the actual
swap.