### PR TITLE
Segregate trading strategy

### DIFF
--- a/nectar/src/ethereum/dai.rs
+++ b/nectar/src/ethereum/dai.rs
@@ -9,7 +9,7 @@ use comit::{
     ethereum::Address,
 };
 use conquer_once::Lazy;
-use num::{BigUint, CheckedAdd, Integer, ToPrimitive, Zero};
+use num::{BigUint, Integer, ToPrimitive, Zero};
 use std::str::FromStr;
 
 pub const ATTOS_IN_DAI_EXP: u16 = 18;
@@ -140,10 +140,6 @@ impl Amount {
         Ok(bitcoin::Amount::from_sat(sats))
     }
 
-    pub fn checked_add(self, rhs: Amount) -> Option<Amount> {
-        self.0.checked_add(&rhs.0).map(Amount)
-    }
-
     pub fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes_le()
     }
@@ -206,6 +202,18 @@ impl std::ops::Sub for Amount {
 
     fn sub(self, rhs: Self) -> Self::Output {
         Amount(self.0 - rhs.0)
+    }
+}
+
+impl std::ops::AddAssign for Amount {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0.add_assign(rhs.0)
+    }
+}
+
+impl std::ops::SubAssign for Amount {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.0.sub_assign(rhs.0)
     }
 }
 

--- a/nectar/src/main.rs
+++ b/nectar/src/main.rs
@@ -47,9 +47,10 @@ use crate::{
     config::{read_config, Settings},
     fs::default_config_path,
 };
-use anyhow::{Context, Result};
+use anyhow::Context;
 use conquer_once::Lazy;
 
+pub use anyhow::Result;
 pub use maker::Maker;
 pub use mid_market_rate::MidMarketRate;
 pub use rate::{Rate, Spread};

