### PR TITLE
Directly join together the two protocols of a swap

### DIFF
--- a/cnd/src/main.rs
+++ b/cnd/src/main.rs
@@ -12,7 +12,7 @@
     clippy::dbg_macro
 )]
 #![forbid(unsafe_code)]
-#![type_length_limit = "3033619"] // Regressed with Rust 1.46.0 :(
+#![type_length_limit = "11386524"] // Regressed with Rust 1.46.0 :(
 
 #[macro_use]
 extern crate diesel;

--- a/cnd/src/spawn.rs
+++ b/cnd/src/spawn.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 use diesel::SqliteConnection;
 use futures::prelude::*;
 use time::OffsetDateTime;
-use tokio::{runtime::Handle, task::JoinHandle};
+use tokio::runtime::Handle;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Swap<A, B> {
@@ -19,37 +19,12 @@ pub struct Swap<A, B> {
     pub start_of_swap: OffsetDateTime,
 }
 
-impl<A, B> Swap<A, B> {
-    fn into_context_pair(
-        self,
-        swap_context: SwapContext,
-    ) -> (ProtocolContext<A>, ProtocolContext<B>) {
-        let alpha = ProtocolContext {
-            id: swap_context.id,
-            start_of_swap: self.start_of_swap,
-            role: swap_context.role,
-            side: Side::Alpha,
-            params: self.alpha,
-        };
-        let beta = ProtocolContext {
-            id: swap_context.id,
-            start_of_swap: self.start_of_swap,
-            role: swap_context.role,
-            side: Side::Beta,
-            params: self.beta,
-        };
-
-        (alpha, beta)
-    }
-}
-
-/// The context within which a protocol can be spawned into a runtime.
-pub struct ProtocolContext<P> {
-    pub id: LocalSwapId,
-    pub start_of_swap: OffsetDateTime,
-    pub side: Side,
-    pub role: Role,
-    pub params: P,
+#[derive(Clone, Copy, Debug)]
+struct MetaData {
+    id: LocalSwapId,
+    role: Role,
+    side: Side,
+    start: OffsetDateTime,
 }
 
 pub async fn spawn(
@@ -60,144 +35,176 @@ pub async fn spawn(
 ) -> anyhow::Result<()> {
     within_swap_context!(swap_context, {
         let swap = Load::<Swap<AlphaParams, BetaParams>>::load(&storage, swap_context.id).await?;
-        let swap_id = swap_context.id;
-        let (alpha, beta) = swap.into_context_pair(swap_context);
 
-        let alpha_handle = alpha
-            .spawn(connectors.clone(), storage.clone(), handle.clone())
-            .context("failed to spawn protocol for alpha ledger")?;
-        let beta_handle = beta
-            .spawn(connectors.clone(), storage.clone(), handle.clone())
-            .context("failed to spawn protocol for alpha ledger")?;
+        handle.spawn(async move {
+            let swap_result = swap
+                .execute(swap_context.id, connectors.clone(), storage.clone())
+                .await;
 
-        handle.spawn(swap_result_handler(
-            alpha_handle,
-            beta_handle,
-            storage,
-            swap_id,
-        ));
+            handle_swap_result(swap_result, storage, swap_context.id).await;
+        });
     });
 
     Ok(())
 }
 
-async fn swap_result_handler(
-    alpha: JoinHandle<Result<()>>,
-    beta: JoinHandle<Result<()>>,
-    storage: Storage,
-    swap_id: LocalSwapId,
-) {
-    let db_update: Box<dyn Fn(&SqliteConnection) -> Result<()> + Send> =
-        match future::try_join(alpha, beta).await {
-            // Join successful and both protocols finish successfully
-            Ok((Ok(()), Ok(()))) => {
-                tracing::info!(swap = %swap_id, "swap completed");
+async fn handle_swap_result(swap_result: Result<()>, storage: Storage, swap_id: LocalSwapId) {
+    let db_update: Box<dyn Fn(&SqliteConnection) -> Result<()> + Send> = match swap_result {
+        Ok(()) => {
+            tracing::info!(swap = %swap_id, "swap completed");
 
-                Box::new(move |conn| {
-                    commands::update_order_of_swap_to_closed(conn, swap_id)?;
-                    commands::mark_swap_as_completed(conn, swap_id, OffsetDateTime::now_utc())?;
+            Box::new(move |conn| {
+                commands::update_order_of_swap_to_closed(conn, swap_id)?;
+                commands::mark_swap_as_completed(conn, swap_id, OffsetDateTime::now_utc())?;
 
-                    Ok(())
-                })
-            }
-            // Join successful but one of the protocols failed
-            Ok((Err(e), _)) | Ok((_, Err(e))) => {
-                tracing::error!(swap = %swap_id, "failed to complete swap: {:#}", e);
+                Ok(())
+            })
+        }
+        Err(e) => {
+            tracing::error!(swap = %swap_id, "failed to complete swap: {:#}", e);
 
-                Box::new(move |conn| {
-                    commands::update_order_of_swap_to_failed(conn, swap_id)?;
-                    // we don't mark a swap as completed in case of failure so that a
-                    // restart of the node will respawn the swap
+            Box::new(move |conn| {
+                commands::update_order_of_swap_to_failed(conn, swap_id)?;
+                // we don't mark a swap as completed in case of failure so that a
+                // restart of the node will respawn the swap
 
-                    Ok(())
-                })
-            }
-            // Join unsuccessful
-            Err(e) => {
-                tracing::error!(swap = %swap_id, "failed to join protocol futures: {:?}", e);
-                return;
-            }
-        };
+                Ok(())
+            })
+        }
+    };
 
     if let Err(e) = storage.db.do_in_transaction(db_update).await {
         tracing::warn!("failed to update db state: {:#}", e)
     }
 }
 
-impl ProtocolContext<herc20::Params> {
-    fn spawn(
-        self,
-        connectors: Connectors,
-        storage: Storage,
-        handle: Handle,
-    ) -> Result<JoinHandle<Result<()>>> {
-        let task = herc20::new(
-            self.id,
-            self.params,
-            self.start_of_swap,
-            self.role,
-            self.side,
-            storage,
-            connectors.ethereum(),
-        );
-
-        Ok(handle.spawn(task))
-    }
-}
-
-impl ProtocolContext<hbit::Params> {
-    fn spawn(
-        self,
-        connectors: Connectors,
-        storage: Storage,
-        handle: Handle,
-    ) -> Result<JoinHandle<Result<()>>> {
-        let task = hbit::new(
-            self.id,
-            self.params,
-            self.start_of_swap,
-            self.role,
-            self.side,
-            storage,
-            connectors.bitcoin(),
-        );
-
-        Ok(handle.spawn(task))
-    }
-}
-
-impl ProtocolContext<halbit::Params> {
-    fn spawn(
-        self,
-        connectors: Connectors,
-        storage: Storage,
-        handle: Handle,
-    ) -> Result<JoinHandle<Result<()>>> {
-        match (self.role, self.side) {
-            (Role::Alice, Side::Alpha) | (Role::Bob, Side::Beta) => {
-                let task = halbit::new(
-                    self.id,
-                    self.params,
-                    self.role,
-                    self.side,
-                    storage,
-                    connectors.lnd_as_sender()?,
+macro_rules! impl_execute {
+    ($alpha:ident, $beta:ident) => {
+        impl Swap<$alpha::Params, $beta::Params> {
+            async fn execute(
+                self,
+                id: LocalSwapId,
+                connectors: Connectors,
+                storage: Storage,
+            ) -> Result<()> {
+                let alpha = $alpha(
+                    MetaData {
+                        id,
+                        side: Side::Alpha,
+                        role: self.role,
+                        start: self.start_of_swap,
+                    },
+                    self.alpha,
+                    connectors.clone(),
+                    storage.clone(),
+                );
+                let beta = $beta(
+                    MetaData {
+                        id,
+                        side: Side::Beta,
+                        role: self.role,
+                        start: self.start_of_swap,
+                    },
+                    self.beta,
+                    connectors.clone(),
+                    storage.clone(),
                 );
 
-                Ok(handle.spawn(task))
-            }
-            (Role::Bob, Side::Alpha) | (Role::Alice, Side::Beta) => {
-                let task = halbit::new(
-                    self.id,
-                    self.params,
-                    self.role,
-                    self.side,
-                    storage,
-                    connectors.lnd_as_receiver()?,
-                );
-
-                Ok(handle.spawn(task))
+                future::try_join(alpha, beta).await.map(|_| ())
             }
         }
+    };
+}
+
+impl_execute!(herc20, hbit);
+impl_execute!(hbit, herc20);
+impl_execute!(halbit, herc20);
+impl_execute!(herc20, halbit);
+
+async fn herc20(
+    metadata: MetaData,
+    params: herc20::Params,
+    connectors: Connectors,
+    storage: Storage,
+) -> Result<()> {
+    herc20::new(
+        metadata.id,
+        params,
+        metadata.start,
+        metadata.role,
+        metadata.side,
+        storage.clone(),
+        connectors.ethereum(),
+    )
+    .await
+    .with_context(|| {
+        format!(
+            "failed to complete herc20 as {} ledger protocol",
+            metadata.side
+        )
+    })
+}
+
+async fn hbit(
+    metadata: MetaData,
+    params: hbit::Params,
+    connectors: Connectors,
+    storage: Storage,
+) -> Result<()> {
+    hbit::new(
+        metadata.id,
+        params,
+        metadata.start,
+        metadata.role,
+        metadata.side,
+        storage.clone(),
+        connectors.bitcoin(),
+    )
+    .await
+    .with_context(|| {
+        format!(
+            "failed to complete hbit as {} ledger protocol",
+            metadata.side
+        )
+    })
+}
+
+async fn halbit(
+    metadata: MetaData,
+    params: halbit::Params,
+    connectors: Connectors,
+    storage: Storage,
+) -> Result<()> {
+    match (metadata.role, metadata.side) {
+        (Role::Alice, Side::Alpha) | (Role::Bob, Side::Beta) => halbit::new(
+            metadata.id,
+            params,
+            metadata.role,
+            metadata.side,
+            storage.clone(),
+            connectors.lnd_as_sender()?,
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "failed to complete halbit as {} ledger protocol",
+                metadata.side
+            )
+        }),
+        (Role::Bob, Side::Alpha) | (Role::Alice, Side::Beta) => halbit::new(
+            metadata.id,
+            params,
+            metadata.role,
+            metadata.side,
+            storage.clone(),
+            connectors.lnd_as_receiver()?,
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "failed to complete halbit as {} ledger protocol",
+                metadata.side
+            )
+        }),
     }
 }


### PR DESCRIPTION
Instead of spawning each protocol individually, we join them
together to a single swap and spawn that into the runtime.
This greatly simplifies the error handling.

To keep things DRY, we use a macro to define the `Swap::execute`
functions.