### PR TITLE
Replace btsieve's `watch_for_event` implementation with `eth_getLogs`

### DIFF
--- a/cnd/src/connectors.rs
+++ b/cnd/src/connectors.rs
@@ -1,6 +1,10 @@
 use crate::{
     btsieve,
-    btsieve::{bitcoin::BitcoindConnector, ethereum::Web3Connector, ConnectedNetwork, LatestBlock},
+    btsieve::{
+        bitcoin::BitcoindConnector,
+        ethereum::{GetLogs, TransactionByHash, Web3Connector},
+        ConnectedNetwork, LatestBlock,
+    },
     ethereum,
     http_api::LedgerNotConfigured,
 };
@@ -57,7 +61,9 @@ impl Connectors {
         impl LatestBlock<Block = ethereum::Block>
             + BlockByHash<Block = ethereum::Block, BlockHash = ethereum::Hash>
             + ReceiptByHash
-            + ConnectedNetwork<Network = ethereum::ChainId>,
+            + TransactionByHash
+            + ConnectedNetwork<Network = ethereum::ChainId>
+            + GetLogs,
     > {
         self.ethereum.clone()
     }

--- a/cnd/src/herc20.rs
+++ b/cnd/src/herc20.rs
@@ -13,7 +13,10 @@ use std::collections::{hash_map::Entry, HashMap};
 use time::OffsetDateTime;
 use tokio::sync::Mutex;
 
-use crate::btsieve::ConnectedNetwork;
+use crate::btsieve::{
+    ethereum::{GetLogs, TransactionByHash},
+    ConnectedNetwork,
+};
 pub use comit::herc20::*;
 
 /// Creates a new instance of the herc20 protocol, annotated with tracing spans
@@ -35,7 +38,9 @@ where
     C: LatestBlock<Block = Block>
         + BlockByHash<Block = Block, BlockHash = Hash>
         + ReceiptByHash
-        + ConnectedNetwork<Network = ChainId>,
+        + TransactionByHash
+        + ConnectedNetwork<Network = ChainId>
+        + GetLogs,
 {
     let mut events = comit::herc20::new(connector.as_ref(), params, start_of_swap);
 

--- a/comit/src/btsieve/ethereum.rs
+++ b/comit/src/btsieve/ethereum.rs
@@ -11,7 +11,7 @@ pub use self::{
 };
 use crate::{
     btsieve::{BlockHash, ConnectedNetwork, Predates, PreviousBlockHash},
-    ethereum::{Address, Block, ChainId, Hash, TransactionReceipt, U256},
+    ethereum::{Address, Block, ChainId, Hash, Log, Transaction, TransactionReceipt, U256},
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -21,6 +21,16 @@ use time::OffsetDateTime;
 #[async_trait]
 pub trait ReceiptByHash: Send + Sync + 'static {
     async fn receipt_by_hash(&self, transaction_hash: Hash) -> Result<TransactionReceipt>;
+}
+
+#[async_trait]
+pub trait TransactionByHash: Send + Sync + 'static {
+    async fn transaction_by_hash(&self, transaction_hash: Hash) -> Result<Transaction>;
+}
+
+#[async_trait]
+pub trait GetLogs: Send + Sync + 'static {
+    async fn get_logs(&self, event: Event) -> Result<Vec<Log>>;
 }
 
 impl BlockHash for Block {
@@ -47,15 +57,12 @@ impl Predates for Block {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct Topic(pub Hash);
-
 /// Event works similar to web3 filters:
 /// https://web3js.readthedocs.io/en/1.0/web3-eth-subscribe.html?highlight=filter#subscribe-logs
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Event {
     pub address: Address,
-    pub topics: Vec<Option<Topic>>,
+    pub topics: Vec<Option<Hash>>,
 }
 
 async fn poll_interval<C>(connector: &C) -> Result<Duration>

--- a/comit/src/btsieve/ethereum/cache.rs
+++ b/comit/src/btsieve/ethereum/cache.rs
@@ -1,9 +1,9 @@
 use crate::{
     btsieve::{
-        ethereum::{self, Hash, ReceiptByHash},
+        ethereum::{self, Event, GetLogs, Hash, ReceiptByHash, TransactionByHash},
         BlockByHash, ConnectedNetwork, LatestBlock,
     },
-    ethereum::{ChainId, TransactionReceipt},
+    ethereum::{ChainId, Log, Transaction, TransactionReceipt},
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -128,5 +128,25 @@ where
         let _ = self.connected_network_cache.lock().await.replace(network);
 
         Ok(network)
+    }
+}
+
+#[async_trait]
+impl<C> GetLogs for Cache<C>
+where
+    C: GetLogs,
+{
+    async fn get_logs(&self, event: Event) -> anyhow::Result<Vec<Log>> {
+        self.connector.get_logs(event).await
+    }
+}
+
+#[async_trait]
+impl<C> TransactionByHash for Cache<C>
+where
+    C: TransactionByHash,
+{
+    async fn transaction_by_hash(&self, transaction_hash: Hash) -> anyhow::Result<Transaction> {
+        self.connector.transaction_by_hash(transaction_hash).await
     }
 }

--- a/comit/src/btsieve/ethereum/watch_for_event.rs
+++ b/comit/src/btsieve/ethereum/watch_for_event.rs
@@ -25,15 +25,15 @@ where
         connector,
         start_of_swap,
         expected_event.topics.clone(),
-        |receipt| find_log_for_event_in_receipt(&expected_event, receipt),
+        |receipt| find_log_for_event(&expected_event, receipt.logs),
     )
     .await
 }
 