--- a/nectar/src/maker/strategy.rs
+++ b/nectar/src/maker/strategy.rs
@@ -1,0 +1,566 @@
+use crate::{
+    ethereum::dai,
+    maker::TakeRequestDecision,
+    order::{BtcDaiOrderForm, Symbol},
+    swap::SwapKind,
+    Rate, Result, Spread,
+};
+use anyhow::anyhow;
+use comit::{Position, Quantity};
+use std::cmp::min;
+
+/// Create orders with the full balance, capped by a configuration setting.
+/// A spread is applied on the passed mid-market rate
+#[derive(Debug)]
+pub struct AllIn {
+    btc_fee: bitcoin::Amount,
+    btc_reserved_funds: bitcoin::Amount,
+    dai_reserved_funds: dai::Amount,
+    btc_max_sell_amount: Option<bitcoin::Amount>,
+    dai_max_sell_amount: Option<dai::Amount>,
+    spread: Spread,
+}
+
+impl AllIn {
+    pub fn new(
+        btc_fee: bitcoin::Amount,
+        btc_max_sell_amount: Option<bitcoin::Amount>,
+        dai_max_sell_amount: Option<dai::Amount>,
+        spread: Spread,
+    ) -> Self {
+        Self {
+            btc_fee,
+            btc_reserved_funds: Default::default(),
+            dai_reserved_funds: Default::default(),
+            btc_max_sell_amount,
+            dai_max_sell_amount,
+            spread,
+        }
+    }
+}
+
+// Methods that are likely to be in the `Strategy` trait
+impl AllIn {
+    /// Inform the strategy that a hbit_herc20 swap execution was resumed
+    pub fn hbit_herc20_swap_resumed(&mut self, fund_amount: dai::Amount) {
+        self.dai_reserved_funds += fund_amount;
+    }
+
+    /// Inform the strategy that a herc20_hbit swap execution was resumed
+    pub fn herc20_hbit_swap_resumed(&mut self, fund_amount: bitcoin::Amount) -> Result<()> {
+        let amount_to_reserve = fund_amount
+            .checked_add(self.btc_fee)
+            .ok_or_else(|| anyhow!(Overflow))?;
+
+        self.btc_reserved_funds = self
+            .btc_reserved_funds
+            .checked_add(amount_to_reserve)
+            .ok_or_else(|| anyhow!(Overflow))?;
+
+        Ok(())
+    }
+
+    /// Create a new sell order given the passed parameters.
+    /// Bitcoin is always the base asset, sell order sells bitcoin.
+    ///
+    /// The amount is the full available balance minus the expected mining fee
+    /// or the max btc sell parameters, whichever is the lowest.
+    /// The spread parameter is then applied on the mid market rate to decide
+    /// the price.
+    pub fn new_sell(
+        &self,
+        base_balance: bitcoin::Amount,
+        mid_market_rate: Rate,
+    ) -> Result<BtcDaiOrderForm> {
+        if let Some(max_amount) = self.btc_max_sell_amount {
+            if max_amount < self.btc_fee {
+                anyhow::bail!(MaxAmountSmallerThanMaxFee)
+            }
+        }
+
+        match self.btc_reserved_funds.checked_add(self.btc_fee) {
+            Some(added) => {
+                if base_balance <= added {
+                    anyhow::bail!(InsufficientFunds(Symbol::Btc))
+                }
+            }
+            None => anyhow::bail!(Overflow),
+        }
+
+        let base_amount = match self.btc_max_sell_amount {
+            Some(max_amount) => {
+                min(base_balance - self.btc_reserved_funds, max_amount) - self.btc_fee
+            }
+            None => base_balance - self.btc_reserved_funds - self.btc_fee,
+        };
+
+        let rate = self.spread.apply(mid_market_rate, Position::Sell)?;
+
+        Ok(BtcDaiOrderForm {
+            position: Position::Sell,
+            quantity: Quantity::new(base_amount),
+            price: rate.into(),
+        })
+    }
+
+    /// Create a new buy order given the passed parameters.
+    /// Bitcoin is always the base asset, buy order buys bitcoin.
+    ///
+    /// The quote amount is the full available dai balance or the max dai sell
+    /// parameter, whichever is the lowest.
+    /// The spread parameter is then applied on the mid market rate to decide
+    /// the price.
+    pub fn new_buy(
+        &self,
+        quote_balance: dai::Amount,
+        mid_market_rate: Rate,
+    ) -> Result<BtcDaiOrderForm> {
+        if quote_balance <= self.dai_reserved_funds {
+            anyhow::bail!(InsufficientFunds(Symbol::Dai))
+        }
+
+        let quote_amount = match &self.dai_max_sell_amount {
+            Some(max_amount) => min(
+                quote_balance - self.dai_reserved_funds.clone(),
+                max_amount.clone(),
+            ),
+            None => quote_balance - self.dai_reserved_funds.clone(),
+        };
+
+        let rate = self.spread.apply(mid_market_rate, Position::Buy)?;
+        let base_amount = quote_amount.worth_in(rate)?;
+
+        Ok(BtcDaiOrderForm {
+            position: Position::Buy,
+            quantity: Quantity::new(base_amount),
+            price: rate.into(),
+        })
+    }
+
+    /// Decide whether we should proceed with an order,
+    /// Checks:
+    /// - funds are available
+    /// - Order is considered profitable
+    /// - Reserve the funds (assumes we proceed with the order)
+    /// // TODO: extract the reserve part and expect consumer to call
+    /// `hbit_herc20_swap_resumed` when a swap starts.
+    pub fn process_taken_order(
+        &mut self,
+        order: BtcDaiOrderForm,
+        current_mid_market_rate: Rate,
+        dai_balance: &dai::Amount,
+        btc_balance: &bitcoin::Amount,
+    ) -> anyhow::Result<TakeRequestDecision> {
+        let current_profitable_rate = self.spread.apply(current_mid_market_rate, order.position)?;
+
+        if !order.is_as_profitable_as(current_profitable_rate)? {
+            return Ok(TakeRequestDecision::RateNotProfitable);
+        }
+
+        match order.position {
+            Position::Buy => {
+                let updated_dai_reserved_funds =
+                    self.dai_reserved_funds.clone() + dai::Amount::from(order.quote());
+                if updated_dai_reserved_funds > *dai_balance {
+                    return Ok(TakeRequestDecision::InsufficientFunds);
+                }
+
+                self.dai_reserved_funds = updated_dai_reserved_funds;
+            }
+            Position::Sell => {
+                let updated_btc_reserved_funds =
+                    self.btc_reserved_funds + order.quantity.to_inner() + self.btc_fee;
+                if updated_btc_reserved_funds > *btc_balance {
+                    return Ok(TakeRequestDecision::InsufficientFunds);
+                }
+
+                self.btc_reserved_funds = updated_btc_reserved_funds;
+            }
+        };
+
+        Ok(TakeRequestDecision::GoForSwap)
+    }
+
+    /// Process a finished swap.
+    pub fn swap_finished(&mut self, swap: SwapKind) {
+        match swap {
+            SwapKind::Herc20Hbit(swap) => {
+                self.btc_reserved_funds -= swap.hbit_params.shared.asset + self.btc_fee;
+            }
+            SwapKind::HbitHerc20(swap) => {
+                self.dai_reserved_funds -= swap.herc20_params.asset.into();
+            }
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, thiserror::Error)]
+#[error("Insufficient {0} funds to create new order.")]
+pub struct InsufficientFunds(Symbol);
+
+#[derive(Debug, Copy, Clone, thiserror::Error)]
+#[error("The maximum amount for an order cannot be smaller than the maximum fee.")]
+pub struct MaxAmountSmallerThanMaxFee;
+
+#[derive(Debug, Copy, Clone, thiserror::Error)]
+#[error("Amounts to large to be added.")]
+pub struct Overflow;
+
+#[derive(Debug, Copy, Clone, thiserror::Error)]
+#[error("{0} balance not available.")]
+pub struct BalanceNotAvailable(Symbol);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        bitcoin::amount::btc, ethereum::dai::dai, order::btc_dai_order_form, rate::rate, StaticStub,
+    };
+    use num::BigUint;
+    use proptest::prelude::*;
+    use std::{convert::TryFrom, str::FromStr};
+
+    impl StaticStub for AllIn {
+        fn static_stub() -> Self {
+            AllIn::new(
+                bitcoin::Amount::default(),
+                None,
+                None,
+                StaticStub::static_stub(),
+            )
+        }
+    }
+
+    #[test]
+    fn given_fee_higher_than_available_funds_return_insufficient_funds() {
+        let rate = Rate::try_from(1.0).unwrap();
+        let spread = Spread::new(0).unwrap();
+
+        let strategy = AllIn::new(btc(0.1), None, None, spread);
+
+        let result = strategy.new_sell(btc(0.09), rate);
+        assert!(result.unwrap_err().downcast::<InsufficientFunds>().is_ok());
+    }
+
+    #[test]
+    fn given_reserved_funds_higher_available_funds_return_insufficient_funds() {
+        let rate = Rate::try_from(1.0).unwrap();
+
+        let mut strategy = AllIn::static_stub();
+
+        // Resuming a swap should take some reserve for the swap amount and fee.
+        strategy.herc20_hbit_swap_resumed(btc(1.0)).unwrap();
+        strategy.hbit_herc20_swap_resumed(dai(1.0));
+
+        let result = strategy.new_sell(btc(1.0), rate);
+        assert!(result.unwrap_err().downcast::<InsufficientFunds>().is_ok());
+
+        let result = strategy.new_buy(dai(1.0), rate);
+        assert!(result.unwrap_err().downcast::<InsufficientFunds>().is_ok());
+    }
+
+    #[test]
+    fn given_a_balance_return_order_selling_full_balance() {
+        let strategy = AllIn::static_stub();
+
+        let rate = Rate::try_from(1.0).unwrap();
+        let order = strategy.new_sell(btc(10.0), rate).unwrap();
+
+        assert_eq!(order.quantity.to_inner(), btc(10.0));
+
+        let order = strategy.new_buy(dai(10.0), rate).unwrap();
+
+        assert_eq!(dai::Amount::from(order.quote()), dai(10.0));
+    }
+
+    #[test]
+    fn given_a_balance_and_locked_funds_return_order_selling_available_balance() {
+        let rate = Rate::try_from(1.0).unwrap();
+        let mut strategy = AllIn::static_stub();
+
+        // Resuming a swap should take some reserve.
+        strategy.herc20_hbit_swap_resumed(btc(2.0)).unwrap();
+        strategy.hbit_herc20_swap_resumed(dai(2.0));
+
+        let order = strategy.new_sell(btc(10.0), rate).unwrap();
+
+        assert_eq!(order.quantity.to_inner(), btc(8.0));
+
+        let order = strategy.new_buy(dai(10.0), rate).unwrap();
+
+        assert_eq!(dai::Amount::from(order.quote()), dai(8.0));
+    }
+
+    #[test]
+    fn given_an_available_balance_and_a_max_amount_sell_min_of_either() {
+        let rate = Rate::try_from(1.0).unwrap();
+        let strategy = AllIn::new(
+            btc(0.000),
+            Some(btc(2.0)),
+            Some(dai(2.0)),
+            Spread::static_stub(),
+        );
+
+        let order = strategy.new_sell(btc(10.0), rate).unwrap();
+
+        assert_eq!(order.quantity.to_inner(), btc(2.0));
+
+        let order = strategy.new_buy(dai(10.0), rate).unwrap();
+
+        assert_eq!(dai::Amount::from(order.quote()), dai(2.0));
+    }
+
+    #[test]
+    fn given_an_available_balance_and_fees_sell_balance_minus_fees() {
+        let rate = Rate::try_from(1.0).unwrap();
+        let strategy = AllIn::new(btc(0.001), None, None, Spread::static_stub());
+
+        let order = strategy.new_sell(btc(10.0), rate).unwrap();
+
+        assert_eq!(order.quantity.to_inner(), btc(9.999));
+    }
+
+    #[test]
+    fn given_a_rate_return_order_with_both_amounts() {
+        let spread = Spread::new(0).unwrap();
+        let mut strategy = AllIn::new(btc(0.5), None, None, spread);
+
+        // Resuming a swap should take some reserve for the swap amount and fee.
+        strategy.herc20_hbit_swap_resumed(btc(50.0)).unwrap();
+        strategy.hbit_herc20_swap_resumed(dai(50.0));
+
+        let rate = Rate::try_from(0.1).unwrap();
+        let order = strategy.new_sell(btc(1051.0), rate).unwrap();
+
+        assert_eq!(order.quantity.to_inner(), btc(1000.0));
+        assert_eq!(dai::Amount::from(order.quote()), dai(100.0));
+
+        let rate = Rate::try_from(10.0).unwrap();
+        let order = strategy.new_sell(btc(1051.0), rate).unwrap();
+
+        assert_eq!(order.quantity.to_inner(), btc(1000.0));
+        assert_eq!(dai::Amount::from(order.quote()), dai(10_000.0));
+
+        let rate = Rate::try_from(0.1).unwrap();
+        let order = strategy.new_buy(dai(1050.0), rate).unwrap();
+
+        assert_eq!(order.quantity.to_inner(), btc(10_000.0));
+        assert_eq!(dai::Amount::from(order.quote()), dai(1000.0));
+
+        let rate = Rate::try_from(10.0).unwrap();
+        let order = strategy.new_buy(dai(1050.0), rate).unwrap();
+
+        assert_eq!(order.quantity.to_inner(), btc(100.0));
+        assert_eq!(dai::Amount::from(order.quote()), dai(1000.0));
+    }
+
+    #[test]
+    fn given_a_rate_and_spread_return_order_with_both_amounts_correct_1() {
+        let rate = Rate::try_from(10_000.0).unwrap();
+        let spread = Spread::new(300).unwrap();
+        let mut strategy = AllIn::new(btc(0.005), None, None, spread);
+
+        assert_eq!(
+            spread.apply(rate, Position::Sell).unwrap().integer(),
+            BigUint::from(103000000000000 as u64)
+        );
+
+        // Resuming a swap should take some reserve for the swap amount and fee.
+        strategy.herc20_hbit_swap_resumed(btc(0.5)).unwrap();
+        strategy.hbit_herc20_swap_resumed(dai(51.0));
+
+        let order = strategy.new_sell(btc(1.51), rate).unwrap();
+
+        assert_eq!(order.quantity.to_inner(), btc(1.0));
+        assert_eq!(dai::Amount::from(order.quote()), dai(10_300.0));
+
+        assert_eq!(
+            spread.apply(rate, Position::Buy).unwrap().integer(),
+            BigUint::from(97000000000000 as u64)
+        );
+
+        let order = strategy.new_buy(dai(10_051.0), rate).unwrap();
+
+        assert_eq!(order.quantity.to_inner(), btc(1.03092783));
+        assert_eq!(dai::Amount::from(order.quote()), dai(9999.999951));
+    }
+
+    #[test]
+    fn btc_funds_reserved_upon_taking_sell_order() {
+        let mut strategy = AllIn::new(bitcoin::Amount::ZERO, None, None, Spread::static_stub());
+
+        let taken_order = btc_dai_order_form(Position::Sell, btc(1.5), rate(0.0));
+
+        let event = strategy
+            .process_taken_order(taken_order, Rate::static_stub(), &dai(0.0), &btc(3.0))
+            .unwrap();
+
+        assert_eq!(event, TakeRequestDecision::GoForSwap);
+        assert_eq!(strategy.btc_reserved_funds, btc(1.5))
+    }
+
+    proptest! {
+        #[test]
+        fn new_buy_does_not_panic(btc_fees in any::<u64>(), dai_balance in "[0-9]+", dai_reserved_funds in "[0-9]+", dai_max_amount in "[0-9]+", rate in any::<f64>(), spread in any::<u16>()) {
+
+            let btc_fees = bitcoin::Amount::from_sat(btc_fees);
+            let dai_balance = BigUint::from_str(&dai_balance);
+            let dai_reserved_funds = BigUint::from_str(&dai_reserved_funds);
+            let dai_max_amount = BigUint::from_str(&dai_max_amount);
+            let rate = Rate::try_from(rate);
+            let spread = Spread::new(spread);
+
+            if let (Ok(dai_balance), Ok(dai_reserved_funds), Ok(dai_max_amount), Ok(rate), Ok(spread)) = (dai_balance, dai_reserved_funds, dai_max_amount, rate, spread) {
+                let dai_balance = dai::Amount::from_atto(dai_balance);
+                let _dai_reserved_funds = dai::Amount::from_atto(dai_reserved_funds);
+                let dai_max_amount = dai::Amount::from_atto(dai_max_amount);
+
+                let strategy = AllIn::new(btc_fees, None, Some(dai_max_amount), spread);
+                let _: anyhow::Result<BtcDaiOrderForm> = strategy.new_buy(dai_balance, rate);
+            }
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn new_buy_no_max_amount_does_not_panic(btc_fees in any::<u64>(), dai_balance in "[0-9]+", rate in any::<f64>(), spread in any::<u16>()) {
+
+            let btc_fees = bitcoin::Amount::from_sat(btc_fees);
+            let dai_balance = BigUint::from_str(&dai_balance);
+            let rate = Rate::try_from(rate);
+            let spread = Spread::new(spread);
+
+            if let (Ok(dai_balance), Ok(rate), Ok(spread)) = (dai_balance, rate, spread) {
+                let strategy = AllIn::new(btc_fees, None, None, spread);
+
+                let dai_balance = dai::Amount::from_atto(dai_balance);
+
+                let _: anyhow::Result<BtcDaiOrderForm> = strategy.new_buy(dai_balance, rate);
+            }
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn new_sell_does_not_panic(btc_balance in any::<u64>(), btc_fees in any::<u64>(), btc_max_amount in any::<u64>(), rate in any::<f64>(), spread in any::<u16>()) {
+
+            let btc_balance = bitcoin::Amount::from_sat(btc_balance);
+            let btc_fees = bitcoin::Amount::from_sat(btc_fees);
+            let btc_max_amount = bitcoin::Amount::from_sat(btc_max_amount);
+            let rate = Rate::try_from(rate);
+            let spread = Spread::new(spread);
+
+            if let (Ok(rate), Ok(spread)) = (rate, spread) {
+                let strategy = AllIn::new(btc_fees, Some(btc_max_amount), None, spread);
+
+                let _: anyhow::Result<BtcDaiOrderForm> = strategy.new_sell(btc_balance, rate);
+            }
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn new_sell_no_max_amount_does_not_panic(btc_balance in any::<u64>(), btc_fees in any::<u64>(), btc_reserved_funds in any::<u64>(), rate in any::<f64>(), spread in any::<u16>()) {
+
+            let btc_balance = bitcoin::Amount::from_sat(btc_balance);
+            let btc_fees = bitcoin::Amount::from_sat(btc_fees);
+            let _btc_reserved_funds = bitcoin::Amount::from_sat(btc_reserved_funds);
+            let rate = Rate::try_from(rate);
+            let spread = Spread::new(spread);
+
+            if let (Ok(rate), Ok(spread)) = (rate, spread) {
+                let strategy = AllIn::new(btc_fees, None, None, spread);
+
+                let _: anyhow::Result<BtcDaiOrderForm> = strategy.new_sell(btc_balance, rate);
+            }
+        }
+    }
+
+    #[test]
+    fn btc_funds_reserved_upon_taking_sell_order_with_fee() {
+        let mut strategy = AllIn::new(btc(1.0), None, None, Spread::static_stub());
+
+        let taken_order = btc_dai_order_form(Position::Sell, btc(1.5), rate(0.0));
+
+        let event = strategy
+            .process_taken_order(taken_order, Rate::static_stub(), &dai(0.0), &btc(3.0))
+            .unwrap();
+
+        assert_eq!(event, TakeRequestDecision::GoForSwap);
+        assert_eq!(strategy.btc_reserved_funds, btc(2.5))
+    }
+
+    #[test]
+    fn dai_funds_reserved_upon_taking_buy_order() {
+        let mut strategy = AllIn::new(
+            bitcoin::Amount::default(),
+            None,
+            None,
+            Spread::static_stub(),
+        );
+
+        let taken_order = btc_dai_order_form(Position::Buy, btc(1.0), rate(1.5));
+
+        let result = strategy
+            .process_taken_order(taken_order, rate(1.5), &dai(10000.0), &btc(0.0))
+            .unwrap();
+
+        assert_eq!(result, TakeRequestDecision::GoForSwap);
+        assert_eq!(strategy.dai_reserved_funds, dai(1.5))
+    }
+
+    #[test]
+    fn dai_funds_reserved_upon_taking_buy_order_with_fee() {
+        let mut strategy = AllIn::new(
+            bitcoin::Amount::default(),
+            None,
+            None,
+            Spread::static_stub(),
+        );
+
+        let taken_order = btc_dai_order_form(Position::Buy, btc(1.0), rate(1.5));
+
+        let result = strategy
+            .process_taken_order(taken_order, rate(1.5), &dai(10000.0), &btc(0.0))
+            .unwrap();
+
+        assert_eq!(result, TakeRequestDecision::GoForSwap);
+        assert_eq!(strategy.dai_reserved_funds, dai(1.5))
+    }
+
+    #[test]
+    fn not_enough_btc_funds_to_reserve_for_a_sell_order() {
+        let mut strategy = AllIn::new(
+            bitcoin::Amount::default(),
+            None,
+            None,
+            Spread::static_stub(),
+        );
+
+        let taken_order = btc_dai_order_form(Position::Sell, btc(1.5), rate(0.0));
+
+        let result = strategy
+            .process_taken_order(taken_order, Rate::static_stub(), &dai(0.1), &btc(0.1))
+            .unwrap();
+
+        assert_eq!(result, TakeRequestDecision::InsufficientFunds);
+    }
+
+    #[test]
+    fn not_enough_btc_funds_to_reserve_for_a_buy_order() {
+        let mut strategy = AllIn::new(
+            bitcoin::Amount::default(),
+            None,
+            None,
+            Spread::static_stub(),
+        );
+
+        let taken_order = btc_dai_order_form(Position::Buy, btc(1.0), rate(1.5));
+
+        let result = strategy
+            .process_taken_order(taken_order, rate(1.5), &dai(0.0), &btc(0.0))
+            .unwrap();
+
+        assert_eq!(result, TakeRequestDecision::InsufficientFunds);
+    }
+}

--- a/nectar/src/mid_market_rate.rs
+++ b/nectar/src/mid_market_rate.rs
@@ -21,7 +21,7 @@ impl MidMarketRate {
 #[cfg(test)]
 impl crate::StaticStub for MidMarketRate {
     fn static_stub() -> Self {
-        Self { 0: Rate::default() }
+        Self(crate::StaticStub::static_stub())
     }
 }
 

--- a/nectar/src/order.rs
+++ b/nectar/src/order.rs
@@ -1,10 +1,9 @@
-use crate::{bitcoin, ethereum::dai, Rate, Spread};
+use crate::Rate;
 use comit::{
     asset::{Bitcoin, Erc20Quantity},
     order::SwapProtocol,
     Position, Price, Quantity,
 };
-use std::cmp::min;
 
 #[derive(Debug, Copy, Clone, strum_macros::Display)]
 #[strum(serialize_all = "UPPERCASE")]
@@ -33,70 +32,6 @@ impl BtcDaiOrderForm {
     pub fn quote(&self) -> Erc20Quantity {
         self.quantity * self.price.clone()
     }
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_sell(
-        base_balance: bitcoin::Amount,
-        base_fees: bitcoin::Amount,
-        base_reserved_funds: bitcoin::Amount,
-        max_amount: Option<bitcoin::Amount>,
-        mid_market_rate: Rate,
-        spread: Spread,
-    ) -> anyhow::Result<BtcDaiOrderForm> {
-        if let Some(max_amount) = max_amount {
-            if max_amount < base_fees {
-                anyhow::bail!(MaxAmountSmallerThanMaxFee)
-            }
-        }
-
-        match base_reserved_funds.checked_add(base_fees) {
-            Some(added) => {
-                if base_balance <= added {
-                    anyhow::bail!(InsufficientFunds(Symbol::Btc))
-                }
-            }
-            None => anyhow::bail!(Overflow),
-        }
-
-        let base_amount = match max_amount {
-            Some(max_amount) => min(base_balance - base_reserved_funds, max_amount) - base_fees,
-            None => base_balance - base_reserved_funds - base_fees,
-        };
-
-        let rate = spread.apply(mid_market_rate, Position::Sell)?;
-
-        Ok(BtcDaiOrderForm {
-            position: Position::Sell,
-            quantity: Quantity::new(base_amount),
-            price: rate.into(),
-        })
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_buy(
-        quote_balance: dai::Amount,
-        quote_reserved_funds: dai::Amount,
-        max_amount: Option<dai::Amount>,
-        mid_market_rate: Rate,
-        spread: Spread,
-    ) -> anyhow::Result<BtcDaiOrderForm> {
-        if quote_balance <= quote_reserved_funds {
-            anyhow::bail!(InsufficientFunds(Symbol::Dai))
-        }
-
-        let quote_amount = match max_amount {
-            Some(max_amount) => min(quote_balance - quote_reserved_funds, max_amount),
-            None => quote_balance - quote_reserved_funds,
-        };
-
-        let rate = spread.apply(mid_market_rate, Position::Buy)?;
-        let base_amount = quote_amount.worth_in(rate)?;
-
-        Ok(BtcDaiOrderForm {
-            position: Position::Buy,
-            quantity: Quantity::new(base_amount),
-            price: rate.into(),
-        })
-    }
 
     pub fn is_as_profitable_as(&self, profitable_rate: Rate) -> anyhow::Result<bool> {
         let order_rate = self.price.clone();
@@ -120,18 +55,6 @@ impl BtcDaiOrderForm {
         }
     }
 }
-
-#[derive(Debug, Copy, Clone, thiserror::Error)]
-#[error("Insufficient {0} funds to create new order.")]
-pub struct InsufficientFunds(Symbol);
-
-#[derive(Debug, Copy, Clone, thiserror::Error)]
-#[error("The maximum amount for an order cannot be smaller than the maximum fee.")]
-pub struct MaxAmountSmallerThanMaxFee;
-
-#[derive(Debug, Copy, Clone, thiserror::Error)]
-#[error("Amounts to large to be added.")]
-pub struct Overflow;
 
 pub trait LockedFunds {
     type Amount;
@@ -176,189 +99,8 @@ pub fn btc_dai_order_form(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use crate::{
-        bitcoin, bitcoin::amount::btc, ethereum::dai::dai, rate::rate, MidMarketRate, Rate,
-    };
-
-    use num::BigUint;
-    use proptest::prelude::*;
-    use std::{convert::TryFrom, str::FromStr};
-
-    #[test]
-    fn given_a_balance_return_order_selling_full_balance() {
-        let rate = Rate::try_from(1.0).unwrap();
-        let order = BtcDaiOrderForm::new_sell(
-            btc(10.0),
-            btc(0.0),
-            btc(0.0),
-            Some(btc(100.0)),
-            rate,
-            Spread::new(0).unwrap(),
-        )
-        .unwrap();
-
-        assert_eq!(order.quantity.to_inner(), btc(10.0));
-
-        let order = BtcDaiOrderForm::new_buy(
-            dai(10.0),
-            dai(0.0),
-            Some(dai(100.0)),
-            rate,
-            Spread::new(0).unwrap(),
-        )
-        .unwrap();
-
-        assert_eq!(dai::Amount::from(order.quote()), dai(10.0));
-    }
-
-    #[test]
-    fn given_a_balance_and_locked_funds_return_order_selling_available_balance() {
-        let rate = Rate::try_from(1.0).unwrap();
-        let order = BtcDaiOrderForm::new_sell(
-            btc(10.0),
-            btc(0.0),
-            btc(2.0),
-            Some(btc(100.0)),
-            rate,
-            Spread::new(0).unwrap(),
-        )
-        .unwrap();
-
-        assert_eq!(order.quantity.to_inner(), btc(8.0));
-
-        let order =
-            BtcDaiOrderForm::new_buy(dai(10.0), dai(2.0), None, rate, Spread::new(0).unwrap())
-                .unwrap();
-
-        assert_eq!(dai::Amount::from(order.quote()), dai(8.0));
-    }
-
-    #[test]
-    fn given_an_available_balance_and_a_max_amount_sell_min_of_either() {
-        let rate = Rate::try_from(1.0).unwrap();
-        let order = BtcDaiOrderForm::new_sell(
-            btc(10.0),
-            btc(0.0),
-            btc(2.0),
-            Some(btc(2.0)),
-            rate,
-            Spread::new(0).unwrap(),
-        )
-        .unwrap();
-
-        assert_eq!(order.quantity.to_inner(), btc(2.0));
-
-        let order = BtcDaiOrderForm::new_buy(
-            dai(10.0),
-            dai(2.0),
-            Some(dai(2.0)),
-            rate,
-            Spread::new(0).unwrap(),
-        )
-        .unwrap();
-
-        assert_eq!(dai::Amount::from(order.quote()), dai(2.0));
-    }
-
-    #[test]
-    fn given_an_available_balance_and_fees_sell_balance_minus_fees() {
-        let rate = Rate::try_from(1.0).unwrap();
-        let order = BtcDaiOrderForm::new_buy(
-            dai(10.0),
-            dai(3.0),
-            Some(dai(1.0)),
-            rate,
-            Spread::new(0).unwrap(),
-        )
-        .unwrap();
-
-        assert_eq!(dai::Amount::from(order.quote()), dai(1.0));
-    }
-
-    #[test]
-    fn given_a_rate_return_order_with_both_amounts() {
-        let spread = Spread::new(0).unwrap();
-
-        let rate = Rate::try_from(0.1).unwrap();
-        let order = BtcDaiOrderForm::new_sell(btc(1051.0), btc(1.0), btc(50.0), None, rate, spread)
-            .unwrap();
-
-        // 1 Sell => 0.1 Buy
-        // 1000 Sell => 100 Buy
-        assert_eq!(order.quantity.to_inner(), btc(1000.0));
-        assert_eq!(dai::Amount::from(order.quote()), dai(100.0));
-
-        let rate = Rate::try_from(10.0).unwrap();
-        let order = BtcDaiOrderForm::new_sell(btc(1051.0), btc(1.0), btc(50.0), None, rate, spread)
-            .unwrap();
-
-        assert_eq!(order.quantity.to_inner(), btc(1000.0));
-        assert_eq!(dai::Amount::from(order.quote()), dai(10_000.0));
-
-        let rate = Rate::try_from(0.1).unwrap();
-        let order = BtcDaiOrderForm::new_buy(dai(1050.0), dai(50.0), None, rate, spread).unwrap();
-
-        assert_eq!(order.quantity.to_inner(), btc(10_000.0));
-        assert_eq!(dai::Amount::from(order.quote()), dai(1000.0));
-
-        let rate = Rate::try_from(10.0).unwrap();
-        let order = BtcDaiOrderForm::new_buy(dai(1050.0), dai(50.0), None, rate, spread).unwrap();
-
-        assert_eq!(order.quantity.to_inner(), btc(100.0));
-        assert_eq!(dai::Amount::from(order.quote()), dai(1000.0));
-    }
-
-    #[test]
-    fn given_a_rate_and_spread_return_order_with_both_amounts() {
-        let rate = Rate::try_from(10_000.0).unwrap();
-        let spread = Spread::new(300).unwrap();
-
-        assert_eq!(
-            spread.apply(rate, Position::Sell).unwrap().integer(),
-            BigUint::from(103000000000000 as u64)
-        );
-
-        let order =
-            BtcDaiOrderForm::new_sell(btc(1.51), btc(0.01), btc(0.5), None, rate, spread).unwrap();
-
-        assert_eq!(order.quantity.to_inner(), btc(1.0));
-        assert_eq!(dai::Amount::from(order.quote()), dai(10_300.0));
-
-        assert_eq!(
-            spread.apply(rate, Position::Buy).unwrap().integer(),
-            BigUint::from(97000000000000 as u64)
-        );
-
-        let order = BtcDaiOrderForm::new_buy(dai(10_051.0), dai(51.0), None, rate, spread).unwrap();
-
-        assert_eq!(order.quantity.to_inner(), btc(1.03092783));
-        assert_eq!(dai::Amount::from(order.quote()), dai(9999.999951));
-    }
-
-    #[test]
-    fn given_fee_higher_than_available_funds_return_insufficient_funds() {
-        let rate = Rate::try_from(1.0).unwrap();
-        let spread = Spread::new(0).unwrap();
-
-        let result = BtcDaiOrderForm::new_sell(btc(1.0), btc(2.0), btc(0.0), None, rate, spread);
-        assert!(result.unwrap_err().downcast::<InsufficientFunds>().is_ok());
-
-        let result = BtcDaiOrderForm::new_buy(dai(1.0), dai(2.0), None, rate, spread);
-        assert!(result.unwrap_err().downcast::<InsufficientFunds>().is_ok());
-    }
-
-    #[test]
-    fn given_reserved_funds_higher_available_funds_return_insufficient_funds() {
-        let rate = Rate::try_from(1.0).unwrap();
-        let spread = Spread::new(0).unwrap();
-
-        let result = BtcDaiOrderForm::new_sell(btc(1.0), btc(0.0), btc(2.0), None, rate, spread);
-        assert!(result.unwrap_err().downcast::<InsufficientFunds>().is_ok());
-
-        let result = BtcDaiOrderForm::new_buy(dai(1.0), dai(2.0), None, rate, spread);
-        assert!(result.unwrap_err().downcast::<InsufficientFunds>().is_ok());
-    }
+    use crate::{bitcoin::amount::btc, rate::rate, MidMarketRate, Rate};
+    use std::convert::TryFrom;
 
     #[test]
     fn sell_order_is_as_good_as_market_rate() {
@@ -418,77 +160,6 @@ mod tests {
 
         let is_profitable = order.is_as_profitable_as(rate.into()).unwrap();
         assert!(!is_profitable)
-    }
-
-    proptest! {
-        #[test]
-        fn new_buy_does_not_panic(dai_balance in "[0-9]+", dai_reserved_funds in "[0-9]+", dai_max_amount in "[0-9]+", rate in any::<f64>(), spread in any::<u16>()) {
-
-            let dai_balance = BigUint::from_str(&dai_balance);
-            let dai_reserved_funds = BigUint::from_str(&dai_reserved_funds);
-            let dai_max_amount = BigUint::from_str(&dai_max_amount);
-            let rate = Rate::try_from(rate);
-            let spread = Spread::new(spread);
-
-            if let (Ok(dai_balance), Ok(dai_reserved_funds), Ok(dai_max_amount), Ok(rate), Ok(spread)) = (dai_balance, dai_reserved_funds, dai_max_amount, rate, spread) {
-                let dai_balance = dai::Amount::from_atto(dai_balance);
-                let dai_reserved_funds = dai::Amount::from_atto(dai_reserved_funds);
-                let dai_max_amount = dai::Amount::from_atto(dai_max_amount);
-
-                let _: anyhow::Result<BtcDaiOrderForm> = BtcDaiOrderForm::new_buy(dai_balance, dai_reserved_funds, Some(dai_max_amount), rate, spread);
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn new_buy_no_max_amount_does_not_panic(dai_balance in "[0-9]+", dai_reserved_funds in "[0-9]+", rate in any::<f64>(), spread in any::<u16>()) {
-
-            let dai_balance = BigUint::from_str(&dai_balance);
-            let dai_reserved_funds = BigUint::from_str(&dai_reserved_funds);
-            let rate = Rate::try_from(rate);
-            let spread = Spread::new(spread);
-
-            if let (Ok(dai_balance), Ok(dai_reserved_funds), Ok(rate), Ok(spread)) = (dai_balance, dai_reserved_funds, rate, spread) {
-                let dai_balance = dai::Amount::from_atto(dai_balance);
-                let dai_reserved_funds = dai::Amount::from_atto(dai_reserved_funds);
-
-                let _: anyhow::Result<BtcDaiOrderForm> = BtcDaiOrderForm::new_buy(dai_balance, dai_reserved_funds, None, rate, spread);
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn new_sell_does_not_panic(btc_balance in any::<u64>(), btc_fees in any::<u64>(), btc_reserved_funds in any::<u64>(), btc_max_amount in any::<u64>(), rate in any::<f64>(), spread in any::<u16>()) {
-
-            let btc_balance = bitcoin::Amount::from_sat(btc_balance);
-            let btc_fees = bitcoin::Amount::from_sat(btc_fees);
-            let btc_reserved_funds = bitcoin::Amount::from_sat(btc_reserved_funds);
-            let btc_max_amount = bitcoin::Amount::from_sat(btc_max_amount);
-            let rate = Rate::try_from(rate);
-            let spread = Spread::new(spread);
-
-            if let (Ok(rate), Ok(spread)) = (rate, spread) {
-                let _: anyhow::Result<BtcDaiOrderForm> = BtcDaiOrderForm::new_sell(btc_balance, btc_fees, btc_reserved_funds, Some(btc_max_amount), rate, spread);
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn new_sell_no_max_amount_does_not_panic(btc_balance in any::<u64>(), btc_fees in any::<u64>(), btc_reserved_funds in any::<u64>(), rate in any::<f64>(), spread in any::<u16>()) {
-
-            let btc_balance = bitcoin::Amount::from_sat(btc_balance);
-            let btc_fees = bitcoin::Amount::from_sat(btc_fees);
-            let btc_reserved_funds = bitcoin::Amount::from_sat(btc_reserved_funds);
-            let rate = Rate::try_from(rate);
-            let spread = Spread::new(spread);
-
-            if let (Ok(rate), Ok(spread)) = (rate, spread) {
-                let _: anyhow::Result<BtcDaiOrderForm> = BtcDaiOrderForm::new_sell(btc_balance, btc_fees, btc_reserved_funds, None, rate, spread);
-            }
-        }
     }
 
     #[test]

--- a/nectar/src/rate.rs
+++ b/nectar/src/rate.rs
@@ -11,7 +11,7 @@ use std::{convert::TryFrom, fmt};
 /// Represent a rate. Note this is designed to support Bitcoin/Dai buy and sell
 /// rates (Bitcoin being in the range of 10k-100kDai) A rate has a maximum
 /// precision of 9 digits after the decimal rate = self.0 * 10e-9
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, PartialOrd)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
 pub struct Rate(u64);
 
 impl fmt::Display for Rate {
@@ -76,7 +76,7 @@ impl Into<Price<comit::asset::Bitcoin, comit::asset::Erc20Quantity>> for Rate {
 
 /// Spread: percentage to be added on top of a rate or amount with
 /// a maximum precision of 2 decimals
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Spread(u16);
 
 impl Spread {
@@ -120,7 +120,20 @@ pub fn rate(rate: f64) -> Rate {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::StaticStub;
     use proptest::prelude::*;
+
+    impl StaticStub for Spread {
+        fn static_stub() -> Self {
+            Self(0)
+        }
+    }
+
+    impl StaticStub for Rate {
+        fn static_stub() -> Self {
+            Self(0)
+        }
+    }
 
     #[test]
     fn from_f64_and_new_matches_1() {


### PR DESCRIPTION
The current trading strategy that takes for input:
- a spread
- mid-market rate
- available balances

Is now in a dedicated module. Allowing this concern to be removed from
the maker.
Some primitives such as the bitcoin fees and the reserved assets for
ongoing swaps are also moved in the strategy module. It could be argued
that they should stay with the maker or moved in yet another module.

I propose that such concern can be reviewed when another trading
strategy is implemented, validating the best scope for trading
strategies.