### PR TITLE
Refactor nectar swap execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2405,6 +2405,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-futures",
  "tracing-log",
  "tracing-subscriber",
  "url 2.1.1",

--- a/nectar/Cargo.toml
+++ b/nectar/Cargo.toml
@@ -41,6 +41,7 @@ time = { version = "0.2", features = ["serde"] }
 tokio = { version = "0.2", features = ["macros", "time"] }
 toml = "0.5"
 tracing = "0.1"
+tracing-futures = "0.2"
 tracing-log = "0.1"
 tracing-subscriber = "0.2"
 url = { version = "2", features = ["serde"] }

--- a/nectar/src/command/resume_only.rs
+++ b/nectar/src/command/resume_only.rs
@@ -31,7 +31,7 @@ pub async fn resume_only(
     );
 
     for swap in db.all_swaps()? {
-        let _ = tokio::spawn(executor.clone().execute(swap));
+        executor.execute(swap);
     }
 
     while let Some(finished_swap) = finished_swap_receiver.next().await {

--- a/nectar/src/command/trade.rs
+++ b/nectar/src/command/trade.rs
@@ -262,7 +262,7 @@ fn respawn_swaps(
             }
         };
 
-        tokio::spawn(swap_executor.clone().execute(swap));
+        swap_executor.execute(swap);
     }
 
     Ok(())

--- a/nectar/src/command/trade.rs
+++ b/nectar/src/command/trade.rs
@@ -2,13 +2,13 @@ mod event_loop;
 
 use crate::{
     bitcoin,
-    command::{trade::event_loop::EventLoop, FinishedSwap},
+    command::trade::event_loop::EventLoop,
     config::{KrakenApiHost, Settings},
     ethereum::{self, dai},
     history::History,
     mid_market_rate::get_btc_dai_mid_market_rate,
     network::{self, new_swarm},
-    swap::{Database, SwapKind, SwapParams},
+    swap::{Database, SwapExecutor, SwapKind, SwapParams},
     Maker, MidMarketRate, Seed, Spread,
 };
 use anyhow::Context;
@@ -16,14 +16,9 @@ use comit::{
     btsieve::{bitcoin::BitcoindConnector, ethereum::Web3Connector},
     Position, Role,
 };
-use futures::{
-    channel::mpsc::{Receiver, Sender},
-    Future, SinkExt,
-};
+use futures::{channel::mpsc, Future, SinkExt};
 use futures_timer::Delay;
 use std::{sync::Arc, time::Duration};
