### PR TITLE
Replace dedicated error structs with anyhow's .context

### DIFF
--- a/cnd/src/bitcoin_fees.rs
+++ b/cnd/src/bitcoin_fees.rs
@@ -31,7 +31,7 @@ impl BitcoinFees {
 
 mod block_cypher {
     use ::bitcoin::Amount;
-    use anyhow::Result;
+    use anyhow::{Context, Result};
     use serde::Deserialize;
 
     #[derive(Debug, Clone)]
@@ -101,20 +101,12 @@ mod block_cypher {
         async fn get(&self) -> Result<Response> {
             Ok(reqwest::get(self.url.clone())
                 .await
-                .map_err(ConnectionFailed)?
+                .with_context(|| format!("failed to perform GET request to {}", self.url))?
                 .json()
                 .await
-                .map_err(DeserializationFailed)?)
+                .context("failed to deserialize response as JSON into struct")?)
         }
     }
-
-    #[derive(Debug, thiserror::Error)]
-    #[error("connection error: {0}")]
-    pub struct ConnectionFailed(#[from] reqwest::Error);
-
-    #[derive(Debug, thiserror::Error)]
-    #[error("deserialization error: {0}")]
-    pub struct DeserializationFailed(#[from] reqwest::Error);
 
     #[derive(Debug, Deserialize, Eq, PartialEq)]
     struct Response {

--- a/cnd/src/config/validation.rs
+++ b/cnd/src/config/validation.rs
@@ -10,10 +10,6 @@ pub struct NetworkMismatch<T: Debug> {
     specified_network: T,
 }
 
-#[derive(Error, Debug, Copy, Clone)]
-#[error("connection failure")]
-pub struct ConnectionFailure;
-
 /// Validate that the connector is connected to the network.
 ///
 /// This function returns a double-result to differentiate between arbitrary
@@ -29,7 +25,7 @@ where
     let actual = connector
         .connected_network()
         .await
-        .context(ConnectionFailure)?;
+        .context("failed to determine the connected network")?;
 
     if actual != specified {
         return Ok(Err(NetworkMismatch {


### PR DESCRIPTION
We don't need to define a struct for the error if we all we want
is to add more information to the error stacktrace. Addititionally,
if we were to define a struct for the error, we shouldn't print the
inner error as part of this error struct's message otherwise the
message will get printed twice once anyhow prints the error stacktrace.
More importantly, we want to include context that would otherwise
be lost like the URL we made the request to.