### PR TITLE
Reduce logging noise of btsieve without losing any of the information

### DIFF
--- a/cnd/src/http_api/route_factory.rs
+++ b/cnd/src/http_api/route_factory.rs
@@ -193,7 +193,13 @@ pub fn create(
         .or(markets::get_btc_dai(swarm, network))
         .or(post_dial_addr)
         .recover(http_api::unpack_problem)
-        .with(warp::log("http"))
+        .with(warp::trace(|info| {
+            tracing::error_span!(
+                "request",
+                method = %info.method(),
+                path = %info.path(),
+            )
+        }))
         .with(cors)
         .boxed()
 }

--- a/cnd/src/trace.rs
+++ b/cnd/src/trace.rs
@@ -14,7 +14,7 @@ pub fn init_tracing(level: log::LevelFilter) -> anyhow::Result<()> {
 
     let is_terminal = atty::is(Stream::Stdout);
     let subscriber = FmtSubscriber::builder()
-        .with_env_filter(format!("cnd={},comit={},http=info,warp=info", level, level))
+        .with_env_filter(format!("cnd={},comit={}", level, level))
         .with_ansi(is_terminal)
         .finish();
 

--- a/comit/src/actions.rs
+++ b/comit/src/actions.rs
@@ -12,6 +12,7 @@ pub trait Actions {
 
 pub mod bitcoin {
     use crate::{asset, ledger};
+    use anyhow::Result;
     use bitcoin::{
         secp256k1::{self, Secp256k1},
         OutPoint,
@@ -60,7 +61,7 @@ pub mod bitcoin {
         secp: &Secp256k1<C>,
         primed_transaction: PrimedTransaction,
         byte_rate: bitcoin::Amount,
-    ) -> anyhow::Result<Transaction>
+    ) -> Result<Transaction>
     where
         C: secp256k1::Signing,
     {

--- a/comit/src/bitcoin.rs
+++ b/comit/src/bitcoin.rs
@@ -10,6 +10,7 @@ use crate::{
     btsieve::{BlockByHash, LatestBlock},
     Timestamp,
 };
+use anyhow::Result;
 use bitcoin::secp256k1;
 use serde::{
     de::{self, Visitor},
@@ -136,7 +137,7 @@ impl<'de> Deserialize<'de> for PublicKey {
 
 /// Median time in Bitcoin is defined as the median of the blocktimes from the
 /// last 11 blocks.
-pub async fn median_time_past<C>(connector: &C) -> anyhow::Result<Timestamp>
+pub async fn median_time_past<C>(connector: &C) -> Result<Timestamp>
 where
     C: LatestBlock<Block = bitcoin::Block>
         + BlockByHash<Block = bitcoin::Block, BlockHash = bitcoin::BlockHash>,

--- a/comit/src/btsieve.rs
+++ b/comit/src/btsieve.rs
@@ -3,6 +3,7 @@ pub mod ethereum;
 mod jsonrpc;
 
 use crate::Never;
+use anyhow::Result;
 use async_trait::async_trait;
 use genawaiter::sync::{Co, Gen};
 use std::{collections::HashSet, future::Future, hash::Hash};
@@ -12,7 +13,7 @@ use time::OffsetDateTime;
 pub trait LatestBlock: Send + Sync + 'static {
     type Block;
 
-    async fn latest_block(&self) -> anyhow::Result<Self::Block>;
+    async fn latest_block(&self) -> Result<Self::Block>;
 }
 
 #[async_trait]
@@ -20,7 +21,7 @@ pub trait BlockByHash: Send + Sync + 'static {
     type Block;
     type BlockHash;
 
-    async fn block_by_hash(&self, block_hash: Self::BlockHash) -> anyhow::Result<Self::Block>;
+    async fn block_by_hash(&self, block_hash: Self::BlockHash) -> Result<Self::Block>;
 }
 
 /// Checks if a given block predates a certain timestamp.
@@ -54,7 +55,7 @@ pub trait PreviousBlockHash {
 pub fn fetch_blocks_since<'a, C, B, H>(
     connector: &'a C,
     start_of_swap: OffsetDateTime,
-) -> Gen<B, (), impl Future<Output = anyhow::Result<Never>> + 'a>
+) -> Gen<B, (), impl Future<Output = Result<Never>> + 'a>
 where
     C: LatestBlock<Block = B> + BlockByHash<Block = B, BlockHash = H>,
     B: Predates + BlockHash<BlockHash = H> + PreviousBlockHash<BlockHash = H> + Clone + 'a,
@@ -97,7 +98,7 @@ async fn walk_back_until<C, P, B, H>(
     starting_block: B,
     connector: &C,
     co: &Co<B>,
-) -> anyhow::Result<HashSet<H>>
+) -> Result<HashSet<H>>
 where
     C: BlockByHash<Block = B, BlockHash = H>,
     P: Fn(&B) -> bool,

--- a/comit/src/btsieve/bitcoin.rs
+++ b/comit/src/btsieve/bitcoin.rs
@@ -11,6 +11,7 @@ use crate::{
     },
     identity,
 };
+use anyhow::Result;
 use bitcoin::{self, OutPoint};
 use genawaiter::GeneratorState;
 use time::OffsetDateTime;
@@ -40,7 +41,7 @@ pub async fn watch_for_spent_outpoint<C>(
     start_of_swap: OffsetDateTime,
     outpoint: OutPoint,
     identity: identity::Bitcoin,
-) -> anyhow::Result<(bitcoin::Transaction, bitcoin::TxIn)>
+) -> Result<(bitcoin::Transaction, bitcoin::TxIn)>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash>,
 {
@@ -62,7 +63,7 @@ pub async fn watch_for_created_outpoint<C>(
     blockchain_connector: &C,
     start_of_swap: OffsetDateTime,
     address: bitcoin::Address,
-) -> anyhow::Result<(bitcoin::Transaction, bitcoin::OutPoint)>
+) -> Result<(bitcoin::Transaction, bitcoin::OutPoint)>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash>,
 {
@@ -91,7 +92,7 @@ async fn watch<C, S, M>(
     connector: &C,
     start_of_swap: OffsetDateTime,
     sieve: S,
-) -> anyhow::Result<(bitcoin::Transaction, M)>
+) -> Result<(bitcoin::Transaction, M)>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash>,
     S: Fn(&bitcoin::Transaction) -> Option<M>,

--- a/comit/src/btsieve/bitcoin.rs
+++ b/comit/src/btsieve/bitcoin.rs
@@ -115,7 +115,7 @@ where
                     }
                 }
 
-                tracing::info!("no transaction matched")
+                tracing::debug!("no transaction matched")
             }
             GeneratorState::Complete(Err(e)) => return Err(e),
             // By matching against the never type explicitly, we assert that the `Ok` value of the

--- a/comit/src/btsieve/bitcoin/bitcoind_connector.rs
+++ b/comit/src/btsieve/bitcoin/bitcoind_connector.rs
@@ -50,8 +50,6 @@ impl BitcoindConnector {
             .await
             .context("failed to deserialize JSON response as chaininfo")?;
 
-        tracing::trace!("Fetched chain info: {:?} from bitcoind", chain_info);
-
         Ok(chain_info)
     }
 }
