### PR TITLE
 Update the expected network times to calculate the expiries

### DIFF
--- a/cnd/CHANGELOG.md
+++ b/cnd/CHANGELOG.md
@@ -19,6 +19,7 @@ Previously, unknown configuration keys would just be ignored.
 
 -   **Breaking Change** Remove support for RFC003 swaps
 -   **Breaking Change** Config directory for MacOS changed from `/Users/<user>/Library/Preferences/comit/` to `/Users/<user>/Library/Application Support/comit/`.
+-   Update the expected network times to calculate the expiries: We expect Bitcoin's transactions to be included within 6 blocks and Ethereum's within 30 blocks.
 
 ## [0.8.0] - 2020-06-12
 

--- a/comit/src/expiries/config.rs
+++ b/comit/src/expiries/config.rs
@@ -44,6 +44,11 @@ mod main {
     pub const ACT_IN_SOFTWARE_SECS: u32 = 15 * 60; // Value arbitrarily chosen.
     pub const ACT_WITH_USER_INTERACTION_SECS: u32 = 60 * 60; // Value arbitrarily
                                                              // chosen.
+
+    // Considering current market, less than 6 blocks is very expensive.
+    pub const BITCOIN_MINE_WITHIN_N_BLOCKS: u8 = 6;
+    // Approx. 10min wait seems to match the `safeLowWait` of ethgasstation.
+    pub const ETHEREUM_MINE_WITHIN_N_BLOCKS: u8 = 30;
 }
 
 mod dev {
@@ -58,10 +63,10 @@ mod dev {
     // The e2e tests act very fast :)
     pub const ACT_IN_SOFTWARE_SECS: u32 = 1;
     pub const ACT_WITH_USER_INTERACTION_SECS: u32 = 1;
-}
 
-const BITCOIN_MINE_WITHIN_N_BLOCKS: u8 = 3; // Value arbitrarily chosen.
-const ETHEREUM_MINE_WITHIN_N_BLOCKS: u8 = 3; // Value arbitrarily chosen.
+    pub const BITCOIN_MINE_WITHIN_N_BLOCKS: u8 = 3;
+    pub const ETHEREUM_MINE_WITHIN_N_BLOCKS: u8 = 3;
+}
 
 /// Configuration values used during transition period calculations.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -90,12 +95,12 @@ impl Config {
             beta_required_confirmations: bitcoin_confirmations(network),
             alpha_average_block_time: ethereum_blocktime(network),
             beta_average_block_time: bitcoin_blocktime(network),
-            alpha_mine_deploy_within_n_blocks: ETHEREUM_MINE_WITHIN_N_BLOCKS,
-            beta_mine_deploy_within_n_blocks: BITCOIN_MINE_WITHIN_N_BLOCKS,
-            alpha_mine_fund_within_n_blocks: ETHEREUM_MINE_WITHIN_N_BLOCKS,
-            beta_mine_fund_within_n_blocks: BITCOIN_MINE_WITHIN_N_BLOCKS,
-            alpha_mine_redeem_within_n_blocks: ETHEREUM_MINE_WITHIN_N_BLOCKS,
-            beta_mine_redeem_within_n_blocks: BITCOIN_MINE_WITHIN_N_BLOCKS,
+            alpha_mine_deploy_within_n_blocks: ethereum_mine_within_blocks(network),
+            beta_mine_deploy_within_n_blocks: bitcoin_mine_within_blocks(network),
+            alpha_mine_fund_within_n_blocks: ethereum_mine_within_blocks(network),
+            beta_mine_fund_within_n_blocks: bitcoin_mine_within_blocks(network),
+            alpha_mine_redeem_within_n_blocks: ethereum_mine_within_blocks(network),
+            beta_mine_redeem_within_n_blocks: bitcoin_mine_within_blocks(network),
             act_in_software: act_in_software(network),
             act_with_user_interaction: act_with_user_interaction(network),
         }
