### PR TITLE
Nectar eth gas price

### DIFF
--- a/nectar/sample-config.toml
+++ b/nectar/sample-config.toml
@@ -31,6 +31,11 @@ bitcoin = 0.00009275
 strategy = "static"
 sats_per_byte = 12
 
+# Strategies used for Ethereum gas price handling.
+[maker.fee_strategies.ethereum]
+service = "geth"
+url = "http://some.geth.url:8545/"
+
 [network]
 # The libp2p socket on which nectar listens for COMIT messages.
 listen = ["/ip4/0.0.0.0/tcp/9939"]

--- a/nectar/src/bitcoin/fee.rs
+++ b/nectar/src/bitcoin/fee.rs
@@ -11,6 +11,8 @@ pub struct Fee {
 }
 
 impl Fee {
+    // TODO: Improve this API, the client is not needed
+    // if we use the static fee
     pub fn new(
         config: config::BitcoinFeeStrategy,
         max_btc_fee: bitcoin::Amount,

--- a/nectar/src/command/resume_only.rs
+++ b/nectar/src/command/resume_only.rs
@@ -15,6 +15,7 @@ pub async fn resume_only(
     bitcoin_wallet: bitcoin::Wallet,
     bitcoin_fee: bitcoin::Fee,
     ethereum_wallet: ethereum::Wallet,
+    ethereum_gas_price: ethereum::GasPrice,
 ) -> anyhow::Result<()> {
     #[cfg(not(test))]
     let db = Database::new(&settings.data.dir.join("database"))?;
@@ -28,6 +29,7 @@ pub async fn resume_only(
         Arc::new(bitcoin_wallet),
         bitcoin_fee,
         Arc::new(ethereum_wallet),
+        ethereum_gas_price,
         Arc::new(BitcoindConnector::new(settings.bitcoin.bitcoind.node_url)?),
         Arc::new(Web3Connector::new(settings.ethereum.node_url)),
     );

--- a/nectar/src/command/trade.rs
+++ b/nectar/src/command/trade.rs
@@ -79,7 +79,7 @@ pub async fn trade(
     tokio::spawn(dai_balance_future);
 
     let bitcoin_connector = Arc::new(BitcoindConnector::new(settings.bitcoin.bitcoind.node_url)?);
-    let ethereum_connector = Arc::new(Web3Connector::new(settings.ethereum.node_url));
+    let ethereum_connector = Arc::new(Web3Connector::new(settings.ethereum.node_url.clone()));
 
     let bitcoin_fee = bitcoin::Fee::new(
         settings.maker.fee_strategies.bitcoin,
@@ -87,11 +87,14 @@ pub async fn trade(
         bitcoind_client,
     );
 
+    let ethereum_gas_price = ethereum::GasPrice::geth_url(settings.ethereum.node_url);
+
     let (swap_executor, swap_execution_finished_receiver) = SwapExecutor::new(
         Arc::clone(&db),
         Arc::clone(&bitcoin_wallet),
         bitcoin_fee,
         Arc::clone(&ethereum_wallet),
+        ethereum_gas_price,
         bitcoin_connector,
         ethereum_connector,
     );

--- a/nectar/src/command/trade.rs
+++ b/nectar/src/command/trade.rs
@@ -87,7 +87,7 @@ pub async fn trade(
         bitcoind_client,
     );
 
-    let ethereum_gas_price = ethereum::GasPrice::geth_url(settings.ethereum.node_url);
+    let ethereum_gas_price = ethereum::GasPrice::new(settings.maker.fee_strategies.ethereum);
 
     let (swap_executor, swap_execution_finished_receiver) = SwapExecutor::new(
         Arc::clone(&db),

--- a/nectar/src/config.rs
+++ b/nectar/src/config.rs
@@ -158,6 +158,10 @@ mod tests {
                         sats_per_byte: Some(bitcoin::Amount::from_sat(12)),
                         estimate_mode: None,
                     }),
+                    ethereum: Some(file::EthereumGasPrice {
+                        service: file::EthereumGasPriceService::Geth,
+                        url: "http://some.geth.url:8545/".parse().unwrap(),
+                    }),
                 }),
                 kraken_api_host: Some("https://api.kraken.com".parse().unwrap()),
             }),

--- a/nectar/src/config/file.rs
+++ b/nectar/src/config/file.rs
@@ -42,10 +42,12 @@ pub struct MaxPossibleFee {
     pub bitcoin: Option<bitcoin::Amount>,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct FeeStrategies {
     #[serde(default)]
     pub bitcoin: Option<BitcoinFee>,
+    #[serde(default)]
+    pub ethereum: Option<EthereumGasPrice>,
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -66,6 +68,20 @@ pub struct BitcoinFee {
 pub enum BitcoinFeeStrategy {
     Static,
     Bitcoind,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct EthereumGasPrice {
+    pub service: EthereumGasPriceService,
+    pub url: url::Url,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EthereumGasPriceService {
+    Geth,
+    EthGasStation,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -194,6 +210,10 @@ kraken_api_host = "https://api.kraken.com"
 [maker.fee_strategies.bitcoin]
 strategy = "bitcoind"
 
+[maker.fee_strategies.ethereum]
+service = "eth_gas_station"
+url = "https://ethgasstation.info/api/ethgasAPI.json?api-key=XXAPI_Key_HereXXX"
+
 [maker.btc_dai]
 max_buy_quantity = 1.23456
 max_sell_quantity = 1.23456
@@ -234,6 +254,12 @@ local_dai_contract_address = "0x6A9865aDE2B6207dAAC49f8bCba9705dEB0B0e6D"
                         strategy: Some(BitcoinFeeStrategy::Bitcoind),
                         sats_per_byte: None,
                         estimate_mode: None,
+                    }),
+                    ethereum: Some(EthereumGasPrice{ service: EthereumGasPriceService::EthGasStation,
+                    url:
+                        "https://ethgasstation.info/api/ethgasAPI.json?api-key=XXAPI_Key_HereXXX"
+                        .parse()
+                        .unwrap()
                     }),
                 }),
             }),
@@ -293,6 +319,12 @@ local_dai_contract_address = "0x6A9865aDE2B6207dAAC49f8bCba9705dEB0B0e6D"
                         sats_per_byte: None,
                         estimate_mode: Some(EstimateMode::Conservative),
                     }),