-fn find_log_for_event_in_receipt(event: &Event, receipt: TransactionReceipt) -> Option<Log> {
+fn find_log_for_event(event: &Event, logs: Vec<Log>) -> Option<Log> {
     match event {
         Event { topics, .. } if topics.is_empty() => None,
-        Event { address, topics } => receipt.logs.into_iter().find(|log| {
+        Event { address, topics } => logs.into_iter().find(|log| {
             if address != &log.address {
                 return false;
             }

--- a/comit/src/btsieve/ethereum/watch_for_event.rs
+++ b/comit/src/btsieve/ethereum/watch_for_event.rs
@@ -1,33 +1,39 @@
 use crate::{
     btsieve::{
-        ethereum::{poll_interval, Event, ReceiptByHash, Topic},
-        fetch_blocks_since, BlockByHash, ConnectedNetwork, LatestBlock,
+        ethereum::{poll_interval, Event, GetLogs, ReceiptByHash, TransactionByHash},
+        BlockByHash, ConnectedNetwork, LatestBlock,
     },
-    ethereum::{Block, ChainId, Hash, Input, Log, Transaction, TransactionReceipt},
+    ethereum::{Block, ChainId, Hash, Log, Transaction},
 };
 use anyhow::Result;
-use genawaiter::GeneratorState;
 use time::OffsetDateTime;
-use tracing_futures::Instrument;
 
 pub async fn watch_for_event<C>(
     connector: &C,
-    start_of_swap: OffsetDateTime,
+    _start_of_swap: OffsetDateTime,
     expected_event: Event,
 ) -> Result<(Transaction, Log)>
 where
     C: LatestBlock<Block = Block>
         + BlockByHash<Block = Block, BlockHash = Hash>
         + ReceiptByHash
-        + ConnectedNetwork<Network = ChainId>,
+        + TransactionByHash
+        + ConnectedNetwork<Network = ChainId>
+        + GetLogs,
 {
-    matching_transaction_and_log(
-        connector,
-        start_of_swap,
-        expected_event.topics.clone(),
-        |receipt| find_log_for_event(&expected_event, receipt.logs),
-    )
-    .await
+    let poll_interval = poll_interval(connector).await?;
+
+    loop {
+        let logs = connector.get_logs(expected_event.clone()).await?;
+
+        if let Some(log) = find_log_for_event(&expected_event, logs) {
+            let tx = connector.transaction_by_hash(log.transaction_hash).await?;
+
+            return Ok((tx, log));
+        }
+
+        tokio::time::delay_for(poll_interval).await;
+    }
 }
 
 fn find_log_for_event(event: &Event, logs: Vec<Log>) -> Option<Log> {
@@ -44,108 +50,8 @@ fn find_log_for_event(event: &Event, logs: Vec<Log>) -> Option<Log> {
 
             log.topics.iter().enumerate().all(|(index, tx_topic)| {
                 let topic = &topics[index];
-                topic.as_ref().map_or(true, |topic| tx_topic == &topic.0)
+                topic.as_ref().map_or(true, |topic| tx_topic == topic)
             })
         }),
     }
-}
-
-async fn matching_transaction_and_log<C, F>(
-    connector: &C,
-    start_of_swap: OffsetDateTime,
-    topics: Vec<Option<Topic>>,
-    matcher: F,
-) -> Result<(Transaction, Log)>
-where
-    C: LatestBlock<Block = Block>
-        + BlockByHash<Block = Block, BlockHash = Hash>
-        + ReceiptByHash
-        + ConnectedNetwork<Network = ChainId>,
-    F: Fn(TransactionReceipt) -> Option<Log> + Clone,
-{
-    let poll_interval = poll_interval(connector).await?;
-    let mut block_generator = fetch_blocks_since(connector, start_of_swap, poll_interval);
-
-    loop {
-        match block_generator.async_resume().await {
-            GeneratorState::Yielded(block) => {
-                if let Some(result) =
-                    process_block(block, connector, topics.clone(), matcher.clone()).await?
-                {
-                    return Ok(result);
-                }
-            }
-            GeneratorState::Complete(Err(e)) => return Err(e),
-            // By matching against the never type explicitly, we assert that the `Ok` value of the
-            // result is actually the never type and has not been changed since this line was
-            // written. The never type can never be constructed, so we can never reach this line.
-            GeneratorState::Complete(Ok(never)) => match never {},
-        }
-    }
-}
-
-#[tracing::instrument(name = "block", skip(block, connector, matcher, topics), fields(hash = %block.hash, tx_count = %block.transactions.len()))]
-async fn process_block<C, F>(
-    block: Block,
-    connector: &C,
-    topics: Vec<Option<Topic>>,
-    matcher: F,
-) -> Result<Option<(Transaction, Log)>>
-where
-    C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
-    F: Fn(TransactionReceipt) -> Option<Log> + Clone,
-{
-    let maybe_contains_transaction = topics.iter().all(|topic| {
-        topic.as_ref().map_or(true, |topic| {
-            block
-                .logs_bloom
-                .contains_input(Input::Raw(&topic.0.as_bytes()))
-        })
-    });
-
-    if !maybe_contains_transaction {
-        tracing::trace!("skipping block due to bloom filter");
-        return Ok(None);
-    }
-
-    for transaction in block.transactions.into_iter() {
-        if let Some(result) = process_transaction(transaction, connector, matcher.clone())
-            .in_current_span()
-            .await?
-        {
-            return Ok(Some(result));
-        }
-    }
-
-    tracing::debug!("no transaction matched");
-
-    Ok(None)
-}
-
-#[tracing::instrument(name = "tx", skip(tx, connector, matcher), fields(hash = %tx.hash))]
-async fn process_transaction<C, F>(
-    tx: Transaction,
-    connector: &C,
-    matcher: F,
-) -> Result<Option<(Transaction, Log)>>
-where
-    C: LatestBlock<Block = Block> + BlockByHash<Block = Block, BlockHash = Hash> + ReceiptByHash,
-    F: Fn(TransactionReceipt) -> Option<Log>,
-{
-    let receipt = connector.receipt_by_hash(tx.hash).await?;
-    let is_successful = receipt.successful;
-
-    if let Some(log) = matcher(receipt) {
-        if !is_successful {
-            // This can be caused by a failed attempt to complete an action,
-            // for example, sending a transaction with low gas.
-            tracing::warn!("transaction matched but status was NOT OK");
-            return Ok(None);
-        }
-        tracing::info!("transaction matched");
-
-        return Ok(Some((tx, log)));
-    }
-
-    Ok(None)
 }

--- a/comit/src/btsieve/ethereum/web3_connector.rs
+++ b/comit/src/btsieve/ethereum/web3_connector.rs
@@ -1,6 +1,9 @@
 use crate::{
-    btsieve::{ethereum::ReceiptByHash, jsonrpc, BlockByHash, ConnectedNetwork, LatestBlock},
-    ethereum::{ChainId, Hash, TransactionReceipt},
+    btsieve::{
+        ethereum::{Event, GetLogs, ReceiptByHash, TransactionByHash},
+        jsonrpc, BlockByHash, ConnectedNetwork, LatestBlock,
+    },
+    ethereum::{ChainId, Hash, Log, Transaction, TransactionReceipt},
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -77,6 +80,20 @@ impl ReceiptByHash for Web3Connector {
 }
 
 #[async_trait]
+impl TransactionByHash for Web3Connector {
+    async fn transaction_by_hash(&self, transaction_hash: Hash) -> Result<Transaction> {
+        let transaction = self
+            .client
+            .send(jsonrpc::Request::new("eth_getTransactionByHash", vec![
+                jsonrpc::serialize(transaction_hash)?,
+            ]))
+            .await?;
+
+        Ok(transaction)
+    }
+}
+
+#[async_trait]
 impl ConnectedNetwork for Web3Connector {
     type Network = ChainId;
 
@@ -84,5 +101,29 @@ impl ConnectedNetwork for Web3Connector {
         let chain_id = self.net_version().await?;
 
         Ok(chain_id)
+    }
+}
+
+#[async_trait]
+impl GetLogs for Web3Connector {
+    async fn get_logs(&self, event: Event) -> Result<Vec<Log>> {
+        // Ideally, we would be computing this based on start-of-swap.
+        // However, some manual testing on mainnet shows that even specifying 0 is
+        // reasonably performant (~ 1sec for Infura). Hence, we just specify 0
+        // here to be on the safe side.
+        let from_block = "0x0";
+
+        let logs = self
+            .client
+            .send(jsonrpc::Request::new("eth_getLogs", vec![
+                serde_json::json!({
+                    "fromBlock": from_block,
+                    "address": event.address,
+                    "topics": event.topics
+                }),
+            ]))
+            .await?;
+
+        Ok(logs)
     }
 }

--- a/comit/src/ethereum.rs
+++ b/comit/src/ethereum.rs
@@ -170,6 +170,8 @@ pub struct Log {
     pub topics: Vec<Hash>,
     /// Data
     pub data: crate::ethereum::UnformattedData,
+    #[serde(rename = "transactionHash")]
+    pub transaction_hash: Hash,
 }
 
 /// The block returned from RPC calls.

--- a/comit/src/herc20.rs
+++ b/comit/src/herc20.rs
@@ -4,7 +4,9 @@ use crate::{
     actions, asset,
     asset::{ethereum::FromWei, Erc20, Erc20Quantity},
     btsieve::{
-        ethereum::{watch_for_contract_creation, watch_for_event, ReceiptByHash, Topic},
+        ethereum::{
+            watch_for_contract_creation, watch_for_event, GetLogs, ReceiptByHash, TransactionByHash,
+        },
         BlockByHash, ConnectedNetwork, LatestBlock,
     },
     ethereum::{Block, ChainId, Hash, U256},
@@ -103,7 +105,9 @@ where
     C: LatestBlock<Block = Block>
         + BlockByHash<Block = Block, BlockHash = Hash>
         + ReceiptByHash
-        + ConnectedNetwork<Network = ChainId>,
+        + TransactionByHash
+        + ConnectedNetwork<Network = ChainId>
+        + GetLogs,
 {
     Gen::new({
         |co| async move {
@@ -124,7 +128,9 @@ where
     C: LatestBlock<Block = Block>
         + BlockByHash<Block = Block, BlockHash = Hash>
         + ReceiptByHash
-        + ConnectedNetwork<Network = ChainId>,
+        + TransactionByHash
+        + ConnectedNetwork<Network = ChainId>
+        + GetLogs,
 {
     co.yield_(Ok(Event::Started)).await;
 
@@ -191,16 +197,18 @@ where
     C: LatestBlock<Block = Block>
         + BlockByHash<Block = Block, BlockHash = Hash>
         + ReceiptByHash
-        + ConnectedNetwork<Network = ChainId>,
+        + TransactionByHash
+        + ConnectedNetwork<Network = ChainId>
+        + GetLogs,
 {
     use crate::btsieve::ethereum::Event;
 
     let event = Event {
         address: params.asset.token_contract,
         topics: vec![
-            Some(Topic(*TRANSFER_LOG_MSG)),
+            Some(*TRANSFER_LOG_MSG),
             None,
-            Some(Topic(deployed.location.into())),
+            Some(deployed.location.into()),
         ],
     };
 
@@ -230,13 +238,15 @@ where
     C: LatestBlock<Block = Block>
         + BlockByHash<Block = Block, BlockHash = Hash>
         + ReceiptByHash
-        + ConnectedNetwork<Network = ChainId>,
+        + TransactionByHash
+        + ConnectedNetwork<Network = ChainId>
+        + GetLogs,
 {
     use crate::btsieve::ethereum::Event;
 
     let event = Event {
         address: deployed.location,
-        topics: vec![Some(Topic(*REDEEM_LOG_MSG))],
+        topics: vec![Some(*REDEEM_LOG_MSG)],
     };
 
     let (transaction, log) = watch_for_event(connector, start_of_swap, event)
@@ -261,13 +271,15 @@ where
     C: LatestBlock<Block = Block>
         + BlockByHash<Block = Block, BlockHash = Hash>
         + ReceiptByHash
-        + ConnectedNetwork<Network = ChainId>,
+        + TransactionByHash
+        + ConnectedNetwork<Network = ChainId>
+        + GetLogs,
 {
     use crate::btsieve::ethereum::Event;
 
     let event = Event {
         address: deployed.location,
-        topics: vec![Some(Topic(*REFUND_LOG_MSG))],
+        topics: vec![Some(*REFUND_LOG_MSG)],
     };
 
     let (transaction, _) = watch_for_event(connector, start_of_swap, event)

--- a/nectar/src/swap/comit/hbit_herc20.rs
+++ b/nectar/src/swap/comit/hbit_herc20.rs
@@ -8,7 +8,10 @@ use crate::{
 use anyhow::{Context, Result};
 use comit::{
     btsieve,
-    btsieve::{BlockByHash, ConnectedNetwork, LatestBlock},
+    btsieve::{
+        ethereum::{GetLogs, TransactionByHash},
+        BlockByHash, ConnectedNetwork, LatestBlock,
+    },
     ethereum, ledger, Secret,
 };
 use time::OffsetDateTime;
@@ -28,7 +31,9 @@ where
     EC: LatestBlock<Block = ethereum::Block>
         + BlockByHash<Block = ethereum::Block, BlockHash = ethereum::Hash>
         + btsieve::ethereum::ReceiptByHash
-        + ConnectedNetwork<Network = ChainId>,
+        + ConnectedNetwork<Network = ChainId>
+        + GetLogs
+        + TransactionByHash,
 {
     let swap_result = async {
         let hbit_funded = alice
@@ -82,7 +87,9 @@ where
     EC: LatestBlock<Block = ethereum::Block>
         + BlockByHash<Block = ethereum::Block, BlockHash = ethereum::Hash>
         + btsieve::ethereum::ReceiptByHash
-        + ConnectedNetwork<Network = ChainId>,
+        + ConnectedNetwork<Network = ChainId>
+        + GetLogs
+        + TransactionByHash,
 {
     tracing::info!("starting swap");
 

--- a/nectar/src/swap/comit/herc20.rs
+++ b/nectar/src/swap/comit/herc20.rs
@@ -1,7 +1,10 @@
 use crate::swap::comit::SwapFailedShouldRefund;
 use anyhow::Result;
 
-use comit::btsieve::ConnectedNetwork;
+use comit::btsieve::{
+    ethereum::{GetLogs, TransactionByHash},
+    ConnectedNetwork,
+};
 pub use comit::{
     actions::ethereum::*,
     asset,
@@ -64,7 +67,9 @@ where
     C: LatestBlock<Block = Block>
         + BlockByHash<Block = Block, BlockHash = Hash>
         + ReceiptByHash
-        + ConnectedNetwork<Network = ChainId>,
+        + ConnectedNetwork<Network = ChainId>
+        + GetLogs
+        + TransactionByHash,
 {
     match comit::herc20::watch_for_funded(connector, params, utc_start_of_swap, deployed).await? {
         comit::herc20::Funded::Correctly { transaction, asset } => {

--- a/nectar/src/swap/comit/herc20_hbit.rs
+++ b/nectar/src/swap/comit/herc20_hbit.rs
@@ -5,7 +5,10 @@ use crate::swap::{
 use anyhow::Context;
 use comit::{
     btsieve,
-    btsieve::{BlockByHash, ConnectedNetwork, LatestBlock},
+    btsieve::{
+        ethereum::{GetLogs, TransactionByHash},
+        BlockByHash, ConnectedNetwork, LatestBlock,
+    },
     ethereum,
     ethereum::ChainId,
     ledger, Secret,
@@ -74,7 +77,9 @@ where
     EC: LatestBlock<Block = ethereum::Block>
         + BlockByHash<Block = ethereum::Block, BlockHash = ethereum::Hash>
         + btsieve::ethereum::ReceiptByHash
-        + ConnectedNetwork<Network = ChainId>,
+        + ConnectedNetwork<Network = ChainId>
+        + GetLogs
+        + TransactionByHash,
     BC: LatestBlock<Block = ::bitcoin::Block>
         + BlockByHash<Block = ::bitcoin::Block, BlockHash = ::bitcoin::BlockHash>
         + ConnectedNetwork<Network = ledger::Bitcoin>,


### PR DESCRIPTION
Instead of scanning the blockchain manually, we can leverage the `eth_getLogs` web3 API of the Ethereum node.

This allows us to directly ask for logs emitted by a contract.

Technically, this functionality should no longer be within the `btsieve` module because it doesn't have anything to do with "sieving transactions". I would defer the fix to this to a later point though.