### PR TITLE
Do not use compare_and_swap for db update

### DIFF
--- a/nectar/src/database/hbit.rs
+++ b/nectar/src/database/hbit.rs
@@ -61,14 +61,12 @@ impl Save<hbit::Funded> for Database {
                 let mut swap = stored_swap.clone();
                 swap.hbit_funded = Some(event.into());
 
-                let old_value =
-                    serialize(&stored_swap).context("Could not serialize old swap value")?;
                 let new_value = serialize(&swap).context("Could not serialize new swap value")?;
 
-                self.db
-                    .compare_and_swap(key, Some(old_value), Some(new_value))
-                    .context("Could not write in the DB")?
-                    .context("Stored swap somehow changed, aborting saving")?;
+                let _ = self
+                    .db
+                    .insert(key, new_value)
+                    .context("Could not write in the DB")?;
 
                 self.db
                     .flush_async()
@@ -125,14 +123,12 @@ impl Save<hbit::Redeemed> for Database {
                 let mut swap = stored_swap.clone();
                 swap.hbit_redeemed = Some(event.into());
 
-                let old_value =
-                    serialize(&stored_swap).context("Could not serialize old swap value")?;
                 let new_value = serialize(&swap).context("Could not serialize new swap value")?;
 
-                self.db
-                    .compare_and_swap(key, Some(old_value), Some(new_value))
-                    .context("Could not write in the DB")?
-                    .context("Stored swap somehow changed, aborting saving")?;
+                let _ = self
+                    .db
+                    .insert(key, new_value)
+                    .context("Could not write in the DB")?;
 
                 self.db
                     .flush_async()
@@ -185,14 +181,12 @@ impl Save<hbit::Refunded> for Database {
                 let mut swap = stored_swap.clone();
                 swap.hbit_refunded = Some(event.into());
 
-                let old_value =
-                    serialize(&stored_swap).context("Could not serialize old swap value")?;
                 let new_value = serialize(&swap).context("Could not serialize new swap value")?;
 
-                self.db
-                    .compare_and_swap(key, Some(old_value), Some(new_value))
-                    .context("Could not write in the DB")?
-                    .context("Stored swap somehow changed, aborting saving")?;
+                let _ = self
+                    .db
+                    .insert(key, new_value)
+                    .context("Could not write in the DB")?;
 
                 self.db
                     .flush_async()

--- a/nectar/src/database/herc20.rs
+++ b/nectar/src/database/herc20.rs
@@ -49,14 +49,12 @@ impl Save<herc20::Deployed> for Database {
                 let mut swap = stored_swap.clone();
                 swap.herc20_deployed = Some(event.into());
 
-                let old_value =
-                    serialize(&stored_swap).context("Could not serialize old swap value")?;
                 let new_value = serialize(&swap).context("Could not serialize new swap value")?;
 
-                self.db
-                    .compare_and_swap(key, Some(old_value), Some(new_value))
-                    .context("Could not write in the DB")?
-                    .context("Stored swap somehow changed, aborting saving")?;
+                let _ = self
+                    .db
+                    .insert(key, new_value)
+                    .context("Could not write in the DB")?;
 
                 self.db
                     .flush_async()
@@ -113,14 +111,12 @@ impl Save<herc20::Funded> for Database {
                 let mut swap = stored_swap.clone();
                 swap.herc20_funded = Some(event.into());
 
-                let old_value =
-                    serialize(&stored_swap).context("Could not serialize old swap value")?;
                 let new_value = serialize(&swap).context("Could not serialize new swap value")?;
 
-                self.db
-                    .compare_and_swap(key, Some(old_value), Some(new_value))
-                    .context("Could not write in the DB")?
-                    .context("Stored swap somehow changed, aborting saving")?;
+                let _ = self
+                    .db
+                    .insert(key, new_value)
+                    .context("Could not write in the DB")?;
 
                 self.db
                     .flush_async()
@@ -177,14 +173,12 @@ impl Save<herc20::Redeemed> for Database {
                 let mut swap = stored_swap.clone();
                 swap.herc20_redeemed = Some(event.into());
 
-                let old_value =
-                    serialize(&stored_swap).context("Could not serialize old swap value")?;
                 let new_value = serialize(&swap).context("Could not serialize new swap value")?;
 
-                self.db
-                    .compare_and_swap(key, Some(old_value), Some(new_value))
-                    .context("Could not write in the DB")?
-                    .context("Stored swap somehow changed, aborting saving")?;
+                let _ = self
+                    .db
+                    .insert(key, new_value)
+                    .context("Could not write in the DB")?;
 
                 self.db
                     .flush_async()
@@ -238,14 +232,12 @@ impl Save<herc20::Refunded> for Database {
                 let mut swap = stored_swap.clone();
                 swap.herc20_refunded = Some(event.into());
 
-                let old_value =
-                    serialize(&stored_swap).context("Could not serialize old swap value")?;
                 let new_value = serialize(&swap).context("Could not serialize new swap value")?;
 
-                self.db
-                    .compare_and_swap(key, Some(old_value), Some(new_value))
-                    .context("Could not write in the DB")?
-                    .context("Stored swap somehow changed, aborting saving")?;
+                let _ = self
+                    .db
+                    .insert(key, new_value)
+                    .context("Could not write in the DB")?;
 
                 self.db
                     .flush_async()


### PR DESCRIPTION
Backward compatibility is maintained to allow newer software to
deserialize older data.
We do not try to guarantee that older data serialised the same way than
newer data.
Which means that `compare_and_swap` fails if the swap was created with
an older version of the software.

As we do not cater for concurrent update of the db, and we just retrieved
the swap to update few lines ago, it is ok to not check again.

This resolves the issue encountered when trying to archive a swap
created before the archive swap feature was introduced.