@@ -109,12 +114,12 @@ impl Config {
             beta_required_confirmations: ethereum_confirmations(network),
             alpha_average_block_time: bitcoin_blocktime(network),
             beta_average_block_time: ethereum_blocktime(network),
-            alpha_mine_deploy_within_n_blocks: BITCOIN_MINE_WITHIN_N_BLOCKS,
-            beta_mine_deploy_within_n_blocks: ETHEREUM_MINE_WITHIN_N_BLOCKS,
-            alpha_mine_fund_within_n_blocks: BITCOIN_MINE_WITHIN_N_BLOCKS,
-            beta_mine_fund_within_n_blocks: ETHEREUM_MINE_WITHIN_N_BLOCKS,
-            alpha_mine_redeem_within_n_blocks: BITCOIN_MINE_WITHIN_N_BLOCKS,
-            beta_mine_redeem_within_n_blocks: ETHEREUM_MINE_WITHIN_N_BLOCKS,
+            alpha_mine_deploy_within_n_blocks: bitcoin_mine_within_blocks(network),
+            beta_mine_deploy_within_n_blocks: ethereum_mine_within_blocks(network),
+            alpha_mine_fund_within_n_blocks: bitcoin_mine_within_blocks(network),
+            beta_mine_fund_within_n_blocks: ethereum_mine_within_blocks(network),
+            alpha_mine_redeem_within_n_blocks: bitcoin_mine_within_blocks(network),
+            beta_mine_redeem_within_n_blocks: ethereum_mine_within_blocks(network),
             act_in_software: act_in_software(network),
             act_with_user_interaction: act_with_user_interaction(network),
         }
@@ -339,6 +344,13 @@ fn bitcoin_confirmations(network: Network) -> u8 {
     }
 }
 
+fn bitcoin_mine_within_blocks(network: Network) -> u8 {
+    match network {
+        Network::Main | Network::Test => main::BITCOIN_MINE_WITHIN_N_BLOCKS,
+        Network::Dev => dev::BITCOIN_MINE_WITHIN_N_BLOCKS,
+    }
+}
+
 fn ethereum_blocktime(network: Network) -> u16 {
     match network {
         Network::Main | Network::Test => main::ETHEREUM_BLOCK_TIME_SECS,
@@ -350,6 +362,13 @@ fn ethereum_confirmations(network: Network) -> u8 {
     match network {
         Network::Main | Network::Test => main::ETHEREUM_CONFIRMATIONS,
         Network::Dev => dev::ETHEREUM_CONFIRMATIONS,
+    }
+}
+
+fn ethereum_mine_within_blocks(network: Network) -> u8 {
+    match network {
+        Network::Main | Network::Test => main::ETHEREUM_MINE_WITHIN_N_BLOCKS,
+        Network::Dev => dev::ETHEREUM_MINE_WITHIN_N_BLOCKS,
     }
 }
 

--- a/comit/src/expiries/config.rs
+++ b/comit/src/expiries/config.rs
@@ -60,7 +60,6 @@ mod dev {
     pub const ACT_WITH_USER_INTERACTION_SECS: u32 = 1;
 }
 
-// TODO: Fee recommendation must use this value of N.
 const BITCOIN_MINE_WITHIN_N_BLOCKS: u8 = 3; // Value arbitrarily chosen.
 const ETHEREUM_MINE_WITHIN_N_BLOCKS: u8 = 3; // Value arbitrarily chosen.
 

--- a/nectar/CHANGELOG.md
+++ b/nectar/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Added
+### Added
 
 -   Ability to configure strategies to be used for Bitcoin fees and Ethereum Gas Price resolution.
     See `./sample-config.toml` for more details.
 -   Disallow unknown keys in the config file.
 Previously, unknown configuration keys would just be ignored.
 `nectar` will now refuse to startup if the configuration file contains unknown keys.
+
+### Changed
+
+-   Update the expected network times to calculate the expiries: We expect Bitcoin's transactions to be included within 6 blocks and Ethereum's within 30 blocks.
 
 [Unreleased]: https://github.com/comit-network/comit-rs/compare/d5d26e42a2d8dd026ae94f2c8a9e0bd80ab81133...HEAD

--- a/nectar/src/config/file.rs
+++ b/nectar/src/config/file.rs
@@ -384,7 +384,6 @@ url = "https://ethgasstation.info/api/ethgasAPI.json?api-key=XXAPI_Key_HereXXX"
 "#;
 
         let serialized = toml::to_string(&file);
-        dbg!(&serialized);
         assert_that(&serialized)
             .is_ok()
             .is_equal_to(expected.to_string());


### PR DESCRIPTION
 We expect Bitcoin's transactions to be included within 6 blocks and Ethereum's within 30 blocks.

Also fix an issue where Bob was told to abort too early.