### PR TITLE
Implement Arbitrary directly on types where possible

### DIFF
--- a/comit/src/arbitrary.rs
+++ b/comit/src/arbitrary.rs
@@ -1,0 +1,27 @@
+use quickcheck::{Arbitrary, Gen};
+
+pub mod secp256k1 {
+    use super::*;
+    use ::bitcoin::secp256k1::SecretKey;
+
+    pub fn secret_key<G: Gen>(g: &mut G) -> SecretKey {
+        let mut bytes = [0u8; 32];
+        for byte in &mut bytes {
+            *byte = u8::arbitrary(g);
+        }
+        SecretKey::from_slice(&bytes).unwrap()
+    }
+}
+
+pub mod bitcoin {
+    use super::*;
+    use ::bitcoin::Address;
+
+    pub fn address<G: Gen>(g: &mut G) -> Address {
+        Address::p2wpkh(
+            &crate::identity::Bitcoin::arbitrary(g).into(),
+            crate::ledger::Bitcoin::arbitrary(g).into(),
+        )
+        .unwrap()
+    }
+}

--- a/comit/src/asset/bitcoin.rs
+++ b/comit/src/asset/bitcoin.rs
@@ -45,3 +45,10 @@ pub mod sats_as_string {
         Ok(amount)
     }
 }
+
+#[cfg(feature = "quickcheck")]
+pub fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Bitcoin {
+    use quickcheck::Arbitrary;
+
+    Bitcoin::from_sat(u64::arbitrary(g))
+}

--- a/comit/src/asset/ethereum/erc20.rs
+++ b/comit/src/asset/ethereum/erc20.rs
@@ -198,6 +198,29 @@ impl Erc20 {
     }
 }
 
+#[cfg(feature = "quickcheck")]
+impl quickcheck::Arbitrary for Erc20 {
+    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        Erc20 {
+            token_contract: Address::arbitrary(g),
+            quantity: Erc20Quantity::arbitrary(g),
+        }
+    }
+}
+
+#[cfg(feature = "quickcheck")]
+impl quickcheck::Arbitrary for Erc20Quantity {
+    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        let mut bytes = [0u8; 8];
+        for byte in bytes.iter_mut() {
+            *byte = u8::arbitrary(g);
+        }
+        let int = num::BigUint::from_bytes_be(&bytes);
+
+        Erc20Quantity::try_from_wei(int).unwrap()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/comit/src/bitcoin.rs
+++ b/comit/src/bitcoin.rs
@@ -108,6 +108,16 @@ impl<'de> Deserialize<'de> for PublicKey {
     }
 }
 
+#[cfg(feature = "quickcheck")]
+impl quickcheck::Arbitrary for PublicKey {
+    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        PublicKey::from_secret_key(
+            &bitcoin::secp256k1::Secp256k1::signing_only(),
+            &crate::arbitrary::secp256k1::secret_key(g),
+        )
+    }
+}
+
 /// Median time in Bitcoin is defined as the median of the blocktimes from the
 /// last 11 blocks.
 pub async fn median_time_past<C>(connector: &C) -> Result<Timestamp>

--- a/comit/src/ethereum.rs
+++ b/comit/src/ethereum.rs
@@ -263,6 +263,25 @@ pub mod serde_hex_data {
     }
 }
 
+#[cfg(feature = "quickcheck")]
+impl quickcheck::Arbitrary for ChainId {
+    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        ChainId::from(u32::arbitrary(g))
+    }
+}
+
+#[cfg(feature = "quickcheck")]
+impl quickcheck::Arbitrary for Address {
+    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        let mut bytes = [0u8; 20];
+        for byte in &mut bytes {
+            *byte = u8::arbitrary(g);
+        }
+
+        Address::from(bytes)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/comit/src/herc20.rs
+++ b/comit/src/herc20.rs
@@ -356,3 +356,17 @@ pub fn build_erc20_htlc(
         asset.quantity.into(),
     )
 }
