### PR TITLE
Commands for manually creating redeem/refund transactions for nectar

### DIFF
--- a/nectar/src/command/create_transaction.rs
+++ b/nectar/src/command/create_transaction.rs
@@ -1,0 +1,126 @@
+use crate::{
+    bitcoin,
+    command::CreateTransaction,
+    database::{Database, Load},
+    ethereum,
+    ethereum::to_clarity_address,
+    swap::SwapKind,
+};
+use anyhow::{Context, Result};
+
+pub async fn create_transaction(
+    input: CreateTransaction,
+    db: Database,
+    bitcoin_wallet: bitcoin::Wallet,
+    bitcoin_fee: bitcoin::Fee,
+    ethereum_wallet: ethereum::Wallet,
+    gas_price: ethereum::GasPrice,
+) -> Result<String> {
+    let swap_id = input.swap_id();
+    let swap = db
+        .load(swap_id)?
+        .with_context(|| format!("unable to find swap with id {}", swap_id))?;
+
+    let hex = match (swap, input) {
+        (
+            SwapKind::HbitHerc20(params),
+            CreateTransaction::Redeem {
+                secret, outpoint, ..
+            },
+        ) => {
+            let redeem_address = bitcoin_wallet.new_address().await?;
+            let vbyte_rate = bitcoin_fee.vbyte_rate().await?;
+
+            let action = params.hbit_params.shared.build_redeem_action(
+                &crate::SECP,
+                params.hbit_params.shared.asset, /* TODO: allow the user to override this on the
+                                                  * commandline */
+                outpoint.context(
+                    "HTLC outpoint required but not provided, please provide with --outpoint",
+                )?,
+                params.hbit_params.transient_sk,
+                redeem_address,
+                secret,
+                vbyte_rate,
+            )?;
+
+            hex::encode(::bitcoin::consensus::serialize(&action.transaction))
+        }
+        (SwapKind::HbitHerc20(params), CreateTransaction::Refund { address, .. }) => {
+            let action = params.herc20_params.build_refund_action(address.context(
+                "HTLC address required but not provided, please provide with --address",
+            )?);
+            let gas_price = gas_price.gas_price().await?;
+            let to = to_clarity_address(action.to)?;
+            let chain_id = action.chain_id;
+
+            ethereum_wallet
+                .sign(
+                    |nonce| clarity::Transaction {
+                        nonce,
+                        gas_price: gas_price.into(),
+                        gas_limit: action.gas_limit.into(),
+                        to,
+                        value: 0u32.into(),
+                        data: action.data.unwrap_or_default(),
+                        signature: None,
+                    },
+                    chain_id,
+                )
+                .await?
+        }
+
+        (
+            SwapKind::Herc20Hbit(params),
+            CreateTransaction::Redeem {
+                secret, address, ..
+            },
+        ) => {
+            let action = params.herc20_params.build_redeem_action(
+                address.context(
+                    "HTLC address required but not provided, please provide with --address",
+                )?,
+                secret,
+            );
+
+            let gas_price = gas_price.gas_price().await?;
+            let to = to_clarity_address(action.to)?;
+            let chain_id = action.chain_id;
+
+            ethereum_wallet
+                .sign(
+                    |nonce| clarity::Transaction {
+                        nonce,
+                        gas_price: gas_price.into(),
+                        gas_limit: action.gas_limit.into(),
+                        to,
+                        value: 0u32.into(),
+                        data: action.data.unwrap_or_default(),
+                        signature: None,
+                    },
+                    chain_id,
+                )
+                .await?
+        }
+        (SwapKind::Herc20Hbit(params), CreateTransaction::Refund { outpoint, .. }) => {
+            let redeem_address = bitcoin_wallet.new_address().await?;
+            let vbyte_rate = bitcoin_fee.vbyte_rate().await?;
+
+            let action = params.hbit_params.shared.build_refund_action(
+                &crate::SECP,
+                params.hbit_params.shared.asset, /* TODO: allow the user to override this on the
+                                                  * commandline */
+                outpoint.context(
+                    "HTLC outpoint required but not provided, please provide with --outpoint",
+                )?,
+                params.hbit_params.transient_sk,
+                redeem_address,
+                vbyte_rate,
+            )?;
+
+            hex::encode(::bitcoin::consensus::serialize(&action.transaction))
+        }
+    };
+
+    Ok(hex)
+}

--- a/nectar/src/database.rs
+++ b/nectar/src/database.rs
@@ -188,6 +188,15 @@ impl Database {
     }
 }
 
