### PR TITLE
Archive swap command

### DIFF
--- a/nectar/CHANGELOG.md
+++ b/nectar/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+**This release includes changes to the DB schema, we recommend to backup your data directory before upgrading.**
+
+### Added
+
+-   New command to archive swaps: `nectar archive-swap <swap id>`.
+    The command should only be used while nectar is stopped as it updates the database.
+    Archiving a swap stops nectar to resume its automated execution, `create-transaction` command can then be used to recover funds.
+
 ## [nectar-0.1.0] - 2020-10-20
 
 ### Added
@@ -20,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   Update the expected network times to calculate the expiries: We expect Bitcoin's transactions to be included within 6 blocks and Ethereum's within 30 blocks.
--   By default, use bitcoind's `estimatsmartfee` feature to estimate Bitcoin fees.
+-   By default, use bitcoind's `estimatesmartfee` feature to estimate Bitcoin fees.
     For Ethereum, Eth Gas Station API is used.
 -   Change log level configuration format from capitalised (e.g. "Debug") to lowercase (e.g. "debug").
 

--- a/nectar/src/command.rs
+++ b/nectar/src/command.rs
@@ -70,6 +70,8 @@ pub enum Command {
     ResumeOnly,
     /// Manually create and sign a transaction for a specific swap.
     CreateTransaction(CreateTransaction),
+    /// Archive a swap, all automated actions will be paused.
+    ArchiveSwap { id: SwapId },
 }
 
 pub fn dump_config(settings: Settings) -> anyhow::Result<()> {

--- a/nectar/src/command/resume_only.rs
+++ b/nectar/src/command/resume_only.rs
@@ -34,7 +34,7 @@ pub async fn resume_only(
         Arc::new(Web3Connector::new(settings.ethereum.node_url)),
     );
 
-    for swap in db.all_swaps()? {
+    for swap in db.all_active_swaps()? {
         executor.execute(swap);
     }
 

--- a/nectar/src/command/trade.rs
+++ b/nectar/src/command/trade.rs
@@ -258,7 +258,7 @@ fn respawn_swaps(
     maker: &mut Maker,
     swap_executor: SwapExecutor,
 ) -> anyhow::Result<()> {
-    for swap in db.all_swaps()?.into_iter() {
+    for swap in db.all_active_swaps()?.into_iter() {
         // Reserve funds
         match swap {
             SwapKind::HbitHerc20(SwapParams {

--- a/nectar/src/database.rs
+++ b/nectar/src/database.rs
@@ -411,9 +411,7 @@ mod tests {
 
         let stored_swaps = db.all_swaps().unwrap();
 
-        assert_eq!(stored_swaps, vec![swap_2]);
-
-        true
+        stored_swaps == vec![swap_2]
     }
 
     #[quickcheck_async::tokio]

--- a/nectar/src/database.rs
+++ b/nectar/src/database.rs
@@ -142,7 +142,7 @@ impl Database {
                     let swap = deserialize::<Swap>(&value).context("failed to deserialize swap");
 
                     match (swap_id, swap) {
-                        (Ok(swap_id), Ok(swap)) => Some(Ok(SwapKind::from((swap, swap_id)))),
+                        (Ok(swap_id), Ok(swap)) => Some(Ok((swap, swap_id))),
                         (Ok(_), Err(err)) => Some(Err(err)), // If the swap id deserialize, then
                         // it should be a swap
                         (..) => None, // This is not a swap item
@@ -150,6 +150,7 @@ impl Database {
                 }
                 Err(err) => Some(Err(err).context("failed to retrieve swaps from DB")),
             })
+            .map(|res| res.map(|(swap, swap_id)| SwapKind::from((swap, swap_id))))
             .collect()
     }
 

--- a/nectar/src/main.rs
+++ b/nectar/src/main.rs
@@ -187,6 +187,16 @@ async fn main() -> Result<()> {
 
             println!("{}", hex);
         }
+        Command::ArchiveSwap { id } => {
+            #[cfg(not(test))]
+            let db = Database::new(&settings.data.dir.join("database"))?;
+            #[cfg(test)]
+            let db = Database::new_test()?;
+
+            db.archive_swap(&id)
+                .await
+                .context("failed to archive swap")?;
+        }
     };
 
     Ok(())


### PR DESCRIPTION
New command to archive swaps: `nectar archive-swap <swap id>`.
The command should be done while nectar is stopped as it updates the database.
Archiving a swap stops nectar to resume its automated execution, `create-transaction` command can then be used to recover funds.