### PR TITLE
Remove Nectar wallet rescan because not needed in production

### DIFF
--- a/nectar/src/bitcoin/bitcoind.rs
+++ b/nectar/src/bitcoin/bitcoind.rs
@@ -60,23 +60,6 @@ impl Client {
         Ok(response)
     }
 
-    pub async fn rescan(&self, wallet_name: &str) -> anyhow::Result<RescanResponse> {
-        let response = self
-            .rpc_client
-            .send_with_path(
-                format!("/wallet/{}", wallet_name),
-                jsonrpc::Request::new(
-                    "rescanblockchain",
-                    Vec::<serde_json::Value>::new(),
-                    JSONRPC_VERSION.into(),
-                ),
-            )
-            .await
-            .context("failed to rescan")?;
-
-        Ok(response)
-    }
-
     pub async fn get_balance(
         &self,
         wallet_name: &str,

--- a/nectar/src/bitcoin/wallet.rs
+++ b/nectar/src/bitcoin/wallet.rs
@@ -64,8 +64,6 @@ impl Wallet {
                     .set_hd_seed(&self.name, Some(true), Some(wif))
                     .await?;
 
-                self.bitcoind_client.rescan(&self.name).await?;
-
                 Ok(())
             }
             Ok(WalletInfoResponse {
@@ -79,8 +77,6 @@ impl Wallet {
                     .set_hd_seed(&self.name, Some(true), Some(wif))
                     .await?;
 
-                // Rescan wallet to ensure funding is picked up
-                self.bitcoind_client.rescan(&self.name).await?;
                 Ok(())
             }
             _ => Ok(()),


### PR DESCRIPTION
@D4nte has pointed out that `rescan` might be counterproductive. This was added before to help us with the dev-blockchain environment.

In prod the address to be funded is only known after wallet creation.
The rescan was convenient for the dev-environment, but Nectar should not be responsible for rescanning. For now, the user has to take care of running `rescan` for the dev-env.