### PR TITLE
Disable e2e tests on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
 
           - target: x86_64-apple-darwin
             os: macos-latest
+            skip_e2e_tests: true
 
           - target: x86_64-pc-windows-gnu
             os: windows-latest


### PR DESCRIPTION
They are unstable. If Linux CI passes we know that things work.

FYI @D4nte @da-kami 