### PR TITLE
[nectar] mainnet Bitcoin fee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,7 +578,7 @@ dependencies = [
  "config",
  "conquer-once",
  "data-encoding",
- "derivative 2.1.1",
+ "derivative",
  "diesel",
  "diesel_migrations",
  "digest 0.1.0",
@@ -613,7 +613,7 @@ dependencies = [
  "strum 0.19.2",
  "strum_macros 0.19.2",
  "tempfile",
- "testcontainers 0.10.0",
+ "testcontainers",
  "thiserror",
  "time 0.2.22",
  "tokio",
@@ -645,7 +645,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "conquer-once",
- "derivative 2.1.1",
+ "derivative",
  "digest 0.1.0",
  "ethbloom",
  "futures",
@@ -668,7 +668,7 @@ dependencies = [
  "spectral",
  "strum 0.19.2",
  "strum_macros 0.19.2",
- "testcontainers 0.10.0",
+ "testcontainers",
  "thiserror",
  "time 0.2.22",
  "tokio",
@@ -855,17 +855,6 @@ name = "data-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d0e2d24e5ee3b23a01de38eefdcd978907890701f08ffffd4cb457ca4ee8d6"
-
-[[package]]
-name = "derivative"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6d883546668a3e2011b6a716a7330b82eabb0151b138217f632c8243e17135"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
-]
 
 [[package]]
 name = "derivative"
@@ -2322,7 +2311,7 @@ dependencies = [
  "config",
  "conquer-once",
  "csv",
- "derivative 2.1.1",
+ "derivative",
  "directories 2.0.2",
  "ethabi",
  "ethereum-types",
@@ -2349,7 +2338,7 @@ dependencies = [
  "strum 0.18.0",
  "strum_macros 0.18.0",
  "tempfile",
- "testcontainers 0.9.1",
+ "testcontainers",
  "thiserror",
  "time 0.2.22",
  "tokio",
@@ -3957,17 +3946,6 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
@@ -4014,27 +3992,11 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af06783709f5254b087f0a1ea4557e372a5c2c597ca4a1157fbe536b1de2fb19"
-dependencies = [
- "derivative 1.0.4",
- "hex 0.4.2",
- "hmac 0.7.1",
- "log 0.4.11",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "sha2 0.8.2",
-]
-
-[[package]]
-name = "testcontainers"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5134c13096bec3ad5d4e468f2ab32788654110de751099b729997fb37e924b4a"
 dependencies = [
- "derivative 2.1.1",
+ "derivative",
  "hex 0.4.2",
  "hmac 0.8.1",
  "log 0.4.11",

--- a/cnd/src/http_api/hbit.rs
+++ b/cnd/src/http_api/hbit.rs
@@ -8,6 +8,9 @@ use bitcoin::secp256k1::SecretKey;
 
 pub use crate::hbit::*;
 
+// TODO: Make it configurable
+const BITCOIN_FEE_RATE_SAT_PER_BYTE: u64 = 10;
+
 /// Data for the hbit protocol.
 #[derive(serde::Deserialize, Clone, Debug)]
 pub struct Hbit {
@@ -99,6 +102,7 @@ impl FinalizedAsFunder {
             *fund_location,
             transient_refund_sk,
             refund_address,
+            asset::Bitcoin::from_sat(BITCOIN_FEE_RATE_SAT_PER_BYTE),
         )
     }
 
@@ -144,6 +148,7 @@ impl FinalizedAsRedeemer {
             transient_redeem_sk,
             redeem_address,
             secret,
+            asset::Bitcoin::from_sat(BITCOIN_FEE_RATE_SAT_PER_BYTE),
         )
     }
 

--- a/comit/src/actions.rs
+++ b/comit/src/actions.rs
@@ -56,16 +56,20 @@ pub mod bitcoin {
         }
     }
 
-    pub fn sign_with_fixed_rate<C>(
+    pub fn sign<C>(
         secp: &Secp256k1<C>,
         primed_transaction: PrimedTransaction,
+        byte_rate: bitcoin::Amount,
     ) -> anyhow::Result<Transaction>
     where
         C: secp256k1::Signing,
     {
-        let rate = 10;
+        let rate = byte_rate.as_sat();
+        // TODO: change this interface to accept an amount instead of a usize and remove
+        // this allow
+        #[allow(clippy::cast_possible_truncation)]
         primed_transaction
-            .sign_with_rate(secp, rate)
+            .sign_with_rate(secp, rate as usize)
             .map_err(|_| anyhow::anyhow!("failed to sign with {} rate", rate))
     }
 

--- a/nectar/Cargo.toml
+++ b/nectar/Cargo.toml
@@ -58,7 +58,7 @@ proptest = "0.10"
 quickcheck = "0.9"
 quickcheck_async = "0.1"
 tempfile = "3"
-testcontainers = "0.9"
+testcontainers = "0.10"
 
 [features]
 default = ["test-docker"]

--- a/nectar/sample-config.toml
+++ b/nectar/sample-config.toml
@@ -23,7 +23,13 @@ dai = 1000
 [maker.maximum_possible_fee]
 # An estimation of the maximum fee that we would expect to pay, used to ensure we always have enough
 # balance to execute an order we publish.
-bitcoin = 0.00009275 
+bitcoin = 0.00009275
+
+# Strategies used for Bitcoin fee handling.
+[maker.fee_strategies.bitcoin]
+# A static sat/byte value can be specified or you can relay on bitcoind's estimatesmartfee feature.
+strategy = "static"
+sats_per_byte = 12
 
 [network]
 # The libp2p socket on which nectar listens for COMIT messages.

--- a/nectar/src/bitcoin.rs
+++ b/nectar/src/bitcoin.rs
@@ -1,9 +1,11 @@
 mod bitcoind;
+mod fee;
 mod wallet;
 
 pub use ::bitcoin::{Address, Network, Txid};
 pub use bitcoind::*;
 pub use comit::asset::Bitcoin as Amount;
+pub use fee::*;
 pub use wallet::Wallet;
 
 pub const SATS_IN_BITCOIN_EXP: u16 = 8;

--- a/nectar/src/bitcoin.rs
+++ b/nectar/src/bitcoin.rs
@@ -2,7 +2,7 @@ mod bitcoind;
 mod fee;
 mod wallet;
 
-pub use ::bitcoin::{Address, Network, Txid};
+pub use ::bitcoin::{Address, Block, BlockHash, Network, Transaction, Txid};
 pub use bitcoind::*;
 pub use comit::asset::Bitcoin as Amount;
 pub use fee::*;

--- a/nectar/src/bitcoin/bitcoind.rs
+++ b/nectar/src/bitcoin/bitcoind.rs
@@ -179,6 +179,7 @@ impl Client {
         wallet_name: &str,
         address: Address,
         amount: Amount,
+        kbyte_fee_rate: Amount,
     ) -> anyhow::Result<OutPoint> {
         let address = address.to_string();
 
@@ -198,7 +199,8 @@ impl Client {
                             ],
                             null,
                             {
-                                "changePosition": 1 // this allows us to assume that the HTLC will always be at output position 0
+                                "changePosition": 1, // this allows us to assume that the HTLC will always be at output position 0,
+                                "feeRate": kbyte_fee_rate.as_btc() // Set a specific fee rate in BTC/kB
                             }
                         ]
                     ),
@@ -496,7 +498,7 @@ struct FinalizePsbtResponse {
 pub struct EstimateSmartFeeResponse {
     #[serde(rename = "feerate")]
     #[serde(with = "btc_as_float")]
-    pub fee_rate: Amount,
+    pub kbyte_rate: Amount,
     pub block: u32,
 }
 

--- a/nectar/src/bitcoin/bitcoind.rs
+++ b/nectar/src/bitcoin/bitcoind.rs
@@ -7,7 +7,7 @@ use anyhow::Context;
 use bitcoin::OutPoint;
 use comit::ledger;
 use ledger::Bitcoin as Network;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 pub const JSONRPC_VERSION: &str = "1.0";
 
@@ -376,6 +376,35 @@ impl Client {
             .context("failed to generate to address")?;
         Ok(response)
     }
+
+    pub async fn estimate_smart_fee(
+        &self,
+        confirmation_target: u32,
+        estimate_mode: Option<EstimateMode>,
+    ) -> anyhow::Result<EstimateSmartFeeResponse> {
+        let response = self
+            .rpc_client
+            .send(jsonrpc::Request::new(
+                "estimatesmartfee",
+                vec![
+                    jsonrpc::serialize(confirmation_target)?,
+                    jsonrpc::serialize(estimate_mode)?,
+                ],
+                JSONRPC_VERSION.into(),
+            ))
+            .await
+            .context("failed to get smart fee estimation")?;
+        Ok(response)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+#[allow(dead_code)] // Fine if the options are not used
+pub enum EstimateMode {
+    Unset,
+    Economical,
+    Conservative,
 }
 
 #[derive(Debug, Deserialize)]
@@ -461,6 +490,36 @@ struct FinalizePsbtResponse {
     psbt: Option<String>,
     hex: Option<String>,
     complete: bool,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
+pub struct EstimateSmartFeeResponse {
+    #[serde(rename = "feerate")]
+    #[serde(with = "btc_as_float")]
+    pub fee_rate: Amount,
+    pub block: u32,
+}
+
+mod btc_as_float {
+    use super::*;
+    use serde::{de::Error, Deserialize, Deserializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Amount, <D as Deserializer<'de>>::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = f64::deserialize(deserializer)?;
+        let amount = Amount::from_btc(value).map_err(<D as Deserializer<'de>>::Error::custom)?;
+
+        Ok(amount)
+    }
+}
+
+#[cfg(test)]
+impl crate::StaticStub for Client {
+    fn static_stub() -> Self {
+        Self::new("http://example.com".parse().unwrap())
+    }
 }
 
 #[cfg(all(test, feature = "test-docker"))]

--- a/nectar/src/bitcoin/fee.rs
+++ b/nectar/src/bitcoin/fee.rs
@@ -1,0 +1,51 @@
+use crate::{bitcoin, config, Result};
+
+const ESTIMATE_FEE_TARGET: u32 = 3;
+
+#[derive(Debug)]
+pub struct Fee {
+    config: config::BitcoinFeeStrategy,
+    max_fee: bitcoin::Amount,
+    client: bitcoin::Client,
+}
+
+impl Fee {
+    pub fn new(
+        config: config::BitcoinFeeStrategy,
+        max_btc_fee: bitcoin::Amount,
+        client: bitcoin::Client,
+    ) -> Self {
+        Self {
+            config,
+            max_fee: max_btc_fee,
+            client,
+        }
+    }
+
+    pub async fn sat_per_byte(&self) -> Result<bitcoin::Amount> {
+        use crate::config::BitcoinFeeStrategy::*;
+        match self.config {
+            SatsPerByte(amount) => Ok(amount),
+            BitcoindEstimateSmartfee(mode) => self
+                .client
+                .estimate_smart_fee(ESTIMATE_FEE_TARGET, Some(mode.into()))
+                .await
+                .map(|res| res.fee_rate),
+        }
+    }
+
+    pub fn max_fee(&self) -> bitcoin::Amount {
+        self.max_fee
+    }
+}
+
+#[cfg(test)]
+impl crate::StaticStub for Fee {
+    fn static_stub() -> Self {
+        Self {
+            config: Default::default(),
+            max_fee: bitcoin::Amount::ZERO,
+            client: bitcoin::Client::new("http://example.com/".parse().unwrap()), // Not used
+        }
+    }
+}

--- a/nectar/src/bitcoin/fee.rs
+++ b/nectar/src/bitcoin/fee.rs
@@ -1,8 +1,9 @@
-use crate::{bitcoin, config, Result};
+use crate::{bitcoin, bitcoin::Amount, config, Result};
+use anyhow::Context;
 
 const ESTIMATE_FEE_TARGET: u32 = 3;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Fee {
     config: config::BitcoinFeeStrategy,
     max_fee: bitcoin::Amount,
@@ -22,15 +23,29 @@ impl Fee {
         }
     }
 
-    pub async fn sat_per_byte(&self) -> Result<bitcoin::Amount> {
+    pub async fn kbyte_rate(&self) -> Result<Amount> {
+        let byte_rate = self.byte_rate().await?;
+        byte_rate
+            .checked_mul(1000)
+            .context("Could not mul byte rate")
+    }
+
+    pub async fn byte_rate(&self) -> Result<Amount> {
         use crate::config::BitcoinFeeStrategy::*;
         match self.config {
             SatsPerByte(amount) => Ok(amount),
-            BitcoindEstimateSmartfee(mode) => self
-                .client
-                .estimate_smart_fee(ESTIMATE_FEE_TARGET, Some(mode.into()))
-                .await
-                .map(|res| res.fee_rate),
+            BitcoindEstimateSmartfee(mode) => {
+                let kbyte_rate = self
+                    .client
+                    .estimate_smart_fee(ESTIMATE_FEE_TARGET, Some(mode.into()))
+                    .await
+                    .map(|res| res.kbyte_rate)?;
+
+                // Return rate per byte
+                kbyte_rate
+                    .checked_div(1000)
+                    .context("Could not div kbyte rate")
+            }
         }
     }
 

--- a/nectar/src/bitcoin/wallet.rs
+++ b/nectar/src/bitcoin/wallet.rs
@@ -228,12 +228,13 @@ impl Wallet {
         address: Address,
         amount: Amount,
         ledger: ledger::Bitcoin,
+        kbyte_fee_rate: Amount,
     ) -> anyhow::Result<OutPoint> {
         self.assert_network(ledger).await?;
 
         let outpoint = self
             .bitcoind_client
-            .fund_htlc(&self.name, address, amount)
+            .fund_htlc(&self.name, address, amount, kbyte_fee_rate)
             .await?;
         Ok(outpoint)
     }

--- a/nectar/src/command/resume_only.rs
+++ b/nectar/src/command/resume_only.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 pub async fn resume_only(
     settings: Settings,
     bitcoin_wallet: bitcoin::Wallet,
+    bitcoin_fee: bitcoin::Fee,
     ethereum_wallet: ethereum::Wallet,
 ) -> anyhow::Result<()> {
     #[cfg(not(test))]
@@ -25,6 +26,7 @@ pub async fn resume_only(
     let (executor, mut finished_swap_receiver) = SwapExecutor::new(
         db.clone(),
         Arc::new(bitcoin_wallet),
+        bitcoin_fee,
         Arc::new(ethereum_wallet),
         Arc::new(BitcoindConnector::new(settings.bitcoin.bitcoind.node_url)?),
         Arc::new(Web3Connector::new(settings.ethereum.node_url)),

--- a/nectar/src/command/trade.rs
+++ b/nectar/src/command/trade.rs
@@ -301,6 +301,7 @@ mod tests {
                 },
                 spread: StaticStub::static_stub(),
                 maximum_possible_fee: Default::default(),
+                fee_strategies: Default::default(),
                 kraken_api_host: Default::default(),
             },
             network: Network {

--- a/nectar/src/command/trade.rs
+++ b/nectar/src/command/trade.rs
@@ -35,7 +35,7 @@ pub async fn trade(
 
     let mut maker = init_maker(
         Arc::clone(&bitcoin_wallet),
-        bitcoind_client,
+        bitcoind_client.clone(),
         Arc::clone(&ethereum_wallet),
         settings.clone(),
         network,
@@ -81,9 +81,16 @@ pub async fn trade(
     let bitcoin_connector = Arc::new(BitcoindConnector::new(settings.bitcoin.bitcoind.node_url)?);
     let ethereum_connector = Arc::new(Web3Connector::new(settings.ethereum.node_url));
 
+    let bitcoin_fee = bitcoin::Fee::new(
+        settings.maker.fee_strategies.bitcoin,
+        settings.maker.maximum_possible_fee.bitcoin,
+        bitcoind_client,
+    );
+
     let (swap_executor, swap_execution_finished_receiver) = SwapExecutor::new(
         Arc::clone(&db),
         Arc::clone(&bitcoin_wallet),
+        bitcoin_fee,
         Arc::clone(&ethereum_wallet),
         bitcoin_connector,
         ethereum_connector,

--- a/nectar/src/config.rs
+++ b/nectar/src/config.rs
@@ -39,6 +39,21 @@ pub struct MaxSell {
     pub dai: Option<dai::Amount>,
 }
 
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EstimateMode {
+    Unset,
+    Economical,
+    Conservative,
+}
+
+/// "Unset" lets bitcoind choose the strategy
+impl Default for EstimateMode {
+    fn default() -> Self {
+        Self::Unset
+    }
+}
+
 pub fn read_config<T>(config_file: &Option<PathBuf>, default_config_path: T) -> anyhow::Result<File>
 where
     T: FnOnce() -> anyhow::Result<PathBuf>,
@@ -123,8 +138,15 @@ mod tests {
                     dai: Some(dai::Amount::from_dai_trunc(1000.0).unwrap()),
                 }),
                 spread: Some(Spread::new(500).unwrap()),
-                maximum_possible_fee: Some(file::Fees {
+                maximum_possible_fee: Some(file::MaxPossibleFee {
                     bitcoin: Some(bitcoin::Amount::from_btc(0.00009275).unwrap()),
+                }),
+                fee_strategies: Some(file::FeeStrategies {
+                    bitcoin: Some(file::BitcoinFee {
+                        strategy: Some(file::BitcoinFeeStrategy::Static),
+                        sats_per_byte: Some(bitcoin::Amount::from_sat(12)),
+                        estimate_mode: None,
+                    }),
                 }),
                 kraken_api_host: Some("https://api.kraken.com".parse().unwrap()),
             }),

--- a/nectar/src/config.rs
+++ b/nectar/src/config.rs
@@ -32,7 +32,7 @@ pub struct Bitcoind {
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct MaxSell {
     #[serde(default)]
-    #[serde(with = "crate::config::serde::bitcoin_amount")]
+    #[serde(with = "crate::config::serde::bitcoin_amount::btc_as_optional_float")]
     pub bitcoin: Option<bitcoin::Amount>,
     #[serde(default)]
     #[serde(with = "crate::config::serde::dai_amount")]

--- a/nectar/src/config.rs
+++ b/nectar/src/config.rs
@@ -54,6 +54,17 @@ impl Default for EstimateMode {
     }
 }
 
+impl From<EstimateMode> for crate::bitcoin::EstimateMode {
+    fn from(config: EstimateMode) -> Self {
+        use crate::bitcoin::EstimateMode::*;
+        match config {
+            EstimateMode::Unset => Unset,
+            EstimateMode::Economical => Economical,
+            EstimateMode::Conservative => Conservative,
+        }
+    }
+}
+
 pub fn read_config<T>(config_file: &Option<PathBuf>, default_config_path: T) -> anyhow::Result<File>
 where
     T: FnOnce() -> anyhow::Result<PathBuf>,

--- a/nectar/src/config/file.rs
+++ b/nectar/src/config/file.rs
@@ -35,6 +35,8 @@ pub struct Maker {
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct MaxPossibleFee {
+    // TODO: This should be a sat/byte fee as the user would have no idea of the size of the COMIT
+    // transactions.
     #[serde(default)]
     #[serde(with = "crate::config::serde::bitcoin_amount::btc_as_optional_float")]
     pub bitcoin: Option<bitcoin::Amount>,

--- a/nectar/src/config/file.rs
+++ b/nectar/src/config/file.rs
@@ -36,7 +36,7 @@ pub struct Maker {
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Fees {
     #[serde(default)]
-    #[serde(with = "crate::config::serde::bitcoin_amount")]
+    #[serde(with = "crate::config::serde::bitcoin_amount::btc_as_optional_float")]
     pub bitcoin: Option<bitcoin::Amount>,
 }
 

--- a/nectar/src/config/serde/bitcoin_amount.rs
+++ b/nectar/src/config/serde/bitcoin_amount.rs
@@ -2,89 +2,188 @@ use crate::bitcoin::*;
 use serde::{de, Deserialize, Deserializer, Serializer};
 use std::{convert::TryFrom, fmt};
 
-pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Amount>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    struct Visitor;
+pub mod btc_as_optional_float {
+    use super::*;
 
-    impl<'de> de::Visitor<'de> for Visitor {
-        type Value = Option<Amount>;
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Amount>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Visitor;
 
-        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            formatter.write_str("an amount in bitcoin")
-        }
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = Option<Amount>;
 
-        fn visit_none<E>(self) -> Result<Self::Value, E>
-        where
-            E: de::Error,
-        {
-            Ok(None)
-        }
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an amount in bitcoin")
+            }
 
-        fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-        where
-            D: Deserializer<'de>,
-        {
-            let s: Option<f64> = Option::deserialize(deserializer)?;
-            match s {
-                Some(value) => {
-                    let amount = Amount::from_btc(value).map_err(serde::de::Error::custom)?;
-                    Ok(Some(amount))
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(None)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let s: Option<f64> = Option::deserialize(deserializer)?;
+                match s {
+                    Some(value) => {
+                        let amount = Amount::from_btc(value).map_err(serde::de::Error::custom)?;
+                        Ok(Some(amount))
+                    }
+                    None => Ok(None),
                 }
-                None => Ok(None),
+            }
+
+            fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Some(Amount::from_btc(value).map_err(E::custom)?))
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let value = u32::try_from(value).map_err(E::custom)?;
+                let value = f64::try_from(value).map_err(E::custom)?;
+                Ok(Some(Amount::from_btc(value).map_err(E::custom)?))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let value = i32::try_from(value).map_err(E::custom)?;
+                let value = f64::try_from(value).map_err(E::custom)?;
+                Ok(Some(Amount::from_btc(value).map_err(E::custom)?))
             }
         }
 
-        fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
-        where
-            E: de::Error,
-        {
-            Ok(Some(Amount::from_btc(value).map_err(|error| {
-                E::custom(format!("Could not deserialize bitcoin amount: {:#}", error))
-            })?))
-        }
-
-        fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
-        where
-            E: de::Error,
-        {
-            let value = u32::try_from(value).map_err(|error| {
-                E::custom(format!("Could not deserialize bitcoin amount: {:#}", error))
-            })?;
-            let value = f64::try_from(value).map_err(|error| {
-                E::custom(format!("Could not deserialize bitcoin amount: {:#}", error))
-            })?;
-            Ok(Some(Amount::from_btc(value).map_err(|error| {
-                E::custom(format!("Could not deserialize bitcoin amount: {:#}", error))
-            })?))
-        }
-
-        fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
-        where
-            E: de::Error,
-        {
-            let value = i32::try_from(value).map_err(|error| {
-                E::custom(format!("Could not deserialize bitcoin amount: {:#}", error))
-            })?;
-            let value = f64::try_from(value).map_err(|error| {
-                E::custom(format!("Could not deserialize bitcoin amount: {:#}", error))
-            })?;
-            Ok(Some(Amount::from_btc(value as f64).map_err(|error| {
-                E::custom(format!("Could not deserialize bitcoin amount: {:#}", error))
-            })?))
-        }
+        deserializer.deserialize_any(Visitor)
     }
 
-    deserializer.deserialize_any(Visitor)
+    pub fn serialize<S>(value: &Option<Amount>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(value) => serializer.serialize_f64(value.as_btc()),
+            None => serializer.serialize_none(),
+        }
+    }
 }
 
-pub fn serialize<S>(value: &Option<Amount>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    match value {
-        Some(value) => serializer.serialize_f64(value.as_btc()),
-        None => serializer.serialize_none(),
+pub mod sat_as_optional_unsigned_int {
+    use super::*;
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Amount>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = Option<Amount>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an amount in satoshi")
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(None)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let s: Option<u64> = Option::deserialize(deserializer)?;
+                match s {
+                    Some(value) => {
+                        let amount = Amount::from_sat(value);
+                        Ok(Some(amount))
+                    }
+                    None => Ok(None),
+                }
+            }
+
+            fn visit_u32<E>(self, value: u32) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Some(Amount::from_sat(value as u64)))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let value = i32::try_from(value).map_err(E::custom)?;
+                let value = u64::try_from(value).map_err(E::custom)?;
+                Ok(Some(Amount::from_sat(value)))
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+
+    pub fn serialize<S>(value: &Option<Amount>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(value) => serializer.serialize_f64(value.as_btc()),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Serialize;
+
+    #[derive(Serialize, Deserialize)]
+    struct BtcOption {
+        #[serde(with = "crate::config::serde::bitcoin_amount::btc_as_optional_float")]
+        pub amount: Option<Amount>,
+    }
+
+    #[test]
+    fn deserialize_btc_float_option_some() {
+        let str = "amount = 1.12345678";
+
+        let value: BtcOption = toml::from_str(str).unwrap();
+
+        assert_eq!(value.amount.unwrap(), Amount::from_sat(112345678));
+    }
+
+    #[test]
+    fn serialize_btc_float_option_some() {
+        let value = BtcOption {
+            amount: Some(Amount::from_sat(112345678)),
+        };
+
+        let str = toml::to_string(&value).unwrap();
+
+        assert_eq!(str, "amount = 1.12345678\n".to_string());
+    }
+
+    #[test]
+    fn serialize_btc_float_option_none() {
+        let value = BtcOption { amount: None };
+
+        let str = toml::to_string(&value).unwrap();
+
+        assert_eq!(str, "".to_string());
     }
 }

--- a/nectar/src/config/settings.rs
+++ b/nectar/src/config/settings.rs
@@ -227,7 +227,7 @@ pub struct Fees {
 }
 
 impl Fees {
-    fn from_file(file: file::Fees) -> Self {
+    fn from_file(file: file::MaxPossibleFee) -> Self {
         Self {
             bitcoin: file.bitcoin.unwrap_or_else(Self::default_bitcoin_fee),
         }
@@ -290,10 +290,12 @@ impl From<Maker> for file::Maker {
                 max_sell => Some(max_sell),
             },
             spread: Some(maker.spread),
-            maximum_possible_fee: Some(file::Fees {
+            maximum_possible_fee: Some(file::MaxPossibleFee {
                 bitcoin: Some(maker.maximum_possible_fee.bitcoin),
             }),
             kraken_api_host: Some(maker.kraken_api_host.0),
+            // TODO
+            fee_strategies: None,
         }
     }
 }

--- a/nectar/src/config/settings.rs
+++ b/nectar/src/config/settings.rs
@@ -163,6 +163,8 @@ pub struct Maker {
     /// Spread to apply to the mid-market rate, format is permyriad. E.g. 5.20
     /// is 5.2% spread
     pub spread: Spread,
+    // TODO: Probably move that under something common to fee_strategies.
+    // I did not realize I would still need it.
     /// Maximum possible network fee to consider when calculating the available
     /// balance. Fees are in the nominal native currency and per
     /// transaction.

--- a/nectar/src/jsonrpc.rs
+++ b/nectar/src/jsonrpc.rs
@@ -52,7 +52,8 @@ impl Client {
                 let response = String::from_utf8_lossy(&response[..]);
                 tracing::debug!("Response received: {}", response);
                 anyhow::bail!(
-                    "failed to deserialize JSON response as JSON-RPC response: {:#}",
+                    "failed to deserialize JSON response {} as JSON-RPC response: {:#}",
+                    response,
                     error
                 );
             }

--- a/nectar/src/maker.rs
+++ b/nectar/src/maker.rs
@@ -132,7 +132,7 @@ impl Maker {
         }
     }
 
-    pub fn new_order(&self, position: Position) -> anyhow::Result<BtcDaiOrderForm> {
+    pub async fn new_order(&self, position: Position) -> anyhow::Result<BtcDaiOrderForm> {
         match position {
             Position::Buy => self.new_buy_order(),
             Position::Sell => self.new_sell_order(),
@@ -355,7 +355,14 @@ mod tests {
 
     #[test]
     fn published_sell_order_can_be_taken() {
-        let strategy = strategy::AllIn::new(btc(0.0), Some(btc(1.0)), None, Spread::static_stub());
+        let strategy = strategy::AllIn::new(
+            Default::default(),
+            btc(0.0),
+            Some(btc(1.0)),
+            None,
+            Spread::static_stub(),
+            StaticStub::static_stub(),
+        );
 
         let mut maker = Maker {
             btc_balance: some_btc(3.0),
@@ -374,7 +381,14 @@ mod tests {
 
     #[test]
     fn published_buy_order_can_be_taken() {
-        let strategy = strategy::AllIn::new(btc(0.0), None, Some(dai(1.0)), Spread::static_stub());
+        let strategy = strategy::AllIn::new(
+            Default::default(),
+            btc(0.0),
+            None,
+            Some(dai(1.0)),
+            Spread::static_stub(),
+            StaticStub::static_stub(),
+        );
 
         let mut maker = Maker {
             dai_balance: some_dai(3.0),
@@ -393,7 +407,14 @@ mod tests {
 
     #[test]
     fn new_buy_order_is_correct() {
-        let strategy = strategy::AllIn::new(btc(0.0), None, Some(dai(18.0)), Spread::static_stub());
+        let strategy = strategy::AllIn::new(
+            Default::default(),
+            btc(0.0),
+            None,
+            Some(dai(18.0)),
+            Spread::static_stub(),
+            StaticStub::static_stub(),
+        );
 
         let maker = Maker {
             dai_balance: some_dai(20.0),

--- a/nectar/src/swap.rs
+++ b/nectar/src/swap.rs
@@ -338,6 +338,7 @@ mod tests {
                 bitcoin::Wallet {
                     inner: Arc::new(bitcoin_wallet),
                     connector: Arc::clone(&bitcoin_connector),
+                    fee: StaticStub::static_stub(),
                 },
                 ethereum::Wallet {
                     inner: Arc::new(ethereum_wallet),
@@ -378,6 +379,7 @@ mod tests {
                 bitcoin::Wallet {
                     inner: Arc::new(bitcoin_wallet),
                     connector: Arc::clone(&bitcoin_connector),
+                    fee: StaticStub::static_stub(),
                 },
                 ethereum::Wallet {
                     inner: Arc::new(ethereum_wallet),
@@ -538,6 +540,7 @@ mod tests {
 pub struct SwapExecutor {
     db: Arc<Database>,
     bitcoin_wallet: Arc<crate::bitcoin::Wallet>,
+    bitcoin_fee: crate::bitcoin::Fee,
     ethereum_wallet: Arc<crate::ethereum::Wallet>,
     finished_swap_sender: mpsc::Sender<FinishedSwap>,
     bitcoin_connector: Arc<BitcoindConnector>,
@@ -548,6 +551,7 @@ impl SwapExecutor {
     pub fn new(
         db: Arc<Database>,
         bitcoin_wallet: Arc<crate::bitcoin::Wallet>,
+        bitcoin_fee: crate::bitcoin::Fee,
         ethereum_wallet: Arc<crate::ethereum::Wallet>,
         bitcoin_connector: Arc<BitcoindConnector>,
         ethereum_connector: Arc<Web3Connector>,
@@ -560,6 +564,7 @@ impl SwapExecutor {
         let executor = Self {
             db,
             bitcoin_wallet,
+            bitcoin_fee,
             ethereum_wallet,
             finished_swap_sender,
             bitcoin_connector,
@@ -577,6 +582,7 @@ impl SwapExecutor {
             bitcoin::Wallet {
                 inner: self.bitcoin_wallet.clone(),
                 connector: self.bitcoin_connector.clone(),
+                fee: self.bitcoin_fee.clone(),
             },
             self.bitcoin_connector.clone(),
             ethereum::Wallet {

--- a/nectar/src/swap/bitcoin.rs
+++ b/nectar/src/swap/bitcoin.rs
@@ -46,6 +46,8 @@ impl hbit::ExecuteRedeem for Wallet {
     ) -> anyhow::Result<hbit::Redeemed> {
         let redeem_address = self.inner.new_address().await?;
 
+        let fee_rate_per_byte = self.fee.byte_rate().await?;
+
         let action = params.shared.build_redeem_action(
             &crate::SECP,
             fund_event.asset,
@@ -53,6 +55,7 @@ impl hbit::ExecuteRedeem for Wallet {
             params.transient_sk,
             redeem_address,
             secret,
+            fee_rate_per_byte,
         )?;
         let transaction = self.spend(action).await?;
 
@@ -85,12 +88,15 @@ impl hbit::ExecuteRefund for Wallet {
 
         let refund_address = self.inner.new_address().await?;
 
+        let fee_rate_per_byte = self.fee.byte_rate().await?;
+
         let action = params.shared.build_refund_action(
             &crate::SECP,
             fund_event.asset,
             fund_event.location,
             params.transient_sk,
             refund_address,
+            fee_rate_per_byte,
         )?;
         let transaction = self.spend(action).await?;
 

--- a/nectar/src/test_harness/bitcoin.rs
+++ b/nectar/src/test_harness/bitcoin.rs
@@ -12,7 +12,7 @@ pub struct Blockchain<'c> {
 
 impl<'c> Blockchain<'c> {
     pub fn new(client: &'c clients::Cli) -> anyhow::Result<Self> {
-        let container = client.run(BitcoinCore::default().with_tag("0.19.1"));
+        let container = client.run(BitcoinCore::default());
         let port = container.get_host_port(18443);
 
         let auth = container.image().auth();

--- a/tests/tests/buy_and_sell_bitcoin_e2e_cnd_nectar.ts
+++ b/tests/tests/buy_and_sell_bitcoin_e2e_cnd_nectar.ts
@@ -28,7 +28,7 @@ test(
 
         await alice.assertBalancesAfterSwap();
         await bob.assertBalancesChangedBy({
-            bitcoin: -(10_000_000n + 3060n), // nectar pays order quantity + the funding fee
+            bitcoin: -(10_000_000n + 1530n), // nectar pays order quantity + the funding fee
             dai: 945_000_000_000_000_000_000n, // = 0.1 * 9450 * 10^18
         });
     })


### PR DESCRIPTION
Improve fee management for nectar. Two configurations options are offered:
- static fee in sat/byte
- Use bitcoind estimate mode

Please note the bitcoind mode is not tested because I was not able to get it to work in regtest despite injecting a bunch of transactions in the network.

Follow-up PRs:
- Make the `maximum_possible_fee` option take a sat/byte fee and calculate internally what that would be in total tx fee instead of expecting the user to know how big the COMIT transactions are.