@@ -84,12 +82,6 @@ impl BlockByHash for BitcoindConnector {
             .text()
             .map_ok(decode_response)
             .await??;
-
-        tracing::trace!(
-            "Fetched block {} with {} transactions from bitcoind",
-            block_hash,
-            block.txdata.len()
-        );
 
         Ok(block)
     }

--- a/comit/src/btsieve/bitcoin/cache.rs
+++ b/comit/src/btsieve/bitcoin/cache.rs
@@ -55,12 +55,10 @@ where
 
     async fn block_by_hash(&self, block_hash: Self::BlockHash) -> Result<Self::Block> {
         if let Some(block) = self.block_cache.lock().await.get(&block_hash) {
-            tracing::trace!("Found block in cache: {:x}", block_hash);
             return Ok(block.clone());
         }
 
         let block = self.connector.block_by_hash(block_hash).await?;
-        tracing::trace!("Fetched block from connector: {:x}", block_hash);
 
         // We dropped the lock so at this stage the block may have been inserted by
         // another thread, no worries, inserting the same block twice does not hurt.

--- a/comit/src/btsieve/bitcoin/cache.rs
+++ b/comit/src/btsieve/bitcoin/cache.rs
@@ -1,4 +1,5 @@
 use crate::btsieve::{BlockByHash, LatestBlock};
+use anyhow::Result;
 use async_trait::async_trait;
 use bitcoin::{Block, BlockHash as Hash, BlockHash};
 use derivative::Derivative;
@@ -31,7 +32,7 @@ where
 {
     type Block = Block;
 
-    async fn latest_block(&self) -> anyhow::Result<Self::Block> {
+    async fn latest_block(&self) -> Result<Self::Block> {
         let block = self.connector.latest_block().await?;
 
         let block_hash = block.block_hash();
@@ -52,7 +53,7 @@ where
     type Block = Block;
     type BlockHash = BlockHash;
 
-    async fn block_by_hash(&self, block_hash: Self::BlockHash) -> anyhow::Result<Self::Block> {
+    async fn block_by_hash(&self, block_hash: Self::BlockHash) -> Result<Self::Block> {
         if let Some(block) = self.block_cache.lock().await.get(&block_hash) {
             tracing::trace!("Found block in cache: {:x}", block_hash);
             return Ok(block.clone());

--- a/comit/src/btsieve/ethereum.rs
+++ b/comit/src/btsieve/ethereum.rs
@@ -1,16 +1,20 @@
 mod cache;
+mod watch_for_contract_creation;
+mod watch_for_event;
 mod web3_connector;
 
-pub use self::{cache::Cache, web3_connector::Web3Connector};
+pub use self::{
+    cache::Cache,
+    watch_for_contract_creation::{matching_transaction_and_receipt, watch_for_contract_creation},
+    watch_for_event::watch_for_event,
+    web3_connector::Web3Connector,
+};
 use crate::{
-    btsieve::{
-        fetch_blocks_since, BlockByHash, BlockHash, LatestBlock, Predates, PreviousBlockHash,
-    },
-    ethereum::{Address, Block, Hash, Input, Log, Transaction, TransactionReceipt, U256},
+    btsieve::{BlockHash, Predates, PreviousBlockHash},
+    ethereum::{Address, Block, Hash, TransactionReceipt, U256},
 };
 use anyhow::Result;
 use async_trait::async_trait;
-use genawaiter::GeneratorState;
 use time::OffsetDateTime;
 
 #[async_trait]
@@ -31,202 +35,6 @@ impl PreviousBlockHash for Block {
 
     fn previous_block_hash(&self) -> Hash {
         self.parent_hash
-    }
-}
-
-// This tracing context is useful because it conveys information through its
-// name although we skip all fields because they would add too much noise.
-#[tracing::instrument(level = "debug", skip(connector, start_of_swap, expected_bytecode))]
-pub async fn watch_for_contract_creation<C>(
-    connector: &C,
-    start_of_swap: OffsetDateTime,
-    expected_bytecode: &[u8],
-) -> Result<(Transaction, Address)>
-where
-    C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
-{
-    let (transaction, receipt) =
-        matching_transaction_and_receipt(connector, start_of_swap, |transaction| {
-            // transaction.to address is None if, and only if, the transaction
-            // creates a contract.
-
-            let is_contract_creation = transaction.to.is_none();
-            let is_expected_contract = transaction.input.as_slice() == expected_bytecode;
-
-            if !is_contract_creation {
-                tracing::trace!("rejected because transaction doesn't create a contract");
-            }
-
-            if !is_expected_contract {
-                tracing::trace!("rejected because contract code doesn't match");
-
-                // only compute levenshtein distance if we are on trace level, converting to hex is expensive at this scale
-                if tracing::level_enabled!(tracing::level_filters::LevelFilter::TRACE) {
-                    let actual = hex::encode(&transaction.input);
-                    let expected = hex::encode(expected_bytecode);
-
-                    let distance = levenshtein::levenshtein(&actual, &expected);
-
-                    // We probably need to find a meaningful value here, expiry is 4 bytes.
-                    if distance < 10 {
-                        tracing::warn!("found contract with slightly different parameters (levenshtein-distance < 10), this could be a bug!")
-                    }
-                }
-            }
-
-            is_contract_creation && is_expected_contract
-        })
-        .await?;
-
-    match receipt.contract_address {
-        Some(location) => Ok((transaction, location)),
-        None => Err(anyhow::anyhow!("contract address missing from receipt")),
-    }
-}
-
-// This tracing context is useful because it conveys information through its
-// name although we skip all fields because they would add too much noise.
-#[tracing::instrument(level = "debug", skip(connector, start_of_swap, expected_event))]
-pub async fn watch_for_event<C>(
-    connector: &C,
-    start_of_swap: OffsetDateTime,
-    expected_event: Event,
-) -> Result<(Transaction, Log)>
-where
-    C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
-{
-    matching_transaction_and_log(
-        connector,
-        start_of_swap,
-        expected_event.topics.clone(),
-        |receipt| find_log_for_event_in_receipt(&expected_event, receipt),
-    )
-    .await
-}
-
-fn find_log_for_event_in_receipt(event: &Event, receipt: TransactionReceipt) -> Option<Log> {
-    match event {
-        Event { topics, .. } if topics.is_empty() => None,
-        Event { address, topics } => receipt.logs.into_iter().find(|log| {
-            if address != &log.address {
-                return false;
-            }
-
-            if log.topics.len() != topics.len() {
-                return false;
-            }
-
-            log.topics.iter().enumerate().all(|(index, tx_topic)| {
-                let topic = &topics[index];
-                topic.as_ref().map_or(true, |topic| tx_topic == &topic.0)
-            })
-        }),
-    }
-}
-
-pub async fn matching_transaction_and_receipt<C, F>(
-    connector: &C,
-    start_of_swap: OffsetDateTime,
-    matcher: F,
-) -> Result<(Transaction, TransactionReceipt)>
-where
-    C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
-    F: Fn(&Transaction) -> bool,
-{
-    let mut block_generator = fetch_blocks_since(connector, start_of_swap);
-
-    loop {
-        match block_generator.async_resume().await {
-            GeneratorState::Yielded(block) => {
-                let block_span = tracing::error_span!("block", hash = %block.hash, tx_count = %block.transactions.len());
-                let _enter_block_span = block_span.enter();
-
-                for transaction in block.transactions.into_iter() {
-                    let tx_hash = transaction.hash;
-                    let tx_span = tracing::error_span!("tx", hash = %tx_hash);
-                    let _enter_tx_span = tx_span.enter();
-
-                    if matcher(&transaction) {
-                        let receipt = connector.receipt_by_hash(tx_hash).await?;
-                        if !receipt.successful {
-                            // This can be caused by a failed attempt to complete an action,
-                            // for example, sending a transaction with low gas.
-                            tracing::warn!("transaction matched but status was NOT OK");
-                            continue;
-                        }
-                        tracing::info!("transaction matched");
-                        return Ok((transaction, receipt));
-                    }
-                }
-
-                tracing::info!("no transaction matched")
-            }
-            GeneratorState::Complete(Err(e)) => return Err(e),
-            // By matching against the never type explicitly, we assert that the `Ok` value of the
-            // result is actually the never type and has not been changed since this line was
-            // written. The never type can never be constructed, so we can never reach this line.
-            GeneratorState::Complete(Ok(never)) => match never {},
-        }
-    }
-}
-
-async fn matching_transaction_and_log<C, F>(
-    connector: &C,
-    start_of_swap: OffsetDateTime,
-    topics: Vec<Option<Topic>>,
-    matcher: F,
-) -> Result<(Transaction, Log)>
-where
-    C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
-    F: Fn(TransactionReceipt) -> Option<Log>,
-{
-    let mut block_generator = fetch_blocks_since(connector, start_of_swap);
-
-    loop {
-        match block_generator.async_resume().await {
-            GeneratorState::Yielded(block) => {
-                let block_span = tracing::error_span!("block", hash = %block.hash, tx_count = %block.transactions.len());
-                let _enter_block_span = block_span.enter();
-
-                let maybe_contains_transaction = topics.iter().all(|topic| {
-                    topic.as_ref().map_or(true, |topic| {
-                        block
-                            .logs_bloom
-                            .contains_input(Input::Raw(&topic.0.as_bytes()))
-                    })
-                });
-                if !maybe_contains_transaction {
-                    tracing::trace!("skipping block due to bloom filter");
-                    continue;
-                }
-
-                for transaction in block.transactions.into_iter() {
-                    let tx_hash = transaction.hash;
-                    let tx_span = tracing::error_span!("tx", hash = %tx_hash);
-                    let _enter_tx_span = tx_span.enter();
-
-                    let receipt = connector.receipt_by_hash(tx_hash).await?;
-                    let is_successful = receipt.successful;
-                    if let Some(log) = matcher(receipt) {
-                        if !is_successful {
-                            // This can be caused by a failed attempt to complete an action,
-                            // for example, sending a transaction with low gas.
-                            tracing::warn!("transaction matched but status was NOT OK");
-                            continue;
-                        }
-                        tracing::info!("transaction matched");
-                        return Ok((transaction, log));
-                    }
-                }
-
-                tracing::info!("no transaction matched")
-            }
-            GeneratorState::Complete(Err(e)) => return Err(e),
-            // By matching against the never type explicitly, we assert that the `Ok` value of the
-            // result is actually the never type and has not been changed since this line was
-            // written. The never type can never be constructed, so we can never reach this line.
-            GeneratorState::Complete(Ok(never)) => match never {},
-        }
     }
 }
 

--- a/comit/src/btsieve/ethereum.rs
+++ b/comit/src/btsieve/ethereum.rs
@@ -104,15 +104,6 @@ where
     .await
 }
 
-/// Fetch receipt from connector using transaction hash.
-async fn fetch_receipt<C>(blockchain_connector: &C, hash: Hash) -> Result<TransactionReceipt>
-where
-    C: ReceiptByHash,
-{
-    let receipt = blockchain_connector.receipt_by_hash(hash).await?;
-    Ok(receipt)
-}
-
 fn find_log_for_event_in_receipt(event: &Event, receipt: TransactionReceipt) -> Option<Log> {
     match event {
         Event { topics, .. } if topics.is_empty() => None,
@@ -156,7 +147,7 @@ where
                     let _enter_tx_span = tx_span.enter();
 
                     if matcher(&transaction) {
-                        let receipt = fetch_receipt(connector, tx_hash).await?;
+                        let receipt = connector.receipt_by_hash(tx_hash).await?;
                         if !receipt.successful {
                             // This can be caused by a failed attempt to complete an action,
                             // for example, sending a transaction with low gas.
@@ -214,7 +205,7 @@ where
                     let tx_span = tracing::error_span!("tx", hash = %tx_hash);
                     let _enter_tx_span = tx_span.enter();
 
-                    let receipt = fetch_receipt(connector, tx_hash).await?;
+                    let receipt = connector.receipt_by_hash(tx_hash).await?;
                     let is_successful = receipt.successful;
                     if let Some(log) = matcher(receipt) {
                         if !is_successful {

--- a/comit/src/btsieve/ethereum.rs
+++ b/comit/src/btsieve/ethereum.rs
@@ -8,13 +8,14 @@ use crate::{
     },
     ethereum::{Address, Block, Hash, Input, Log, Transaction, TransactionReceipt, U256},
 };
+use anyhow::Result;
 use async_trait::async_trait;
 use genawaiter::GeneratorState;
 use time::OffsetDateTime;
 
 #[async_trait]
 pub trait ReceiptByHash: Send + Sync + 'static {
-    async fn receipt_by_hash(&self, transaction_hash: Hash) -> anyhow::Result<TransactionReceipt>;
+    async fn receipt_by_hash(&self, transaction_hash: Hash) -> Result<TransactionReceipt>;
 }
 
 impl BlockHash for Block {
@@ -40,7 +41,7 @@ pub async fn watch_for_contract_creation<C>(
     connector: &C,
     start_of_swap: OffsetDateTime,
     expected_bytecode: &[u8],
-) -> anyhow::Result<(Transaction, Address)>
+) -> Result<(Transaction, Address)>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
 {
@@ -90,7 +91,7 @@ pub async fn watch_for_event<C>(
     connector: &C,
     start_of_swap: OffsetDateTime,
     expected_event: Event,
-) -> anyhow::Result<(Transaction, Log)>
+) -> Result<(Transaction, Log)>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
 {
@@ -104,10 +105,7 @@ where
 }
 
 /// Fetch receipt from connector using transaction hash.
-async fn fetch_receipt<C>(
-    blockchain_connector: &C,
-    hash: Hash,
-) -> anyhow::Result<TransactionReceipt>
+async fn fetch_receipt<C>(blockchain_connector: &C, hash: Hash) -> Result<TransactionReceipt>
 where
     C: ReceiptByHash,
 {
@@ -139,7 +137,7 @@ pub async fn matching_transaction_and_receipt<C, F>(
     connector: &C,
     start_of_swap: OffsetDateTime,
     matcher: F,
-) -> anyhow::Result<(Transaction, TransactionReceipt)>
+) -> Result<(Transaction, TransactionReceipt)>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
     F: Fn(&Transaction) -> bool,
@@ -190,7 +188,7 @@ async fn matching_transaction_and_log<C, F>(
     start_of_swap: OffsetDateTime,
     topics: Vec<Option<Topic>>,
     matcher: F,
-) -> anyhow::Result<(Transaction, Log)>
+) -> Result<(Transaction, Log)>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
     F: Fn(TransactionReceipt) -> Option<Log>,

--- a/comit/src/btsieve/ethereum/cache.rs
+++ b/comit/src/btsieve/ethereum/cache.rs
@@ -5,6 +5,7 @@ use crate::{
     },
     ethereum::TransactionReceipt,
 };
+use anyhow::Result;
 use async_trait::async_trait;
 use derivative::Derivative;
 use lru::LruCache;
@@ -49,7 +50,7 @@ where
 {
     type Block = Block;
 
-    async fn latest_block(&self) -> anyhow::Result<Self::Block> {
+    async fn latest_block(&self) -> Result<Self::Block> {
         let block = self.connector.latest_block().await?;
 
         let mut guard = self.block_cache.lock().await;
@@ -69,7 +70,7 @@ where
     type Block = Block;
     type BlockHash = Hash;
 
-    async fn block_by_hash(&self, block_hash: Self::BlockHash) -> anyhow::Result<Self::Block> {
+    async fn block_by_hash(&self, block_hash: Self::BlockHash) -> Result<Self::Block> {
         if let Some(block) = self.block_cache.lock().await.get(&block_hash) {
             tracing::trace!("Found block in cache: {}", block_hash);
             return Ok(block.clone());
@@ -92,7 +93,7 @@ impl<C> ReceiptByHash for Cache<C>
 where
     C: ReceiptByHash,
 {
-    async fn receipt_by_hash(&self, transaction_hash: Hash) -> anyhow::Result<TransactionReceipt> {
+    async fn receipt_by_hash(&self, transaction_hash: Hash) -> Result<TransactionReceipt> {
         if let Some(receipt) = self.receipt_cache.lock().await.get(&transaction_hash) {
             tracing::trace!("Found receipt in cache: {}", transaction_hash);
             return Ok(receipt.clone());

--- a/comit/src/btsieve/ethereum/cache.rs
+++ b/comit/src/btsieve/ethereum/cache.rs
@@ -72,12 +72,10 @@ where
 
     async fn block_by_hash(&self, block_hash: Self::BlockHash) -> Result<Self::Block> {
         if let Some(block) = self.block_cache.lock().await.get(&block_hash) {
-            tracing::trace!("Found block in cache: {}", block_hash);
             return Ok(block.clone());
         }
 
         let block = self.connector.block_by_hash(block_hash).await?;
-        tracing::trace!("Fetched block from connector: {}", block_hash);
 
         // We dropped the lock so at this stage the block may have been inserted by
         // another thread, no worries, inserting the same block twice does not hurt.
@@ -95,13 +93,10 @@ where
 {
     async fn receipt_by_hash(&self, transaction_hash: Hash) -> Result<TransactionReceipt> {
         if let Some(receipt) = self.receipt_cache.lock().await.get(&transaction_hash) {
-            tracing::trace!("Found receipt in cache: {}", transaction_hash);
             return Ok(receipt.clone());
         }
 
         let receipt = self.connector.receipt_by_hash(transaction_hash).await?;
-
-        tracing::trace!("Fetched receipt from connector: {}", transaction_hash);
 
         // We dropped the lock so at this stage the receipt may have been inserted by
         // another thread, no worries, inserting the same receipt twice does not hurt.

--- a/comit/src/btsieve/ethereum/watch_for_contract_creation.rs
+++ b/comit/src/btsieve/ethereum/watch_for_contract_creation.rs
@@ -91,7 +91,7 @@ where
                     }
                 }
 
-                tracing::info!("no transaction matched")
+                tracing::debug!("no transaction matched")
             }
             GeneratorState::Complete(Err(e)) => return Err(e),
             // By matching against the never type explicitly, we assert that the `Ok` value of the

--- a/comit/src/btsieve/ethereum/watch_for_contract_creation.rs
+++ b/comit/src/btsieve/ethereum/watch_for_contract_creation.rs
@@ -7,9 +7,6 @@ use genawaiter::GeneratorState;
 use time::OffsetDateTime;
 use tracing_futures::Instrument;
 
-// This tracing context is useful because it conveys information through its
-// name although we skip all fields because they would add too much noise.
-#[tracing::instrument(level = "debug", skip(connector, start_of_swap, expected_bytecode))]
 pub async fn watch_for_contract_creation<C>(
     connector: &C,
     start_of_swap: OffsetDateTime,

--- a/comit/src/btsieve/ethereum/watch_for_contract_creation.rs
+++ b/comit/src/btsieve/ethereum/watch_for_contract_creation.rs
@@ -1,0 +1,103 @@
+use crate::{
+    btsieve::{ethereum::ReceiptByHash, fetch_blocks_since, BlockByHash, LatestBlock},
+    ethereum::{Address, Block, Hash, Transaction, TransactionReceipt},
+};
+use anyhow::Result;
+use genawaiter::GeneratorState;
+use time::OffsetDateTime;
+
+// This tracing context is useful because it conveys information through its
+// name although we skip all fields because they would add too much noise.
+#[tracing::instrument(level = "debug", skip(connector, start_of_swap, expected_bytecode))]
+pub async fn watch_for_contract_creation<C>(
+    connector: &C,
+    start_of_swap: OffsetDateTime,
+    expected_bytecode: &[u8],
+) -> Result<(Transaction, Address)>
+where
+    C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
+{
+    let (transaction, receipt) =
+        matching_transaction_and_receipt(connector, start_of_swap, |transaction| {
+            // transaction.to address is None if, and only if, the transaction
+            // creates a contract.
+
+            let is_contract_creation = transaction.to.is_none();
+            let is_expected_contract = transaction.input.as_slice() == expected_bytecode;
+
+            if !is_contract_creation {
+                tracing::trace!("rejected because transaction doesn't create a contract");
+            }
+
+            if !is_expected_contract {
+                tracing::trace!("rejected because contract code doesn't match");
+
+                // only compute levenshtein distance if we are on trace level, converting to hex is expensive at this scale
+                if tracing::level_enabled!(tracing::level_filters::LevelFilter::TRACE) {
+                    let actual = hex::encode(&transaction.input);
+                    let expected = hex::encode(expected_bytecode);
+
+                    let distance = levenshtein::levenshtein(&actual, &expected);
+
+                    // We probably need to find a meaningful value here, expiry is 4 bytes.
+                    if distance < 10 {
+                        tracing::warn!("found contract with slightly different parameters (levenshtein-distance < 10), this could be a bug!")
+                    }
+                }
+            }
+
+            is_contract_creation && is_expected_contract
+        })
+            .await?;
+
+    match receipt.contract_address {
+        Some(location) => Ok((transaction, location)),
+        None => Err(anyhow::anyhow!("contract address missing from receipt")),
+    }
+}
+
+pub async fn matching_transaction_and_receipt<C, F>(
+    connector: &C,
+    start_of_swap: OffsetDateTime,
+    matcher: F,
+) -> Result<(Transaction, TransactionReceipt)>
+where
+    C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
+    F: Fn(&Transaction) -> bool,
+{
+    let mut block_generator = fetch_blocks_since(connector, start_of_swap);
+
+    loop {
+        match block_generator.async_resume().await {
+            GeneratorState::Yielded(block) => {
+                let block_span = tracing::error_span!("block", hash = %block.hash, tx_count = %block.transactions.len());
+                let _enter_block_span = block_span.enter();
+
+                for transaction in block.transactions.into_iter() {
+                    let tx_hash = transaction.hash;
+                    let tx_span = tracing::error_span!("tx", hash = %tx_hash);
+                    let _enter_tx_span = tx_span.enter();
+
+                    if matcher(&transaction) {
+                        let receipt = connector.receipt_by_hash(tx_hash).await?;
+                        if !receipt.successful {
+                            // This can be caused by a failed attempt to complete an action,
+                            // for example, sending a transaction with low gas.
+                            tracing::warn!("transaction matched but status was NOT OK");
+                            continue;
+                        }
+                        tracing::info!("transaction matched");
+                        return Ok((transaction, receipt));
+                    }
+                }
+
+                tracing::info!("no transaction matched")
+            }
+            GeneratorState::Complete(Err(e)) => return Err(e),
+            // By matching against the never type explicitly, we assert that the `Ok` value of the
+            // result is actually the never type and has not been changed since this line was
+            // written. The never type can never be constructed, so we can never reach this line.
+            GeneratorState::Complete(Ok(never)) => match never {},
+        }
+    }
+}

--- a/comit/src/btsieve/ethereum/watch_for_event.rs
+++ b/comit/src/btsieve/ethereum/watch_for_event.rs
@@ -8,6 +8,7 @@ use crate::{
 use anyhow::Result;
 use genawaiter::GeneratorState;
 use time::OffsetDateTime;
+use tracing_futures::Instrument;
 
 // This tracing context is useful because it conveys information through its
 // name although we skip all fields because they would add too much noise.
@@ -57,48 +58,18 @@ async fn matching_transaction_and_log<C, F>(
 ) -> Result<(Transaction, Log)>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
-    F: Fn(TransactionReceipt) -> Option<Log>,
+    F: Fn(TransactionReceipt) -> Option<Log> + Clone,
 {
     let mut block_generator = fetch_blocks_since(connector, start_of_swap);
 
     loop {
         match block_generator.async_resume().await {
             GeneratorState::Yielded(block) => {
-                let block_span = tracing::error_span!("block", hash = %block.hash, tx_count = %block.transactions.len());
-                let _enter_block_span = block_span.enter();
-
-                let maybe_contains_transaction = topics.iter().all(|topic| {
-                    topic.as_ref().map_or(true, |topic| {
-                        block
-                            .logs_bloom
-                            .contains_input(Input::Raw(&topic.0.as_bytes()))
-                    })
-                });
-                if !maybe_contains_transaction {
-                    tracing::trace!("skipping block due to bloom filter");
-                    continue;
+                if let Some(result) =
+                    process_block(block, connector, topics.clone(), matcher.clone()).await?
+                {
+                    return Ok(result);
                 }
-
-                for transaction in block.transactions.into_iter() {
-                    let receipt = connector.receipt_by_hash(transaction.hash).await?;
-                    let is_successful = receipt.successful;
-
-                    let tx_span = tracing::error_span!("tx", hash = %transaction.hash);
-                    let _enter_tx_span = tx_span.enter();
-
-                    if let Some(log) = matcher(receipt) {
-                        if !is_successful {
-                            // This can be caused by a failed attempt to complete an action,
-                            // for example, sending a transaction with low gas.
-                            tracing::warn!("transaction matched but status was NOT OK");
-                            continue;
-                        }
-                        tracing::info!("transaction matched");
-                        return Ok((transaction, log));
-                    }
-                }
-
-                tracing::debug!("no transaction matched")
             }
             GeneratorState::Complete(Err(e)) => return Err(e),
             // By matching against the never type explicitly, we assert that the `Ok` value of the
@@ -107,4 +78,70 @@ where
             GeneratorState::Complete(Ok(never)) => match never {},
         }
     }
+}
+
+#[tracing::instrument(name = "block", skip(block, connector, matcher, topics), fields(hash = %block.hash, tx_count = %block.transactions.len()))]
+async fn process_block<C, F>(
+    block: Block,
+    connector: &C,
+    topics: Vec<Option<Topic>>,
+    matcher: F,
+) -> Result<Option<(Transaction, Log)>>
+where
+    C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
+    F: Fn(TransactionReceipt) -> Option<Log> + Clone,
+{
+    let maybe_contains_transaction = topics.iter().all(|topic| {
+        topic.as_ref().map_or(true, |topic| {
+            block
+                .logs_bloom
+                .contains_input(Input::Raw(&topic.0.as_bytes()))
+        })
+    });
+
+    if !maybe_contains_transaction {
+        tracing::trace!("skipping block due to bloom filter");
+        return Ok(None);
+    }
+
+    for transaction in block.transactions.into_iter() {
+        if let Some(result) = process_transaction(transaction, connector, matcher.clone())
+            .in_current_span()
+            .await?
+        {
+            return Ok(Some(result));
+        }
+    }
+
+    tracing::debug!("no transaction matched");
+
+    Ok(None)
+}
+
+#[tracing::instrument(name = "tx", skip(tx, connector, matcher), fields(hash = %tx.hash))]
+async fn process_transaction<C, F>(
+    tx: Transaction,
+    connector: &C,
+    matcher: F,
+) -> Result<Option<(Transaction, Log)>>
+where
+    C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
+    F: Fn(TransactionReceipt) -> Option<Log>,
+{
+    let receipt = connector.receipt_by_hash(tx.hash).await?;
+    let is_successful = receipt.successful;
+
+    if let Some(log) = matcher(receipt) {
+        if !is_successful {
+            // This can be caused by a failed attempt to complete an action,
+            // for example, sending a transaction with low gas.
+            tracing::warn!("transaction matched but status was NOT OK");
+            return Ok(None);
+        }
+        tracing::info!("transaction matched");
+
+        return Ok(Some((tx, log)));
+    }
+
+    Ok(None)
 }

--- a/comit/src/btsieve/ethereum/watch_for_event.rs
+++ b/comit/src/btsieve/ethereum/watch_for_event.rs
@@ -98,7 +98,7 @@ where
                     }
                 }
 
-                tracing::info!("no transaction matched")
+                tracing::debug!("no transaction matched")
             }
             GeneratorState::Complete(Err(e)) => return Err(e),
             // By matching against the never type explicitly, we assert that the `Ok` value of the

--- a/comit/src/btsieve/ethereum/watch_for_event.rs
+++ b/comit/src/btsieve/ethereum/watch_for_event.rs
@@ -1,0 +1,110 @@
+use crate::{
+    btsieve::{
+        ethereum::{Event, ReceiptByHash, Topic},
+        fetch_blocks_since, BlockByHash, LatestBlock,
+    },
+    ethereum::{Block, Hash, Input, Log, Transaction, TransactionReceipt},
+};
+use anyhow::Result;
+use genawaiter::GeneratorState;
+use time::OffsetDateTime;
+
+// This tracing context is useful because it conveys information through its
+// name although we skip all fields because they would add too much noise.
+#[tracing::instrument(level = "debug", skip(connector, start_of_swap, expected_event))]
+pub async fn watch_for_event<C>(
+    connector: &C,
+    start_of_swap: OffsetDateTime,
+    expected_event: Event,
+) -> Result<(Transaction, Log)>
+where
+    C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
+{
+    matching_transaction_and_log(
+        connector,
+        start_of_swap,
+        expected_event.topics.clone(),
+        |receipt| find_log_for_event_in_receipt(&expected_event, receipt),
+    )
+    .await
+}
+
+fn find_log_for_event_in_receipt(event: &Event, receipt: TransactionReceipt) -> Option<Log> {
+    match event {
+        Event { topics, .. } if topics.is_empty() => None,
+        Event { address, topics } => receipt.logs.into_iter().find(|log| {
+            if address != &log.address {
+                return false;
+            }
+
+            if log.topics.len() != topics.len() {
+                return false;
+            }
+
+            log.topics.iter().enumerate().all(|(index, tx_topic)| {
+                let topic = &topics[index];
+                topic.as_ref().map_or(true, |topic| tx_topic == &topic.0)
+            })
+        }),
+    }
+}
+
+async fn matching_transaction_and_log<C, F>(
+    connector: &C,
+    start_of_swap: OffsetDateTime,
+    topics: Vec<Option<Topic>>,
+    matcher: F,
+) -> Result<(Transaction, Log)>
+where
+    C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
+    F: Fn(TransactionReceipt) -> Option<Log>,
+{
+    let mut block_generator = fetch_blocks_since(connector, start_of_swap);
+
+    loop {
+        match block_generator.async_resume().await {
+            GeneratorState::Yielded(block) => {
+                let block_span = tracing::error_span!("block", hash = %block.hash, tx_count = %block.transactions.len());
+                let _enter_block_span = block_span.enter();
+
+                let maybe_contains_transaction = topics.iter().all(|topic| {
+                    topic.as_ref().map_or(true, |topic| {
+                        block
+                            .logs_bloom
+                            .contains_input(Input::Raw(&topic.0.as_bytes()))
+                    })
+                });
+                if !maybe_contains_transaction {
+                    tracing::trace!("skipping block due to bloom filter");
+                    continue;
+                }
+
+                for transaction in block.transactions.into_iter() {
+                    let receipt = connector.receipt_by_hash(transaction.hash).await?;
+                    let is_successful = receipt.successful;
+
+                    let tx_span = tracing::error_span!("tx", hash = %transaction.hash);
+                    let _enter_tx_span = tx_span.enter();
+
+                    if let Some(log) = matcher(receipt) {
+                        if !is_successful {
+                            // This can be caused by a failed attempt to complete an action,
+                            // for example, sending a transaction with low gas.
+                            tracing::warn!("transaction matched but status was NOT OK");
+                            continue;
+                        }
+                        tracing::info!("transaction matched");
+                        return Ok((transaction, log));
+                    }
+                }
+
+                tracing::info!("no transaction matched")
+            }
+            GeneratorState::Complete(Err(e)) => return Err(e),
+            // By matching against the never type explicitly, we assert that the `Ok` value of the
+            // result is actually the never type and has not been changed since this line was
+            // written. The never type can never be constructed, so we can never reach this line.
+            GeneratorState::Complete(Ok(never)) => match never {},
+        }
+    }
+}

--- a/comit/src/btsieve/ethereum/watch_for_event.rs
+++ b/comit/src/btsieve/ethereum/watch_for_event.rs
@@ -10,9 +10,6 @@ use genawaiter::GeneratorState;
 use time::OffsetDateTime;
 use tracing_futures::Instrument;
 
-// This tracing context is useful because it conveys information through its
-// name although we skip all fields because they would add too much noise.
-#[tracing::instrument(level = "debug", skip(connector, start_of_swap, expected_event))]
 pub async fn watch_for_event<C>(
     connector: &C,
     start_of_swap: OffsetDateTime,

--- a/comit/src/btsieve/ethereum/web3_connector.rs
+++ b/comit/src/btsieve/ethereum/web3_connector.rs
@@ -23,8 +23,6 @@ impl Web3Connector {
             .send::<Vec<()>, String>(jsonrpc::Request::new("net_version", vec![]))
             .await?;
 
-        tracing::trace!("Fetched net_version from web3: {:?}", version);
-
         Ok(ChainId::from(version.parse::<u32>()?))
     }
 }
@@ -41,8 +39,6 @@ impl LatestBlock for Web3Connector {
                 jsonrpc::serialize(true)?,
             ]))
             .await?;
-
-        tracing::trace!("Fetched block from web3: {}", block.hash);
 
         Ok(block)
     }
@@ -62,8 +58,6 @@ impl BlockByHash for Web3Connector {
             ]))
             .await?;
 
-        tracing::trace!("Fetched block from web3: {}", block_hash);
-
         Ok(block)
     }
 }
@@ -77,8 +71,6 @@ impl ReceiptByHash for Web3Connector {
                 jsonrpc::serialize(transaction_hash)?,
             ]))
             .await?;
-
-        tracing::trace!("Fetched receipt from web3: {}", transaction_hash);
 
         Ok(receipt)
     }

--- a/comit/src/btsieve/ethereum/web3_connector.rs
+++ b/comit/src/btsieve/ethereum/web3_connector.rs
@@ -2,6 +2,7 @@ use crate::{
     btsieve::{ethereum::ReceiptByHash, jsonrpc, BlockByHash, LatestBlock},
     ethereum::{ChainId, Hash, TransactionReceipt},
 };
+use anyhow::Result;
 use async_trait::async_trait;
 
 #[derive(Debug)]
@@ -16,7 +17,7 @@ impl Web3Connector {
         }
     }
 
-    pub async fn net_version(&self) -> anyhow::Result<ChainId> {
+    pub async fn net_version(&self) -> Result<ChainId> {
         let version = self
             .client
             .send::<Vec<()>, String>(jsonrpc::Request::new("net_version", vec![]))
@@ -32,7 +33,7 @@ impl Web3Connector {
 impl LatestBlock for Web3Connector {
     type Block = crate::ethereum::Block;
 
-    async fn latest_block(&self) -> anyhow::Result<Self::Block> {
+    async fn latest_block(&self) -> Result<Self::Block> {
         let block: Self::Block = self
             .client
             .send(jsonrpc::Request::new("eth_getBlockByNumber", vec![
@@ -52,7 +53,7 @@ impl BlockByHash for Web3Connector {
     type Block = crate::ethereum::Block;
     type BlockHash = crate::ethereum::Hash;
 
-    async fn block_by_hash(&self, block_hash: Self::BlockHash) -> anyhow::Result<Self::Block> {
+    async fn block_by_hash(&self, block_hash: Self::BlockHash) -> Result<Self::Block> {
         let block = self
             .client
             .send(jsonrpc::Request::new("eth_getBlockByHash", vec![
@@ -69,7 +70,7 @@ impl BlockByHash for Web3Connector {
 
 #[async_trait]
 impl ReceiptByHash for Web3Connector {
-    async fn receipt_by_hash(&self, transaction_hash: Hash) -> anyhow::Result<TransactionReceipt> {
+    async fn receipt_by_hash(&self, transaction_hash: Hash) -> Result<TransactionReceipt> {
         let receipt = self
             .client
             .send(jsonrpc::Request::new("eth_getTransactionReceipt", vec![

--- a/comit/src/btsieve/jsonrpc.rs
+++ b/comit/src/btsieve/jsonrpc.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use anyhow::{Context, Result};
 use futures::TryFutureExt;
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
@@ -17,7 +17,7 @@ impl Client {
         }
     }
 
-    pub async fn send<Req, Res>(&self, request: Request<Req>) -> anyhow::Result<Res>
+    pub async fn send<Req, Res>(&self, request: Request<Req>) -> Result<Res>
     where
         Req: Debug + Serialize,
         Res: DeserializeOwned,
@@ -80,7 +80,7 @@ pub struct JsonRpcError {
 #[error("connection error: {0}")]
 pub struct ConnectionFailed(#[from] reqwest::Error);
 
-pub fn serialize<T>(t: T) -> anyhow::Result<serde_json::Value>
+pub fn serialize<T>(t: T) -> Result<serde_json::Value>
 where
     T: Serialize,
 {

--- a/comit/src/ethereum.rs
+++ b/comit/src/ethereum.rs
@@ -1,4 +1,5 @@
 use crate::{btsieve::LatestBlock, Timestamp};
+use anyhow::Result;
 pub use ethbloom::{Bloom as H2048, Input};
 use hex::FromHexError;
 pub use primitive_types::U256;
@@ -9,7 +10,7 @@ use std::{
     str::FromStr,
 };
 
-pub async fn latest_time<C>(connector: &C) -> anyhow::Result<Timestamp>
+pub async fn latest_time<C>(connector: &C) -> Result<Timestamp>
 where
     C: LatestBlock<Block = Block>,
 {

--- a/comit/src/halbit.rs
+++ b/comit/src/halbit.rs
@@ -1,4 +1,5 @@
 use crate::{asset, identity, RelativeTime, Secret, SecretHash};
+use anyhow::Result;
 use bitcoin::hashes::core::fmt::Formatter;
 use futures::{future, future::Either, Stream, TryFutureExt};
 use genawaiter::sync::Gen;
@@ -7,10 +8,7 @@ use std::fmt;
 /// Creates a new instance of the halbit protocol.
 ///
 /// Returns a stream of events happening during the execution.
-pub fn new<'a, C>(
-    connector: &'a C,
-    params: Params,
-) -> impl Stream<Item = anyhow::Result<Event>> + 'a
+pub fn new<'a, C>(connector: &'a C, params: Params) -> impl Stream<Item = Result<Event>> + 'a
 where
     C: WaitForOpened + WaitForAccepted + WaitForSettled + WaitForCancelled,
 {
@@ -62,22 +60,22 @@ pub struct Params {
 /// Resolves when said event has occured.
 #[async_trait::async_trait]
 pub trait WaitForOpened {
-    async fn wait_for_opened(&self, params: &Params) -> anyhow::Result<Opened>;
+    async fn wait_for_opened(&self, params: &Params) -> Result<Opened>;
 }
 
 #[async_trait::async_trait]
 pub trait WaitForAccepted {
-    async fn wait_for_accepted(&self, params: &Params) -> anyhow::Result<Accepted>;
+    async fn wait_for_accepted(&self, params: &Params) -> Result<Accepted>;
 }
 
 #[async_trait::async_trait]
 pub trait WaitForSettled {
-    async fn wait_for_settled(&self, params: &Params) -> anyhow::Result<Settled>;
+    async fn wait_for_settled(&self, params: &Params) -> Result<Settled>;
 }
 
 #[async_trait::async_trait]
 pub trait WaitForCancelled {
-    async fn wait_for_cancelled(&self, params: &Params) -> anyhow::Result<Cancelled>;
+    async fn wait_for_cancelled(&self, params: &Params) -> Result<Cancelled>;
 }
 
 /// Represents the events in the halbit protocol.

--- a/comit/src/hbit.rs
+++ b/comit/src/hbit.rs
@@ -11,6 +11,7 @@ use crate::{
     timestamp::Timestamp,
     transaction, Secret, SecretHash,
 };
+use anyhow::Result;
 use bitcoin::{
     hashes::{hash160, Hash},
     secp256k1::{Secp256k1, SecretKey, Signing},
@@ -85,7 +86,7 @@ pub fn new<'a, C>(
     connector: &'a C,
     params: Params,
     start_of_swap: OffsetDateTime,
-) -> impl Stream<Item = anyhow::Result<Event>> + 'a
+) -> impl Stream<Item = Result<Event>> + 'a
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = BlockHash>,
 {
@@ -102,8 +103,8 @@ async fn watch_ledger<C, R>(
     connector: &C,
     params: Params,
     start_of_swap: OffsetDateTime,
-    co: &Co<anyhow::Result<Event>, R>,
-) -> anyhow::Result<()>
+    co: &Co<Result<Event>, R>,
+) -> Result<()>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = BlockHash>,
 {
@@ -143,7 +144,7 @@ pub async fn watch_for_funded<C>(
     connector: &C,
     params: &Params,
     start_of_swap: OffsetDateTime,
-) -> anyhow::Result<Funded>
+) -> Result<Funded>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = BlockHash>,
 {
@@ -177,7 +178,7 @@ pub async fn watch_for_redeemed<C>(
     params: &Params,
     location: htlc_location::Bitcoin,
     start_of_swap: OffsetDateTime,
-) -> anyhow::Result<Redeemed>
+) -> Result<Redeemed>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = BlockHash>,
 {
@@ -200,7 +201,7 @@ pub async fn watch_for_refunded<C>(
     params: &Params,
     location: htlc_location::Bitcoin,
     start_of_swap: OffsetDateTime,
-) -> anyhow::Result<Refunded>
+) -> Result<Refunded>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = BlockHash>,
 {
@@ -243,7 +244,7 @@ impl Params {
         transient_refund_sk: SecretKey,
         refund_address: Address,
         vbyte_rate: asset::Bitcoin,
-    ) -> anyhow::Result<BroadcastSignedTransaction>
+    ) -> Result<BroadcastSignedTransaction>
     where
         C: Signing,
     {
@@ -268,7 +269,7 @@ impl Params {
         redeem_address: Address,
         secret: Secret,
         vbyte_rate: asset::Bitcoin,
-    ) -> anyhow::Result<BroadcastSignedTransaction>
+    ) -> Result<BroadcastSignedTransaction>
     where
         C: Signing,
     {
@@ -290,7 +291,7 @@ impl Params {
         spend_address: Address,
         vbyte_rate: asset::Bitcoin,
         unlock_fn: impl Fn(Htlc) -> UnlockParameters,
-    ) -> anyhow::Result<BroadcastSignedTransaction>
+    ) -> Result<BroadcastSignedTransaction>
     where
         C: Signing,
     {

--- a/comit/src/herc20.rs
+++ b/comit/src/herc20.rs
@@ -12,6 +12,7 @@ use crate::{
     timestamp::Timestamp,
     transaction, Secret, SecretHash,
 };
+use anyhow::Result;
 use blockchain_contracts::ethereum::herc20::Htlc;
 use conquer_once::Lazy;
 use futures::{
@@ -97,7 +98,7 @@ pub fn new<'a, C>(
     connector: &'a C,
     params: Params,
     start_of_swap: OffsetDateTime,
-) -> impl Stream<Item = anyhow::Result<Event>> + 'a
+) -> impl Stream<Item = Result<Event>> + 'a
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
 {
@@ -114,8 +115,8 @@ async fn watch_ledger<C, R>(
     connector: &C,
     params: Params,
     start_of_swap: OffsetDateTime,
-    co: &Co<anyhow::Result<Event>, R>,
-) -> anyhow::Result<()>
+    co: &Co<Result<Event>, R>,
+) -> Result<()>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
 {
@@ -154,7 +155,7 @@ pub async fn watch_for_deployed<C>(
     connector: &C,
     params: Params,
     start_of_swap: OffsetDateTime,
-) -> anyhow::Result<Deployed>
+) -> Result<Deployed>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
 {
@@ -176,7 +177,7 @@ pub async fn watch_for_funded<C>(
     params: Params,
     start_of_swap: OffsetDateTime,
     deployed: Deployed,
-) -> anyhow::Result<Funded>
+) -> Result<Funded>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
 {
@@ -212,7 +213,7 @@ pub async fn watch_for_redeemed<C>(
     connector: &C,
     start_of_swap: OffsetDateTime,
     deployed: Deployed,
-) -> anyhow::Result<Redeemed>
+) -> Result<Redeemed>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
 {
@@ -240,7 +241,7 @@ pub async fn watch_for_refunded<C>(
     connector: &C,
     start_of_swap: OffsetDateTime,
     deployed: Deployed,
-) -> anyhow::Result<Refunded>
+) -> Result<Refunded>
 where
     C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
 {


### PR DESCRIPTION
This PR presents a series of patches that eventually aim to reduce the logging noise of btsieve.

The biggest problem here is/was that we emitted several events for a single block / tx. All of these events were annotated with big spans, which made it quite hard to see relevant information in the logs.

Additionally, there were some issues were tracing spans were no correctly preserved within async functions.

Finally, we also make a change to btsieve where we yielded the same block several times. This also caused duplicated log messages.

The result is now only a single line per block that still contains a lot of relevant information:

- the block hash: this is useful if we want to check whether btsieve has checked a block
- protocol information: this is useful once btsieve processes several swaps concurrently
- the number of transactions in the block: probably less useful for mainnet but interesting during testing
- the transaction hash: in case of a match, we include the transaction hash. this makes it very quick to answer the question "has btsieve seen my transaction" with a simple `CTRL+F` / `grep`

Here are some examples:

#### No transaction matched for the mentioned blockhash when looking for the the contract creation in the herc20 protocol:

`Sep 29 17:02:01.878 DEBUG {swap_id=63b13265-2ff0-4082-bd47-afae31967dc3 role=Alice side=Alpha protocol=herc20}:{action="deploy"}:block{hash=0xf751e364f3260775fb0f309310ab6c32a4fec7a6f3346598f93b47ed38fce9d0 tx_count=0}: comit::btsieve::ethereum::watch_for_contract_creation: no transaction matched`

#### No transaction matched for the mentioned blockhash when looking for the created output in the hbit protocol:

`Sep 29 17:02:01.880 DEBUG {swap_id=63b13265-2ff0-4082-bd47-afae31967dc3 role=Alice side=Beta protocol=hbit}:{action="fund"}:watch_for_created_outpoint{address=bcrt1qh8vg4p9pfhj9lr5wqmymdpl2ta6sdf74pqxcd8mllmaexz7vp9cqz40h9j}:block{hash=5d69e29ddaaf4e4a518f43436c5c762c428421ba9fbf1a0abeed35b5b013ec06 tx_count=1}: comit::btsieve::bitcoin: no transaction matched`

#### We found the transaction that deploys the contract

`Sep 29 17:02:05.959  INFO {swap_id=63b13265-2ff0-4082-bd47-afae31967dc3 role=Alice side=Alpha protocol=herc20}:{action="deploy"}:block{hash=0x4216e5d16ac8add35f81df7692c4b68ceef67f4c80f1224361622bd0dabe30e6 tx_count=1}:tx{hash=0x7f555c5ea80d15457525bd8471d207e464b24552f805e6050c51042889db353e}: comit::btsieve::ethereum::watch_for_contract_creation: transaction matched`

#### We ignore a block because of the bloom filter

`Sep 29 17:02:05.962 TRACE {swap_id=63b13265-2ff0-4082-bd47-afae31967dc3 role=Alice side=Alpha protocol=herc20}:{action="fund"}:block{hash=0x4216e5d16ac8add35f81df7692c4b68ceef67f4c80f1224361622bd0dabe30e6 tx_count=1}: comit::btsieve::ethereum::watch_for_event: skipping block due to bloom filter`


#### We find the transaction that emitted an event

`Sep 29 17:02:10.000  INFO {swap_id=63b13265-2ff0-4082-bd47-afae31967dc3 role=Alice side=Alpha protocol=herc20}:{action="fund"}:block{hash=0xfe338ccf191eb763e3fb3f42f106fcf100000d63110f0ebfc8e02d6af988237b tx_count=1}:tx{hash=0x637a6d1196a6ae40ee33df2aebf9c1319913fb85a580cfd35b376f274f583690}: comit::btsieve::ethereum::watch_for_event: transaction matched`