### PR TITLE
Update stale comment

### DIFF
--- a/nectar/src/network.rs
+++ b/nectar/src/network.rs
@@ -211,7 +211,7 @@ mod transport {
     /// Builds a libp2p transport with the following features:
     /// - TcpConnection
     /// - DNS name resolution
-    /// - authentication via secio
+    /// - authentication via noise
     /// - multiplexing via yamux or mplex
     pub fn build_transport(keypair: libp2p::identity::Keypair) -> anyhow::Result<NectarTransport> {
         let dh_keys = noise::Keypair::<X25519Spec>::new().into_authentic(&keypair)?;


### PR DESCRIPTION
We recently changed to using the noise protocol for authentication, the comment
didn't get updated.

Update comment to accurately state the authentication protocol.