+impl Load<SwapKind> for Database {
+    fn load(&self, swap_id: SwapId) -> anyhow::Result<Option<SwapKind>> {
+        let swap = self.get_swap(&swap_id)?;
+        let swap_kind = swap.map(|swap| SwapKind::from((swap, swap_id)));
+
+        Ok(swap_kind)
+    }
+}
+
 /// These methods are used to prevent a peer from having more than one ongoing
 /// swap with nectar An active peer refers to one that has an ongoing swap with
 /// nectar.

--- a/nectar/src/database/hbit.rs
+++ b/nectar/src/database/hbit.rs
@@ -51,7 +51,7 @@ impl From<hbit::Funded> for HbitFunded {
 #[async_trait::async_trait]
 impl Save<hbit::Funded> for Database {
     async fn save(&self, event: hbit::Funded, swap_id: SwapId) -> anyhow::Result<()> {
-        let stored_swap = self.get_swap(&swap_id)?;
+        let stored_swap = self.get_swap_or_bail(&swap_id)?;
 
         match stored_swap.hbit_funded {
             Some(_) => Err(anyhow!("Hbit Funded event is already stored")),
@@ -82,7 +82,7 @@ impl Save<hbit::Funded> for Database {
 
 impl Load<hbit::Funded> for Database {
     fn load(&self, swap_id: SwapId) -> anyhow::Result<Option<hbit::Funded>> {
-        let swap = self.get_swap(&swap_id)?;
+        let swap = self.get_swap_or_bail(&swap_id)?;
 
         Ok(swap.hbit_funded.map(Into::into))
     }
@@ -115,7 +115,7 @@ impl From<hbit::Redeemed> for HbitRedeemed {
 #[async_trait::async_trait]
 impl Save<hbit::Redeemed> for Database {
     async fn save(&self, event: hbit::Redeemed, swap_id: SwapId) -> anyhow::Result<()> {
-        let stored_swap = self.get_swap(&swap_id)?;
+        let stored_swap = self.get_swap_or_bail(&swap_id)?;
 
         match stored_swap.hbit_redeemed {
             Some(_) => Err(anyhow!("Hbit Redeemed event is already stored")),
@@ -146,7 +146,7 @@ impl Save<hbit::Redeemed> for Database {
 
 impl Load<hbit::Redeemed> for Database {
     fn load(&self, swap_id: SwapId) -> anyhow::Result<Option<hbit::Redeemed>> {
-        let swap = self.get_swap(&swap_id)?;
+        let swap = self.get_swap_or_bail(&swap_id)?;
 
         Ok(swap.hbit_redeemed.map(Into::into))
     }
@@ -176,7 +176,7 @@ impl From<hbit::Refunded> for HbitRefunded {
 #[async_trait::async_trait]
 impl Save<hbit::Refunded> for Database {
     async fn save(&self, event: hbit::Refunded, swap_id: SwapId) -> anyhow::Result<()> {
-        let stored_swap = self.get_swap(&swap_id)?;
+        let stored_swap = self.get_swap_or_bail(&swap_id)?;
         match stored_swap.hbit_refunded {
             Some(_) => Err(anyhow!("Hbit Refunded event is already stored")),
             None => {
@@ -206,7 +206,7 @@ impl Save<hbit::Refunded> for Database {
 
 impl Load<hbit::Refunded> for Database {
     fn load(&self, swap_id: SwapId) -> anyhow::Result<Option<hbit::Refunded>> {
-        let swap = self.get_swap(&swap_id)?;
+        let swap = self.get_swap_or_bail(&swap_id)?;
 
         Ok(swap.hbit_refunded.map(Into::into))
     }

--- a/nectar/src/database/herc20.rs
+++ b/nectar/src/database/herc20.rs
@@ -40,7 +40,7 @@ impl From<herc20::Deployed> for Herc20Deployed {
 #[async_trait::async_trait]
 impl Save<herc20::Deployed> for Database {
     async fn save(&self, event: herc20::Deployed, swap_id: SwapId) -> anyhow::Result<()> {
-        let stored_swap = self.get_swap(&swap_id)?;
+        let stored_swap = self.get_swap_or_bail(&swap_id)?;
 
         match stored_swap.herc20_deployed {
             Some(_) => Err(anyhow!("Herc20 Deployed event is already stored")),
@@ -71,7 +71,7 @@ impl Save<herc20::Deployed> for Database {
 
 impl Load<herc20::Deployed> for Database {
     fn load(&self, swap_id: SwapId) -> anyhow::Result<Option<herc20::Deployed>> {
-        let swap = self.get_swap(&swap_id)?;
+        let swap = self.get_swap_or_bail(&swap_id)?;
 
         Ok(swap.herc20_deployed.map(Into::into))
     }
@@ -104,7 +104,7 @@ impl From<herc20::Funded> for Herc20Funded {
 #[async_trait::async_trait]
 impl Save<herc20::Funded> for Database {
     async fn save(&self, event: herc20::Funded, swap_id: SwapId) -> anyhow::Result<()> {
-        let stored_swap = self.get_swap(&swap_id)?;
+        let stored_swap = self.get_swap_or_bail(&swap_id)?;
 
         match stored_swap.herc20_funded {
             Some(_) => Err(anyhow!("Herc20 Funded event is already stored")),
@@ -135,7 +135,7 @@ impl Save<herc20::Funded> for Database {
 
 impl Load<herc20::Funded> for Database {
     fn load(&self, swap_id: SwapId) -> anyhow::Result<Option<herc20::Funded>> {
-        let swap = self.get_swap(&swap_id)?;
+        let swap = self.get_swap_or_bail(&swap_id)?;
 
         Ok(swap.herc20_funded.map(Into::into))
     }
@@ -168,7 +168,7 @@ impl From<herc20::Redeemed> for Herc20Redeemed {
 #[async_trait::async_trait]
 impl Save<herc20::Redeemed> for Database {
     async fn save(&self, event: herc20::Redeemed, swap_id: SwapId) -> anyhow::Result<()> {
-        let stored_swap = self.get_swap(&swap_id)?;
+        let stored_swap = self.get_swap_or_bail(&swap_id)?;
 
         match stored_swap.herc20_redeemed {
             Some(_) => Err(anyhow!("Herc20 Redeemed event is already stored")),
@@ -199,7 +199,7 @@ impl Save<herc20::Redeemed> for Database {
 
 impl Load<herc20::Redeemed> for Database {
     fn load(&self, swap_id: SwapId) -> anyhow::Result<Option<herc20::Redeemed>> {
-        let swap = self.get_swap(&swap_id)?;
+        let swap = self.get_swap_or_bail(&swap_id)?;
 
         Ok(swap.herc20_redeemed.map(Into::into))
     }
@@ -229,7 +229,7 @@ impl From<herc20::Refunded> for Herc20Refunded {
 #[async_trait::async_trait]
 impl Save<herc20::Refunded> for Database {
     async fn save(&self, event: herc20::Refunded, swap_id: SwapId) -> anyhow::Result<()> {
-        let stored_swap = self.get_swap(&swap_id)?;
+        let stored_swap = self.get_swap_or_bail(&swap_id)?;
 
         match stored_swap.herc20_refunded {
             Some(_) => Err(anyhow!("Herc20 Refunded event is already stored")),
@@ -260,7 +260,7 @@ impl Save<herc20::Refunded> for Database {
 
 impl Load<herc20::Refunded> for Database {
     fn load(&self, swap_id: SwapId) -> anyhow::Result<Option<herc20::Refunded>> {
-        let swap = self.get_swap(&swap_id)?;
+        let swap = self.get_swap_or_bail(&swap_id)?;
 
         Ok(swap.herc20_refunded.map(Into::into))
     }

--- a/nectar/src/ethereum.rs
+++ b/nectar/src/ethereum.rs
@@ -11,6 +11,8 @@ pub use wallet::Wallet;
 pub const STANDARD_ETH_TRANSFER_GAS_LIMIT: u64 = 21_000;
 pub const DAI_TRANSFER_GAS_LIMIT: u64 = 100_000;
 
+use anyhow::{Context, Result};
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Chain {
     Mainnet,
@@ -63,6 +65,11 @@ impl Chain {
             Local { chain_id, .. } => ChainId::from(*chain_id),
         }
     }
+}
+
+pub fn to_clarity_address(to: Address) -> Result<clarity::Address> {
+    clarity::Address::from_slice(to.as_bytes())
+        .context("failed to create private key from byte slice")
 }
 
 #[cfg(test)]

--- a/nectar/src/ethereum/wallet.rs
+++ b/nectar/src/ethereum/wallet.rs
@@ -2,11 +2,11 @@ use crate::{
     ethereum::{
         self, dai, ether,
         geth::{Client, EstimateGasRequest},
-        Address, ChainId, Hash, DAI_TRANSFER_GAS_LIMIT,
+        to_clarity_address, Address, ChainId, Hash, DAI_TRANSFER_GAS_LIMIT,
     },
     Seed,
 };
-use anyhow::{Context, Result};
+use anyhow::Context;
 use bitcoin::util::bip32::{DerivationPath, ExtendedPrivKey};
 use clarity::Uint256;
 use comit::{
@@ -607,9 +607,4 @@ mod tests {
             .await
             .unwrap();
     }
-}
-
-fn to_clarity_address(to: Address) -> Result<clarity::Address> {
-    clarity::Address::from_slice(to.as_bytes())
-        .context("failed to create private key from byte slice")
 }

--- a/nectar/src/ethereum/wallet.rs
+++ b/nectar/src/ethereum/wallet.rs
@@ -127,24 +127,15 @@ impl Wallet {
         }: DeployContract,
         gas_price: ether::Amount,
     ) -> anyhow::Result<DeployedContract> {
-        self.assert_chain(chain_id).await?;
-
-        let nonce = self.get_transaction_count().await?;
-
-        let transaction = clarity::Transaction {
-            nonce: nonce.into(),
-            gas_price: gas_price.into(),
-            gas_limit: gas_limit.into(),
-            to: clarity::Address::default(),
-            value: 0u64.into(),
-            data,
-            signature: None,
-        };
-        let transaction_hex = self.sign(transaction)?;
-
         let hash = self
-            .geth_client
-            .send_raw_transaction(transaction_hex)
+            .sign_and_send(
+                data,
+                0u64.into(),
+                clarity::Address::default(),
+                gas_limit.into(),
+                gas_price.into(),
+                chain_id,
+            )
             .await?;
 
         let contract_address = match self.wait_until_transaction_receipt(hash, chain_id).await? {
@@ -179,10 +170,6 @@ impl Wallet {
         chain_id: ChainId,
         gas_price: ether::Amount,
     ) -> anyhow::Result<Hash> {
-        self.assert_chain(chain_id).await?;
-
-        let nonce = self.get_transaction_count().await?;
-
         let gas_limit = match gas_limit {
             Some(gas_limit) => gas_limit.into(),
             None => {
@@ -196,21 +183,15 @@ impl Wallet {
                 .await?
             }
         };
-
-        let transaction = clarity::Transaction {
-            nonce: nonce.into(),
-            gas_price: gas_price.into(),
-            gas_limit,
-            to: to_clarity_address(to)?,
-            value: value.into(),
-            data: data.unwrap_or_default(),
-            signature: None,
-        };
-        let transaction_hex = self.sign(transaction)?;
-
         let hash = self
-            .geth_client
-            .send_raw_transaction(transaction_hex)
+            .sign_and_send(
+                data.unwrap_or_default(),
+                value.into(),
+                to_clarity_address(to)?,
+                gas_limit,
+                gas_price.into(),
+                chain_id,
+            )
             .await?;
 
         let _ = self.wait_until_transaction_receipt(hash, chain_id).await?;
@@ -225,10 +206,6 @@ impl Wallet {
         chain_id: ChainId,
         gas_price: ether::Amount,
     ) -> anyhow::Result<Hash> {
-        self.assert_chain(chain_id).await?;
-
-        let nonce = self.get_transaction_count().await?;
-
         let to = to_clarity_address(to)?;
         let dai_contract_addr = to_clarity_address(self.chain.dai_contract_address())?;
 
@@ -237,20 +214,15 @@ impl Wallet {
             clarity::abi::Token::Uint(Uint256::from_bytes_le(value.to_bytes().as_slice())),
         ])?;
 
-        let transaction = clarity::Transaction {
-            nonce: nonce.into(),
-            gas_price: gas_price.into(),
-            gas_limit: DAI_TRANSFER_GAS_LIMIT.into(),
-            to: dai_contract_addr,
-            value: 0u16.into(),
-            data,
-            signature: None,
-        };
-        let transaction_hex = self.sign(transaction)?;
-
         let hash = self
-            .geth_client
-            .send_raw_transaction(transaction_hex)
+            .sign_and_send(
+                data,
+                0u64.into(),
+                dai_contract_addr,
+                DAI_TRANSFER_GAS_LIMIT.into(),
+                gas_price.into(),
+                chain_id,
+            )
             .await?;
 
         let _ = self.wait_until_transaction_receipt(hash, chain_id).await?;
@@ -269,27 +241,50 @@ impl Wallet {
         }: CallContract,
         gas_price: ether::Amount,
     ) -> anyhow::Result<Hash> {
-        self.assert_chain(chain_id).await?;
+        let hash = self
+            .sign_and_send(
+                data.unwrap_or_default(),
+                0u64.into(),
+                to_clarity_address(to)?,
+                gas_limit.into(),
+                gas_price.into(),
+                chain_id,
+            )
+            .await?;
 
-        let nonce = self.get_transaction_count().await?;
+        let _ = self.wait_until_transaction_receipt(hash, chain_id).await?;
 
-        let transaction = clarity::Transaction {
-            nonce: nonce.into(),
-            gas_price: gas_price.into(),
-            gas_limit: gas_limit.into(),
-            to: to_clarity_address(to)?,
-            value: 0u32.into(),
-            data: data.unwrap_or_default(),
-            signature: None,
-        };
-        let transaction_hex = self.sign(transaction)?;
+        Ok(hash)
+    }
+
+    pub async fn sign_and_send(
+        &self,
+        data: Vec<u8>,
+        value: Uint256,
+        to: clarity::Address,
+        gas_limit: Uint256,
+        gas_price: Uint256,
+        chain_id: ChainId,
+    ) -> anyhow::Result<Hash> {
+        let transaction_hex = self
+            .sign(
+                |nonce| clarity::Transaction {
+                    nonce,
+                    gas_price,
+                    gas_limit,
+                    to,
+                    value,
+                    data,
+                    signature: None,
+                },
+                chain_id,
+            )
+            .await?;
 
         let hash = self
             .geth_client
             .send_raw_transaction(transaction_hex)
             .await?;
-
-        let _ = self.wait_until_transaction_receipt(hash, chain_id).await?;
 
         Ok(hash)
     }
@@ -369,7 +364,16 @@ impl Wallet {
         self.geth_client.gas_limit(request).await
     }
 
-    fn sign(&self, transaction: clarity::Transaction) -> anyhow::Result<String> {
+    async fn sign(
+        &self,
+        transaction_fn: impl FnOnce(Uint256) -> clarity::Transaction,
+        chain_id: ChainId,
+    ) -> anyhow::Result<String> {
+        self.assert_chain(chain_id).await?;
+
+        let nonce = self.get_transaction_count().await?;
+        let transaction = transaction_fn(nonce.into());
+
         let signed_transaction = transaction.sign(
             &self.private_key,
             Some(u32::from(self.chain.chain_id()) as u64),

--- a/nectar/src/jsonrpc.rs
+++ b/nectar/src/jsonrpc.rs
@@ -1,5 +1,4 @@
 use anyhow::Context;
-use futures::TryFutureExt;
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
 
@@ -41,8 +40,8 @@ impl Client {
             .post(url.clone())
             .json(&request)
             .send()
-            .map_err(ConnectionFailed)
-            .await?
+            .await
+            .context("failed to send request")?
             .json::<Response<Res>>()
             .await
             .context("failed to deserialize JSON response as JSON-RPC response")?
@@ -106,10 +105,6 @@ pub struct JsonRpcError {
     code: i64,
     message: String,
 }
-
-#[derive(Debug, thiserror::Error)]
-#[error("connection error: {0}")]
-pub struct ConnectionFailed(#[from] reqwest::Error);
 
 pub fn serialize<T>(t: T) -> anyhow::Result<serde_json::Value>
 where

--- a/nectar/src/swap_id.rs
+++ b/nectar/src/swap_id.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::{fmt, str::FromStr};
 use uuid::Uuid;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -20,6 +20,14 @@ impl Default for SwapId {
 impl fmt::Display for SwapId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0.to_string())
+    }
+}
+
+impl FromStr for SwapId {
+    type Err = uuid::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(SwapId(Uuid::from_str(s)?))
     }
 }
 


### PR DESCRIPTION
Last patch introduces the commands, all previous patches are smaller refactorings to make it happen.

Here is an example invocation for creating a redeem transaction for the herc20 protocol:

> nectar create-transaction redeem 5c1c2771-4405-46a7-acbc-850ef80b3929 --secret abababababababababababababababababababababababababababababababab --address 0x0011001100110011001100110011001100110011

The hex output is written to stdout whereas all the logging to stderr, meaning one can directly pipe the output to a file or the clipboard if we one wants.

I was also thinking of adding a `--and-broadcast` option if it should be directly broadcasted to the network but refrained from doing so for now. We can add that later if we want to.
At the moment, we also depend on the connections to the wallet to be present even though we would not necessarily need that but I also saw that as an optimization on top of this.