### PR TITLE
Upgrade rust-bitcoin version to 0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,10 +303,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a32c9d2fa897cfbb0db45d71e3d2838666194abc4828c0f994e4b5c3bf85ba4"
 dependencies = [
  "bech32 0.7.2",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.7.6",
  "hex 0.3.2",
  "secp256k1 0.17.2",
  "serde",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c82d2d6e4ee70935df77021042cbc3262d0e6abf10e4f511364b3e04279780"
+dependencies = [
+ "bech32 0.7.2",
+ "bitcoin_hashes 0.9.0",
+ "secp256k1 0.19.0",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -316,6 +328,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b375d62f341cef9cd9e77793ec8f1db3fc9ce2e4d57e982c8fe697a2c16af3b6"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed2ce8078898876263683749be6f50af005cc77f93be1422f1c56fecf0b34d7"
+dependencies = [
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -337,7 +358,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6d55f23cd516d515ae10911164c603ea1040024670ec109715a20d7f6c9d0c"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.23.0",
  "hex 0.3.2",
  "serde",
  "serde_json",
@@ -442,19 +463,14 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blockchain_contracts"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92228e44179c99d5c61e0c8c3d869c070e6a6fe65ae62006eadc572568db1f"
+checksum = "5a03be37fcc500553a77460ac4879e0f6562d492ff958cfc40f96f800ee3ccdd"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.25.0",
  "byteorder",
- "hex 0.4.2",
  "hex-literal",
- "itertools",
  "regex",
- "serde",
- "serde_json",
- "tiny-keccak 2.0.2",
 ]
 
 [[package]]
@@ -635,7 +651,7 @@ dependencies = [
  "async-trait",
  "atty",
  "base64 0.12.3",
- "bitcoin",
+ "bitcoin 0.25.0",
  "bitcoincore-rpc",
  "chrono",
  "comit",
@@ -704,7 +720,7 @@ dependencies = [
  "async-trait",
  "atty",
  "base64 0.12.3",
- "bitcoin",
+ "bitcoin 0.25.0",
  "bitcoincore-rpc",
  "blockchain_contracts",
  "byteorder",
@@ -2416,7 +2432,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.12.3",
- "bitcoin",
+ "bitcoin 0.25.0",
  "chrono",
  "clarity",
  "comit",
@@ -3570,7 +3586,6 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2932dc07acd2066ff2e3921a4419606b220ba6cd03a9935123856cc534877056"
 dependencies = [
- "rand 0.6.5",
  "secp256k1-sys 0.1.2",
  "serde",
 ]
@@ -3581,7 +3596,9 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6179428c22c73ac0fbb7b5579a56353ce78ba29759b3b8575183336ea74cdfb"
 dependencies = [
+ "rand 0.6.5",
  "secp256k1-sys 0.3.0",
+ "serde 1.0.115",
 ]
 
 [[package]]

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1"
 async-trait = "0.1"
 atty = "0.2"
 base64 = "0.12.3"
-bitcoin = { version = "0.23", features = ["use-serde"] }
+bitcoin = { version = "0.25", features = ["use-serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 comit = { path = "../comit" }
 config = { version = "0.10", features = ["toml"], default-features = false }
@@ -64,7 +64,7 @@ void = "1"
 warp = { version = "0.2", default-features = false }
 
 [dev-dependencies]
-bitcoin = { version = "0.23", features = ["rand"] }
+bitcoin = { version = "0.25", features = ["rand"] }
 bitcoincore-rpc = "0.11.0"
 comit = { path = "../comit", features = ["test"] }
 proptest = "0.10.1"

--- a/cnd/src/proptest.rs
+++ b/cnd/src/proptest.rs
@@ -110,7 +110,7 @@ pub mod bitcoin {
             public_key in identity::bitcoin(),
             network in ledger::bitcoin(),
         ) -> ::bitcoin::Address {
-            ::bitcoin::Address::p2wpkh(&public_key.into(), network.into())
+            ::bitcoin::Address::p2wpkh(&public_key.into(), network.into()).expect("our public keys are always compressed")
         }
     }
 }

--- a/comit/Cargo.toml
+++ b/comit/Cargo.toml
@@ -9,8 +9,8 @@ description = "Core components of the COMIT protocol"
 anyhow = "1"
 async-trait = "0.1"
 base64 = "0.12"
-bitcoin = { version = "0.23", features = ["rand", "use-serde"] }
-blockchain_contracts = "0.3"
+bitcoin = { version = "0.25", features = ["rand", "use-serde"] }
+blockchain_contracts = "0.4"
 byteorder = "1.3"
 chrono = { version = "0.4", features = ["serde"] }
 conquer-once = "0.2"

--- a/comit/src/btsieve/bitcoin.rs
+++ b/comit/src/btsieve/bitcoin.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     identity,
 };
-use bitcoin::{self, BitcoinHash, OutPoint};
+use bitcoin::{self, OutPoint};
 use chrono::{DateTime, Utc};
 use genawaiter::GeneratorState;
 
@@ -22,7 +22,7 @@ impl BlockHash for Block {
     type BlockHash = Hash;
 
     fn block_hash(&self) -> Hash {
-        self.bitcoin_hash()
+        self.block_hash()
     }
 }
 

--- a/comit/src/btsieve/bitcoin/cache.rs
+++ b/comit/src/btsieve/bitcoin/cache.rs
@@ -1,6 +1,6 @@
 use crate::btsieve::{BlockByHash, LatestBlock};
 use async_trait::async_trait;
-use bitcoin::{util::hash::BitcoinHash, Block, BlockHash as Hash, BlockHash};
+use bitcoin::{Block, BlockHash as Hash, BlockHash};
 use derivative::Derivative;
 use lru::LruCache;
 use std::sync::Arc;
@@ -34,7 +34,7 @@ where
     async fn latest_block(&self) -> anyhow::Result<Self::Block> {
         let block = self.connector.latest_block().await?;
 
-        let block_hash = block.bitcoin_hash();
+        let block_hash = block.block_hash();
         let mut guard = self.block_cache.lock().await;
         if !guard.contains(&block_hash) {
             guard.put(block_hash, block.clone());

--- a/comit/tests/bitcoin_helper/connector_mock.rs
+++ b/comit/tests/bitcoin_helper/connector_mock.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use async_trait::async_trait;
-use bitcoin::{util::hash::BitcoinHash, BlockHash};
+use bitcoin::BlockHash;
 use comit::btsieve::{BlockByHash, LatestBlock};
 use futures::{stream::BoxStream, StreamExt};
 use std::{collections::HashMap, time::Duration};
@@ -17,7 +17,7 @@ impl BitcoinConnectorMock {
             all_blocks: all_blocks
                 .into_iter()
                 .fold(HashMap::new(), |mut hm, block| {
-                    hm.insert(block.bitcoin_hash(), block);
+                    hm.insert(block.block_hash(), block);
                     hm
                 }),
             latest_blocks: Mutex::new(

--- a/comit/tests/bitcoin_transaction_pattern_e2e.rs
+++ b/comit/tests/bitcoin_transaction_pattern_e2e.rs
@@ -1,4 +1,3 @@
-use bitcoin::Amount;
 use bitcoincore_rpc::RpcApi;
 use chrono::offset::Utc;
 use comit::btsieve::bitcoin::{watch_for_created_outpoint, BitcoindConnector};
@@ -44,7 +43,7 @@ async fn bitcoin_transaction_pattern_e2e_test() {
                 let transaction_hash = client
                     .send_to_address(
                         &target_address,
-                        Amount::from_sat(100_000_000),
+                        bitcoincore_rpc::bitcoin::Amount::from_sat(100_000_000),
                         None,
                         None,
                         None,
@@ -65,12 +64,18 @@ async fn bitcoin_transaction_pattern_e2e_test() {
         .await
         .expect("failed to send money to address");
 
-    let (funding_transaction, _out_point) =
-        watch_for_created_outpoint(&connector, start_of_swap, target_address)
-            .await
-            .unwrap();
+    let (funding_transaction, _out_point) = watch_for_created_outpoint(
+        &connector,
+        start_of_swap,
+        target_address.to_string().parse().unwrap(),
+    )
+    .await
+    .unwrap();
 
-    assert_eq!(funding_transaction.txid(), actual_transaction.unwrap())
+    assert_eq!(
+        funding_transaction.txid().to_string(),
+        actual_transaction.unwrap().to_string()
+    )
 }
 
 pub fn new_bitcoincore_client<D>(

--- a/nectar/Cargo.toml
+++ b/nectar/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-bitcoin = { version = "0.23", features = ["rand", "use-serde"] }
+bitcoin = { version = "0.25", features = ["rand", "use-serde"] }
 chrono = "0.4"
 clarity = "0.1"
 comit = { path = "../comit/", package = "comit" }


### PR DESCRIPTION
This implies an update of blockchain-contracts to 0.4.0 where rust-bitcoin
has already been bumped to 0.25.

Unfortunately, there isn't a recent version of bitcoincore-rpc available that
depends on rust-bitcoin 0.25. Hence, we have to do a to_string() and parse()
dance to make the tests pass again.