### PR TITLE
Make Kraken API host in nectar configurable

### DIFF
--- a/nectar/sample-config.toml
+++ b/nectar/sample-config.toml
@@ -7,6 +7,10 @@
 [maker]
 # The spread to apply to the mid-market when publish an offer. It's a pyrimiad format, 12.34 = 12.34% spread.
 spread = 500
+# The host to use when fetching the rate for BTC/DAI. If you want to use something other than Kraken, configure it here.
+# Be aware that nectar still expects the response format to match the one from Kraken,
+# hence you will likely have to write a proxy if you want to use something else here.
+kraken_api_host = "https://api.kraken.com"
 
 [maker.max_sell]
 # The maximum amount of bitcoin to sell in one order, optional field.

--- a/nectar/src/config.rs
+++ b/nectar/src/config.rs
@@ -126,6 +126,7 @@ mod tests {
                 maximum_possible_fee: Some(file::Fees {
                     bitcoin: Some(bitcoin::Amount::from_btc(0.00009275).unwrap()),
                 }),
+                kraken_api_host: Some("https://api.kraken.com".parse().unwrap()),
             }),
             network: Some(Network {
                 listen: vec!["/ip4/0.0.0.0/tcp/9939".parse().unwrap()],

--- a/nectar/src/config.rs
+++ b/nectar/src/config.rs
@@ -29,7 +29,7 @@ pub struct Bitcoind {
     pub node_url: Url,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct MaxSell {
     #[serde(default)]
     #[serde(with = "crate::config::serde::bitcoin_amount")]

--- a/nectar/src/config/file.rs
+++ b/nectar/src/config/file.rs
@@ -28,6 +28,7 @@ pub struct File {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Maker {
     pub spread: Option<Spread>,
+    pub kraken_api_host: Option<Url>,
     pub max_sell: Option<MaxSell>,
     pub maximum_possible_fee: Option<Fees>,
 }
@@ -161,6 +162,7 @@ mod tests {
 # 1000 is 10.00% spread
 spread = 1000
 maximum_possible_fee = { bitcoin = 0.01 }
+kraken_api_host = "https://api.kraken.com"
 
 [maker.max_sell]
 bitcoin = 1.23456
@@ -196,6 +198,7 @@ local_dai_contract_address = "0x6A9865aDE2B6207dAAC49f8bCba9705dEB0B0e6D"
                 maximum_possible_fee: Some(Fees {
                     bitcoin: Some(bitcoin::Amount::from_btc(0.01).unwrap()),
                 }),
+                kraken_api_host: Some("https://api.kraken.com".parse().unwrap()),
             }),
             network: Some(Network {
                 listen: vec!["/ip4/0.0.0.0/tcp/9939".parse().unwrap()],
@@ -246,6 +249,7 @@ local_dai_contract_address = "0x6A9865aDE2B6207dAAC49f8bCba9705dEB0B0e6D"
                 maximum_possible_fee: Some(Fees {
                     bitcoin: Some(bitcoin::Amount::from_btc(0.01).unwrap()),
                 }),
+                kraken_api_host: Some("https://api.kraken.com".parse().unwrap()),
             }),
             network: Some(Network {
                 listen: vec!["/ip4/0.0.0.0/tcp/9939".parse().unwrap()],
@@ -275,6 +279,7 @@ local_dai_contract_address = "0x6A9865aDE2B6207dAAC49f8bCba9705dEB0B0e6D"
 
         let expected = r#"[maker]
 spread = 1000
+kraken_api_host = "https://api.kraken.com/"
 
 [maker.max_sell]
 bitcoin = 1.23456

--- a/nectar/src/config/settings.rs
+++ b/nectar/src/config/settings.rs
@@ -169,17 +169,53 @@ pub struct Maker {
     pub maximum_possible_fee: Fees,
 }
 
+impl Maker {
+    fn from_file(file: file::Maker) -> Self {
+        Self {
+            max_sell: file.max_sell.unwrap_or_default(),
+            spread: file
+                .spread
+                .unwrap_or_else(|| Spread::new(500).expect("500 is a valid spread value")),
+            maximum_possible_fee: file
+                .maximum_possible_fee
+                .map_or_else(Fees::default, Fees::from_file),
+        }
+    }
+}
+
+impl Default for Maker {
+    fn default() -> Self {
+        Self {
+            max_sell: MaxSell::default(),
+            spread: Spread::new(500).expect("500 is a valid spread value"),
+            maximum_possible_fee: Fees::default(),
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Fees {
     pub bitcoin: bitcoin::Amount,
 }
 
+impl Fees {
+    fn from_file(file: file::Fees) -> Self {
+        Self {
+            bitcoin: file.bitcoin.unwrap_or_else(Self::default_bitcoin_fee),
+        }
+    }
+
+    // ~265 vbytes (2 inputs 2 outputs segwit transaction)
+    // * 35 sat/vbytes (Looking at https://bitcoinfees.github.io/#1m)
+    fn default_bitcoin_fee() -> bitcoin::Amount {
+        bitcoin::Amount::from_sat(265 * 35)
+    }
+}
+
 impl Default for Fees {
     fn default() -> Self {
         Fees {
-            // ~265 vbytes (2 inputs 2 outputs segwit transaction)
-            // * 35 sat/vbytes (Looking at https://bitcoinfees.github.io/#1m)
-            bitcoin: bitcoin::Amount::from_sat(265 * 35),
+            bitcoin: Self::default_bitcoin_fee(),
         }
     }
 }
@@ -248,41 +284,7 @@ impl Settings {
         } = config_file;
 
         Ok(Self {
-            maker: Maker {
-                max_sell: if let Some(file::Maker {
-                    max_sell: Some(ref max_sell),
-                    ..
-                }) = maker
-                {
-                    max_sell.clone()
-                } else {
-                    MaxSell {
-                        bitcoin: None,
-                        dai: None,
-                    }
-                },
-                spread: match maker {
-                    Some(file::Maker {
-                        spread: Some(spread),
-                        ..
-                    }) => spread,
-                    _ => Spread::new(500).expect("500 is a valid spread value"),
-                },
-                maximum_possible_fee: {
-                    if let Some(file::Maker {
-                        maximum_possible_fee:
-                            Some(file::Fees {
-                                bitcoin: Some(bitcoin),
-                            }),
-                        ..
-                    }) = maker
-                    {
-                        Fees { bitcoin }
-                    } else {
-                        Fees::default()
-                    }
-                },
-            },
+            maker: maker.map_or_else(Maker::default, Maker::from_file),
             network: network.unwrap_or_else(|| {
                 let default_socket = "/ip4/0.0.0.0/tcp/9939"
                     .parse()

--- a/nectar/src/config/settings.rs
+++ b/nectar/src/config/settings.rs
@@ -167,6 +167,30 @@ pub struct Maker {
     /// balance. Fees are in the nominal native currency and per
     /// transaction.
     pub maximum_possible_fee: Fees,
+    pub kraken_api_host: KrakenApiHost,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct KrakenApiHost(Url);
+
+impl KrakenApiHost {
+    pub fn with_trading_pair(&self, trading_pair: &str) -> Result<Url> {
+        let url = self
+            .0
+            .join(&format!("/0/public/Ticker?pair={}", trading_pair))?;
+
+        Ok(url)
+    }
+}
+
+impl Default for KrakenApiHost {
+    fn default() -> Self {
+        let url = "https://api.kraken.com"
+            .parse()
+            .expect("static url always parses correctly");
+
+        Self(url)
+    }
 }
 
 impl Maker {
@@ -179,6 +203,9 @@ impl Maker {
             maximum_possible_fee: file
                 .maximum_possible_fee
                 .map_or_else(Fees::default, Fees::from_file),
+            kraken_api_host: file
+                .kraken_api_host
+                .map_or_else(KrakenApiHost::default, KrakenApiHost),
         }
     }
 }
@@ -189,6 +216,7 @@ impl Default for Maker {
             max_sell: MaxSell::default(),
             spread: Spread::new(500).expect("500 is a valid spread value"),
             maximum_possible_fee: Fees::default(),
+            kraken_api_host: KrakenApiHost::default(),
         }
     }
 }
@@ -265,6 +293,7 @@ impl From<Maker> for file::Maker {
             maximum_possible_fee: Some(file::Fees {
                 bitcoin: Some(maker.maximum_possible_fee.bitcoin),
             }),
+            kraken_api_host: Some(maker.kraken_api_host.0),
         }
     }
 }

--- a/nectar/src/mid_market_rate.rs
+++ b/nectar/src/mid_market_rate.rs
@@ -1,12 +1,12 @@
-use crate::Rate;
+use crate::{config::KrakenApiHost, Rate};
 use std::convert::TryInto;
 
 /// Get mid-market rate for the trading pair BTC-DAI.
 ///
 /// Currently, this function only delegates to Kraken. Eventually, it
 /// could return a value based on multiple sources.
-pub async fn get_btc_dai_mid_market_rate() -> anyhow::Result<MidMarketRate> {
-    kraken::get_btc_dai_mid_market_rate().await
+pub async fn get_btc_dai_mid_market_rate(host: &KrakenApiHost) -> anyhow::Result<MidMarketRate> {
+    kraken::get_btc_dai_mid_market_rate(host).await
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -42,8 +42,12 @@ mod kraken {
     /// More info here: https://www.kraken.com/features/api
     /// Rate limits: For public API a frequency of 1 call per second is
     /// acceptable, More info here: https://support.kraken.com/hc/en-us/articles/206548367-What-are-the-REST-API-rate-limits-
-    pub async fn get_btc_dai_mid_market_rate() -> anyhow::Result<MidMarketRate> {
-        let ask_and_bid = reqwest::get("https://api.kraken.com/0/public/Ticker?pair=XBTDAI")
+    pub async fn get_btc_dai_mid_market_rate(
+        host: &KrakenApiHost,
+    ) -> anyhow::Result<MidMarketRate> {
+        let endpoint = host.with_trading_pair("XBTDAI")?;
+
+        let ask_and_bid = reqwest::get(endpoint)
             .await?
             .json::<TickerResponse>()
             .await


### PR DESCRIPTION
We want e2e tests between nectar and cnd. For this, we will need to be able to control the rate at which nectar publishes orders.

We make the kraken API host configurable so that we can later plug in a local mock.