### PR TITLE
Remove the type_length_limit from the `comit` crate

### DIFF
--- a/comit/src/lib.rs
+++ b/comit/src/lib.rs
@@ -12,7 +12,6 @@
     clippy::dbg_macro
 )]
 #![forbid(unsafe_code)]
-#![type_length_limit = "1049479"] // Regressed with Rust 1.46.0 :(
 
 pub mod actions;
 pub mod asset;


### PR DESCRIPTION
We no longer need this as we are compiling our code with 1.48 by now.