### PR TITLE
Fix fees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
           export PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH
           cd tests
           yarn install
-          yarn ci
+          yarn test
 
       - name: Upload bitcoind log
         if: matrix.e2e && failure()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
+checksum = "dd2bc6d3f370b5666245ff421e231cba4353df936e26986d2918e61a8fd6aef6"
 dependencies = [
  "aes-soft",
  "aesni",
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f5007801316299f922a6198d1d09a0bae95786815d066d5880d13f7c45ead1"
+checksum = "0301c9e9c443494d970a07885e8cf3e587bae8356a1d5abd0999068413f7205f"
 dependencies = [
  "aead",
  "aes",
@@ -35,23 +35,23 @@ dependencies = [
 
 [[package]]
 name = "aes-soft"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
+checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
 dependencies = [
  "block-cipher",
  "byteorder",
- "opaque-debug 0.2.3",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
 name = "aesni"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
+checksum = "0a6fe808308bb07d393e2ea47780043ec47683fcf19cf5efc8ca51c50cc8c68a"
 dependencies = [
  "block-cipher",
- "opaque-debug 0.2.3",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "block-cipher"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
+checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
 dependencies = [
  "generic-array 0.14.4",
 ]
@@ -395,9 +395,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blockchain_contracts"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a03be37fcc500553a77460ac4879e0f6562d492ff958cfc40f96f800ee3ccdd"
+checksum = "dc2452b20fe06584a09b40428e16000a72a8f241493577565b5e89505ba017e7"
 dependencies = [
  "bitcoin 0.25.0",
  "byteorder",
@@ -483,9 +483,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chacha20"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086c0f07ac275808b7bf9a39f2fd013aae1498be83632814c8c4e0bd53f2dc58"
+checksum = "244fbce0d47e97e8ef2f63b81d5e05882cb518c68531eb33194990d7b7e85845"
 dependencies = [
  "stream-cipher",
  "zeroize",
@@ -493,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b0c90556d8e3fec7cf18d84a2f53d27b21288f2fe481b830fadcf809e48205"
+checksum = "9bf18d374d66df0c05cdddd528a7db98f78c28e2519b120855c4f84c5027b1f5"
 dependencies = [
  "aead",
  "chacha20",
@@ -974,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d2e93f837d749c16d118e7ddf7a4dfd0ac8f452cf51e46e9348824e5ef6851"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek 3.0.0",
  "ed25519",
@@ -1392,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "headers"
@@ -1432,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
 ]
@@ -1667,7 +1667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg 1.0.1",
- "hashbrown 0.9.0",
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -1779,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.77"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
+checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
 name = "libp2p"
@@ -1926,7 +1926,7 @@ dependencies = [
  "sha2 0.8.2",
  "snow",
  "static_assertions",
- "x25519-dalek",
+ "x25519-dalek 0.6.0",
  "zeroize",
 ]
 
@@ -2121,9 +2121,9 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memoffset"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
  "autocfg 1.0.1",
 ]
@@ -2613,9 +2613,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.10.2+1.1.1g"
+version = "111.11.0+1.1.1h"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a287fdb22e32b5b60624d4a5a7a02dbe82777f730ec0dbc42a0554326fef5a70"
+checksum = "380fe324132bea01f45239fadfec9343adb044615f29930d039bec1ae7b9fa5b"
 dependencies = [
  "cc",
 ]
@@ -2749,18 +2749,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.23"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
+checksum = "13fbdfd6bdee3dc9be46452f86af4a4072975899cf8592466668620bebfbcc17"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.23"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
+checksum = "c82fb1329f632c3552cf352d14427d57a511b1cf41db93b3a7d77906a82dcc8e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -2769,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.7"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
+checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
 
 [[package]]
 name = "pin-utils"
@@ -2787,18 +2787,18 @@ checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
 name = "poly1305"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b42192ab143ed7619bf888a7f9c6733a9a2153b218e2cd557cfdb52fbf9bb1"
+checksum = "22ce46de8e53ee414ca4d02bfefac75d8c12fba948b76622a40b4be34dfce980"
 dependencies = [
  "universal-hash",
 ]
 
 [[package]]
 name = "polyval"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
+checksum = "a5884790f1ce3553ad55fec37b5aaac5882e0e845a2612df744d6c85c9bf046c"
 dependencies = [
  "cfg-if",
  "universal-hash",
@@ -3285,9 +3285,9 @@ dependencies = [
 
 [[package]]
 name = "rlp"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7d3f9bed94764eac15b8f14af59fac420c236adaff743b7bcc88e265cb4345"
+checksum = "1190dcc8c3a512f1eef5d09bb8c84c7f39e1054e174d1795482e18f5272f2e73"
 dependencies = [
  "rustc-hex",
 ]
@@ -3720,9 +3720,9 @@ checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "snow"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32bf8474159a95551661246cda4976e89356999e3cbfef36f493dacc3fae1e8e"
+checksum = "795dd7aeeee24468e5a32661f6d27f7b5cbed802031b2d7640c7b10f8fb2dd50"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -3733,7 +3733,7 @@ dependencies = [
  "rustc_version",
  "sha2 0.9.1",
  "subtle 2.3.0",
- "x25519-dalek",
+ "x25519-dalek 1.1.0",
 ]
 
 [[package]]
@@ -3765,9 +3765,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "standback"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a71ea1ea5f8747d1af1979bfb7e65c3a025a70609f04ceb78425bc5adad8e6"
+checksum = "f4e0831040d2cf2bdfd51b844be71885783d489898a192f254ae25d57cce725c"
 dependencies = [
  "version_check 0.9.2",
 ]
@@ -3829,10 +3829,11 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "stream-cipher"
-version = "0.4.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f8ed9974042b8c3672ff3030a69fcc03b74c47c3d1ecb7755e8a3626011e88"
+checksum = "c80e15f898d8d8f25db24c253ea615cc14acf418ff307822995814e7d42cfa89"
 dependencies = [
+ "block-cipher",
  "generic-array 0.14.4",
 ]
 
@@ -3971,18 +3972,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -4027,9 +4028,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9b6e9f095bc105e183e3cd493d72579be3181ad4004fceb01adbe9eecab2d"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
 dependencies = [
  "proc-macro-hack",
  "time-macros-impl",
@@ -4212,9 +4213,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82bb5079aa76438620837198db8a5c529fb9878c730bc2b28179b0241cf04c10"
+checksum = "4ef0a5e15477aa303afbfac3a44cba9b6430fdaad52423b1e6c0dbbe28c3eedd"
 dependencies = [
  "ansi_term 0.12.1",
  "lazy_static",
@@ -4222,6 +4223,7 @@ dependencies = [
  "regex",
  "sharded-slab",
  "thread_local",
+ "tracing",
  "tracing-core",
 ]
 
@@ -4645,6 +4647,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
 dependencies = [
  "curve25519-dalek 2.1.0",
+ "rand_core 0.5.1",
+ "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
+dependencies = [
+ "curve25519-dalek 3.0.0",
  "rand_core 0.5.1",
  "zeroize",
 ]

--- a/cnd/CHANGELOG.md
+++ b/cnd/CHANGELOG.md
@@ -20,6 +20,7 @@ Previously, unknown configuration keys would just be ignored.
 -   **Breaking Change** Remove support for RFC003 swaps
 -   **Breaking Change** Config directory for MacOS changed from `/Users/<user>/Library/Preferences/comit/` to `/Users/<user>/Library/Application Support/comit/`.
 -   Update the expected network times to calculate the expiries: We expect Bitcoin's transactions to be included within 6 blocks and Ethereum's within 30 blocks.
+-   Changed the default Bitcoin fee value for redeem and refund to 50 sats/vByte.
 
 ## [0.8.0] - 2020-06-12
 

--- a/cnd/src/config.rs
+++ b/cnd/src/config.rs
@@ -45,7 +45,9 @@ static DAI_ROPSTEN: Lazy<ethereum::Address> =
 
 static COMIT_SOCKET: Lazy<Multiaddr> = Lazy::new(|| parse_unchecked("/ip4/0.0.0.0/tcp/9939"));
 
-static FEERATE_SAT_PER_VBYTE: Lazy<bitcoin::Amount> = Lazy::new(|| bitcoin::Amount::from_sat(10));
+// Low value that would allow inclusion in ~6 blocks:
+// https://txstats.com/dashboard/db/fee-estimation?orgId=1&panelId=2&fullscreen&from=now-6M&to=now&var-source=blockcypher
+static FEERATE_SAT_PER_VBYTE: Lazy<bitcoin::Amount> = Lazy::new(|| bitcoin::Amount::from_sat(50));
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/cnd/src/config/settings.rs
+++ b/cnd/src/config/settings.rs
@@ -301,7 +301,7 @@ mod tests {
                     node_url: "http://localhost:8332".parse().unwrap(),
                 },
                 fees: BitcoinFees {
-                    sat_per_vbyte: bitcoin::Amount::from_sat(10),
+                    sat_per_vbyte: bitcoin::Amount::from_sat(50),
                 },
             })
     }

--- a/comit/src/actions.rs
+++ b/comit/src/actions.rs
@@ -65,13 +65,9 @@ pub mod bitcoin {
     where
         C: secp256k1::Signing,
     {
-        let rate = byte_rate.as_sat();
-        // TODO: change this interface to accept an amount instead of a usize and remove
-        // this allow
-        #[allow(clippy::cast_possible_truncation)]
         primed_transaction
-            .sign_with_rate(secp, rate as usize)
-            .map_err(|_| anyhow::anyhow!("failed to sign with {} rate", rate))
+            .sign_with_rate(secp, byte_rate)
+            .map_err(|_| anyhow::anyhow!("failed to sign with {} rate", byte_rate))
     }
 
     #[derive(Debug, Clone, PartialEq)]

--- a/comit/src/expiries.rs
+++ b/comit/src/expiries.rs
@@ -6,7 +6,8 @@
 
 mod config;
 
-use self::config::{Config, Protocol};
+pub use self::config::*;
+
 use crate::{
     timestamp::{self, Timestamp},
     Network,

--- a/comit/src/expiries/config.rs
+++ b/comit/src/expiries/config.rs
@@ -344,7 +344,7 @@ fn bitcoin_confirmations(network: Network) -> u8 {
     }
 }
 
-fn bitcoin_mine_within_blocks(network: Network) -> u8 {
+pub fn bitcoin_mine_within_blocks(network: Network) -> u8 {
     match network {
         Network::Main | Network::Test => main::BITCOIN_MINE_WITHIN_N_BLOCKS,
         Network::Dev => dev::BITCOIN_MINE_WITHIN_N_BLOCKS,
@@ -365,7 +365,7 @@ fn ethereum_confirmations(network: Network) -> u8 {
     }
 }
 
-fn ethereum_mine_within_blocks(network: Network) -> u8 {
+pub fn ethereum_mine_within_blocks(network: Network) -> u8 {
     match network {
         Network::Main | Network::Test => main::ETHEREUM_MINE_WITHIN_N_BLOCKS,
         Network::Dev => dev::ETHEREUM_MINE_WITHIN_N_BLOCKS,

--- a/comit/src/lib.rs
+++ b/comit/src/lib.rs
@@ -171,4 +171,26 @@ impl From<Network> for ethereum::ChainId {
     }
 }
 
+impl From<ledger::Bitcoin> for Network {
+    fn from(network: ledger::Bitcoin) -> Self {
+        match network {
+            ledger::Bitcoin::Mainnet => Network::Main,
+            ledger::Bitcoin::Testnet => Network::Test,
+            ledger::Bitcoin::Regtest => Network::Dev,
+        }
+    }
+}
+
+impl From<ethereum::ChainId> for Network {
+    fn from(chain_id: ethereum::ChainId) -> Self {
+        match chain_id {
+            ethereum::ChainId::MAINNET => Network::Main,
+            ethereum::ChainId::ROPSTEN => Network::Test,
+            ethereum::ChainId::KOVAN => Network::Test,
+            ethereum::ChainId::GETH_DEV => Network::Dev,
+            _ => Network::Dev,
+        }
+    }
+}
+
 pub type Never = std::convert::Infallible;

--- a/nectar/CHANGELOG.md
+++ b/nectar/CHANGELOG.md
@@ -19,4 +19,9 @@ Previously, unknown configuration keys would just be ignored.
 
 -   Update the expected network times to calculate the expiries: We expect Bitcoin's transactions to be included within 6 blocks and Ethereum's within 30 blocks.
 
+### Changed
+
+-   By default, use bitcoind's `estimatsmartfee` feature to estimate Bitcoin fees.
+For Ethereum, Eth Gas Station API is used.
+
 [Unreleased]: https://github.com/comit-network/comit-rs/compare/d5d26e42a2d8dd026ae94f2c8a9e0bd80ab81133...HEAD

--- a/nectar/src/bitcoin/fee.rs
+++ b/nectar/src/bitcoin/fee.rs
@@ -49,7 +49,7 @@ impl Fee {
 impl crate::StaticStub for Fee {
     fn static_stub() -> Self {
         Self {
-            config: Default::default(),
+            config: crate::StaticStub::static_stub(),
             client: bitcoin::Client::new("http://example.com/".parse().unwrap()), // Not used
         }
     }

--- a/nectar/src/bitcoin/fee.rs
+++ b/nectar/src/bitcoin/fee.rs
@@ -1,7 +1,6 @@
 use crate::{bitcoin, bitcoin::Amount, config, Result};
 use anyhow::Context;
-
-const ESTIMATE_FEE_TARGET: u32 = 3;
+use comit::expiries::bitcoin_mine_within_blocks;
 
 #[derive(Clone, Debug)]
 pub struct Fee {
@@ -26,9 +25,12 @@ impl Fee {
         match self.config.fees {
             SatsPerByte(fee) => Ok(fee),
             BitcoindEstimateSmartfee { mode, .. } => {
+                let network = self.config.network.into();
+                let mine_within_blocks = bitcoin_mine_within_blocks(network) as u32;
+
                 let kvbyte_rate = self
                     .client
-                    .estimate_smart_fee(ESTIMATE_FEE_TARGET, Some(mode.into()))
+                    .estimate_smart_fee(mine_within_blocks, Some(mode.into()))
                     .await
                     .map(|res| res.kbyte_rate)?;
 

--- a/nectar/src/bitcoin/fee.rs
+++ b/nectar/src/bitcoin/fee.rs
@@ -5,14 +5,14 @@ const ESTIMATE_FEE_TARGET: u32 = 3;
 
 #[derive(Clone, Debug)]
 pub struct Fee {
-    config: config::BitcoinFees,
+    config: config::Bitcoin,
     client: bitcoin::Client,
 }
 
 impl Fee {
     // TODO: Improve this API, the client is not needed
     // if we use the static fee
-    pub fn new(config: config::BitcoinFees, client: bitcoin::Client) -> Self {
+    pub fn new(config: config::Bitcoin, client: bitcoin::Client) -> Self {
         Self { config, client }
     }
 
@@ -23,7 +23,7 @@ impl Fee {
 
     pub async fn vbyte_rate(&self) -> Result<Amount> {
         use crate::config::BitcoinFees::*;
-        match self.config {
+        match self.config.fees {
             SatsPerByte(fee) => Ok(fee),
             BitcoindEstimateSmartfee { mode, .. } => {
                 let kvbyte_rate = self
@@ -41,7 +41,7 @@ impl Fee {
     }
 
     pub fn max_tx_fee(&self) -> bitcoin::Amount {
-        self.config.max_tx_fee()
+        self.config.fees.max_tx_fee()
     }
 }
 

--- a/nectar/src/config/settings.rs
+++ b/nectar/src/config/settings.rs
@@ -243,6 +243,11 @@ static DEFAULT_BITCOIN_STATIC_FEE_SAT: Lazy<bitcoin::Amount> =
     // https://txstats.com/dashboard/db/fee-estimation?orgId=1&panelId=2&fullscreen&from=now-6M&to=now&var-source=blockcypher
     Lazy::new(|| bitcoin::Amount::from_sat(50));
 
+static DEFAULT_MAX_BITCOIN_FEE_SAT_PER_VBYTE: Lazy<bitcoin::Amount> =
+// Bitcoind's highest estimate in the past year:
+// https://txstats.com/dashboard/db/fee-estimation?orgId=1&panelId=5&fullscreen&from=now-1y&to=now
+    Lazy::new(|| bitcoin::Amount::from_sat(200));
+
 #[cfg(test)]
 impl crate::StaticStub for BitcoinFees {
     fn static_stub() -> Self {
@@ -270,7 +275,10 @@ impl From<file::BitcoinFees> for BitcoinFees {
 
 impl Default for BitcoinFees {
     fn default() -> Self {
-        Self::SatsPerByte(*DEFAULT_BITCOIN_STATIC_FEE_SAT)
+        Self::BitcoindEstimateSmartfee {
+            mode: EstimateMode::Economical,
+            max_sat_per_vbyte: *DEFAULT_MAX_BITCOIN_FEE_SAT_PER_VBYTE,
+        }
     }
 }
 
@@ -523,7 +531,10 @@ mod tests {
                 bitcoind: Bitcoind {
                     node_url: "http://localhost:8332".parse().unwrap(),
                 },
-                fees: BitcoinFees::SatsPerByte(bitcoin::Amount::from_sat(50)),
+                fees: BitcoinFees::BitcoindEstimateSmartfee {
+                    mode: EstimateMode::Economical,
+                    max_sat_per_vbyte: bitcoin::Amount::from_sat(200),
+                },
             })
     }
 

--- a/nectar/src/config/settings.rs
+++ b/nectar/src/config/settings.rs
@@ -64,6 +64,17 @@ impl Bitcoin {
     }
 }
 
+#[cfg(test)]
+impl crate::StaticStub for Bitcoin {
+    fn static_stub() -> Self {
+        Bitcoin {
+            network: ledger::Bitcoin::Regtest,
+            bitcoind: Bitcoind::new(ledger::Bitcoin::Regtest),
+            fees: BitcoinFees::static_stub(),
+        }
+    }
+}
+
 impl Bitcoind {
     fn new(network: ledger::Bitcoin) -> Self {
         let node_url = match network {

--- a/nectar/src/ethereum/gas_price/eth_gas_station.rs
+++ b/nectar/src/ethereum/gas_price/eth_gas_station.rs
@@ -40,8 +40,8 @@ pub struct ConnectionFailed(#[from] reqwest::Error);
 #[error("deserialization error: {0}")]
 pub struct DeserializationFailed(#[from] reqwest::Error);
 
-// Many possibilities, one could consider using the `gasPriceRange` entries to
-// get a lower price.
+// TODO: Use the value that would satisfy
+// comit::expiries::config::ETHEREUM_MINE_WITHIN_N_BLOCKS;
 #[derive(Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 struct Response {

--- a/nectar/src/main.rs
+++ b/nectar/src/main.rs
@@ -149,7 +149,7 @@ async fn main() -> Result<()> {
         Command::DumpConfig => unreachable!(),
         Command::ResumeOnly => {
             let bitcoind_client = bitcoin::Client::new(settings.bitcoin.bitcoind.node_url.clone());
-            let bitcoin_fee = bitcoin::Fee::new(settings.bitcoin.fees, bitcoind_client);
+            let bitcoin_fee = bitcoin::Fee::new(settings.bitcoin.clone(), bitcoind_client);
 
             let ethereum_gas_price = ethereum::GasPrice::new(settings.ethereum.gas_price.clone());
 

--- a/nectar/src/maker.rs
+++ b/nectar/src/maker.rs
@@ -369,7 +369,7 @@ mod tests {
     #[test]
     fn published_sell_order_can_be_taken() {
         let strategy = strategy::AllIn::new(
-            Default::default(),
+            StaticStub::static_stub(),
             None,
             Some(btc(1.0)),
             Spread::static_stub(),
@@ -394,7 +394,7 @@ mod tests {
     #[test]
     fn published_buy_order_can_be_taken() {
         let strategy = strategy::AllIn::new(
-            Default::default(),
+            StaticStub::static_stub(),
             Some(btc(1.0)),
             None,
             Spread::static_stub(),
@@ -419,7 +419,7 @@ mod tests {
     #[test]
     fn new_buy_order_with_max_buy() {
         let strategy = strategy::AllIn::new(
-            Default::default(),
+            StaticStub::static_stub(),
             Some(btc(0.002)),
             None,
             Spread::static_stub(),
@@ -442,7 +442,7 @@ mod tests {
     #[test]
     fn new_buy_order() {
         let strategy = strategy::AllIn::new(
-            Default::default(),
+            StaticStub::static_stub(),
             None,
             None,
             Spread::static_stub(),

--- a/nectar/src/maker/strategy.rs
+++ b/nectar/src/maker/strategy.rs
@@ -245,7 +245,7 @@ mod test {
     impl StaticStub for AllIn {
         fn static_stub() -> Self {
             AllIn::new(
-                Default::default(),
+                StaticStub::static_stub(),
                 None,
                 None,
                 StaticStub::static_stub(),
@@ -310,7 +310,7 @@ mod test {
         let order = strategy.new_sell(btc(10.0), rate).unwrap();
 
         // 35 sat * 1000 fees.
-        assert_eq!(order.quantity.to_inner(), btc(7.9997));
+        assert_eq!(order.quantity.to_inner(), btc(8.0));
 
         let order = strategy.new_buy(dai(10.0), rate).unwrap();
 
@@ -321,7 +321,7 @@ mod test {
     fn given_an_available_balance_and_a_max_quantity_sell_min_of_either() {
         let rate = Rate::try_from(1.0).unwrap();
         let strategy = AllIn::new(
-            Default::default(),
+            StaticStub::static_stub(),
             Some(btc(2.0)),
             Some(btc(2.0)),
             Spread::static_stub(),
@@ -341,7 +341,7 @@ mod test {
     fn given_an_available_balance_and_fees_sell_balance() {
         let rate = Rate::try_from(1.0).unwrap();
         let strategy = AllIn::new(
-            Default::default(),
+            StaticStub::static_stub(),
             None,
             None,
             Spread::static_stub(),
@@ -470,7 +470,7 @@ mod test {
     #[test]
     fn btc_funds_reserved_upon_taking_sell_order() {
         let mut strategy = AllIn::new(
-            BitcoinFees::default(),
+            StaticStub::static_stub(),
             None,
             None,
             Spread::static_stub(),
@@ -484,7 +484,7 @@ mod test {
             .unwrap();
 
         assert_eq!(event, TakeRequestDecision::GoForSwap);
-        assert_eq!(strategy.btc_reserved_funds, btc(1.5003))
+        assert_eq!(strategy.btc_reserved_funds, btc(1.5))
     }
 
     proptest! {
@@ -499,7 +499,7 @@ mod test {
             if let (Ok(dai_balance), Ok(rate), Ok(spread)) = (dai_balance, rate, spread) {
                 let dai_balance = dai::Amount::from_atto(dai_balance);
 
-                let strategy = AllIn::new(Default::default(), None, Some(max_buy_quantity), spread, StaticStub::static_stub(),);
+                let strategy = AllIn::new(StaticStub::static_stub(), None, Some(max_buy_quantity), spread, StaticStub::static_stub(),);
                 let _: anyhow::Result<BtcDaiOrderForm> = strategy.new_buy(dai_balance, rate);
             }
         }
@@ -514,7 +514,7 @@ mod test {
             let spread = Spread::new(spread);
 
             if let (Ok(dai_balance), Ok(rate), Ok(spread)) = (dai_balance, rate, spread) {
-                let strategy = AllIn::new(Default::default(), None, None, spread, StaticStub::static_stub(),);
+                let strategy = AllIn::new(StaticStub::static_stub(), None, None, spread, StaticStub::static_stub(),);
 
                 let dai_balance = dai::Amount::from_atto(dai_balance);
 
@@ -533,7 +533,7 @@ mod test {
             let spread = Spread::new(spread);
 
             if let (Ok(rate), Ok(spread)) = (rate, spread) {
-                let strategy = AllIn::new(Default::default(), Some(max_sell_quantity), None, spread, StaticStub::static_stub());
+                let strategy = AllIn::new(StaticStub::static_stub(), Some(max_sell_quantity), None, spread, StaticStub::static_stub());
 
                 let _: anyhow::Result<BtcDaiOrderForm> = strategy.new_sell(btc_balance, rate);
             }
@@ -549,7 +549,7 @@ mod test {
             let spread = Spread::new(spread);
 
             if let (Ok(rate), Ok(spread)) = (rate, spread) {
-                let strategy = AllIn::new(Default::default(), None, None, spread, StaticStub::static_stub());
+                let strategy = AllIn::new(StaticStub::static_stub(), None, None, spread, StaticStub::static_stub());
 
                 let _: anyhow::Result<BtcDaiOrderForm> = strategy.new_sell(btc_balance, rate);
             }
@@ -581,7 +581,7 @@ mod test {
     #[test]
     fn dai_funds_reserved_upon_taking_buy_order() {
         let mut strategy = AllIn::new(
-            Default::default(),
+            StaticStub::static_stub(),
             None,
             None,
             Spread::static_stub(),
@@ -601,7 +601,7 @@ mod test {
     #[test]
     fn dai_funds_reserved_upon_taking_buy_order_with_fee() {
         let mut strategy = AllIn::new(
-            Default::default(),
+            StaticStub::static_stub(),
             None,
             None,
             Spread::static_stub(),
@@ -621,7 +621,7 @@ mod test {
     #[test]
     fn not_enough_btc_funds_to_reserve_for_a_sell_order() {
         let mut strategy = AllIn::new(
-            Default::default(),
+            StaticStub::static_stub(),
             None,
             None,
             Spread::static_stub(),
@@ -640,7 +640,7 @@ mod test {
     #[test]
     fn not_enough_btc_funds_to_reserve_for_a_buy_order() {
         let mut strategy = AllIn::new(
-            Default::default(),
+            StaticStub::static_stub(),
             None,
             None,
             Spread::static_stub(),

--- a/nectar/src/maker/strategy.rs
+++ b/nectar/src/maker/strategy.rs
@@ -26,13 +26,13 @@ pub struct AllIn {
 
 impl AllIn {
     pub fn new(
-        bitcoin_fees: config::BitcoinFees,
+        config: config::Bitcoin,
         max_buy_quantity: Option<bitcoin::Amount>,
         max_sell_quantity: Option<bitcoin::Amount>,
         spread: Spread,
         bitcoind_client: bitcoin::Client,
     ) -> Self {
-        let bitcoin_fee = Fee::new(bitcoin_fees, bitcoind_client);
+        let bitcoin_fee = Fee::new(config, bitcoind_client);
         Self {
             bitcoin_fee,
             btc_reserved_funds: Default::default(),
@@ -259,9 +259,12 @@ mod test {
         let rate = Rate::try_from(1.0).unwrap();
         let spread = Spread::new(0).unwrap();
 
-        let bitcoin_fees = config::BitcoinFees::SatsPerByte(btc(0.001));
+        let config = config::Bitcoin {
+            fees: config::BitcoinFees::SatsPerByte(btc(0.001)),
+            ..StaticStub::static_stub()
+        };
 
-        let strategy = AllIn::new(bitcoin_fees, None, None, spread, StaticStub::static_stub());
+        let strategy = AllIn::new(config, None, None, spread, StaticStub::static_stub());
 
         let result = strategy.new_sell(btc(0.07), rate);
         assert!(result.unwrap_err().downcast::<InsufficientFunds>().is_ok());
@@ -356,10 +359,13 @@ mod test {
     #[test]
     fn given_balance_is_fees_sell_order_fails() {
         let rate = Rate::try_from(1.0).unwrap();
-        let bitcoin_fees = config::BitcoinFees::SatsPerByte(btc(0.1));
+        let config = config::Bitcoin {
+            fees: config::BitcoinFees::SatsPerByte(btc(0.1)),
+            ..StaticStub::static_stub()
+        };
 
         let strategy = AllIn::new(
-            bitcoin_fees,
+            config,
             None,
             None,
             Spread::static_stub(),
@@ -374,11 +380,13 @@ mod test {
     #[test]
     fn given_balance_is_less_than_fees_sell_order_fails() {
         let rate = Rate::try_from(1.0).unwrap();
-
-        let bitcoin_fees = BitcoinFees::SatsPerByte(bitcoin::Amount::from_sat(10000));
+        let config = config::Bitcoin {
+            fees: BitcoinFees::SatsPerByte(bitcoin::Amount::from_sat(10000)),
+            ..StaticStub::static_stub()
+        };
 
         let strategy = AllIn::new(
-            bitcoin_fees,
+            config,
             None,
             None,
             Spread::static_stub(),
@@ -558,10 +566,13 @@ mod test {
 
     #[test]
     fn btc_funds_reserved_upon_taking_sell_order_with_fee() {
-        let bitcoin_fees = BitcoinFees::SatsPerByte(bitcoin::Amount::from_sat(1000));
+        let config = config::Bitcoin {
+            fees: BitcoinFees::SatsPerByte(bitcoin::Amount::from_sat(1000)),
+            ..StaticStub::static_stub()
+        };
 
         let mut strategy = AllIn::new(
-            bitcoin_fees,
+            config,
             None,
             None,
             Spread::static_stub(),

--- a/nectar/src/swap.rs
+++ b/nectar/src/swap.rs
@@ -334,11 +334,16 @@ mod tests {
             let ethereum_gas_price =
                 crate::ethereum::GasPrice::geth_url(ethereum_blockchain.node_url.clone());
 
+            let bitcoin_fee = crate::bitcoin::Fee::new(
+                Default::default(),
+                crate::bitcoin::Client::new(bitcoind_url.clone()),
+            );
+
             (
                 bitcoin::Wallet {
                     inner: Arc::new(bitcoin_wallet),
                     connector: Arc::clone(&bitcoin_connector),
-                    fee: StaticStub::static_stub(),
+                    fee: bitcoin_fee,
                 },
                 ethereum::Wallet {
                     inner: Arc::new(ethereum_wallet),
@@ -379,11 +384,16 @@ mod tests {
             let ethereum_gas_price =
                 crate::ethereum::GasPrice::geth_url(ethereum_blockchain.node_url.clone());
 
+            let bitcoin_fee = crate::bitcoin::Fee::new(
+                Default::default(),
+                crate::bitcoin::Client::new(bitcoind_url),
+            );
+
             (
                 bitcoin::Wallet {
                     inner: Arc::new(bitcoin_wallet),
                     connector: Arc::clone(&bitcoin_connector),
-                    fee: StaticStub::static_stub(),
+                    fee: bitcoin_fee,
                 },
                 ethereum::Wallet {
                     inner: Arc::new(ethereum_wallet),

--- a/nectar/src/swap.rs
+++ b/nectar/src/swap.rs
@@ -335,7 +335,7 @@ mod tests {
                 crate::ethereum::GasPrice::geth_url(ethereum_blockchain.node_url.clone());
 
             let bitcoin_fee = crate::bitcoin::Fee::new(
-                Default::default(),
+                crate::config::BitcoinFees::SatsPerByte(bitcoin::Amount::from_sat(50)),
                 crate::bitcoin::Client::new(bitcoind_url.clone()),
             );
 
@@ -385,7 +385,7 @@ mod tests {
                 crate::ethereum::GasPrice::geth_url(ethereum_blockchain.node_url.clone());
 
             let bitcoin_fee = crate::bitcoin::Fee::new(
-                Default::default(),
+                crate::config::BitcoinFees::SatsPerByte(bitcoin::Amount::from_sat(50)),
                 crate::bitcoin::Client::new(bitcoind_url),
             );
 

--- a/nectar/src/swap.rs
+++ b/nectar/src/swap.rs
@@ -335,7 +335,13 @@ mod tests {
                 crate::ethereum::GasPrice::geth_url(ethereum_blockchain.node_url.clone());
 
             let bitcoin_fee = crate::bitcoin::Fee::new(
-                crate::config::BitcoinFees::SatsPerByte(bitcoin::Amount::from_sat(50)),
+                crate::config::Bitcoin {
+                    network: ledger::Bitcoin::Regtest,
+                    bitcoind: crate::config::Bitcoind {
+                        node_url: bitcoind_url.clone(),
+                    },
+                    fees: crate::config::BitcoinFees::SatsPerByte(bitcoin::Amount::from_sat(50)),
+                },
                 crate::bitcoin::Client::new(bitcoind_url.clone()),
             );
 
@@ -385,8 +391,14 @@ mod tests {
                 crate::ethereum::GasPrice::geth_url(ethereum_blockchain.node_url.clone());
 
             let bitcoin_fee = crate::bitcoin::Fee::new(
-                crate::config::BitcoinFees::SatsPerByte(bitcoin::Amount::from_sat(50)),
-                crate::bitcoin::Client::new(bitcoind_url),
+                crate::config::Bitcoin {
+                    network: ledger::Bitcoin::Regtest,
+                    bitcoind: crate::config::Bitcoind {
+                        node_url: bitcoind_url.clone(),
+                    },
+                    fees: crate::config::BitcoinFees::SatsPerByte(bitcoin::Amount::from_sat(50)),
+                },
+                crate::bitcoin::Client::new(bitcoind_url.clone()),
             );
 
             (

--- a/tests/package.json
+++ b/tests/package.json
@@ -7,7 +7,6 @@
         "check": "tsc && prettier --check '**/*.{ts,json,yml}' && tslint --project .",
         "pretest": "tsc",
         "test": "jest --forceExit",
-        "ci": "tsc && jest --forceExit",
         "fix": "tslint --project . --fix && prettier --write '**/*.{ts,js,json,yml}'"
     },
     "engines": {

--- a/tests/tests/buy_and_sell_bitcoin_e2e_cnd_nectar.ts
+++ b/tests/tests/buy_and_sell_bitcoin_e2e_cnd_nectar.ts
@@ -28,7 +28,7 @@ test(
         await alice.assertOrderClosed();
         await alice.assertSwapInactive();
         await bob.assertBalancesChangedBy({
-            bitcoin: -(10_000_000n + 1530n), // nectar pays order quantity + the funding fee
+            bitcoin: -(10_000_000n + 7650n), // nectar pays order quantity + the funding fee
             dai: 945_000_000_000_000_000_000n, // = 0.1 * 9450 * 10^18
         });
     })
@@ -55,7 +55,7 @@ test(
         await alice.assertOrderClosed();
         await alice.assertSwapInactive();
         await bob.assertBalancesChangedBy({
-            bitcoin: 10000000n - 5700n, // nectar receives order quantity but pays the redeem fee
+            bitcoin: 10000000n - 16200n, // nectar receives order quantity but pays the redeem fee
             dai: -855_000_000_000_000_000_000n, // = 0.1 * 8550 * 10^18
         });
     })


### PR DESCRIPTION
- Update time to mine values to some more realistic times from looking at mainnet Ethereum and Bitcoin fees.
- Did a fix in the `expiries` modules where "bob time to complete" would include "alice's time to act" when the clock started, making Bob abort when Alice would act after 50min (she is allowed 60min).
- Default to use `bitcoind estimatesmartfee` feature for nectar instead of static value.