### PR TITLE
Use `comit::hbit::Params` throughout nectar

### DIFF
--- a/nectar/src/command.rs
+++ b/nectar/src/command.rs
@@ -136,7 +136,7 @@ pub fn into_history_trade(
         base_symbol: Symbol::Btc,
         quote_symbol: Symbol::Dai,
         position,
-        base_precise_amount: swap.hbit_params.shared.asset.as_sat().into(),
+        base_precise_amount: swap.hbit_params.asset.as_sat().into(),
         quote_precise_amount: BigUint::from_str(&swap.herc20_params.asset.quantity.to_wei_dec())
             .expect("number to number conversion"),
         peer: peer_id,

--- a/nectar/src/command/trade.rs
+++ b/nectar/src/command/trade.rs
@@ -267,7 +267,7 @@ fn respawn_swaps(
                 maker.strategy.hbit_herc20_swap_resumed(fund_amount);
             }
             SwapKind::Herc20Hbit(SwapParams { hbit_params, .. }) => {
-                let fund_amount = hbit_params.shared.asset;
+                let fund_amount = hbit_params.asset;
                 maker.strategy.herc20_hbit_swap_resumed(fund_amount)?;
             }
         };

--- a/nectar/src/database/hbit.rs
+++ b/nectar/src/database/hbit.rs
@@ -3,7 +3,6 @@ use crate::{
     swap::hbit,
     SwapId,
 };
-use ::bitcoin::secp256k1;
 use anyhow::{anyhow, Context};
 use comit::{identity, Secret, SecretHash, Timestamp};
 use serde::{Deserialize, Serialize};
@@ -220,7 +219,6 @@ pub struct Params {
     pub refund_identity: identity::Bitcoin,
     pub expiry: Timestamp,
     pub secret_hash: SecretHash,
-    pub transient_sk: secp256k1::SecretKey,
 }
 
 impl From<Params> for hbit::Params {
@@ -232,19 +230,15 @@ impl From<Params> for hbit::Params {
             refund_identity,
             expiry,
             secret_hash,
-            transient_sk,
         } = params;
 
         hbit::Params {
-            shared: hbit::SharedParams {
-                network: network.into(),
-                asset: asset.into(),
-                redeem_identity,
-                refund_identity,
-                expiry,
-                secret_hash,
-            },
-            transient_sk,
+            network: network.into(),
+            asset: asset.into(),
+            redeem_identity,
+            refund_identity,
+            expiry,
+            secret_hash,
         }
     }
 }
@@ -252,13 +246,12 @@ impl From<Params> for hbit::Params {
 impl From<hbit::Params> for Params {
     fn from(params: hbit::Params) -> Self {
         Params {
-            network: params.shared.network.into(),
-            asset: params.shared.asset.into(),
-            redeem_identity: params.shared.redeem_identity,
-            refund_identity: params.shared.refund_identity,
-            expiry: params.shared.expiry,
-            secret_hash: params.shared.secret_hash,
-            transient_sk: params.transient_sk,
+            network: params.network.into(),
+            asset: params.asset.into(),
+            redeem_identity: params.redeem_identity,
+            refund_identity: params.refund_identity,
+            expiry: params.expiry,
+            secret_hash: params.secret_hash,
         }
     }
 }
@@ -281,10 +274,6 @@ impl crate::StaticStub for Params {
             .unwrap(),
             expiry: 12345678.into(),
             secret_hash: SecretHash::new(Secret::from(*b"hello world, you are beautiful!!")),
-            transient_sk: secp256k1::SecretKey::from_str(
-                "01010101010101010001020304050607ffff0000ffff00006363636363636363",
-            )
-            .unwrap(),
         }
     }
 }

