### PR TITLE
Use the native-tls-vendored feature flag from reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,6 +2649,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.10.2+1.1.1g"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a287fdb22e32b5b60624d4a5a7a02dbe82777f730ec0dbc42a0554326fef5a70"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,6 +2666,7 @@ dependencies = [
  "autocfg 1.0.1",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/cnd/Cargo.toml
+++ b/cnd/Cargo.toml
@@ -35,7 +35,7 @@ log = { version = "0.4", features = ["serde"] }
 num = "0.3"
 pem = "0.8"
 rand = "0.7"
-reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }
+reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls-vendored"] }
 serde = { version = "1", features = ["derive"] }
 serde-hex = "0.1.0"
 serde_derive = "1.0"

--- a/comit/Cargo.toml
+++ b/comit/Cargo.toml
@@ -26,7 +26,7 @@ lru = "0.6"
 num = "0.3"
 primitive-types = { version = "0.7", features = ["serde"] }
 rand = "0.7"
-reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }
+reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls-vendored"] }
 serde = { version = "1", features = ["derive"] }
 serde-hex = "0.1.0"
 serde_derive = "1.0"

--- a/nectar/Cargo.toml
+++ b/nectar/Cargo.toml
@@ -26,7 +26,7 @@ libp2p = { version = "0.28", default-features = false, features = ["tcp-tokio", 
 log = "0.4"
 num = "0.3"
 pem = "0.8"
-reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }
+reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls-vendored"] }
 rust_decimal = "1.8"
 serde = { version = "1", features = ["derive"] }
 serde-hex = "0.1"


### PR DESCRIPTION
Instead of requiring our users to have openssl installed, we can
compile it from scratch during the build time.