### PR TITLE
New command to migrate the database to a new format

### DIFF
--- a/nectar/CHANGELOG.md
+++ b/nectar/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   New command to archive swaps: `nectar archive-swap <swap id>`.
     The command should only be used while nectar is stopped as it updates the database.
     Archiving a swap stops nectar to resume its automated execution, `create-transaction` command can then be used to recover funds.
+-   New command to migrate the database to a new format;
+    Use `nectar migrate-db status` to check if migration is needed;
+    If so, backup your data and then execute `nectar migrate-db run` to proceed with the migration.
 
 ## [nectar-0.1.0] - 2020-10-20
 

--- a/nectar/src/command.rs
+++ b/nectar/src/command.rs
@@ -4,6 +4,7 @@ use structopt::StructOpt;
 mod balance;
 mod create_transaction;
 mod deposit;
+mod migrate_db;
 mod resume_only;
 mod trade;
 mod wallet_info;
@@ -25,6 +26,7 @@ pub use balance::balance;
 use comit::Secret;
 pub use create_transaction::create_transaction;
 pub use deposit::deposit;
+pub use migrate_db::migrate_db;
 pub use resume_only::resume_only;
 use time::OffsetDateTime;
 pub use trade::trade;
@@ -72,6 +74,8 @@ pub enum Command {
     CreateTransaction(CreateTransaction),
     /// Archive a swap, all automated actions will be paused.
     ArchiveSwap { id: SwapId },
+    /// Migrate the database to the current format.
+    MigrateDb(MigrateDb),
 }
 
 pub fn dump_config(settings: Settings) -> anyhow::Result<()> {
@@ -142,6 +146,14 @@ impl CreateTransaction {
             CreateTransaction::Refund { swap_id, .. } => *swap_id,
         }
     }
+}
+
+#[derive(StructOpt, Debug, Clone)]
+pub enum MigrateDb {
+    /// Print whether the database needs a migration.
+    Status,
+    /// Runs a database migration, please backup before proceeding.
+    Run,
 }
 
 fn parse_bitcoin(str: &str) -> anyhow::Result<bitcoin::Amount> {

--- a/nectar/src/command/migrate_db.rs
+++ b/nectar/src/command/migrate_db.rs
@@ -1,0 +1,84 @@
+use crate::{command::MigrateDb, database, database::Database};
+use anyhow::{bail, Result};
+use std::path::PathBuf;
+use time::OffsetDateTime;
+
+pub async fn migrate_db(action: MigrateDb, db_dir: &PathBuf) -> Result<()> {
+    match action {
+        MigrateDb::Status => {
+            match status(db_dir).await? {
+                MigrationStatus::NotNeeded => {
+                    println!("Database migration is not needed.");
+                }
+                MigrationStatus::NeededSledFormat => println!(
+                    "Database migration is needed due to sled format upgrade. Backup your database located at '{:?}' first.",
+                    db_dir
+                ),
+                MigrationStatus::NeededSerializationFormat => println!(
+                    "Database migration is needed due to nectar format upgrade. Backup your database located at '{:?}' first.",
+                    db_dir
+                ),
+            }
+            Ok(())
+        }
+        MigrateDb::Run => run(db_dir).await,
+    }
+}
+
+async fn status(db_dir: &PathBuf) -> Result<MigrationStatus> {
+    let db = match Database::new(db_dir.as_path()) {
+        Err(database::Error::Sled(sled::Error::Unsupported(_))) => {
+            println!("Database needs migration due to an upgrade of sled data type");
+            return Ok(MigrationStatus::NeededSledFormat);
+        }
+        Err(err) => bail!("Issue opening the db: {:#?}", err),
+        Ok(db) => db,
+    };
+
+    if db.are_any_swap_stored_in_old_format().await? {
+        Ok(MigrationStatus::NeededSerializationFormat)
+    } else {
+        Ok(MigrationStatus::NotNeeded)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum MigrationStatus {
+    NotNeeded,
+    NeededSledFormat,
+    NeededSerializationFormat,
+}
+
+async fn run(db_dir: &PathBuf) -> Result<()> {
+    match status(db_dir).await? {
+        MigrationStatus::NotNeeded => {
+            bail!("Database migration is not necessary");
+        }
+
+        MigrationStatus::NeededSledFormat => {
+            let now = OffsetDateTime::now_local().lazy_format("%Y-%0m-%d_%0H%0M%0S.%N");
+            let backup_dir_name = format!("database_bk_{}", now);
+            let backup_dir = db_dir
+                .parent()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("failed to get the parent folder of the database directory")
+                })?
+                .join(backup_dir_name);
+
+            std::fs::rename(db_dir, backup_dir.clone())?;
+
+            let old_db = sled::open(backup_dir.as_path())?;
+            let new_db = sled::open(db_dir.as_path())?;
+
+            let export = old_db.export();
+
+            new_db.import(export);
+
+            Ok(())
+        }
+        MigrationStatus::NeededSerializationFormat => {
+            let db = Database::new(db_dir.as_path())?;
+            db.reserialize().await
+        }
+    }
+}

--- a/nectar/src/main.rs
+++ b/nectar/src/main.rs
@@ -41,8 +41,8 @@ mod arbitrary;
 
 use crate::{
     command::{
-        balance, create_transaction, deposit, dump_config, resume_only, trade, wallet_info,
-        withdraw, Command, Options,
+        balance, create_transaction, deposit, dump_config, migrate_db, resume_only, trade,
+        wallet_info, withdraw, Command, Options,
     },
     config::{read_config, Settings},
     fs::default_config_path,
@@ -201,6 +201,9 @@ async fn main() -> Result<()> {
             db.archive_swap(&id)
                 .await
                 .context("failed to archive swap")?;
+        }
+        Command::MigrateDb(action) => {
+            migrate_db(action, &settings.data.dir.join("database")).await?
         }
     };
 


### PR DESCRIPTION
Use `nectar migrate-db status` to check if migration is needed;
If so, backup your data and then execute `nectar migrate-db run` to
proceed with the migration.