### PR TITLE
Compile cnd and nectar on demand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,14 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: make test
 
+      # We've ran `cargo build --all-targets` earlier, that is different to from just building the binary.
+      # Our e2e tests lazily re-build the binaries, that can timeout our tests so build them here in advance.
+      - name: Build binaries for e2e test
+        if: matrix.e2e
+        run: |
+          cargo build -p cnd
+          cargo build -p nectar
+
       - name: Upload cnd-${{ matrix.os }} archive that contains the cnd binary
         if: matrix.e2e
         uses: actions/upload-artifact@v1
@@ -116,7 +124,6 @@ jobs:
           name: cnd-${{ matrix.os }}
           path: target/debug/cnd
 
-      ## Run e2e tests
       - name: Install NodeJS 14.x
         if: matrix.e2e
         uses: actions/setup-node@v1

--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -12,6 +12,6 @@ module.exports = {
     setupFilesAfterEnv: [
         "<rootDir>/src/environment/jasmine_capture_current_testname.ts",
     ],
-    testTimeout: 123000,
+    testTimeout: 180000, // we are compiling cnd & nectar on demand, that can take quite a while sometimes
     bail: true,
 };

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "scripts": {
         "check": "tsc && prettier --check '**/*.{ts,json,yml}' && tslint --project .",
-        "pretest": "cargo build --bin cnd && cargo build --bin nectar && tsc",
+        "pretest": "tsc",
         "test": "jest --forceExit",
         "ci": "tsc && jest --forceExit",
         "fix": "tslint --project . --fix && prettier --write '**/*.{ts,js,json,yml}'"

--- a/tests/src/environment/nectar_instance.ts
+++ b/tests/src/environment/nectar_instance.ts
@@ -25,9 +25,7 @@ export class NectarInstance {
     }
 
     public async deposit(): Promise<DepositAddresses> {
-        const bin = process.env.NECTAR_BIN
-            ? process.env.NECTAR_BIN
-            : path.join(this.cargoTargetDirectory, "debug", "nectar");
+        const bin = await this.pathToNectar();
 
         this.logger.info("Using binary", bin);
 
@@ -47,9 +45,7 @@ export class NectarInstance {
     }
 
     public async balance(): Promise<Balances> {
-        const bin = process.env.NECTAR_BIN
-            ? process.env.NECTAR_BIN
-            : path.join(this.cargoTargetDirectory, "debug", "nectar");
+        const bin = await this.pathToNectar();
 
         this.logger.info("Using binary", bin);
 
@@ -74,9 +70,7 @@ export class NectarInstance {
      * Returns the PeerId under which this nectar instance participates in the COMIT network.
      */
     public async trade(): Promise<string> {
-        const bin = process.env.NECTAR_BIN
-            ? process.env.NECTAR_BIN
-            : path.join(this.cargoTargetDirectory, "debug", "nectar");
+        const bin = await this.pathToNectar();
 
         this.logger.info("Using binary", bin);
 
@@ -119,6 +113,20 @@ export class NectarInstance {
         this.logger.info("nectar started with PID", this.process.pid);
 
         return peerId;
+    }
+
+    private async pathToNectar() {
+        if (process.env.NECTAR_BIN) {
+            return process.env.NECTAR_BIN;
+        }
+
+        this.logger.debug(
+            "Path to `nectar` has not been provided, building from scratch"
+        );
+
+        await execAsync("cargo build -p nectar");
+
+        return path.join(this.cargoTargetDirectory, "debug", "nectar");
     }
 
     public stop() {


### PR DESCRIPTION
FYI @comit-network/comit-devs: With this patch, `cnd` and `nectar` are re-compiled automatically if needed for an e2e test run!

Given that this can take a long time, your initial test run might time out although I've set the timeout to 3 minutes now.