+                    ethereum: Some(EthereumGasPrice{ service: EthereumGasPriceService::EthGasStation,
+                        url:
+                        "https://ethgasstation.info/api/ethgasAPI.json?api-key=XXAPI_Key_HereXXX"
+                            .parse()
+                            .unwrap()
+                    }),
                 }),
             }),
             network: Some(Network {
@@ -334,6 +366,10 @@ bitcoin = 0.01
 [maker.fee_strategies.bitcoin]
 strategy = "bitcoind"
 estimate_mode = "conservative"
+
+[maker.fee_strategies.ethereum]
+service = "eth_gas_station"
+url = "https://ethgasstation.info/api/ethgasAPI.json?api-key=XXAPI_Key_HereXXX"
 
 [network]
 listen = ["/ip4/0.0.0.0/tcp/9939"]

--- a/nectar/src/config/settings.rs
+++ b/nectar/src/config/settings.rs
@@ -166,12 +166,14 @@ pub struct Maker {
     /// Spread to apply to the mid-market rate, format is permyriad. E.g. 5.20
     /// is 5.2% spread
     pub spread: Spread,
-    // TODO: Probably move that under something common to fee_strategies.
-    // I did not realize I would still need it.
+    // TODO: Leave it here. Make it as a sat/vbyte fee
     /// Maximum possible network fee to consider when calculating the available
     /// balance. Fees are in the nominal native currency and per
     /// transaction.
     pub maximum_possible_fee: Fees,
+    // TODO: Fees strategy can actually be moved out of maker as they are also used for withdrawal
+    // for example. They are more to do with the execution than they are with the market making
+    // strategy
     /// Fee strategies
     pub fee_strategies: FeeStrategies,
     pub kraken_api_host: KrakenApiHost,

--- a/nectar/src/ethereum.rs
+++ b/nectar/src/ethereum.rs
@@ -1,8 +1,10 @@
 pub mod dai;
+mod gas_price;
 mod geth;
 mod wallet;
 
 pub use comit::ethereum::{Address, ChainId, Hash};
+pub use gas_price::*;
 pub use geth::Client;
 pub use wallet::Wallet;
 

--- a/nectar/src/ethereum/gas_price.rs
+++ b/nectar/src/ethereum/gas_price.rs
@@ -1,0 +1,49 @@
+use crate::{
+    ethereum::{ether, geth},
+    Result,
+};
+
+#[derive(Debug, Clone)]
+pub struct GasPrice {
+    service: Service,
+}
+
+#[derive(Debug, Clone)]
+enum Service {
+    Geth(geth::Client),
+}
+
+impl GasPrice {
+    pub fn geth_url(geth_url: url::Url) -> Self {
+        let client = geth::Client::new(geth_url);
+        Self {
+            service: Service::Geth(client),
+        }
+    }
+
+    pub async fn gas_price(&self) -> Result<ether::Amount> {
+        match &self.service {
+            Service::Geth(client) => client.gas_price().await,
+        }
+    }
+}
+
+#[cfg(all(test, feature = "test-docker"))]
+mod tests {
+    use super::*;
+    use crate::test_harness::ethereum::Blockchain;
+
+    #[tokio::test]
+    async fn gas_price() {
+        let client = testcontainers::clients::Cli::default();
+
+        let mut blockchain = Blockchain::new(&client).unwrap();
+        blockchain.init().await.unwrap();
+
+        let gas_price = GasPrice::geth_url(blockchain.node_url.clone());
+
+        let gas_price = gas_price.gas_price().await.unwrap();
+
+        println!("Gas price: {}", gas_price)
+    }
+}

--- a/nectar/src/ethereum/gas_price/eth_gas_station.rs
+++ b/nectar/src/ethereum/gas_price/eth_gas_station.rs
@@ -1,0 +1,14 @@
+use crate::{ethereum::ether, Result};
+
+#[derive(Debug, Clone)]
+pub struct Client;
+
+impl Client {
+    pub fn new(_url: url::Url) -> Self {
+        todo!()
+    }
+
+    pub async fn gas_price(&self) -> Result<ether::Amount> {
+        todo!()
+    }
+}

--- a/nectar/src/ethereum/gas_price/eth_gas_station.rs
+++ b/nectar/src/ethereum/gas_price/eth_gas_station.rs
@@ -1,14 +1,170 @@
-use crate::{ethereum::ether, Result};
+use crate::{ethereum::ether::Amount, Result};
+use num::BigUint;
+use serde::{de::Error, Deserialize, Deserializer};
+use std::convert::TryFrom;
+use time::Duration;
 
 #[derive(Debug, Clone)]
-pub struct Client;
+pub struct Client {
+    url: url::Url,
+}
 
 impl Client {
-    pub fn new(_url: url::Url) -> Self {
-        todo!()
+    pub fn new(url: url::Url) -> Self {
+        Self { url }
     }
 
-    pub async fn gas_price(&self) -> Result<ether::Amount> {
-        todo!()
+    pub async fn gas_price(&self) -> Result<Amount> {
+        let response: Response = reqwest::get(self.url.clone())
+            .await
+            .map_err(ConnectionFailed)?
+            .json()
+            .await
+            .map_err(DeserializationFailed)?;
+
+        tracing::info!(
+            "Eth Gas Station estimate a wait of {:?} for {} gwei gas price",
+            response.safe_low_wait,
+            response.safe_low
+        );
+
+        Ok(response.safe_low)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("connection error: {0}")]
+pub struct ConnectionFailed(#[from] reqwest::Error);
+
+#[derive(Debug, thiserror::Error)]
+#[error("deserialization error: {0}")]
+pub struct DeserializationFailed(#[from] reqwest::Error);
+
+// Many possibilities, one could consider using the `gasPriceRange` entries to
+// get a lower price.
+#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct Response {
+    /// Low gas price value that is safe
+    #[serde(deserialize_with = "ether_tenx_gigawei")]
+    pub safe_low: Amount,
+    /// Estimated wait duration using safe low gas price
+    #[serde(deserialize_with = "minute_duration")]
+    pub safe_low_wait: Duration,
+}
+
+fn ether_tenx_gigawei<'de, D>(deserializer: D) -> Result<Amount, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let int = u64::deserialize(deserializer)?;
+    let amount = BigUint::from(int);
+
+    // We want wei from 10x gwei
+    // Make it gwei: *1_000_000_000
+    // But actually it's 10x gwei: /10
+    let amount = amount * (1_000_000_000u64 / 10u64);
+
+    // Accepts the amount is wei
+    let amount = Amount::try_from(amount).map_err(D::Error::custom)?;
+    Ok(amount)
+}
+
+fn minute_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let minutes = f64::deserialize(deserializer)?;
+    let duration = Duration::seconds_f64(minutes * 60.0);
+    Ok(duration)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_response() {
+        let str = r#"
+{
+  "fast": 780,
+  "fastest": 860,
+  "safeLow": 630,
+  "average": 700,
+  "block_time": 8.625,
+  "blockNum": 10960796,
+  "speed": 0.8947913750497876,
+  "safeLowWait": 7.3,
+  "avgWait": 0.8,
+  "fastWait": 0.4,
+  "fastestWait": 0.3,
+  "gasPriceRange": {
+    "4": 143.8,
+    "6": 143.8,
+    "8": 143.8,
+    "10": 143.8,
+    "20": 143.8,
+    "30": 143.8,
+    "40": 143.8,
+    "50": 143.8,
+    "60": 143.8,
+    "70": 143.8,
+    "80": 143.8,
+    "90": 143.8,
+    "100": 143.8,
+    "110": 143.8,
+    "120": 143.8,
+    "130": 143.8,
+    "140": 143.8,
+    "150": 143.8,
+    "160": 143.8,
+    "170": 143.8,
+    "180": 143.8,
+    "190": 143.8,
+    "200": 143.8,
+    "220": 143.8,
+    "240": 143.8,
+    "260": 143.8,
+    "280": 143.8,
+    "300": 143.8,
+    "320": 143.8,
+    "340": 143.8,
+    "360": 143.8,
+    "380": 143.8,
+    "400": 143.8,
+    "420": 143.8,
+    "440": 143.8,
+    "460": 143.8,
+    "480": 143.8,
+    "500": 143.8,
+    "520": 143.8,
+    "540": 9.9,
+    "560": 9.6,
+    "580": 9.3,
+    "600": 8,
+    "620": 7.8,
+    "630": 7.3,
+    "640": 6.9,
+    "660": 5.9,
+    "680": 5.6,
+    "700": 0.8,
+    "720": 0.6,
+    "740": 0.5,
+    "760": 0.4,
+    "780": 0.4,
+    "800": 0.3,
+    "820": 0.3,
+    "840": 0.3,
+    "860": 0.3
+  }
+}
+        "#;
+
+        let value: Response = serde_json::from_str(str).unwrap();
+
+        assert_eq!(value, Response {
+            safe_low: Amount::from_ether_str("0.000000063").expect("eth value"), /* 63 gwei = 0.000000063 eth */
+            safe_low_wait: Duration::seconds(438) // 7.3 minutes = 438 seconds
+        })
     }
 }

--- a/nectar/src/ethereum/geth.rs
+++ b/nectar/src/ethereum/geth.rs
@@ -159,7 +159,7 @@ impl Client {
         Ok(amount)
     }
 
-    pub async fn gas_price(&self) -> anyhow::Result<clarity::Uint256> {
+    pub async fn gas_price(&self) -> anyhow::Result<ether::Amount> {
         let amount = self
             .rpc_client
             .send::<Vec<()>, String>(jsonrpc::Request::new(
@@ -169,7 +169,7 @@ impl Client {
             ))
             .await
             .context("failed to get gas price")?;
-        let amount = clarity::Uint256::from_str_radix(&amount[2..], 16)?;
+        let amount = ether::Amount::try_from_hex(String::from(&amount[2..]))?;
 
         Ok(amount)
     }

--- a/nectar/src/main.rs
+++ b/nectar/src/main.rs
@@ -136,7 +136,8 @@ async fn main() -> Result<()> {
             println!("{}", deposit);
         }
         Command::Withdraw(arguments) => {
-            let ethereum_gas_price = ethereum::GasPrice::geth_url(settings.ethereum.node_url);
+            let ethereum_gas_price =
+                ethereum::GasPrice::new(settings.maker.fee_strategies.ethereum);
             let tx_id = withdraw(
                 ethereum_wallet.expect("could not initialise ethereum wallet"),
                 ethereum_gas_price,
@@ -157,7 +158,7 @@ async fn main() -> Result<()> {
             );
 
             let ethereum_gas_price =
-                ethereum::GasPrice::geth_url(settings.ethereum.node_url.clone());
+                ethereum::GasPrice::new(settings.maker.fee_strategies.ethereum.clone());
 
             resume_only(
                 settings,

--- a/nectar/src/main.rs
+++ b/nectar/src/main.rs
@@ -136,8 +136,10 @@ async fn main() -> Result<()> {
             println!("{}", deposit);
         }
         Command::Withdraw(arguments) => {
+            let ethereum_gas_price = ethereum::GasPrice::geth_url(settings.ethereum.node_url);
             let tx_id = withdraw(
                 ethereum_wallet.expect("could not initialise ethereum wallet"),
+                ethereum_gas_price,
                 bitcoin_wallet.expect("could not initialise bitcoin wallet"),
                 arguments,
             )
@@ -154,11 +156,15 @@ async fn main() -> Result<()> {
                 bitcoind_client,
             );
 
+            let ethereum_gas_price =
+                ethereum::GasPrice::geth_url(settings.ethereum.node_url.clone());
+
             resume_only(
                 settings,
                 bitcoin_wallet.expect("could not initialise bitcoin wallet"),
                 bitcoin_fee,
                 ethereum_wallet.expect("could not initialise ethereum wallet"),
+                ethereum_gas_price,
             )
             .await
             .expect("Wrapping up")

--- a/nectar/src/swap.rs
+++ b/nectar/src/swap.rs
@@ -331,6 +331,9 @@ mod tests {
                 )
                 .await?;
 
+            let ethereum_gas_price =
+                crate::ethereum::GasPrice::geth_url(ethereum_blockchain.node_url.clone());
+
             (
                 bitcoin::Wallet {
                     inner: Arc::new(bitcoin_wallet),
@@ -340,6 +343,7 @@ mod tests {
                 ethereum::Wallet {
                     inner: Arc::new(ethereum_wallet),
                     connector: Arc::clone(&ethereum_connector),
+                    gas_price: ethereum_gas_price,
                 },
             )
         };
@@ -372,6 +376,9 @@ mod tests {
                 )
                 .await?;
 
+            let ethereum_gas_price =
+                crate::ethereum::GasPrice::geth_url(ethereum_blockchain.node_url.clone());
+
             (
                 bitcoin::Wallet {
                     inner: Arc::new(bitcoin_wallet),
@@ -381,6 +388,7 @@ mod tests {
                 ethereum::Wallet {
                     inner: Arc::new(ethereum_wallet),
                     connector: Arc::clone(&ethereum_connector),
+                    gas_price: ethereum_gas_price,
                 },
             )
         };
@@ -539,6 +547,7 @@ pub struct SwapExecutor {
     bitcoin_wallet: Arc<crate::bitcoin::Wallet>,
     bitcoin_fee: crate::bitcoin::Fee,
     ethereum_wallet: Arc<crate::ethereum::Wallet>,
+    ethereum_gas_price: crate::ethereum::GasPrice,
     finished_swap_sender: mpsc::Sender<FinishedSwap>,
     bitcoin_connector: Arc<BitcoindConnector>,
     ethereum_connector: Arc<Web3Connector>,
@@ -550,6 +559,7 @@ impl SwapExecutor {
         bitcoin_wallet: Arc<crate::bitcoin::Wallet>,
         bitcoin_fee: crate::bitcoin::Fee,
         ethereum_wallet: Arc<crate::ethereum::Wallet>,
+        ethereum_gas_price: crate::ethereum::GasPrice,
         bitcoin_connector: Arc<BitcoindConnector>,
         ethereum_connector: Arc<Web3Connector>,
     ) -> (Self, mpsc::Receiver<FinishedSwap>) {
@@ -563,6 +573,7 @@ impl SwapExecutor {
             bitcoin_wallet,
             bitcoin_fee,
             ethereum_wallet,
+            ethereum_gas_price,
             finished_swap_sender,
             bitcoin_connector,
             ethereum_connector,
@@ -585,6 +596,7 @@ impl SwapExecutor {
             ethereum::Wallet {
                 inner: self.ethereum_wallet.clone(),
                 connector: self.ethereum_connector.clone(),
+                gas_price: self.ethereum_gas_price.clone(),
             },
             self.ethereum_connector.clone(),
             self.db.clone(),


### PR DESCRIPTION
Allow the user to configure the usage of geth or ethgasstation for gas price.
When using eth gas station, the "safe low" value is chosen.

I introduce a number of TODOs related to the configuration design. I will tacle them in a separate PR once cnd is sorted.