### PR TITLE
Improve JSON-RPC error reporting

### DIFF
--- a/nectar/src/jsonrpc.rs
+++ b/nectar/src/jsonrpc.rs
@@ -42,29 +42,20 @@ impl Client {
             .json(&request)
             .send()
             .map_err(ConnectionFailed)
-            .await?;
+            .await?
+            .json::<Response<Res>>()
+            .await
+            .context("failed to deserialize JSON response as JSON-RPC response")?
+            .payload
+            .into_result()
+            .with_context(|| {
+                format!(
+                    "JSON-RPC request {} failed",
+                    serde_json::to_string(&request).expect("can always serialize to JSON")
+                )
+            })?;
 
-        let response = response.bytes().await?;
-
-        let response: Response<Res> = match serde_json::from_slice(&response) {
-            Ok(response) => response,
-            Err(error) => {
-                let response = String::from_utf8_lossy(&response[..]);
-                tracing::debug!("Response received: {}", response);
-                anyhow::bail!(
-                    "failed to deserialize JSON response {} as JSON-RPC response: {:#}",
-                    response,
-                    error
-                );
-            }
-        };
-
-        match response {
-            Response::Success { result } => Ok(result),
-            Response::Error { error } | Response::RpcError(error) => {
-                Err(error).with_context(|| format!("JSON-RPC request {:?} failed", request))
-            }
-        }
+        Ok(response)
     }
 }
 
@@ -87,15 +78,29 @@ impl<T> Request<T> {
     }
 }
 
-#[derive(serde::Deserialize, Debug)]
-#[serde(untagged)]
-pub enum Response<T> {
-    Success { result: T },
-    Error { error: JsonRpcError },
-    RpcError(JsonRpcError),
+#[derive(serde::Deserialize, Debug, PartialEq)]
+pub struct Response<R> {
+    #[serde(flatten)]
+    pub payload: ResponsePayload<R>,
 }
 
-#[derive(Debug, serde::Deserialize, thiserror::Error)]
+#[derive(serde::Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ResponsePayload<R> {
+    Result(R),
+    Error(JsonRpcError),
+}
+
+impl<R> ResponsePayload<R> {
+    fn into_result(self) -> Result<R, JsonRpcError> {
+        match self {
+            ResponsePayload::Result(result) => Ok(result),
+            ResponsePayload::Error(e) => Err(e),
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize, thiserror::Error, PartialEq)]
 #[error("JSON-RPC request failed with code {code}: {message}")]
 pub struct JsonRpcError {
     code: i64,


### PR DESCRIPTION
Instead of using an untagged enum, we can model the JSON-RPC response
as a tagged enum that is flattened into another struct. This greatly
improves the error message we get from serde if we can't deserialize
a response.

This also allows us to directly go into JSON again within nectar's
RPC client because serde's error messages are actually pretty good
if we don't use untagged enums.