+
+#[cfg(feature = "quickcheck")]
+impl quickcheck::Arbitrary for Params {
+    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        Self {
+            asset: asset::Erc20::arbitrary(g),
+            redeem_identity: ethereum::Address::arbitrary(g),
+            refund_identity: ethereum::Address::arbitrary(g),
+            expiry: Timestamp::arbitrary(g),
+            secret_hash: SecretHash::arbitrary(g),
+            chain_id: ChainId::arbitrary(g),
+        }
+    }
+}

--- a/comit/src/ledger/bitcoin.rs
+++ b/comit/src/ledger/bitcoin.rs
@@ -93,6 +93,18 @@ pub mod bitcoind_jsonrpc_network {
     }
 }
 
+#[cfg(feature = "quickcheck")]
+impl quickcheck::Arbitrary for Bitcoin {
+    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        match u8::arbitrary(g) % 3 {
+            0 => Bitcoin::Mainnet,
+            1 => Bitcoin::Testnet,
+            2 => Bitcoin::Regtest,
+            _ => unreachable!(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/comit/src/lib.rs
+++ b/comit/src/lib.rs
@@ -14,6 +14,8 @@
 #![forbid(unsafe_code)]
 
 pub mod actions;
+#[cfg(feature = "quickcheck")]
+pub mod arbitrary;
 pub mod asset;
 pub mod bitcoin;
 pub mod btsieve;

--- a/nectar/src/swap.rs
+++ b/nectar/src/swap.rs
@@ -108,11 +108,7 @@ impl crate::StaticStub for SwapParams {
 #[cfg(test)]
 mod arbitrary {
     use super::*;
-    use comit::{
-        asset::{ethereum::TryFromWei, Erc20, Erc20Quantity},
-        ethereum::ChainId,
-        SecretHash, Timestamp,
-    };
+    use comit::SecretHash;
     use quickcheck::{Arbitrary, Gen};
 
     impl Arbitrary for SwapKind {
@@ -127,44 +123,14 @@ mod arbitrary {
 
     impl Arbitrary for SwapParams {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            let herc20_params = herc20::Params {
-                asset: erc20(g),
-                redeem_identity: ethereum_address(g),
-                refund_identity: ethereum_address(g),
-                expiry: Timestamp::arbitrary(g),
-                secret_hash: SecretHash::arbitrary(g),
-                chain_id: ChainId::from(u32::arbitrary(g)),
-            };
-
             SwapParams {
                 hbit_params: hbit::Params::arbitrary(g),
-                herc20_params,
+                herc20_params: herc20::Params::arbitrary(g),
                 secret_hash: SecretHash::arbitrary(g),
                 start_of_swap: OffsetDateTime::from_unix_timestamp(u32::arbitrary(g) as i64),
                 swap_id: SwapId::arbitrary(g),
                 taker: ActivePeer::arbitrary(g),
             }
-        }
-    }
-
-    fn ethereum_address<G: Gen>(g: &mut G) -> ethereum::Address {
-        let mut bytes = [0u8; 20];
-        for byte in &mut bytes {
-            *byte = u8::arbitrary(g);
-        }
-        ethereum::Address::from(bytes)
-    }
-
-    fn erc20<G: Gen>(g: &mut G) -> Erc20 {
-        let mut bytes = [0u8; 8];
-        for byte in bytes.iter_mut() {
-            *byte = u8::arbitrary(g);
-        }
-        let int = num::BigUint::from_bytes_be(&bytes);
-        let quantity = Erc20Quantity::try_from_wei(int).unwrap();
-        Erc20 {
-            token_contract: ethereum_address(g),
-            quantity,
         }
     }
 }


### PR DESCRIPTION
With the introduction swap execution in the comit lib, we also
introduced a dependency on quickcheck. Previously, a lot of the
`Arbitrary` impls where defined within nectar. We can now move
them to the `comit` lib.