### PR TITLE
Make sure we always put the HTLC on out-index 0

### DIFF
--- a/nectar/src/bitcoin/wallet.rs
+++ b/nectar/src/bitcoin/wallet.rs
@@ -8,7 +8,7 @@ use ::bitcoin::{
     util::bip32::{ChainCode, ChildNumber, ExtendedPrivKey},
     PrivateKey, Transaction, Txid,
 };
-use bitcoin::util::bip32::DerivationPath;
+use bitcoin::{util::bip32::DerivationPath, OutPoint};
 use std::str::FromStr;
 use url::Url;
 
@@ -221,6 +221,21 @@ impl Wallet {
             .send_to_address(&self.name, address, amount)
             .await?;
         Ok(txid)
+    }
+
+    pub async fn fund_htlc(
+        &self,
+        address: Address,
+        amount: Amount,
+        network: Network,
+    ) -> anyhow::Result<OutPoint> {
+        self.assert_network(network).await?;
+
+        let outpoint = self
+            .bitcoind_client
+            .fund_htlc(&self.name, address, amount)
+            .await?;
+        Ok(outpoint)
     }
 
     pub async fn send_raw_transaction(

--- a/nectar/src/swap/bitcoin.rs
+++ b/nectar/src/swap/bitcoin.rs
@@ -20,13 +20,10 @@ impl hbit::ExecuteFund for Wallet {
     async fn execute_fund(&self, params: &hbit::Params) -> anyhow::Result<hbit::Funded> {
         let action = params.shared.build_fund_action();
 
-        let txid = self
+        let location = self
             .inner
-            .send_to_address(action.to, action.amount, action.network.into())
+            .fund_htlc(action.to, action.amount, action.network.into())
             .await?;
-
-        // we send money to a single address, vout is always 0
-        let location = OutPoint { txid, vout: 0 };
         let asset = action.amount;
 
         Ok(hbit::Funded { asset, location })


### PR DESCRIPTION
The implementation is not particularly pretty at the moment but at least it is contained :)

I opted for using PSBT's because it allows us to configure, where the change-output should be. I believe this is superior to taking the serialized transaction and "finding" the output again. Could be convinced otherwise though :)