### PR TITLE
Allow user to specify desired swap protocol role through config

### DIFF
--- a/nectar/sample-config.toml
+++ b/nectar/sample-config.toml
@@ -7,6 +7,7 @@
 [maker]
 # The spread to apply to the mid-market when publish an offer. It's a pyrimiad format, 12.34 = 12.34% spread.
 spread = 500
+role = "Bob"
 
 [maker.max_sell]
 # The maximum amount of bitcoin to sell in one order, optional field.
@@ -19,7 +20,7 @@ dai = 1000
 [maker.maximum_possible_fee]
 # An estimation of the maximum fee that we would expect to pay, used to ensure we always have enough
 # balance to execute an order we publish.
-bitcoin = 0.00009275 
+bitcoin = 0.00009275
 
 [network]
 # The libp2p socket on which nectar listens for COMIT messages.

--- a/nectar/src/command/trade.rs
+++ b/nectar/src/command/trade.rs
@@ -22,7 +22,7 @@ use crate::{
     maker::TakeRequestDecision,
     network::{new_swarm, ActivePeer, SetupSwapContext},
 };
-use comit::{Position, Role};
+use comit::Position;
 use std::{sync::Arc, time::Duration};
 
 const ENSURED_CONSUME_ZERO_BUFFER: usize = 0;
@@ -171,8 +171,7 @@ async fn init_maker(
         spread,
         settings.bitcoin.network,
         settings.ethereum.chain,
-        // todo: get from config
-        Role::Bob,
+        settings.maker.role,
     ))
 }
 
@@ -556,7 +555,7 @@ mod tests {
         swap::herc20::asset::ethereum::FromWei,
         test_harness, Seed,
     };
-    use comit::{asset, asset::Erc20Quantity, ethereum::ChainId};
+    use comit::{asset, asset::Erc20Quantity, ethereum::ChainId, Role};
     use ethereum::ether;
     use log::LevelFilter;
 
@@ -581,6 +580,7 @@ mod tests {
                 },
                 spread: Default::default(),
                 maximum_possible_fee: Default::default(),
+                role: Role::Bob,
             },
             network: Network {
                 listen: vec!["/ip4/98.97.96.95/tcp/20500"

--- a/nectar/src/config.rs
+++ b/nectar/src/config.rs
@@ -79,6 +79,7 @@ where
 mod tests {
     use super::*;
     use crate::{bitcoin, config::file::Level, ethereum::ChainId, Spread};
+    use comit::Role;
     use std::{fs, io::Write};
 
     #[test]
@@ -125,6 +126,7 @@ mod tests {
                 maximum_possible_fee: Some(file::Fees {
                     bitcoin: Some(bitcoin::Amount::from_btc(0.00009275).unwrap()),
                 }),
+                role: Some(Role::Bob),
             }),
             network: Some(Network {
                 listen: vec!["/ip4/0.0.0.0/tcp/9939".parse().unwrap()],

--- a/nectar/src/config/file.rs
+++ b/nectar/src/config/file.rs
@@ -3,7 +3,7 @@ use crate::{
     config::{Bitcoind, Data, MaxSell, Network},
     Spread,
 };
-use comit::ethereum::ChainId;
+use comit::{ethereum::ChainId, Role};
 use config as config_rs;
 use log::LevelFilter;
 use serde::{Deserialize, Serialize};
@@ -30,6 +30,7 @@ pub struct Maker {
     pub spread: Option<Spread>,
     pub max_sell: Option<MaxSell>,
     pub maximum_possible_fee: Option<Fees>,
+    pub role: Option<Role>,
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -162,6 +163,7 @@ mod tests {
 # 1000 is 10.00% spread
 spread = 1000
 maximum_possible_fee = { bitcoin = 0.01 }
+role = "Alice"
 
 [maker.max_sell]
 bitcoin = 1.23456
@@ -197,6 +199,7 @@ local_dai_contract_address = "0x6A9865aDE2B6207dAAC49f8bCba9705dEB0B0e6D"
                 maximum_possible_fee: Some(Fees {
                     bitcoin: Some(bitcoin::Amount::from_btc(0.01).unwrap()),
                 }),
+                role: Some(Role::Alice),
             }),
             network: Some(Network {
                 listen: vec!["/ip4/0.0.0.0/tcp/9939".parse().unwrap()],
@@ -247,6 +250,7 @@ local_dai_contract_address = "0x6A9865aDE2B6207dAAC49f8bCba9705dEB0B0e6D"
                 maximum_possible_fee: Some(Fees {
                     bitcoin: Some(bitcoin::Amount::from_btc(0.01).unwrap()),
                 }),
+                role: Some(Role::Alice),
             }),
             network: Some(Network {
                 listen: vec!["/ip4/0.0.0.0/tcp/9939".parse().unwrap()],
@@ -276,6 +280,7 @@ local_dai_contract_address = "0x6A9865aDE2B6207dAAC49f8bCba9705dEB0B0e6D"
 
         let expected = r#"[maker]
 spread = 1000
+role = "Alice"
 
 [maker.max_sell]
 bitcoin = 1.23456


### PR DESCRIPTION
The role that nectar was previously hard coded to be bob. This PR adds an optional role field to the config file that allows the user to specify a role. If a role is not specified, Bob is chosen as a default to prevent a user unexpectedly losing fees from failed swaps.