--- a/nectar/src/maker/strategy.rs
+++ b/nectar/src/maker/strategy.rs
@@ -184,8 +184,7 @@ impl AllIn {
     pub fn swap_finished(&mut self, swap: SwapKind) {
         match swap {
             SwapKind::Herc20Hbit(swap) => {
-                self.btc_reserved_funds -=
-                    swap.hbit_params.shared.asset + self.bitcoin_fee.max_tx_fee();
+                self.btc_reserved_funds -= swap.hbit_params.asset + self.bitcoin_fee.max_tx_fee();
             }
             SwapKind::HbitHerc20(swap) => {
                 self.dai_reserved_funds -= swap.herc20_params.asset.into();

--- a/nectar/src/network.rs
+++ b/nectar/src/network.rs
@@ -60,7 +60,6 @@ impl From<setup_swap::BehaviourOutEvent<SetupSwapContext>> for BehaviourOutEvent
 #[derive(Debug, Copy, Clone)]
 pub struct SetupSwapContext {
     pub swap_id: SwapId,
-    pub bitcoin_transient_key_index: u32,
     pub match_ref_point: OffsetDateTime,
 }
 

--- a/nectar/src/swap/comit/hbit.rs
+++ b/nectar/src/swap/comit/hbit.rs
@@ -1,6 +1,6 @@
 use crate::swap::comit::SwapFailedShouldRefund;
 use anyhow::Result;
-use bitcoin::{secp256k1::SecretKey, Block, BlockHash};
+use bitcoin::{Block, BlockHash};
 use comit::{asset, ledger};
 
 use comit::btsieve::ConnectedNetwork;
@@ -11,23 +11,6 @@ pub use comit::{
     htlc_location, transaction, Secret, SecretHash, Timestamp,
 };
 use time::OffsetDateTime;
-
-pub type SharedParams = comit::hbit::Params;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct Params {
-    pub shared: SharedParams,
-    pub transient_sk: SecretKey,
-}
-
-impl Params {
-    pub fn new(shared: SharedParams, transient_sk: SecretKey) -> Self {
-        Self {
-            shared,
-            transient_sk,
-        }
-    }
-}
 
 #[async_trait::async_trait]
 pub trait ExecuteFund {
@@ -57,7 +40,7 @@ pub struct Funded {
 
 pub async fn watch_for_funded<C>(
     connector: &C,
-    params: &SharedParams,
+    params: &Params,
     utc_start_of_swap: OffsetDateTime,
 ) -> Result<Funded>
 where
@@ -90,25 +73,20 @@ where
 }
 
 #[cfg(test)]
-mod arbitrary {
-    use crate::swap::hbit::{Params, SharedParams};
+pub mod arbitrary {
+    use super::*;
     use ::bitcoin::secp256k1::SecretKey;
     use comit::{asset, identity, ledger};
     use quickcheck::{Arbitrary, Gen};
 
-    impl Arbitrary for Params {
-        fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            Params {
-                shared: SharedParams {
-                    network: bitcoin_network(g),
-                    asset: bitcoin_asset(g),
-                    redeem_identity: bitcoin_identity(g),
-                    refund_identity: bitcoin_identity(g),
-                    expiry: crate::arbitrary::timestamp(g),
-                    secret_hash: crate::arbitrary::secret_hash(g),
-                },
-                transient_sk: secret_key(g),
-            }
+    pub fn params<G: Gen>(g: &mut G) -> Params {
+        Params {
+            network: bitcoin_network(g),
+            asset: bitcoin_asset(g),
+            redeem_identity: bitcoin_identity(g),
+            refund_identity: bitcoin_identity(g),
+            expiry: crate::arbitrary::timestamp(g),
+            secret_hash: crate::arbitrary::secret_hash(g),
         }
     }
 

--- a/nectar/src/swap/comit/hbit_herc20.rs
+++ b/nectar/src/swap/comit/hbit_herc20.rs
@@ -88,7 +88,7 @@ where
 
     let swap_result = async {
         let hbit_funded =
-            hbit::watch_for_funded(bitcoin_connector, &hbit_params.shared, utc_start_of_swap)
+            hbit::watch_for_funded(bitcoin_connector, &hbit_params, utc_start_of_swap)
                 .await
                 .context(SwapFailedNoRefund)?;
 

--- a/nectar/src/swap/comit/herc20_hbit.rs
+++ b/nectar/src/swap/comit/herc20_hbit.rs
@@ -44,7 +44,7 @@ where
             .context(SwapFailedNoRefund)?;
 
         let hbit_funded =
-            hbit::watch_for_funded(bitcoin_connector, &hbit_params.shared, utc_start_of_swap)
+            hbit::watch_for_funded(bitcoin_connector, &hbit_params, utc_start_of_swap)
                 .await
                 .context(SwapFailedShouldRefund(herc20_deployed.clone()))?;
 
@@ -112,7 +112,7 @@ where
 
         let hbit_redeemed = hbit::watch_for_redeemed(
             bitcoin_connector,
-            &hbit_params.shared,
+            &hbit_params,
             hbit_funded.location,
             utc_start_of_swap,
         )


### PR DESCRIPTION
In order to upstream nectar's swap execution to comit, it is
important that we only use data structures that belong there.

Currently, nectar uses a custom `hbit::Params` struct that contains
the transient key among the remaining params. This does not (yet)
belong in `comit` and hence needs to be removed.