### PR TITLE
[cnd] add peer bootstrap configuration feature

### DIFF
--- a/api_tests/src/actor_test.ts
+++ b/api_tests/src/actor_test.ts
@@ -186,7 +186,10 @@ async function newCndActor(role: Role, startCnd: boolean) {
         ethereum: await ethereumWallet,
         lightning: newLightningStubChannel(), // Lightning channels are initialized lazily
     });
-    await cndStarting;
+
+    if (cndStarting !== undefined) {
+        await cndStarting;
+    }
 
     const lndClient = (() => {
         switch (role) {

--- a/api_tests/src/actors/cnd_actor.ts
+++ b/api_tests/src/actors/cnd_actor.ts
@@ -526,7 +526,7 @@ export class CndActor {
         );
     }
 
-    private async pollUntilConnectedTo(peer: string) {
+    public async pollUntilConnectedTo(peer: string) {
         interface Peers {
             peers: Peer[];
         }

--- a/api_tests/src/cnd_client/index.ts
+++ b/api_tests/src/cnd_client/index.ts
@@ -50,7 +50,7 @@ export default class CndClient {
     }
 
     /**
-     * Get the address on which cnd is listening for peer-to-peer/COMIT messages.
+     * Get the addresses on which cnd is listening for peer-to-peer/COMIT messages.
      *
      * @returns An array of multiaddresses
      * @throws A {@link Problem} from the cnd REST API or an {@link Error}.

--- a/api_tests/src/config.ts
+++ b/api_tests/src/config.ts
@@ -11,7 +11,10 @@ import {
 export interface CndConfigFile {
     http_api: HttpApi;
     data?: { dir: string };
-    network: { listen: string[] };
+    network: {
+        listen: string[];
+        peer_addresses?: string[];
+    };
     logging: { level: string };
     bitcoin?: BitcoinConfig;
     ethereum?: EthereumConfig;

--- a/api_tests/src/environment/cnd_instance.ts
+++ b/api_tests/src/environment/cnd_instance.ts
@@ -16,11 +16,18 @@ export class CndInstance {
         private readonly cargoTargetDirectory: string,
         private readonly logFile: string,
         private readonly logger: Logger,
-        private readonly configFile: CndConfigFile
+        private configFile: CndConfigFile
     ) {}
 
     public getConfigFile() {
         return this.configFile;
+    }
+
+    /**
+     * Override the config of the node.
+     */
+    public setConfigFile(config: CndConfigFile) {
+        this.configFile = config;
     }
 
     public async start() {

--- a/api_tests/tests/sanity.ts
+++ b/api_tests/tests/sanity.ts
@@ -166,10 +166,7 @@ describe("Sanity", () => {
         createAliceAndBob(async ([alice, bob]) => {
             await alice.cndInstance.start();
 
-            const aliceId = await alice.cnd.getPeerId();
-
             const aliceAddresses = await alice.cnd.getPeerListenAddresses();
-
             const configOverride = {
                 network: {
                     peer_addresses: aliceAddresses,
@@ -177,13 +174,12 @@ describe("Sanity", () => {
             };
 
             const currentConfig = bob.cndInstance.getConfigFile();
-
-            const updatedConfig = merge(configOverride, currentConfig);
+            const updatedConfig = merge(currentConfig, configOverride);
 
             bob.cndInstance.setConfigFile(updatedConfig);
-
             await bob.cndInstance.start();
 
+            const aliceId = await alice.cnd.getPeerId();
             await bob.pollUntilConnectedTo(aliceId);
         })
     );

--- a/cnd/src/config.rs
+++ b/cnd/src/config.rs
@@ -59,19 +59,6 @@ impl Data {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct Network {
-    pub listen: Vec<Multiaddr>,
-}
-
-impl Default for Network {
-    fn default() -> Self {
-        Self {
-            listen: vec![COMIT_SOCKET.clone()],
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Bitcoin {
     pub network: ledger::Bitcoin,
     pub bitcoind: Bitcoind,
@@ -366,38 +353,6 @@ where
 mod tests {
     use super::*;
     use spectral::prelude::*;
-
-    #[test]
-    fn network_deserializes_correctly() {
-        let file_contents = vec![
-            r#"
-            listen = ["/ip4/0.0.0.0/tcp/9939"]
-            "#,
-            r#"
-            listen = ["/ip4/0.0.0.0/tcp/9939", "/ip4/127.0.0.1/tcp/9939"]
-            "#,
-        ];
-
-        let expected = vec![
-            Network {
-                listen: vec!["/ip4/0.0.0.0/tcp/9939".parse().unwrap()],
-            },
-            Network {
-                listen: (vec![
-                    "/ip4/0.0.0.0/tcp/9939".parse().unwrap(),
-                    "/ip4/127.0.0.1/tcp/9939".parse().unwrap(),
-                ]),
-            },
-        ];
-
-        let actual = file_contents
-            .into_iter()
-            .map(toml::from_str)
-            .collect::<Result<Vec<Network>, toml::de::Error>>()
-            .unwrap();
-
-        assert_eq!(actual, expected);
-    }
 
     #[test]
     fn lnd_deserializes_correctly() {

--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -204,13 +204,13 @@ fn main() -> anyhow::Result<()> {
         storage.clone(),
     );
 
-    let swarm = Swarm::new(
+    let swarm = runtime.block_on(Swarm::new(
         &settings,
         seed,
         runtime.handle().clone(),
         storage.clone(),
         protocol_spawner.clone(),
-    )?;
+    ))?;
 
     let http_api_listener = runtime.block_on(bind_http_api_socket(&settings))?;
     match runtime.block_on(respawn(storage.clone(), protocol_spawner)) {

--- a/cnd/src/network/swarm.rs
+++ b/cnd/src/network/swarm.rs
@@ -105,16 +105,10 @@ impl Swarm {
         let mut guard = self.inner.lock().await;
 
         if let Some(address_hint) = address_hint {
-            if let Some(addr) = guard
+            guard
                 .peer_tracker
-                .add_address_hint(peer.clone(), address_hint.clone())
-            {
-                tracing::warn!(
-                    "clobbered old address hint, old: {}, new: {}",
-                    addr,
-                    address_hint,
-                );
-            }
+                .add_recent_address_hint(peer.clone(), address_hint);
+
             let existing_connection_to_peer =
                 libp2p::Swarm::connection_info(&mut guard, &peer).is_some();
 
@@ -253,14 +247,17 @@ async fn new_match_worker(
 
         let mut guard = swarm.lock().await;
 
-        if let Err(e) = guard
-            .setup_swap
-            .send(&peer, role, common, protocol, SetupSwapContext {
+        if let Err(e) = guard.setup_swap.send(
+            &peer,
+            role,
+            common,
+            protocol,
+            SetupSwapContext {
                 swap: swap_id,
                 order: order_id,
                 match_reference_point,
-            })
-        {
+            },
+        ) {
             tracing::warn!("failed to setup swap for order {}: {:#}", order_id, e);
         }
     }

--- a/cnd/src/network/swarm.rs
+++ b/cnd/src/network/swarm.rs
@@ -263,17 +263,14 @@ async fn new_match_worker(
 
         let mut guard = swarm.lock().await;
 
-        if let Err(e) = guard.setup_swap.send(
-            &peer,
-            role,
-            common,
-            protocol,
-            SetupSwapContext {
+        if let Err(e) = guard
+            .setup_swap
+            .send(&peer, role, common, protocol, SetupSwapContext {
                 swap: swap_id,
                 order: order_id,
                 match_reference_point,
-            },
-        ) {
+            })
+        {
             tracing::warn!("failed to setup swap for order {}: {:#}", order_id, e);
         }
     }


### PR DESCRIPTION
Add a new config option to pass an array of multiaddress to which the cnd node will try to connect when starting.

Went for addresses only because because at this stage the identification of the peers (via peer id) does not really matter. We just want to connect to another node to get order and execute trustless atomic swaps.