### PR TITLE
Merge master into dev instead of the release branch

### DIFF
--- a/.github/workflows/merge-release-branch-back-into-dev.yml
+++ b/.github/workflows/merge-release-branch-back-into-dev.yml
@@ -13,13 +13,14 @@ jobs:
     name: Merge release-branch back into dev
     runs-on: ubuntu-latest
     steps:
-      - name: Create pull request for merging release-branch back into dev
+      - name: Create pull request for merging master back into dev
         uses: thomaseizinger/create-pull-request@1.0.0
         with:
           GITHUB_TOKEN: ${{ secrets.BOTTY_GITHUB_TOKEN }}
-          head: ${{ github.event.pull_request.head.ref }}
+          head: master
           base: dev
-          title: Merge `${{ github.event.pull_request.head.ref }}` into `dev`
+          title: Merge `master` into `dev`
           body: |
-            This PR merges the `${{ github.event.pull_request.head.ref }}` branch back into `dev`.
+            This PR merges the `master` branch back into `dev`.
             This happens to ensure that the updates that happend on the release branch, i.e. CHANGELOG and manifest updates are also present on the dev branch.
+            Otherwise, GitHub will "complain" that the next release branch is not up to date with master because it is missing the merge commit from the last release.


### PR DESCRIPTION
Previously, we've only merged the release branch back into dev after
a release. That ensured that any commits to the release branch like
bumping the version in the manifest and updating the changelog were
also present in the dev branch.

Even though those changes were merged back into dev, GitHub still
considered a new release branch to be "out-of-date" with master because
it was missing the _merge_ commit that represents the actual release.

There is no semantic difference between merging the release branch
and merging the master branch back into dev.

We change the workflow to use the master branch to have the warning
go away and avoid developers being distracted by it, thinking the
have to action it somehow.