### PR TITLE
Remove fee subtraction from sell order creation

### DIFF
--- a/tests/tests/buy_and_sell_bitcoin_e2e_cnd_nectar.ts
+++ b/tests/tests/buy_and_sell_bitcoin_e2e_cnd_nectar.ts
@@ -16,7 +16,7 @@ test(
             (market) => market.entities.length > 0
         );
 
-        await alice.makeBtcDaiOrder(Position.Buy, "0.09990725", "9450"); // This matches what nectar publishes.
+        await alice.makeBtcDaiOrder(Position.Buy, "0.1", "9450"); // This matches what nectar publishes.
         await alice.waitForSwap();
 
         await alice.assertAndExecuteNextAction("deploy");
@@ -28,8 +28,8 @@ test(
 
         await alice.assertBalancesAfterSwap();
         await bob.assertBalancesChangedBy({
-            bitcoin: -(9990725n + 3060n), // nectar pays order quantity + the funding fee
-            dai: 944_123_512_500_000_000_000n, // = 0.09990725 * 9450 * 10^18
+            bitcoin: -(10_000_000n + 3060n), // nectar pays order quantity + the funding fee
+            dai: 945_000_000_000_000_000_000n, // = 0.1 * 9450 * 10^18
         });
     })
 );


### PR DESCRIPTION
The max_sell represents the maximum amount to be traded for each
currency. This should not be concerned by the fees. Fees are on top
of the maximum amount.
Note that checks for sufficient funds are already in place, so we just
remove the fee subtraction, add unit tests to show the bahavior and
adap existing integration and e2e tests.