-
-const ENSURED_CONSUME_ZERO_BUFFER: usize = 0;
 
 pub async fn trade(
     seed: &Seed,
@@ -162,11 +157,9 @@ fn init_rate_updates(
     kraken_api_host: KrakenApiHost,
 ) -> (
     impl Future<Output = comit::Never> + Send,
-    Receiver<anyhow::Result<MidMarketRate>>,
+    mpsc::Receiver<anyhow::Result<MidMarketRate>>,
 ) {
-    let (mut sender, receiver) = futures::channel::mpsc::channel::<anyhow::Result<MidMarketRate>>(
-        ENSURED_CONSUME_ZERO_BUFFER,
-    );
+    let (mut sender, receiver) = make_update_channel();
 
     let future = async move {
         loop {
@@ -186,16 +179,23 @@ fn init_rate_updates(
     (future, receiver)
 }
 
+fn make_update_channel<T>() -> (mpsc::Sender<T>, mpsc::Receiver<T>) {
+    // We start with one sender and never clone it, hence we have an effective
+    // buffer size of 1. This is good because we actually want back-pressure on
+    // the sender to not update the rate more often than the event-loop can process.
+    let buffer_size = 0;
+
+    mpsc::channel(buffer_size)
+}
+
 fn init_bitcoin_balance_updates(
     update_interval: Duration,
     wallet: Arc<bitcoin::Wallet>,
 ) -> (
     impl Future<Output = comit::Never> + Send,
-    Receiver<anyhow::Result<bitcoin::Amount>>,
+    mpsc::Receiver<anyhow::Result<bitcoin::Amount>>,
 ) {
-    let (mut sender, receiver) = futures::channel::mpsc::channel::<anyhow::Result<bitcoin::Amount>>(
-        ENSURED_CONSUME_ZERO_BUFFER,
-    );
+    let (mut sender, receiver) = make_update_channel();
 
     let future = async move {
         loop {
@@ -220,10 +220,9 @@ fn init_dai_balance_updates(
     wallet: Arc<ethereum::Wallet>,
 ) -> (
     impl Future<Output = comit::Never> + Send,
-    Receiver<anyhow::Result<dai::Amount>>,
+    mpsc::Receiver<anyhow::Result<dai::Amount>>,
 ) {
-    let (mut sender, receiver) =
-        futures::channel::mpsc::channel::<anyhow::Result<dai::Amount>>(ENSURED_CONSUME_ZERO_BUFFER);
+    let (mut sender, receiver) = make_update_channel();
 
     let future = async move {
         loop {
@@ -241,70 +240,6 @@ fn init_dai_balance_updates(
     };
 
     (future, receiver)
-}
-
-#[derive(Debug, Clone)]
-struct SwapExecutor {
-    db: Arc<Database>,
-    bitcoin_wallet: Arc<bitcoin::Wallet>,
-    ethereum_wallet: Arc<ethereum::Wallet>,
-    finished_swap_sender: Sender<FinishedSwap>,
-    bitcoin_connector: Arc<comit::btsieve::bitcoin::BitcoindConnector>,
-    ethereum_connector: Arc<comit::btsieve::ethereum::Web3Connector>,
-}
-
-impl SwapExecutor {
-    pub fn new(
-        db: Arc<Database>,
-        bitcoin_wallet: Arc<bitcoin::Wallet>,
-        ethereum_wallet: Arc<ethereum::Wallet>,
-        bitcoin_connector: Arc<comit::btsieve::bitcoin::BitcoindConnector>,
-        ethereum_connector: Arc<comit::btsieve::ethereum::Web3Connector>,
-    ) -> (Self, Receiver<FinishedSwap>) {
-        let (finished_swap_sender, finished_swap_receiver) =
-            futures::channel::mpsc::channel::<FinishedSwap>(ENSURED_CONSUME_ZERO_BUFFER);
-
-        (
-            Self {
-                db,
-                bitcoin_wallet,
-                ethereum_wallet,
-                finished_swap_sender,
-                bitcoin_connector,
-                ethereum_connector,
-            },
-            finished_swap_receiver,
-        )
-    }
-}
-
-impl SwapExecutor {
-    async fn execute(mut self, swap: SwapKind) -> anyhow::Result<()> {
-        self.db.insert_swap(swap.clone()).await?;
-
-        swap.execute(
-            self.db,
-            self.bitcoin_wallet,
-            self.ethereum_wallet,
-            self.bitcoin_connector,
-            self.ethereum_connector,
-        )
-        .await?;
-
-        let _ = self
-            .finished_swap_sender
-            .send(FinishedSwap::new(
-                swap.clone(),
-                swap.params().taker,
-                chrono::Utc::now(),
-            ))
-            .await
-            .map_err(|_| {
-                tracing::trace!("Error when sending execution finished from sender to receiver.")
-            });
-
-        Ok(())
-    }
 }
 
 fn respawn_swaps(

--- a/nectar/src/command/trade.rs
+++ b/nectar/src/command/trade.rs
@@ -279,7 +279,7 @@ impl SwapExecutor {
 }
 
 impl SwapExecutor {
-    async fn run(mut self, swap: SwapKind) -> anyhow::Result<()> {
+    async fn execute(mut self, swap: SwapKind) -> anyhow::Result<()> {
         self.db.insert_swap(swap.clone()).await?;
 
         swap.execute(
@@ -327,7 +327,7 @@ fn respawn_swaps(
             }
         };
 
-        tokio::spawn(swap_executor.clone().run(swap));
+        tokio::spawn(swap_executor.clone().execute(swap));
     }
 
     Ok(())

--- a/nectar/src/command/trade/event_loop.rs
+++ b/nectar/src/command/trade/event_loop.rs
@@ -1,12 +1,12 @@
 use crate::{
     bitcoin,
-    command::{into_history_trade, trade::SwapExecutor, FinishedSwap},
+    command::{into_history_trade, FinishedSwap},
     ethereum::{self, dai},
     history::History,
     maker::{PublishOrders, TakeRequestDecision},
     network::{self, ActivePeer, SetupSwapContext, Swarm},
     order::BtcDaiOrderForm,
-    swap::{hbit, Database, SwapKind, SwapParams},
+    swap::{hbit, Database, SwapExecutor, SwapKind, SwapParams},
     Maker, MidMarketRate, SwapId,
 };
 use anyhow::{bail, Context, Result};

--- a/nectar/src/command/trade/event_loop.rs
+++ b/nectar/src/command/trade/event_loop.rs
@@ -237,9 +237,7 @@ impl EventLoop {
                     .await
                     .with_context(|| format!("Could not insert swap {}", swap_id))?;
 
-                let _ = tokio::spawn(self.swap_executor.clone().execute(swap_kind))
-                    .await
-                    .with_context(|| format!("Execution failed for swap {}", swap_id))?;
+                self.swap_executor.execute(swap_kind);
             }
             setup_swap::BehaviourOutEvent::AlreadyHaveRoleParams { peer, .. } => {
                 bail!("already received role params from {}", peer)

--- a/nectar/src/command/trade/event_loop.rs
+++ b/nectar/src/command/trade/event_loop.rs
@@ -237,7 +237,7 @@ impl EventLoop {
                     .await
                     .with_context(|| format!("Could not insert swap {}", swap_id))?;
 
-                let _ = tokio::spawn(self.swap_executor.clone().run(swap_kind))
+                let _ = tokio::spawn(self.swap_executor.clone().execute(swap_kind))
                     .await
                     .with_context(|| format!("Execution failed for swap {}", swap_id))?;
             }

--- a/nectar/src/main.rs
+++ b/nectar/src/main.rs
@@ -13,7 +13,7 @@
 #![cfg_attr(not(test), warn(clippy::unwrap_used))]
 #![forbid(unsafe_code)]
 #![recursion_limit = "512"]
-#![type_length_limit = "1944624"]
+#![type_length_limit = "7743004"]
 
 mod bitcoin;
 mod command;

--- a/nectar/src/swap.rs
+++ b/nectar/src/swap.rs
@@ -604,10 +604,6 @@ async fn execute(
     db: Arc<Database>,
     mut sender: mpsc::Sender<FinishedSwap>,
 ) -> Result<()> {
-    db.insert_swap(swap.clone())
-        .await
-        .context("failed to insert swap into database")?;
-
     match swap.clone() {
         SwapKind::HbitHerc20(SwapParams {
             hbit_params,

--- a/nectar/src/swap.rs
+++ b/nectar/src/swap.rs
@@ -9,11 +9,12 @@ mod comit;
 pub mod ethereum;
 
 use crate::{network::ActivePeer, swap::bob::Bob, SwapId};
+use chrono::{DateTime, Utc};
 use std::sync::Arc;
+use tracing_futures::Instrument;
 
 pub use self::comit::{hbit, herc20};
 pub use crate::database::Database;
-use chrono::{DateTime, Utc};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SwapKind {
@@ -76,6 +77,7 @@ impl SwapKind {
                     herc20_params.clone(),
                     *start_of_swap,
                 )
+                .instrument(tracing::error_span!("hbit_herc20_bob", %swap_id))
                 .await?
             }
             SwapKind::Herc20Hbit(SwapParams {
@@ -104,6 +106,7 @@ impl SwapKind {
                     *hbit_params,
                     *start_of_swap,
                 )
+                .instrument(tracing::error_span!("herc20_hbit_bob", %swap_id))
                 .await?
             }
         };

--- a/nectar/src/swap/comit.rs
+++ b/nectar/src/swap/comit.rs
@@ -8,3 +8,18 @@ mod herc20_hbit;
 pub use comit::{ethereum, *};
 pub use hbit_herc20::{hbit_herc20_alice, hbit_herc20_bob};
 pub use herc20_hbit::{herc20_hbit_alice, herc20_hbit_bob};
+
+use std::fmt::Debug;
+use thiserror::Error;
+
+/// Indicates that a swap failed AND that we should refund as a result.
+///
+/// The contained event holds the necessary information to refund.
+#[derive(Clone, Copy, Debug, Error)]
+#[error("swap execution failed")]
+pub struct SwapFailedShouldRefund<E: Debug>(pub E);
+
+/// Indicates that a swap failed but we don't have to refund.
+#[derive(Clone, Copy, Debug, Error)]
+#[error("swap execution failed")]
+pub struct SwapFailedNoRefund;

--- a/nectar/src/swap/comit/hbit.rs
+++ b/nectar/src/swap/comit/hbit.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use bitcoin::{secp256k1::SecretKey, Block, BlockHash};
 use chrono::{DateTime, Utc};
 use comit::asset;
@@ -28,7 +29,7 @@ impl Params {
 
 #[async_trait::async_trait]
 pub trait ExecuteFund {
-    async fn execute_fund(&self, params: &Params) -> anyhow::Result<Funded>;
+    async fn execute_fund(&self, params: &Params) -> Result<Funded>;
 }
 
 #[async_trait::async_trait]
@@ -38,12 +39,12 @@ pub trait ExecuteRedeem {
         params: Params,
         fund_event: Funded,
         secret: Secret,
-    ) -> anyhow::Result<Redeemed>;
+    ) -> Result<Redeemed>;
 }
 
 #[async_trait::async_trait]
 pub trait ExecuteRefund {
-    async fn execute_refund(&self, params: Params, fund_event: Funded) -> anyhow::Result<Refunded>;
+    async fn execute_refund(&self, params: Params, fund_event: Funded) -> Result<Refunded>;
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -56,7 +57,7 @@ pub async fn watch_for_funded<C>(
     connector: &C,
     params: &SharedParams,
     utc_start_of_swap: DateTime<Utc>,
-) -> anyhow::Result<Funded>
+) -> Result<Funded>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = BlockHash>,
 {

--- a/nectar/src/swap/comit/hbit_herc20.rs
+++ b/nectar/src/swap/comit/hbit_herc20.rs
@@ -7,9 +7,6 @@ use comit::{
 };
 
 /// Execute a Hbit<->Herc20 swap for Alice.
-///
-/// Delegates to `hbit_herc20_happy_alice` and handles errors by
-/// executing refund for Alice when necessary.
 #[allow(dead_code)] // This is library code
 pub async fn hbit_herc20_alice<A, EC>(
     alice: A,
@@ -25,19 +22,41 @@ where
         + BlockByHash<Block = ethereum::Block, BlockHash = ethereum::Hash>
         + btsieve::ethereum::ReceiptByHash,
 {
-    let res = hbit_herc20_happy_alice(
-        &alice,
-        ethereum_connector,
-        hbit_params,
-        herc20_params,
-        secret,
-        utc_start_of_swap,
-    )
-    .await;
-
     use HbitHerc20AliceError::*;
+
+    let happy_path = async {
+        let hbit_funded = alice
+            .execute_fund(&hbit_params)
+            .await
+            .map_err(|_| AliceFund)?;
+
+        let herc20_deployed = herc20::watch_for_deployed(
+            ethereum_connector,
+            herc20_params.clone(),
+            utc_start_of_swap,
+        )
+        .await
+        .map_err(|_| BobDeploy(hbit_funded))?;
+
+        let _herc20_funded = herc20::watch_for_funded(
+            ethereum_connector,
+            herc20_params.clone(),
+            utc_start_of_swap,
+            herc20_deployed.clone(),
+        )
+        .await
+        .map_err(|_| BobFund(hbit_funded))?;
+
+        let _herc20_redeemed = alice
+            .execute_redeem(herc20_params, secret, herc20_deployed, utc_start_of_swap)
+            .await
+            .map_err(|_| AliceRedeem(hbit_funded))?;
+
+        Ok(())
+    };
+
     if let Err(BobDeploy(hbit_funded)) | Err(BobFund(hbit_funded)) | Err(AliceRedeem(hbit_funded)) =
-        res
+        happy_path.await
     {
         alice.execute_refund(hbit_params, hbit_funded).await?;
     };
@@ -45,54 +64,7 @@ where
     Ok(())
 }
 
-/// Execute the happy path of a Hbit<->Herc20 swap for Alice.
-async fn hbit_herc20_happy_alice<A, EC>(
-    alice: &A,
-    ethereum_connector: &EC,
-    hbit_params: hbit::Params,
-    herc20_params: herc20::Params,
-    secret: Secret,
-    utc_start_of_swap: DateTime<Utc>,
-) -> Result<(), HbitHerc20AliceError>
-where
-    A: hbit::ExecuteFund + herc20::ExecuteRedeem,
-    EC: LatestBlock<Block = ethereum::Block>
-        + BlockByHash<Block = ethereum::Block, BlockHash = ethereum::Hash>
-        + btsieve::ethereum::ReceiptByHash,
-{
-    use HbitHerc20AliceError::*;
-
-    let hbit_funded = alice
-        .execute_fund(&hbit_params)
-        .await
-        .map_err(|_| AliceFund)?;
-
-    let herc20_deployed =
-        herc20::watch_for_deployed(ethereum_connector, herc20_params.clone(), utc_start_of_swap)
-            .await
-            .map_err(|_| BobDeploy(hbit_funded))?;
-
-    let _herc20_funded = herc20::watch_for_funded(
-        ethereum_connector,
-        herc20_params.clone(),
-        utc_start_of_swap,
-        herc20_deployed.clone(),
-    )
-    .await
-    .map_err(|_| BobFund(hbit_funded))?;
-
-    let _herc20_redeemed = alice
-        .execute_redeem(herc20_params, secret, herc20_deployed, utc_start_of_swap)
-        .await
-        .map_err(|_| AliceRedeem(hbit_funded))?;
-
-    Ok(())
-}
-
 /// Execute a Hbit<->Herc20 swap for Bob.
-///
-/// Delegates to `hbit_herc20_happy_bob` and handles errors by
-/// executing refund for Bob when necessary.
 pub async fn hbit_herc20_bob<B, BC, EC>(
     bob: B,
     bitcoin_connector: &BC,
@@ -109,77 +81,48 @@ where
         + BlockByHash<Block = ethereum::Block, BlockHash = ethereum::Hash>
         + btsieve::ethereum::ReceiptByHash,
 {
-    let res = hbit_herc20_happy_bob(
-        &bob,
-        bitcoin_connector,
-        ethereum_connector,
-        hbit_params,
-        herc20_params.clone(),
-        utc_start_of_swap,
-    )
-    .await;
-
     use HbitHerc20BobError::*;
-    if let Err(AliceRedeem(herc20_deployed)) = res {
+
+    let happy_path = async {
+        let hbit_funded =
+            hbit::watch_for_funded(bitcoin_connector, &hbit_params.shared, utc_start_of_swap)
+                .await
+                .map_err(|_| AliceFund)?;
+
+        let herc20_deployed = bob
+            .execute_deploy(herc20_params.clone())
+            .await
+            .map_err(|_| BobDeploy)?;
+
+        let _herc20_funded = bob
+            .execute_fund(
+                herc20_params.clone(),
+                herc20_deployed.clone(),
+                utc_start_of_swap,
+            )
+            .await
+            .map_err(|_| BobFund)?;
+
+        let herc20_redeemed = herc20::watch_for_redeemed(
+            ethereum_connector,
+            utc_start_of_swap,
+            herc20_deployed.clone(),
+        )
+        .await
+        .map_err(|_| AliceRedeem(herc20_deployed))?;
+
+        let _hbit_redeem = bob
+            .execute_redeem(hbit_params, hbit_funded, herc20_redeemed.secret)
+            .await
+            .map_err(|_| BobRedeem)?;
+
+        Ok(())
+    };
+
+    if let Err(AliceRedeem(herc20_deployed)) = happy_path.await {
         bob.execute_refund(herc20_params, herc20_deployed, utc_start_of_swap)
             .await?;
     }
-
-    Ok(())
-}
-
-/// Execute the happy path of a Hbit<->Herc20 swap for Bob.
-async fn hbit_herc20_happy_bob<B, BC, EC>(
-    bob: &B,
-    bitcoin_connector: &BC,
-    ethereum_connector: &EC,
-    hbit_params: hbit::Params,
-    herc20_params: herc20::Params,
-    utc_start_of_swap: DateTime<Utc>,
-) -> Result<(), HbitHerc20BobError>
-where
-    B: herc20::ExecuteDeploy + herc20::ExecuteFund + hbit::ExecuteRedeem,
-    BC: LatestBlock<Block = ::bitcoin::Block>
-        + BlockByHash<Block = ::bitcoin::Block, BlockHash = ::bitcoin::BlockHash>,
-    EC: LatestBlock<Block = ethereum::Block>
-        + BlockByHash<Block = ethereum::Block, BlockHash = ethereum::Hash>
-        + btsieve::ethereum::ReceiptByHash,
-{
-    use HbitHerc20BobError::*;
-
-    let hbit_funded =
-        hbit::watch_for_funded(bitcoin_connector, &hbit_params.shared, utc_start_of_swap)
-            .await
-            .map_err(|_| AliceFund)?;
-
-    let herc20_deployed = bob
-        .execute_deploy(herc20_params.clone())
-        .await
-        .map_err(|_| BobDeploy)?;
-
-    let _herc20_funded = bob
-        .execute_fund(
-            herc20_params.clone(),
-            herc20_deployed.clone(),
-            utc_start_of_swap,
-        )
-        .await
-        .map_err(|_| BobFund)?;
-
-    let herc20_redeemed = herc20::watch_for_redeemed(
-        ethereum_connector,
-        utc_start_of_swap,
-        herc20_deployed.clone(),
-    )
-    .await
-    .map_err(|_| AliceRedeem(herc20_deployed))?;
-
-    let _hbit_redeem = bob
-        .execute_redeem(hbit_params, hbit_funded, herc20_redeemed.secret)
-        .await
-        .map_err(|_| BobRedeem)?;
-
-    dbg!(_hbit_redeem);
 
     Ok(())
 }

--- a/nectar/src/swap/comit/herc20.rs
+++ b/nectar/src/swap/comit/herc20.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use chrono::{DateTime, Utc};
 
 pub use comit::{
@@ -11,7 +12,7 @@ pub use comit::{
 
 #[async_trait::async_trait]
 pub trait ExecuteDeploy {
-    async fn execute_deploy(&self, params: Params) -> anyhow::Result<Deployed>;
+    async fn execute_deploy(&self, params: Params) -> Result<Deployed>;
 }
 
 #[async_trait::async_trait]
@@ -21,7 +22,7 @@ pub trait ExecuteFund {
         params: Params,
         deploy_event: Deployed,
         utc_start_of_swap: DateTime<Utc>,
-    ) -> anyhow::Result<Funded>;
+    ) -> Result<Funded>;
 }
 
 #[async_trait::async_trait]
@@ -32,7 +33,7 @@ pub trait ExecuteRedeem {
         secret: Secret,
         deploy_event: Deployed,
         utc_start_of_swap: DateTime<Utc>,
-    ) -> anyhow::Result<Redeemed>;
+    ) -> Result<Redeemed>;
 }
 
 #[async_trait::async_trait]
@@ -42,7 +43,7 @@ pub trait ExecuteRefund {
         params: Params,
         deploy_event: Deployed,
         utc_start_of_swap: DateTime<Utc>,
-    ) -> anyhow::Result<Refunded>;
+    ) -> Result<Refunded>;
 }
 
 #[derive(Debug, Clone)]
@@ -56,7 +57,7 @@ pub async fn watch_for_funded<C>(
     params: Params,
     utc_start_of_swap: DateTime<Utc>,
     deployed: Deployed,
-) -> anyhow::Result<Funded>
+) -> Result<Funded>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
 {

--- a/nectar/src/swap/comit/herc20_hbit.rs
+++ b/nectar/src/swap/comit/herc20_hbit.rs
@@ -74,6 +74,8 @@ where
     BC: LatestBlock<Block = ::bitcoin::Block>
         + BlockByHash<Block = ::bitcoin::Block, BlockHash = ::bitcoin::BlockHash>,
 {
+    tracing::info!("starting swap");
+
     let swap_result = async {
         let herc20_deployed = herc20::watch_for_deployed(
             ethereum_connector,
@@ -82,6 +84,8 @@ where
         )
         .await
         .context(SwapFailedNoRefund)?;
+
+        tracing::info!("alice deployed the herc20 htlc");
 
         let _herc20_funded = herc20::watch_for_funded(
             ethereum_connector,
@@ -92,10 +96,14 @@ where
         .await
         .context(SwapFailedNoRefund)?;
 
+        tracing::info!("alice funded the herc20 htlc");
+
         let hbit_funded = bob
             .execute_fund(&hbit_params)
             .await
             .context(SwapFailedNoRefund)?;
+
+        tracing::info!("we funded the hbit htlc");
 
         let hbit_redeemed = hbit::watch_for_redeemed(
             bitcoin_connector,
@@ -106,6 +114,8 @@ where
         .await
         .context(SwapFailedShouldRefund(hbit_funded))?;
 
+        tracing::info!("alice redeemed the hbit htlc");
+
         let _herc20_redeem = bob
             .execute_redeem(
                 herc20_params,
@@ -115,6 +125,8 @@ where
             )
             .await
             .context(SwapFailedNoRefund)?;
+
+        tracing::info!("we redeemed the herc20 htlc");
 
         Ok(())
     }

--- a/nectar/src/swap/comit/herc20_hbit.rs
+++ b/nectar/src/swap/comit/herc20_hbit.rs
@@ -7,9 +7,6 @@ use comit::{
 };
 
 /// Execute a Herc20<->Hbit swap for Alice.
-///
-/// Delegates to `herc20_hbit_happy_alice` and handles errors by
-/// executing refund for Alice when necessary.
 #[allow(dead_code)] // This is library code
 pub async fn herc20_hbit_alice<A, BC>(
     alice: A,
@@ -24,18 +21,37 @@ where
     BC: LatestBlock<Block = ::bitcoin::Block>
         + BlockByHash<Block = ::bitcoin::Block, BlockHash = ::bitcoin::BlockHash>,
 {
-    let res = herc20_hbit_happy_alice(
-        &alice,
-        bitcoin_connector,
-        herc20_params.clone(),
-        hbit_params,
-        secret,
-        utc_start_of_swap,
-    )
-    .await;
-
     use Herc20HbitAliceError::*;
-    if let Err(BobFund(herc20_deployed)) | Err(AliceRedeem(herc20_deployed)) = res {
+
+    let happy_path = async {
+        let herc20_deployed = alice
+            .execute_deploy(herc20_params.clone())
+            .await
+            .map_err(|_| AliceDeploy)?;
+
+        let _herc20_funded = alice
+            .execute_fund(
+                herc20_params.clone(),
+                herc20_deployed.clone(),
+                utc_start_of_swap,
+            )
+            .await
+            .map_err(|_| AliceFund)?;
+
+        let hbit_funded =
+            hbit::watch_for_funded(bitcoin_connector, &hbit_params.shared, utc_start_of_swap)
+                .await
+                .map_err(|_| BobFund(herc20_deployed.clone()))?;
+
+        let _hbit_redeemed = alice
+            .execute_redeem(hbit_params, hbit_funded, secret)
+            .await
+            .map_err(|_| AliceRedeem(herc20_deployed))?;
+
+        Ok(())
+    };
+
+    if let Err(BobFund(herc20_deployed)) | Err(AliceRedeem(herc20_deployed)) = happy_path.await {
         alice
             .execute_refund(herc20_params, herc20_deployed, utc_start_of_swap)
             .await?;
@@ -44,53 +60,7 @@ where
     Ok(())
 }
 
-/// Execute the happy path of a Herc20<->Hbit swap for Alice.
-async fn herc20_hbit_happy_alice<A, BC>(
-    alice: &A,
-    bitcoin_connector: &BC,
-    herc20_params: herc20::Params,
-    hbit_params: hbit::Params,
-    secret: Secret,
-    utc_start_of_swap: DateTime<Utc>,
-) -> Result<(), Herc20HbitAliceError>
-where
-    A: herc20::ExecuteDeploy + herc20::ExecuteFund + hbit::ExecuteRedeem,
-    BC: LatestBlock<Block = ::bitcoin::Block>
-        + BlockByHash<Block = ::bitcoin::Block, BlockHash = ::bitcoin::BlockHash>,
-{
-    use Herc20HbitAliceError::*;
-
-    let herc20_deployed = alice
-        .execute_deploy(herc20_params.clone())
-        .await
-        .map_err(|_| AliceDeploy)?;
-
-    let _herc20_funded = alice
-        .execute_fund(
-            herc20_params.clone(),
-            herc20_deployed.clone(),
-            utc_start_of_swap,
-        )
-        .await
-        .map_err(|_| AliceFund)?;
-
-    let hbit_funded =
-        hbit::watch_for_funded(bitcoin_connector, &hbit_params.shared, utc_start_of_swap)
-            .await
-            .map_err(|_| BobFund(herc20_deployed.clone()))?;
-
-    let _hbit_redeemed = alice
-        .execute_redeem(hbit_params, hbit_funded, secret)
-        .await
-        .map_err(|_| AliceRedeem(herc20_deployed))?;
-
-    Ok(())
-}
-
 /// Execute a Herc20<->Hbit swap for Bob.
-///
-/// Delegates to `herc20_hbit_happy_bob` and handles errors by
-/// executing refund for Bob when necessary.
 pub async fn herc20_hbit_bob<B, EC, BC>(
     bob: B,
     ethereum_connector: &EC,
@@ -107,77 +77,53 @@ where
     BC: LatestBlock<Block = ::bitcoin::Block>
         + BlockByHash<Block = ::bitcoin::Block, BlockHash = ::bitcoin::BlockHash>,
 {
-    let res = herc20_hbit_happy_bob(
-        &bob,
-        ethereum_connector,
-        bitcoin_connector,
-        herc20_params,
-        hbit_params,
-        utc_start_of_swap,
-    )
-    .await;
-
-    use Herc20HbitBobError::*;
-    if let Err(AliceRedeem(hbit_funded)) = res {
-        bob.execute_refund(hbit_params, hbit_funded).await?;
-    };
-
-    Ok(())
-}
-
-/// Execute the happy path of a Herc20<->Hbit swap for Bob.
-async fn herc20_hbit_happy_bob<B, EC, BC>(
-    bob: &B,
-    ethereum_connector: &EC,
-    bitcoin_connector: &BC,
-    herc20_params: herc20::Params,
-    hbit_params: hbit::Params,
-    utc_start_of_swap: DateTime<Utc>,
-) -> Result<(), Herc20HbitBobError>
-where
-    B: hbit::ExecuteFund + herc20::ExecuteRedeem,
-    EC: LatestBlock<Block = ethereum::Block>
-        + BlockByHash<Block = ethereum::Block, BlockHash = ethereum::Hash>
-        + btsieve::ethereum::ReceiptByHash,
-    BC: LatestBlock<Block = ::bitcoin::Block>
-        + BlockByHash<Block = ::bitcoin::Block, BlockHash = ::bitcoin::BlockHash>,
-{
     use Herc20HbitBobError::*;
 
-    let herc20_deployed =
-        herc20::watch_for_deployed(ethereum_connector, herc20_params.clone(), utc_start_of_swap)
-            .await
-            .map_err(|_| AliceDeploy)?;
-
-    let _herc20_funded = herc20::watch_for_funded(
-        ethereum_connector,
-        herc20_params.clone(),
-        utc_start_of_swap,
-        herc20_deployed.clone(),
-    )
-    .await
-    .map_err(|_| AliceFund)?;
-
-    let hbit_funded = bob.execute_fund(&hbit_params).await.map_err(|_| BobFund)?;
-
-    let hbit_redeemed = hbit::watch_for_redeemed(
-        bitcoin_connector,
-        &hbit_params.shared,
-        hbit_funded.location,
-        utc_start_of_swap,
-    )
-    .await
-    .map_err(|_| AliceRedeem(hbit_funded))?;
-
-    let _herc20_redeem = bob
-        .execute_redeem(
-            herc20_params,
-            hbit_redeemed.secret,
-            herc20_deployed.clone(),
+    let happy_path = async {
+        let herc20_deployed = herc20::watch_for_deployed(
+            ethereum_connector,
+            herc20_params.clone(),
             utc_start_of_swap,
         )
         .await
-        .map_err(|_| BobRedeem)?;
+        .map_err(|_| AliceDeploy)?;
+
+        let _herc20_funded = herc20::watch_for_funded(
+            ethereum_connector,
+            herc20_params.clone(),
+            utc_start_of_swap,
+            herc20_deployed.clone(),
+        )
+        .await
+        .map_err(|_| AliceFund)?;
+
+        let hbit_funded = bob.execute_fund(&hbit_params).await.map_err(|_| BobFund)?;
+
+        let hbit_redeemed = hbit::watch_for_redeemed(
+            bitcoin_connector,
+            &hbit_params.shared,
+            hbit_funded.location,
+            utc_start_of_swap,
+        )
+        .await
+        .map_err(|_| AliceRedeem(hbit_funded))?;
+
+        let _herc20_redeem = bob
+            .execute_redeem(
+                herc20_params,
+                hbit_redeemed.secret,
+                herc20_deployed.clone(),
+                utc_start_of_swap,
+            )
+            .await
+            .map_err(|_| BobRedeem)?;
+
+        Ok(())
+    };
+
+    if let Err(AliceRedeem(hbit_funded)) = happy_path.await {
+        bob.execute_refund(hbit_params, hbit_funded).await?;
+    };
 
     Ok(())
 }


### PR DESCRIPTION
This patch serious refactors nectar's swap execution to more generally deal with scenarios in which we want to refund.

We also add logging so we can see what is going on.

Lastly, we refactor `SwapExecutor#execute` to no longer be an async function to avoid accidential blocking of the event-loop.

FYI: @luckysori 